### PR TITLE
[fix] 修复延迟数据存放位置不对的问题

### DIFF
--- a/adapter/adapter.go
+++ b/adapter/adapter.go
@@ -48,6 +48,10 @@ func (p *Proxy) AliveForTestUrl(url string) bool {
 	return p.alive.Load()
 }
 
+func (p *Proxy) OriginalHealthCheckUrl(url string) {
+	p.url = url
+}
+
 // Dial implements C.Proxy
 func (p *Proxy) Dial(metadata *C.Metadata) (C.Conn, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), C.DefaultTCPTimeout)

--- a/adapter/provider/provider.go
+++ b/adapter/provider/provider.go
@@ -114,6 +114,10 @@ func (pp *proxySetProvider) RegisterHealthCheckTask(url string, expectedStatus u
 
 func (pp *proxySetProvider) setProxies(proxies []C.Proxy) {
 	pp.proxies = proxies
+	for _, proxy := range pp.proxies {
+		proxy.OriginalHealthCheckUrl(pp.healthCheck.url)
+	}
+
 	pp.healthCheck.setProxy(proxies)
 	if pp.healthCheck.auto() {
 		go pp.healthCheck.check()

--- a/constant/adapters.go
+++ b/constant/adapters.go
@@ -155,6 +155,7 @@ type Proxy interface {
 	DelayHistory() []DelayHistory
 	ExtraDelayHistory() map[string][]DelayHistory
 	LastDelayForTestUrl(url string) uint16
+	OriginalHealthCheckUrl(url string)
 	URLTest(ctx context.Context, url string, expectedStatus utils.IntRanges[uint16]) (uint16, error)
 
 	// Deprecated: use DialContext instead.


### PR DESCRIPTION
+ 我学习源代码的时候发现 [判断延迟数据存放位置](https://github.com/MetaCubeX/mihomo/blob/aef87b29ba8bab652dce24a08560d257e1fb3c78/adapter/adapter.go#L191) 的逻辑不是很对。翻看 [PR记录](https://github.com/MetaCubeX/mihomo/pull/855) 里说 history 主要存 ProxyProvider 的健康检查的延迟数据，extra 存 ProxyGroup 对应的延迟数据。按照现有逻辑，应该用测试的 url 与 ProxyProvider 里 healthcheck 的 url 进行比较（如果 Proxy 来自于某个 ProxyProvider 的话），如果 url 一致 或者 没有 healthcheck 则存 history，否则存 extra。但是，Proxy 并没有持有 healthcheck 的 url，导致存的位置不一定对。

> 例外我有个疑惑，为什么不直接把所有的数据都存在 extra 这样的 Map 里呢？是因为 涉及到 Dashboard 解析数据吗？个人感觉我这个 PR 的方案不够优雅😳，最好的办法还是把两个数据合到一起，这样就不用判断存哪了