### PR TITLE
fix redundant WindowsDNS

### DIFF
--- a/dns/system_windows.go
+++ b/dns/system_windows.go
@@ -16,6 +16,9 @@ func dnsReadConfig() (servers []string, err error) {
 	if err != nil {
 		return
 	}
+
+	seenIPs := make(map[string]bool)
+
 	for _, aa := range aas {
 		for dns := aa.FirstDnsServerAddress; dns != nil; dns = dns.Next {
 			sa, err := dns.Address.Sockaddr.Sockaddr()
@@ -40,7 +43,12 @@ func dnsReadConfig() (servers []string, err error) {
 				// Unexpected type.
 				continue
 			}
-			servers = append(servers, ip.String())
+			
+			ipStr := ip.String()
+            if !seenIPs[ipStr] {
+                seenIPs[ipStr] = true
+                servers = append(servers, ipStr)
+            }
 		}
 	}
 	return

--- a/dns/system_windows.go
+++ b/dns/system_windows.go
@@ -17,7 +17,7 @@ func dnsReadConfig() (servers []string, err error) {
 		return
 	}
 
-	seenIPs := make(map[string]bool)
+	uniqueIPs := make(map[string]struct{})
 
 	for _, aa := range aas {
 		for dns := aa.FirstDnsServerAddress; dns != nil; dns = dns.Next {
@@ -44,13 +44,15 @@ func dnsReadConfig() (servers []string, err error) {
 				continue
 			}
 			
-			ipStr := ip.String()
-            if !seenIPs[ipStr] {
-                seenIPs[ipStr] = true
-                servers = append(servers, ipStr)
-            }
+			uniqueIPs[ip.String()] = struct{}{}
 		}
 	}
+	
+    servers = make([]string, 0, len(uniqueIPs))
+    for ip := range uniqueIPs {
+        servers = append(servers, ip)
+    }
+
 	return
 }
 


### PR DESCRIPTION
When using `system` to get Windows system DNS, mihomo always get three same DNS. It's unnecessary and redundant, so just reserve unique one.