### PR TITLE
feat: add DSCP rule for Tproxy UDP packets

### DIFF
--- a/adapter/inbound/addition.go
+++ b/adapter/inbound/addition.go
@@ -63,3 +63,9 @@ func WithInAddr(addr net.Addr) Addition {
 		}
 	}
 }
+
+func WithDSCP(dscp uint8) Addition {
+	return func(metadata *C.Metadata) {
+		metadata.DSCP = dscp
+	}
+}

--- a/constant/metadata.go
+++ b/constant/metadata.go
@@ -147,6 +147,7 @@ type Metadata struct {
 	SpecialProxy string     `json:"specialProxy"`
 	SpecialRules string     `json:"specialRules"`
 	RemoteDst    string     `json:"remoteDestination"`
+	DSCP         uint8      `json:"dscp"`
 
 	RawSrcAddr net.Addr `json:"-"`
 	RawDstAddr net.Addr `json:"-"`

--- a/constant/rule.go
+++ b/constant/rule.go
@@ -14,6 +14,7 @@ const (
 	SrcPort
 	DstPort
 	InPort
+	DSCP
 	InUser
 	InName
 	InType
@@ -73,6 +74,8 @@ func (rt RuleType) String() string {
 		return "RuleSet"
 	case Network:
 		return "Network"
+	case DSCP:
+		return "DSCP"
 	case Uid:
 		return "Uid"
 	case SubRules:

--- a/listener/tproxy/setsockopt_linux.go
+++ b/listener/tproxy/setsockopt_linux.go
@@ -34,6 +34,14 @@ func setsockopt(rc syscall.RawConn, addr string) error {
 		if err == nil && isIPv6 {
 			err = syscall.SetsockoptInt(int(fd), syscall.SOL_IPV6, IPV6_RECVORIGDSTADDR, 1)
 		}
+
+		if err == nil {
+			err = syscall.SetsockoptInt(int(fd), syscall.SOL_IP, syscall.IP_RECVTOS, 1)
+		}
+
+		if err == nil {
+			err = syscall.SetsockoptInt(int(fd), syscall.SOL_IPV6, syscall.IPV6_RECVTCLASS, 1)
+		}
 	})
 
 	return err

--- a/listener/tproxy/udp.go
+++ b/listener/tproxy/udp.go
@@ -74,11 +74,13 @@ func NewUDP(addr string, tunnel C.Tunnel, additions ...inbound.Addition) (*UDPLi
 				continue
 			}
 
-			rAddr, dscp, err := getOrigDstAndDSCP(oob[:oobn])
-			additions = append(additions, inbound.WithDSCP(dscp))
+			rAddr, err := getOrigDst(oob[:oobn])
 			if err != nil {
 				continue
 			}
+
+			dscp, _ := getDSCP(oob[:oobn])
+			additions = append(additions, inbound.WithDSCP(dscp))
 
 			if rAddr.Addr().Is4() {
 				// try to unmap 4in6 address

--- a/listener/tproxy/udp.go
+++ b/listener/tproxy/udp.go
@@ -74,7 +74,8 @@ func NewUDP(addr string, tunnel C.Tunnel, additions ...inbound.Addition) (*UDPLi
 				continue
 			}
 
-			rAddr, err := getOrigDst(oob[:oobn])
+			rAddr, dscp, err := getOrigDstAndDSCP(oob[:oobn])
+			additions = append(additions, inbound.WithDSCP(dscp))
 			if err != nil {
 				continue
 			}

--- a/listener/tproxy/udp_linux.go
+++ b/listener/tproxy/udp_linux.go
@@ -105,13 +105,8 @@ func getOrigDst(oob []byte) (netip.AddrPort, error) {
 
 	// retrieve the destination address from the SCM.
 	sa, err := unix.ParseOrigDstAddr(&scms[1])
-
 	if err != nil {
 		return netip.AddrPort{}, fmt.Errorf("retrieve destination: %w", err)
-	}
-
-	if err != nil {
-		return netip.AddrPort{}, fmt.Errorf("retrieve DSCP: %w", err)
 	}
 
 	// encode the destination address into a cmsg.

--- a/listener/tproxy/udp_other.go
+++ b/listener/tproxy/udp_other.go
@@ -12,6 +12,10 @@ func getOrigDst(oob []byte) (netip.AddrPort, error) {
 	return netip.AddrPort{}, errors.New("UDP redir not supported on current platform")
 }
 
+func getDSCP(oob []byte) (uint8, error) {
+	return 0, errors.New("UDP redir not supported on current platform")
+}
+
 func dialUDP(network string, lAddr, rAddr netip.AddrPort) (*net.UDPConn, error) {
 	return nil, errors.New("UDP redir not supported on current platform")
 }

--- a/rules/common/dscp.go
+++ b/rules/common/dscp.go
@@ -1,0 +1,47 @@
+package common
+
+import (
+	"fmt"
+	"strconv"
+
+	C "github.com/metacubex/mihomo/constant"
+)
+
+type DSCP struct {
+	*Base
+	dscp    uint8
+	payload string
+	adapter string
+}
+
+func (d *DSCP) RuleType() C.RuleType {
+	return C.DSCP
+}
+
+func (d *DSCP) Match(metadata *C.Metadata) (bool, string) {
+	return metadata.DSCP == d.dscp, d.adapter
+}
+
+func (d *DSCP) Adapter() string {
+	return d.adapter
+}
+
+func (d *DSCP) Payload() string {
+	return d.payload
+}
+
+func NewDSCP(dscp string, adapter string) (*DSCP, error) {
+	dscpi, err := strconv.Atoi(dscp)
+	if err != nil {
+		return nil, fmt.Errorf("parse DSCP rule fail: %w", err)
+	}
+	if dscpi < 0 || dscpi > 63 {
+		return nil, fmt.Errorf("DSCP couldn't be negative or exceed 63")
+	}
+	return &DSCP{
+		Base:    &Base{},
+		payload: dscp,
+		dscp:    uint8(dscpi),
+		adapter: adapter,
+	}, nil
+}

--- a/rules/parser.go
+++ b/rules/parser.go
@@ -38,6 +38,8 @@ func ParseRule(tp, payload, target string, params []string, subRules map[string]
 		parsed, parseErr = RC.NewPort(payload, target, C.DstPort)
 	case "IN-PORT":
 		parsed, parseErr = RC.NewPort(payload, target, C.InPort)
+	case "DSCP":
+		parsed, parseErr = RC.NewDSCP(payload, target)
 	case "PROCESS-NAME":
 		parsed, parseErr = RC.NewProcess(payload, target, true)
 	case "PROCESS-PATH":


### PR DESCRIPTION
为 Tproxy 模式下的 UDP 包增加 DSCP 规则，使得 UDP 可以根据其 IP 报文头部的 DSCP 进行分流。

在 Windows 下，可以设置 [QoS 策略](https://learn.microsoft.com/en-us/windows-server/networking/technologies/qos/qos-policy-manage)，此策略可以根据进程修改 IP 报文的 DSCP；在 Linux 下，可以通过 [iptables](https://ipset.netfilter.org/iptables-extensions.man.html#:~:text=for%20translated%20flows.-,DSCP,-This%20target%20allows) 等用户态工具为应用或用户修改 IP 报文的 DSCP。从而，在开启 Tproxy 的透明代理模式下，通过 DSCP 规则进行 UDP 分流可以等效地实现针对代理下客户端的分应用 UDP 分流或分用户 UDP 分流。