### PR TITLE
feat: Allow provider.dialer-proxy to specify all-proxies

### DIFF
--- a/component/proxydialer/proxydialer.go
+++ b/component/proxydialer/proxydialer.go
@@ -27,7 +27,7 @@ func New(proxy C.ProxyAdapter, dialer C.Dialer, statistic bool) C.Dialer {
 }
 
 func NewByName(proxyName string, dialer C.Dialer) (C.Dialer, error) {
-	proxies := tunnel.Proxies()
+	proxies := tunnel.ProxiesWithProviders()
 	if proxy, ok := proxies[proxyName]; ok {
 		return New(proxy, dialer, true), nil
 	}


### PR DESCRIPTION
Modify the `tunnel.Proxies()` of `component/proxydialer/proxydialer.go` to `tunnel.ProxiesWithProviders()`