### PR TITLE
chore: add a new cors response header

### DIFF
--- a/hub/route/server.go
+++ b/hub/route/server.go
@@ -63,6 +63,7 @@ func Start(addr string, tlsAddr string, secret string,
 		AllowedHeaders: []string{"Content-Type", "Authorization"},
 		MaxAge:         300,
 	})
+	r.Use(setPrivateNetworkAccess)
 	r.Use(corsM.Handler)
 	if isDebug {
 		r.Mount("/debug", func() http.Handler {
@@ -147,6 +148,15 @@ func Start(addr string, tlsAddr string, secret string,
 		log.Errorln("External controller serve error: %s", err)
 	}
 
+}
+
+func setPrivateNetworkAccess(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodOptions && r.Header.Get("Access-Control-Request-Method") != "" {
+			w.Header().Add("Access-Control-Allow-Private-Network", "true")
+		}
+		next.ServeHTTP(w, r)
+	})
 }
 
 func safeEuqal(a, b string) bool {


### PR DESCRIPTION
自从 `chrome 98` 开始，google 提出了一个新的功能，[对专用网络资源访问进行预检](https://chromestatus.com/feature/5737414355058688) ，它的前身是来自 W3C 社区的 [此草案](https://wicg.github.io/private-network-access/) 。在高版本 chrome 中已出现因此无法使用网络面板进行控制的情况（特指搭载在开放网络上的公用网络面板而非由核心拉起的本地网络面板），故对 `Preflight request` 添加相应响应头，使浏览器按预期进行工作。