### PR TITLE
build.yml: using loong64 and loongarch64

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,8 +43,8 @@ jobs:
           - { goos: linux, goarch: mipsle, mips: softfloat, output: mipsle-softfloat }
           - { goos: linux, goarch: mips64, output: mips64 }
           - { goos: linux, goarch: mips64le, output: mips64le }
-          - { goos: linux, goarch: loong64, output: loong64-abi1, abi: '1' }
-          - { goos: linux, goarch: loong64, output: loong64-abi2, abi: '2' }
+          - { goos: linux, goarch: loong64, output: loong64 }
+          - { goos: linux, goarch: loongarch64, output: loongarch64 }
           - { goos: linux, goarch: riscv64, output: riscv64 }
           - { goos: linux, goarch: s390x, output: s390x }
 
@@ -83,29 +83,22 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Set up Go
-      if: ${{ matrix.jobs.goversion == '' && matrix.jobs.goarch != 'loong64' }}
+      if: ${{ matrix.jobs.goversion == '' && matrix.jobs.goarch != 'loongarch64' }}
       uses: actions/setup-go@v5
       with:
         go-version: '1.22'
 
     - name: Set up Go
-      if: ${{ matrix.jobs.goversion != '' && matrix.jobs.goarch != 'loong64' }}
+      if: ${{ matrix.jobs.goversion != '' && matrix.jobs.goarch != 'loongarch64' }}
       uses: actions/setup-go@v5
       with:
         go-version: ${{ matrix.jobs.goversion }}
 
-    - name: Set up Go1.21 loongarch abi1
-      if: ${{ matrix.jobs.goarch == 'loong64' && matrix.jobs.abi == '1' }}
+    - name: Set up Go1.21 loongarch64
+      if: ${{ matrix.jobs.goarch == 'loongarch64' }}
       run: |
         wget -q https://github.com/xishang0128/loongarch64-golang/releases/download/1.21.5/go1.21.5.linux-amd64-abi1.tar.gz
         sudo tar zxf go1.21.5.linux-amd64-abi1.tar.gz -C /usr/local
-        echo "/usr/local/go/bin" >> $GITHUB_PATH
-
-    - name: Set up Go1.21 loongarch abi2
-      if: ${{ matrix.jobs.goarch == 'loong64' && matrix.jobs.abi == '2' }}
-      run: |
-        wget -q https://github.com/xishang0128/loongarch64-golang/releases/download/1.21.5/go1.21.5.linux-amd64-abi2.tar.gz
-        sudo tar zxf go1.21.5.linux-amd64-abi2.tar.gz -C /usr/local
         echo "/usr/local/go/bin" >> $GITHUB_PATH
 
     - name: Set variables
@@ -172,11 +165,7 @@ jobs:
       if: ${{ matrix.jobs.goos == 'linux' && !contains(matrix.jobs.goarch, 'mips') }}
       run: |
         sudo apt-get install dpkg
-        if [ "${{matrix.jobs.abi}}" = "1" ]; then
-          ARCH=loongarch64
-        else
-          ARCH=${{matrix.jobs.goarch}}
-        fi
+        ARCH=${{matrix.jobs.goarch}}
         PackageVersion=$(curl -s "https://api.github.com/repos/MetaCubeX/mihomo/releases/latest" | grep -o '"tag_name": "[^"]*' | grep -o '[^"]*$' | sed 's/v//g' )
         if [ $(git branch | awk -F ' ' '{print $2}') = "Alpha" ]; then
           PackageVersion="$(echo "${PackageVersion}" | awk -F '.' '{$NF = $NF + 1; print}' OFS='.')-${VERSION}"


### PR DESCRIPTION
 新世界用loong64，旧世界用loongarch64是广泛的默认做法。
 主流的做法是将二者视为不同的架构分别处理
 这样新世界的loong64，可以和其他架构一样，直接抓上游的包，而不需要第三方仓库加patch。对下游也更方便，不用专门为loong64加patch。
 对于旧世界的loongarch64，本来就是由龙芯公司维护的妥协的产物。对loongarch64的支持，不应该影响到loong64
 讨论见https://github.com/MetaCubeX/mihomo/issues/1141