### PR TITLE
fix: add dependencies for docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN FILE_NAME=`sh file-name.sh` && echo $FILE_NAME && \
 FROM alpine:latest
 LABEL org.opencontainers.image.source="https://github.com/MetaCubeX/mihomo"
 
-RUN apk add --no-cache ca-certificates tzdata iptables
+RUN apk add --no-cache ca-certificates tzdata iptables nftables iproute2
 
 VOLUME ["/root/.config/mihomo/"]
 


### PR DESCRIPTION
Mihomo with auto-route enabled cannot work in docker image due to missing dependencies.