### PR TITLE
[fix] latency of extra should not overwrite the history

### DIFF
--- a/adapter/adapter.go
+++ b/adapter/adapter.go
@@ -208,10 +208,6 @@ func (p *Proxy) URLTest(ctx context.Context, url string, expectedStatus utils.In
 			if alive {
 				record.Delay = t
 			}
-			p.history.Put(record)
-			if p.history.Len() > defaultHistoriesNum {
-				p.history.Pop()
-			}
 
 			state, ok := p.extra.Load(url)
 			if !ok {


### PR DESCRIPTION
Usually,`history` is used to store the latency generated by healthcheck of `ProxyProvider`, while `extra` stores the latency generated by testURL configured in each ProxyGroup. Therefore, when updating the `extra` data, it should not overwrite the `history`.