### PR TITLE
feat: add proxy name replacement functionality for override

### DIFF
--- a/adapter/provider/parser.go
+++ b/adapter/provider/parser.go
@@ -27,6 +27,13 @@ type healthCheckSchema struct {
 	ExpectedStatus string `provider:"expected-status,omitempty"`
 }
 
+type OverrideProxyNameSchema struct {
+	// matching expression for regex replacement
+	Pattern string `provider:"pattern,omitempty"`
+	// the new content after regex matching
+	Target string `provider:"target,omitempty"`
+}
+
 type OverrideSchema struct {
 	TFO              *bool   `provider:"tfo,omitempty"`
 	MPTcp            *bool   `provider:"mptcp,omitempty"`
@@ -41,6 +48,8 @@ type OverrideSchema struct {
 	IPVersion        *string `provider:"ip-version,omitempty"`
 	AdditionalPrefix *string `provider:"additional-prefix,omitempty"`
 	AdditionalSuffix *string `provider:"additional-suffix,omitempty"`
+
+	ProxyName []*OverrideProxyNameSchema `provider:"proxy-name,omitempty"`
 }
 
 type proxyProviderSchema struct {

--- a/docs/config.yaml
+++ b/docs/config.yaml
@@ -929,6 +929,13 @@ proxy-providers:
       # ip-version: ipv4-prefer
       # additional-prefix: "[provider1]"
       # additional-suffix: "test"
+      # # 名字替换，支持正则表达式
+      # proxy-name:
+      #   - pattern: "test"
+      #     target: "TEST"
+      #   - pattern: "IPLC-(.*?)倍"
+      #     target: "iplc x $1"
+
   test:
     type: file
     path: /test.yaml


### PR DESCRIPTION
add proxy `name` field replacement functionality. When there are multiple proxy providers, the information in proxy-name can be replaced, making it easier to group them. Replacement content supports using regular expressions.
```yaml
proxy-providers:
  provider1:
    type: http
    url: "url"
    path: ./provider1.yaml
    override:
      proxy-name:
        - pattern: "test"
          target: "TEST"
        - pattern: "IPLC-(.*?)倍"
          target: "iplc x $1"
```
override增加了proxy-name替换功能。当存在多个proxy-provider的时候将可以将proxy-name中的信息进行替换，方便进行代理分组，替换内容支持使用正则表达式