### PR TITLE
fix(listener/tproxy): possilly using released buffer in tproxy

### DIFF
--- a/listener/tproxy/packet.go
+++ b/listener/tproxy/packet.go
@@ -105,11 +105,13 @@ func listenLocalConn(rAddr, lAddr net.Addr, tunnel C.Tunnel) (*net.UDPConn, erro
 			buf := pool.Get(pool.UDPBufferSize)
 			br, err := lc.Read(buf)
 			if err != nil {
-				pool.Put(buf)
 				if errors.Is(err, net.ErrClosed) {
 					log.Debugln("TProxy local conn listener exit.. rAddr=%s lAddr=%s", rAddr.String(), lAddr.String())
+					pool.Put(buf)
 					return
 				}
+
+				log.Debugln("TProxy local conn read err=%v", err)
 			}
 			// since following localPackets are pass through this socket which listen rAddr
 			// I choose current listener as packet's packet conn


### PR DESCRIPTION
tproxy panic randomly when running for a long time