### PR TITLE
feat: Support VLESS XTLS Vision

### DIFF
--- a/adapter/outbound/vless.go
+++ b/adapter/outbound/vless.go
@@ -171,7 +171,7 @@ func (v *Vless) StreamConn(c net.Conn, metadata *C.Metadata) (net.Conn, error) {
 func (v *Vless) streamTLSOrXTLSConn(conn net.Conn, isH2 bool) (net.Conn, error) {
 	host, _, _ := net.SplitHostPort(v.addr)
 
-	if v.isXTLSEnabled() && !isH2 {
+	if v.isLegacyXTLSEnabled() && !isH2 {
 		xtlsOpts := vless.XTLSConfig{
 			Host:           host,
 			SkipCertVerify: v.option.SkipCertVerify,
@@ -206,8 +206,8 @@ func (v *Vless) streamTLSOrXTLSConn(conn net.Conn, isH2 bool) (net.Conn, error) 
 	return conn, nil
 }
 
-func (v *Vless) isXTLSEnabled() bool {
-	return v.client.Addons != nil
+func (v *Vless) isLegacyXTLSEnabled() bool {
+	return v.client.Addons != nil && v.client.Addons.Flow != vless.XRV
 }
 
 // DialContext implements C.ProxyAdapter

--- a/adapter/outbound/vless.go
+++ b/adapter/outbound/vless.go
@@ -479,7 +479,7 @@ func NewVless(option VlessOption) (*Vless, error) {
 	if option.Network != "ws" && len(option.Flow) >= 16 {
 		option.Flow = option.Flow[:16]
 		switch option.Flow {
-		case vless.XRO, vless.XRD, vless.XRS:
+		case vless.XRO, vless.XRD, vless.XRS, vless.XRV:
 			addons = &vless.Addons{
 				Flow: option.Flow,
 			}

--- a/common/buf/sing.go
+++ b/common/buf/sing.go
@@ -7,6 +7,7 @@ import (
 
 type Buffer = buf.Buffer
 
+var StackNew = buf.StackNew
 var StackNewSize = buf.StackNewSize
 var KeepAlive = common.KeepAlive
 

--- a/transport/vless/conn.go
+++ b/transport/vless/conn.go
@@ -11,7 +11,6 @@ import (
 	"net"
 	"reflect"
 	"sync"
-	"time"
 	"unsafe"
 
 	"github.com/Dreamacro/clash/common/buf"
@@ -20,10 +19,10 @@ import (
 	tlsC "github.com/Dreamacro/clash/component/tls"
 	"github.com/Dreamacro/clash/log"
 	"github.com/gofrs/uuid"
-	utls "github.com/refraction-networking/utls"
 	buf2 "github.com/sagernet/sing/common/buf"
 	"github.com/sagernet/sing/common/network"
 	"github.com/sagernet/sing/common/rw"
+	utls "github.com/sagernet/utls"
 	xtls "github.com/xtls/go"
 	"google.golang.org/protobuf/proto"
 )
@@ -487,12 +486,5 @@ func newConn(conn net.Conn, client *Client, dst *DstAddr) (*Conn, error) {
 		}
 	}
 
-	go func() {
-		select {
-		case <-c.handshake:
-		case <-time.After(200 * time.Millisecond):
-			c.sendRequest(nil)
-		}
-	}()
 	return c, nil
 }

--- a/transport/vless/conn.go
+++ b/transport/vless/conn.go
@@ -62,7 +62,7 @@ type Conn struct {
 func (vc *Conn) Read(b []byte) (int, error) {
 	if vc.received {
 		if vc.readProcess {
-			buffer := buf2.As(b)
+			buffer := buf2.With(b)
 			err := vc.ReadBuffer(buffer)
 			return buffer.Len(), err
 		}

--- a/transport/vless/conn.go
+++ b/transport/vless/conn.go
@@ -104,7 +104,12 @@ func (vc *Conn) ReadBuffer(buffer *buf.Buffer) error {
 				if vc.readFilterUUID {
 					headerUUIDLen = uuid.Size
 				}
-				header := buffer.FreeBytes()[:paddingHeaderLen+headerUUIDLen]
+				var header []byte
+				if need := headerUUIDLen + paddingHeaderLen; buffer.FreeLen() < need {
+					header = make([]byte, need)
+				} else {
+					header = buffer.FreeBytes()[:need]
+				}
 				_, err := io.ReadFull(vc.ExtendedReader, header)
 				if err != nil {
 					return err

--- a/transport/vless/filter.go
+++ b/transport/vless/filter.go
@@ -1,0 +1,76 @@
+package vless
+
+import (
+	"bytes"
+	"encoding/binary"
+
+	log "github.com/sirupsen/logrus"
+)
+
+var (
+	tls13SupportedVersions  = []byte{0x00, 0x2b, 0x00, 0x02, 0x03, 0x04}
+	tlsClientHandshakeStart = []byte{0x16, 0x03}
+	tlsServerHandshakeStart = []byte{0x16, 0x03, 0x03}
+	tlsApplicationDataStart = []byte{0x17, 0x03, 0x03}
+
+	tls13CipherSuiteMap = map[uint16]string{
+		0x1301: "TLS_AES_128_GCM_SHA256",
+		0x1302: "TLS_AES_256_GCM_SHA384",
+		0x1303: "TLS_CHACHA20_POLY1305_SHA256",
+		0x1304: "TLS_AES_128_CCM_SHA256",
+		0x1305: "TLS_AES_128_CCM_8_SHA256",
+	}
+)
+
+const (
+	tlsHandshakeTypeClientHello byte = 0x01
+	tlsHandshakeTypeServerHello byte = 0x02
+)
+
+func (vc *Conn) FilterTLS(p []byte) (index int) {
+	lenP := len(p)
+	vc.packetsToFilter -= 1
+	if index = bytes.Index(p, tlsServerHandshakeStart); index != -1 {
+		if lenP >= index+5 && p[index+5] == tlsHandshakeTypeServerHello {
+			vc.remainingServerHello = binary.BigEndian.Uint16(p[index+3:]) + 5
+			vc.isTLS = true
+			vc.isTLS12orAbove = true
+			if lenP-index >= 79 && vc.remainingServerHello >= 79 {
+				sessionIDLen := int(p[index+43])
+				vc.cipher = binary.BigEndian.Uint16(p[index+43+sessionIDLen+1:])
+			}
+		}
+	} else if index = bytes.Index(p, tlsClientHandshakeStart); index != -1 {
+		if lenP >= index+5 && p[index+5] == tlsHandshakeTypeClientHello {
+			vc.isTLS = true
+		}
+	}
+
+	if vc.remainingServerHello > 0 {
+		end := vc.remainingServerHello
+		vc.remainingServerHello -= end
+		if end > uint16(lenP) {
+			end = uint16(lenP)
+		}
+		if bytes.Contains(p[index:end], tls13SupportedVersions) {
+			// TLS 1.3 Client Hello
+			cs, ok := tls13CipherSuiteMap[vc.cipher]
+			if ok && cs != "TLS_AES_128_CCM_8_SHA256" {
+				vc.enableXTLS = true
+			}
+			log.Debugln("XTLS Vision found TLS 1.3, packetLength=", lenP, ", CipherSuite=", cs)
+			vc.packetsToFilter = 0
+			return
+		} else if vc.remainingServerHello < 0 {
+			log.Debugln("XTLS Vision found TLS 1.2, packetLength=", lenP)
+			vc.packetsToFilter = 0
+			return
+		}
+		log.Debugln("XTLS Vision found inconclusive server hello, packetLength=", lenP,
+			", remainingServerHelloBytes=", vc.remainingServerHello)
+	}
+	if vc.packetsToFilter <= 0 {
+		log.Debugln("XTLS Vision stop filtering")
+	}
+	return
+}

--- a/transport/vless/filter.go
+++ b/transport/vless/filter.go
@@ -28,6 +28,9 @@ const (
 )
 
 func (vc *Conn) FilterTLS(p []byte) (index int) {
+	if vc.packetsToFilter <= 0 {
+		return 0
+	}
 	lenP := len(p)
 	vc.packetsToFilter -= 1
 	if index = bytes.Index(p, tlsServerHandshakeStart); index != -1 {

--- a/transport/vless/vision.go
+++ b/transport/vless/vision.go
@@ -7,12 +7,13 @@ import (
 
 	"github.com/Dreamacro/clash/common/buf"
 
+	"github.com/Dreamacro/clash/log"
 	"github.com/gofrs/uuid"
 	buf2 "github.com/sagernet/sing/common/buf"
 )
 
 const (
-	paddingHeaderLen = 16 + 1 + 2 + 2 // =21
+	paddingHeaderLen = uuid.Size + 1 + 2 + 2 // =21
 
 	commandPaddingContinue byte = 0x00
 	commandPaddingEnd      byte = 0x01
@@ -34,6 +35,7 @@ func WriteWithPadding(buffer *buf.Buffer, p []byte, command byte, userUUID *uuid
 	binary.BigEndian.PutUint16(buffer.Extend(2), uint16(paddingLen))
 	buffer.Write(p)
 	buffer.Extend(int(paddingLen))
+	log.Debugln("XTLS Vision write padding1: command=%v, payloadLen=%v, paddingLen=%v", command, contentLen, paddingLen)
 }
 
 func ApplyPadding(buffer *buf.Buffer, command byte, userUUID *uuid.UUID) {
@@ -50,6 +52,7 @@ func ApplyPadding(buffer *buf.Buffer, command byte, userUUID *uuid.UUID) {
 		copy(buffer.ExtendHeader(uuid.Size), userUUID.Bytes())
 	}
 	buffer.Extend(int(paddingLen))
+	log.Debugln("XTLS Vision write padding2: command=%d, payloadLen=%d, paddingLen=%d", command, contentLen, paddingLen)
 }
 
 func ReshapeBuffer(buffer *buf.Buffer) *buf.Buffer {

--- a/transport/vless/vision.go
+++ b/transport/vless/vision.go
@@ -13,7 +13,7 @@ import (
 )
 
 const (
-	paddingHeaderLen = uuid.Size + 1 + 2 + 2 // =21
+	paddingHeaderLen = 1 + 2 + 2 // =5
 
 	commandPaddingContinue byte = 0x00
 	commandPaddingEnd      byte = 0x01

--- a/transport/vless/vision.go
+++ b/transport/vless/vision.go
@@ -1,0 +1,67 @@
+package vless
+
+import (
+	"bytes"
+	"encoding/binary"
+	"math/rand"
+
+	"github.com/Dreamacro/clash/common/buf"
+
+	"github.com/gofrs/uuid"
+	buf2 "github.com/sagernet/sing/common/buf"
+)
+
+const (
+	paddingHeaderLen = 16 + 1 + 2 + 2 // =21
+
+	commandPaddingContinue byte = 0x00
+	commandPaddingEnd      byte = 0x01
+	commandPaddingDirect   byte = 0x02
+)
+
+func WriteWithPadding(buffer *buf.Buffer, p []byte, command byte, userUUID *uuid.UUID) {
+	contentLen := int32(len(p))
+	var paddingLen int32
+	if contentLen < 900 {
+		paddingLen = rand.Int31n(500) + 900 - contentLen
+	}
+
+	if userUUID != nil { // unnecessary, but keep the same with Xray
+		buffer.Write(userUUID.Bytes())
+	}
+	buffer.WriteByte(command)
+	binary.BigEndian.PutUint16(buffer.Extend(2), uint16(contentLen))
+	binary.BigEndian.PutUint16(buffer.Extend(2), uint16(paddingLen))
+	buffer.Write(p)
+	buffer.Extend(int(paddingLen))
+}
+
+func ApplyPadding(buffer *buf.Buffer, command byte, userUUID *uuid.UUID) {
+	contentLen := int32(buffer.Len())
+	var paddingLen int32
+	if contentLen < 900 {
+		paddingLen = rand.Int31n(500) + 900 - contentLen
+	}
+
+	binary.BigEndian.PutUint16(buffer.ExtendHeader(2), uint16(paddingLen))
+	binary.BigEndian.PutUint16(buffer.ExtendHeader(2), uint16(contentLen))
+	buffer.ExtendHeader(1)[0] = command
+	if userUUID != nil { // unnecessary, but keep the same with Xray
+		copy(buffer.ExtendHeader(uuid.Size), userUUID.Bytes())
+	}
+	buffer.Extend(int(paddingLen))
+}
+
+func ReshapeBuffer(buffer *buf.Buffer) *buf.Buffer {
+	if buffer.Len() <= buf2.BufferSize-paddingHeaderLen {
+		return nil
+	}
+	cutAt := bytes.LastIndex(buffer.Bytes(), tlsApplicationDataStart)
+	if cutAt == -1 {
+		cutAt = buf2.BufferSize / 2
+	}
+	buffer2 := buf2.New()
+	buffer2.Write(buffer.From(cutAt))
+	buffer.Truncate(cutAt)
+	return buffer2
+}

--- a/transport/vless/vless.go
+++ b/transport/vless/vless.go
@@ -12,6 +12,7 @@ const (
 	XRO = "xtls-rprx-origin"
 	XRD = "xtls-rprx-direct"
 	XRS = "xtls-rprx-splice"
+	XRV = "xtls-rprx-vision"
 
 	Version byte = 0 // protocol version. preview version is 0
 )

--- a/transport/vless/xtls.go
+++ b/transport/vless/xtls.go
@@ -2,11 +2,16 @@ package vless
 
 import (
 	"context"
+	"errors"
 	"net"
 
 	tlsC "github.com/Dreamacro/clash/component/tls"
 	C "github.com/Dreamacro/clash/constant"
 	xtls "github.com/xtls/go"
+)
+
+var (
+	ErrNotTLS13 = errors.New("XTLS Vision based on TLS 1.3 outer connection")
 )
 
 type XTLSConfig struct {


### PR DESCRIPTION
This is now ready for tests. I've already tested (with Firefox and NatTypeTester) and it looks good for me:

- [x] XUDP and FullCone support
- [x] Speedtest passed
- [x] Connect SSH (untested)

The code of TLS filtering is similar to Xray but is not the same. So there is no guarantee that the effect will be exactly the same. Anyhow, this PR has implemented all Vision protocol semantics, except splice support on Linux.