### PR TITLE
Reduce docker image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ WORKDIR /mihomo
 COPY bin/ bin/
 RUN FILE_NAME=`sh file-name.sh` && echo $FILE_NAME && \
     FILE_NAME=`ls bin/ | egrep "$FILE_NAME.gz"|awk NR==1` && echo $FILE_NAME && \
-    mv bin/$FILE_NAME mihomo.gz && gzip -d mihomo.gz && echo "$FILE_NAME" > /mihomo-config/test
+    mv bin/$FILE_NAME mihomo.gz && gzip -d mihomo.gz && chmod +x mihomo && echo "$FILE_NAME" > /mihomo-config/test
 FROM alpine:latest
 LABEL org.opencontainers.image.source="https://github.com/MetaCubeX/mihomo"
 
@@ -23,5 +23,4 @@ VOLUME ["/root/.config/mihomo/"]
 
 COPY --from=builder /mihomo-config/ /root/.config/mihomo/
 COPY --from=builder /mihomo/mihomo /mihomo
-RUN chmod +x /mihomo
 ENTRYPOINT [ "/mihomo" ]


### PR DESCRIPTION
Docker image size is nearly doubled due to `RUN /bin/sh -c chmod +x /mihomo`, move this command to build stage.

```log
root@omv:~# docker history metacubex/mihomo
IMAGE          CREATED        CREATED BY                                       SIZE      COMMENT
9f4c64430d2a   2 months ago   ENTRYPOINT ["/mihomo"]                           0B        buildkit.dockerfile.v0
<missing>      2 months ago   RUN /bin/sh -c chmod +x /mihomo # buildkit       28.1MB    buildkit.dockerfile.v0
<missing>      2 months ago   COPY /mihomo/mihomo /mihomo # buildkit           28.1MB    buildkit.dockerfile.v0
<missing>      2 months ago   COPY /mihomo-config/ /root/.config/mihomo/ #…   20.1MB    buildkit.dockerfile.v0
<missing>      2 months ago   VOLUME [/root/.config/mihomo/]                   0B        buildkit.dockerfile.v0
<missing>      2 months ago   RUN /bin/sh -c apk add --no-cache ca-certifi…   3.86MB    buildkit.dockerfile.v0
<missing>      2 months ago   LABEL org.opencontainers.image.source=https:…   0B        buildkit.dockerfile.v0
<missing>      5 months ago   /bin/sh -c #(nop)  CMD ["/bin/sh"]               0B
<missing>      5 months ago   /bin/sh -c #(nop) ADD file:37a76ec18f9887751…   7.38MB
```