### PR TITLE
feat(fakeip-rules): add fakeip-rules as fakip-filter

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -37,6 +37,7 @@ import (
 	LC "github.com/metacubex/mihomo/listener/config"
 	"github.com/metacubex/mihomo/log"
 	R "github.com/metacubex/mihomo/rules"
+	RC "github.com/metacubex/mihomo/rules/common"
 	RP "github.com/metacubex/mihomo/rules/provider"
 	T "github.com/metacubex/mihomo/tunnel"
 
@@ -179,6 +180,7 @@ type Config struct {
 	Hosts         *trie.DomainTrie[resolver.HostValue]
 	Profile       *Profile
 	Rules         []C.Rule
+	FakeipRules   []C.Rule
 	SubRules      map[string][]C.Rule
 	Users         []auth.AuthUser
 	Proxies       map[string]C.Proxy
@@ -334,6 +336,7 @@ type RawConfig struct {
 	Proxy         []map[string]any          `yaml:"proxies"`
 	ProxyGroup    []map[string]any          `yaml:"proxy-groups"`
 	Rule          []string                  `yaml:"rules"`
+	FakeipRules   []string                  `yaml:"fakeip-rules"`
 	SubRules      map[string][]string       `yaml:"sub-rules"`
 	RawTLS        TLS                       `yaml:"tls"`
 	Listeners     []map[string]any          `yaml:"listeners"`
@@ -554,6 +557,12 @@ func ParseRawConfig(rawCfg *RawConfig) (*Config, error) {
 		return nil, err
 	}
 	config.Rules = rules
+
+	fakeip_rules, err := parseFakeipRules(rawCfg.FakeipRules)
+	if err != nil {
+		return nil, err
+	}
+	config.FakeipRules = fakeip_rules
 
 	hosts, err := parseHosts(rawCfg)
 	if err != nil {
@@ -930,6 +939,66 @@ func parseRules(rulesConfig []string, proxies map[string]C.Proxy, subRules map[s
 		parsed, parseErr := R.ParseRule(ruleName, payload, target, params, subRules)
 		if parseErr != nil {
 			return nil, fmt.Errorf("%s[%d] [%s] error: %s", format, idx, line, parseErr.Error())
+		}
+
+		rules = append(rules, parsed)
+	}
+
+	return rules, nil
+}
+
+func parseFakeipRules(rulesConfig []string) ([]C.Rule, error) {
+	var rules []C.Rule
+	var parsed C.Rule
+	var parsedErr error
+
+	for _, line := range rulesConfig {
+		rule := trimArr(strings.Split(line, ","))
+		var (
+			payload  string
+			target   string
+			ruleName = strings.ToUpper(rule[0])
+			l        = len(rule)
+		)
+
+		if l == 2 {
+			if ruleName == "MATCH" {
+				target = rule[1]
+			} else {
+				target = "DIRECT"
+				payload = rule[1]
+			}
+		} else if l == 3 {
+			if ruleName == "MATCH" {
+				return nil, fmt.Errorf("rule `%s` error: MATCH only accept 1 parameter", line)
+			} else {
+				target = rule[2]
+				payload = rule[1]
+			}
+		} else {
+			return nil, fmt.Errorf("rule `%s` formate error", line)
+		}
+
+		switch ruleName {
+		case "DOMAIN":
+			parsed = RC.NewDomain(payload, target)
+		case "DOMAIN-SUFFIX":
+			parsed = RC.NewDomainSuffix(payload, target)
+		case "DOMAIN-KEYWORD":
+			parsed = RC.NewDomainKeyword(payload, target)
+		case "RULE-SET":
+			parsed, parsedErr = RP.NewRuleSet(payload, target, true)
+		case "GEOSITE":
+			parsed, parsedErr = RC.NewGEOSITE(payload, target)
+		case "MATCH":
+			parsed = RC.NewMatch(target)
+			parsedErr = nil
+		default:
+			parsedErr = fmt.Errorf("unsupported rule type %s", ruleName)
+		}
+
+		if parsedErr != nil {
+			return nil, parsedErr
 		}
 
 		rules = append(rules, parsed)

--- a/hub/executor/executor.go
+++ b/hub/executor/executor.go
@@ -98,6 +98,7 @@ func ApplyConfig(cfg *config.Config, force bool) {
 	updateGeneral(cfg.General)
 	updateNTP(cfg.NTP)
 	updateDNS(cfg.DNS, cfg.RuleProviders, cfg.General.IPv6)
+	cfg.DNS.FakeIPRange.FakeipRules = cfg.FakeipRules
 	updateListeners(cfg.General, cfg.Listeners, force)
 	updateIPTables(cfg)
 	updateTun(cfg.General)


### PR DESCRIPTION
add fakeip-rules in config.yaml:

fakeip-rules:
 - RULE-SET,Youku,DIRECT
 - RULE-SET,Netflix,Proxy
 - DOMAIN,dl.google.com,DIRECT

fakeip-rules works as `rules` filed, but only accept the types: DOMAIN, DOMAIN-SUFFIX, DOMAIN-KEYWORD, RULE-SET, GEOSITE, MATCH

In the rules, only `DIRECT` target will resolve the real-ip, other targets will resolve the fake-ip