### PR TITLE
Assume 403 status code as timeout in urlTest to filter blocked proxies.

### DIFF
--- a/adapter/adapter.go
+++ b/adapter/adapter.go
@@ -156,18 +156,27 @@ func (p *Proxy) URLTest(ctx context.Context, url string) (t uint16, err error) {
 	defer client.CloseIdleConnections()
 
 	resp, err := client.Do(req)
-
+	
+	
+	
 	if err != nil {
 		return
 	}
 
 	_ = resp.Body.Close()
+	
+	if resp.StatusCode == 403 {
+		return
+	}
 
 	if unifiedDelay {
 		second := time.Now()
 		resp, err = client.Do(req)
 		if err == nil {
 			_ = resp.Body.Close()
+			if resp.StatusCode == 403 {
+				return
+			}
 			start = second
 		}
 	}


### PR DESCRIPTION
When a web site block or black list a proxy urlTest return a valid ping to to target url while it has been blocked! So I just add a condition to behave 403 response code as timeout.