### PR TITLE
fix && chore

### DIFF
--- a/adapter/outboundgroup/urltest.go
+++ b/adapter/outboundgroup/urltest.go
@@ -4,12 +4,15 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
+	"sync"
 	"time"
 
 	"github.com/metacubex/mihomo/adapter/outbound"
 	"github.com/metacubex/mihomo/common/callback"
 	N "github.com/metacubex/mihomo/common/net"
 	"github.com/metacubex/mihomo/common/singledo"
+	"github.com/metacubex/mihomo/common/utils"
 	"github.com/metacubex/mihomo/component/dialer"
 	C "github.com/metacubex/mihomo/constant"
 	"github.com/metacubex/mihomo/constant/provider"
@@ -172,6 +175,34 @@ func (u *URLTest) MarshalJSON() ([]byte, error) {
 		"expectedStatus": u.expectedStatus,
 		"fixed":          u.selected,
 	})
+}
+
+func (u *URLTest) URLTest(ctx context.Context, url string, expectedStatus utils.IntRanges[uint16]) (map[string]uint16, error) {
+	var wg sync.WaitGroup
+	var lock sync.Mutex
+	mp := map[string]uint16{}
+	proxies := u.GetProxies(false)
+	for _, proxy := range proxies {
+		proxy := proxy
+		wg.Add(1)
+		go func() {
+			delay, err := proxy.URLTest(ctx, u.testUrl, expectedStatus)
+			if err == nil {
+				lock.Lock()
+				mp[proxy.Name()] = delay
+				lock.Unlock()
+			}
+
+			wg.Done()
+		}()
+	}
+	wg.Wait()
+
+	if len(mp) == 0 {
+		return mp, fmt.Errorf("get delay: all proxies timeout")
+	} else {
+		return mp, nil
+	}
 }
 
 func parseURLTestOption(config map[string]any) []urlTestOption {

--- a/constant/adapters.go
+++ b/constant/adapters.go
@@ -47,7 +47,7 @@ const (
 	DefaultDropTime   = 12 * DefaultTCPTimeout
 	DefaultUDPTimeout = DefaultTCPTimeout
 	DefaultTLSTimeout = DefaultTCPTimeout
-	DefaultTestURL    = "https://cp.cloudflare.com/generate_204"
+	DefaultTestURL    = "https://www.gstatic.com/generate_204"
 )
 
 var ErrNotSupport = errors.New("no support")


### PR DESCRIPTION
89da296
由于 [这个修改](https://github.com/MetaCubeX/mihomo/pull/588) ，`url-test` 将不再使用最新 `delay` 测试作为排序结果，导致如果 api 传入 url 和 `url-test` 默认值不符的时候并不会采用此时测量所得的延迟进行排序。
现修改 `url-test` 组延迟测试逻辑为强制使用 `url-test` 的 `health-check.url`，使得每次按组测试后可正常触发重新选择
8f10ce4
更新默认 `healthcheck.url` 到 `https://www.gstatic.com/generate_204`