### PR TITLE
fix: correct type for vmess.ws-opts.path in ConvertsV2Ray

### DIFF
--- a/common/convert/converter.go
+++ b/common/convert/converter.go
@@ -333,7 +333,7 @@ func ConvertsV2Ray(buf []byte) ([]map[string]any, error) {
 			case "ws":
 				headers := make(map[string]any)
 				wsOpts := make(map[string]any)
-				wsOpts["path"] = []string{"/"}
+				wsOpts["path"] = "/"
 				if host, ok := values["host"]; ok && host != "" {
 					headers["Host"] = host.(string)
 				}


### PR DESCRIPTION
It should be a string for the following reasons:
1. During conversion, it is conditionally assigned with `wsOpts["path"] = path.(string)`
2. After conversion, it is decoded into `WSOptions.Path` in `adapter/outbound/vmess.go` which requires a string.