### PR TITLE
gun支持健康检查

### DIFF
--- a/transport/gun/gun.go
+++ b/transport/gun/gun.go
@@ -256,7 +256,7 @@ func NewHTTP2Client(dialFn DialFn, tlsConfig *tls.Config, Fingerprint string, re
 		TLSClientConfig:    tlsConfig,
 		AllowHTTP:          false,
 		DisableCompression: true,
-		PingTimeout:        0,
+		ReadIdleTimeout:    15 * time.Second,
 	}
 
 	return &wrap


### PR DESCRIPTION
根据[文档](https://pkg.go.dev/golang.org/x/net/http2#Transport)，`ReadIdleTimeout` 不为0的时候没有通信的时候会定期进行健康检查，`PingTimeout` 是健康检查的超时时间，未指定(值为0时)是15秒，只有启动了健康检查才生效。