### PR TITLE
return expected status through Rest API and clean useless code

### DIFF
--- a/adapter/adapter.go
+++ b/adapter/adapter.go
@@ -17,8 +17,6 @@ import (
 	"github.com/metacubex/mihomo/common/utils"
 	"github.com/metacubex/mihomo/component/dialer"
 	C "github.com/metacubex/mihomo/constant"
-	"github.com/metacubex/mihomo/log"
-
 	"github.com/puzpuzpuz/xsync/v3"
 )
 
@@ -39,11 +37,6 @@ type Proxy struct {
 	alive   atomic.Bool
 	url     string
 	extra   *xsync.MapOf[string, *extraProxyState]
-}
-
-// Alive implements C.Proxy
-func (p *Proxy) Alive() bool {
-	return p.alive.Load()
 }
 
 // AliveForTestUrl implements C.Proxy
@@ -181,7 +174,7 @@ func (p *Proxy) MarshalJSON() ([]byte, error) {
 	_ = json.Unmarshal(inner, &mapping)
 	mapping["history"] = p.DelayHistory()
 	mapping["extra"] = p.ExtraDelayHistory()
-	mapping["alive"] = p.Alive()
+	mapping["alive"] = p.AliveForTestUrl(p.url)
 	mapping["name"] = p.Name()
 	mapping["udp"] = p.SupportUDP()
 	mapping["xudp"] = p.SupportXUDP()
@@ -191,13 +184,11 @@ func (p *Proxy) MarshalJSON() ([]byte, error) {
 
 // URLTest get the delay for the specified URL
 // implements C.Proxy
-func (p *Proxy) URLTest(ctx context.Context, url string, expectedStatus utils.IntRanges[uint16], store C.DelayHistoryStoreType) (t uint16, err error) {
+func (p *Proxy) URLTest(ctx context.Context, url string, expectedStatus utils.IntRanges[uint16]) (t uint16, err error) {
 	defer func() {
 		alive := err == nil
-		store = p.determineFinalStoreType(store, url)
 
-		switch store {
-		case C.OriginalHistory:
+		if len(p.url) == 0 || url == p.url {
 			p.alive.Store(alive)
 			record := C.DelayHistory{Time: time.Now()}
 			if alive {
@@ -212,7 +203,7 @@ func (p *Proxy) URLTest(ctx context.Context, url string, expectedStatus utils.In
 			if len(p.url) == 0 {
 				p.url = url
 			}
-		case C.ExtraHistory:
+		} else {
 			record := C.DelayHistory{Time: time.Now()}
 			if alive {
 				record.Delay = t
@@ -236,8 +227,6 @@ func (p *Proxy) URLTest(ctx context.Context, url string, expectedStatus utils.In
 			if state.history.Len() > defaultHistoriesNum {
 				state.history.Pop()
 			}
-		default:
-			log.Debugln("health check result will be discarded, url: %s alive: %t, delay: %d", url, alive, t)
 		}
 	}()
 
@@ -348,25 +337,4 @@ func urlToMetadata(rawURL string) (addr C.Metadata, err error) {
 		DstPort: uint16(uintPort),
 	}
 	return
-}
-
-func (p *Proxy) determineFinalStoreType(store C.DelayHistoryStoreType, url string) C.DelayHistoryStoreType {
-	if store != C.DropHistory {
-		return store
-	}
-
-	if len(p.url) == 0 || url == p.url {
-		return C.OriginalHistory
-	}
-
-	if p.extra.Size() < 2*C.DefaultMaxHealthCheckUrlNum {
-		return C.ExtraHistory
-	}
-
-	_, ok := p.extra.Load(url)
-	if ok {
-		return C.ExtraHistory
-	}
-
-	return store
 }

--- a/adapter/outboundgroup/fallback.go
+++ b/adapter/outboundgroup/fallback.go
@@ -84,11 +84,11 @@ func (f *Fallback) MarshalJSON() ([]byte, error) {
 		all = append(all, proxy.Name())
 	}
 	return json.Marshal(map[string]any{
-		"type":     f.Type().String(),
-		"now":      f.Now(),
-		"all":      all,
-		"testUrl":  f.testUrl,
-		"expected": f.expectedStatus,
+		"type":           f.Type().String(),
+		"now":            f.Now(),
+		"all":            all,
+		"testUrl":        f.testUrl,
+		"expectedStatus": f.expectedStatus,
 	})
 }
 
@@ -102,13 +102,11 @@ func (f *Fallback) findAliveProxy(touch bool) C.Proxy {
 	proxies := f.GetProxies(touch)
 	for _, proxy := range proxies {
 		if len(f.selected) == 0 {
-			// if proxy.Alive() {
 			if proxy.AliveForTestUrl(f.testUrl) {
 				return proxy
 			}
 		} else {
 			if proxy.Name() == f.selected {
-				// if proxy.Alive() {
 				if proxy.AliveForTestUrl(f.testUrl) {
 					return proxy
 				} else {
@@ -135,12 +133,11 @@ func (f *Fallback) Set(name string) error {
 	}
 
 	f.selected = name
-	// if !p.Alive() {
 	if !p.AliveForTestUrl(f.testUrl) {
 		ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond*time.Duration(5000))
 		defer cancel()
 		expectedStatus, _ := utils.NewIntRanges[uint16](f.expectedStatus)
-		_, _ = p.URLTest(ctx, f.testUrl, expectedStatus, C.ExtraHistory)
+		_, _ = p.URLTest(ctx, f.testUrl, expectedStatus)
 	}
 
 	return nil

--- a/adapter/outboundgroup/groupbase.go
+++ b/adapter/outboundgroup/groupbase.go
@@ -202,7 +202,7 @@ func (gb *GroupBase) URLTest(ctx context.Context, url string, expectedStatus uti
 		proxy := proxy
 		wg.Add(1)
 		go func() {
-			delay, err := proxy.URLTest(ctx, url, expectedStatus, C.DropHistory)
+			delay, err := proxy.URLTest(ctx, url, expectedStatus)
 			if err == nil {
 				lock.Lock()
 				mp[proxy.Name()] = delay

--- a/adapter/outboundgroup/parser.go
+++ b/adapter/outboundgroup/parser.go
@@ -95,7 +95,8 @@ func ParseProxyGroup(config map[string]any, proxyMap map[string]C.Proxy, provide
 		// select don't need health check
 		if groupOption.Type != "select" && groupOption.Type != "relay" {
 			if groupOption.URL == "" {
-				groupOption.URL = "https://cp.cloudflare.com/generate_204"
+				groupOption.URL = C.DefaultTestURL
+				testUrl = groupOption.URL
 			}
 
 			if groupOption.Interval == 0 {

--- a/adapter/outboundgroup/urltest.go
+++ b/adapter/outboundgroup/urltest.go
@@ -101,7 +101,7 @@ func (u *URLTest) fast(touch bool) C.Proxy {
 	proxies := u.GetProxies(touch)
 	if u.selected != "" {
 		for _, proxy := range proxies {
-			if !proxy.Alive() {
+			if !proxy.AliveForTestUrl(u.testUrl) {
 				continue
 			}
 			if proxy.Name() == u.selected {
@@ -113,7 +113,6 @@ func (u *URLTest) fast(touch bool) C.Proxy {
 
 	elm, _, shared := u.fastSingle.Do(func() (C.Proxy, error) {
 		fast := proxies[0]
-		// min := fast.LastDelay()
 		min := fast.LastDelayForTestUrl(u.testUrl)
 		fastNotExist := true
 
@@ -122,12 +121,10 @@ func (u *URLTest) fast(touch bool) C.Proxy {
 				fastNotExist = false
 			}
 
-			// if !proxy.Alive() {
 			if !proxy.AliveForTestUrl(u.testUrl) {
 				continue
 			}
 
-			// delay := proxy.LastDelay()
 			delay := proxy.LastDelayForTestUrl(u.testUrl)
 			if delay < min {
 				fast = proxy
@@ -136,7 +133,6 @@ func (u *URLTest) fast(touch bool) C.Proxy {
 
 		}
 		// tolerance
-		// if u.fastNode == nil || fastNotExist || !u.fastNode.Alive() || u.fastNode.LastDelay() > fast.LastDelay()+u.tolerance {
 		if u.fastNode == nil || fastNotExist || !u.fastNode.AliveForTestUrl(u.testUrl) || u.fastNode.LastDelayForTestUrl(u.testUrl) > fast.LastDelayForTestUrl(u.testUrl)+u.tolerance {
 			u.fastNode = fast
 		}
@@ -169,11 +165,11 @@ func (u *URLTest) MarshalJSON() ([]byte, error) {
 		all = append(all, proxy.Name())
 	}
 	return json.Marshal(map[string]any{
-		"type":     u.Type().String(),
-		"now":      u.Now(),
-		"all":      all,
-		"testUrl":  u.testUrl,
-		"expected": u.expectedStatus,
+		"type":           u.Type().String(),
+		"now":            u.Now(),
+		"all":            all,
+		"testUrl":        u.testUrl,
+		"expectedStatus": u.expectedStatus,
 	})
 }
 

--- a/adapter/provider/provider.go
+++ b/adapter/provider/provider.go
@@ -48,12 +48,18 @@ type proxySetProvider struct {
 }
 
 func (pp *proxySetProvider) MarshalJSON() ([]byte, error) {
+	expectedStatus := "*"
+	if pp.healthCheck.expectedStatus != nil {
+		expectedStatus = pp.healthCheck.expectedStatus.ToString()
+	}
+
 	return json.Marshal(map[string]any{
 		"name":             pp.Name(),
 		"type":             pp.Type().String(),
 		"vehicleType":      pp.VehicleType().String(),
 		"proxies":          pp.Proxies(),
 		"testUrl":          pp.healthCheck.url,
+		"expectedStatus":   expectedStatus,
 		"updatedAt":        pp.UpdatedAt,
 		"subscriptionInfo": pp.subscriptionInfo,
 	})
@@ -214,12 +220,18 @@ type compatibleProvider struct {
 }
 
 func (cp *compatibleProvider) MarshalJSON() ([]byte, error) {
+	expectedStatus := "*"
+	if cp.healthCheck.expectedStatus != nil {
+		expectedStatus = cp.healthCheck.expectedStatus.ToString()
+	}
+
 	return json.Marshal(map[string]any{
-		"name":        cp.Name(),
-		"type":        cp.Type().String(),
-		"vehicleType": cp.VehicleType().String(),
-		"proxies":     cp.Proxies(),
-		"testUrl":     cp.healthCheck.url,
+		"name":           cp.Name(),
+		"type":           cp.Type().String(),
+		"vehicleType":    cp.VehicleType().String(),
+		"proxies":        cp.Proxies(),
+		"testUrl":        cp.healthCheck.url,
+		"expectedStatus": expectedStatus,
 	})
 }
 

--- a/common/utils/ranges.go
+++ b/common/utils/ranges.go
@@ -75,3 +75,26 @@ func (ranges IntRanges[T]) Check(status T) bool {
 
 	return false
 }
+
+func (ranges IntRanges[T]) ToString() string {
+	if len(ranges) == 0 {
+		return "*"
+	}
+
+	terms := make([]string, len(ranges))
+	for i, r := range ranges {
+		start := r.Start()
+		end := r.End()
+
+		var term string
+		if start == end {
+			term = strconv.Itoa(int(start))
+		} else {
+			term = strconv.Itoa(int(start)) + "-" + strconv.Itoa(int(end))
+		}
+
+		terms[i] = term
+	}
+
+	return strings.Join(terms, "/")
+}

--- a/constant/adapters.go
+++ b/constant/adapters.go
@@ -43,11 +43,11 @@ const (
 )
 
 const (
-	DefaultTCPTimeout           = 5 * time.Second
-	DefaultDropTime             = 12 * DefaultTCPTimeout
-	DefaultUDPTimeout           = DefaultTCPTimeout
-	DefaultTLSTimeout           = DefaultTCPTimeout
-	DefaultMaxHealthCheckUrlNum = 16
+	DefaultTCPTimeout = 5 * time.Second
+	DefaultDropTime   = 12 * DefaultTCPTimeout
+	DefaultUDPTimeout = DefaultTCPTimeout
+	DefaultTLSTimeout = DefaultTCPTimeout
+	DefaultTestURL    = "https://cp.cloudflare.com/generate_204"
 )
 
 var ErrNotSupport = errors.New("no support")
@@ -149,21 +149,13 @@ type DelayHistory struct {
 
 type DelayHistoryStoreType int
 
-const (
-	OriginalHistory DelayHistoryStoreType = iota
-	ExtraHistory
-	DropHistory
-)
-
 type Proxy interface {
 	ProxyAdapter
-	Alive() bool
 	AliveForTestUrl(url string) bool
 	DelayHistory() []DelayHistory
 	ExtraDelayHistory() map[string][]DelayHistory
-	LastDelay() uint16
 	LastDelayForTestUrl(url string) uint16
-	URLTest(ctx context.Context, url string, expectedStatus utils.IntRanges[uint16], store DelayHistoryStoreType) (uint16, error)
+	URLTest(ctx context.Context, url string, expectedStatus utils.IntRanges[uint16]) (uint16, error)
 
 	// Deprecated: use DialContext instead.
 	Dial(metadata *Metadata) (Conn, error)

--- a/hub/route/proxies.go
+++ b/hub/route/proxies.go
@@ -125,7 +125,7 @@ func getProxyDelay(w http.ResponseWriter, r *http.Request) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond*time.Duration(timeout))
 	defer cancel()
 
-	delay, err := proxy.URLTest(ctx, url, expectedStatus, C.ExtraHistory)
+	delay, err := proxy.URLTest(ctx, url, expectedStatus)
 	if ctx.Err() != nil {
 		render.Status(r, http.StatusGatewayTimeout)
 		render.JSON(w, r, ErrRequestTimeout)


### PR DESCRIPTION
+ clear useless code
+ return the expected state configured by the user for ProxyGroup or ProxyProvider through Rest API
+ unified default delay test url