### PR TITLE
align time fields in logs

### DIFF
--- a/log/log.go
+++ b/log/log.go
@@ -20,7 +20,7 @@ func init() {
 	log.SetLevel(log.DebugLevel)
 	log.SetFormatter(&log.TextFormatter{
 		FullTimestamp:             true,
-		TimestampFormat:           "2006-01-02T15:04:05.999999999Z07:00",
+		TimestampFormat:           "2006-01-02T15:04:05.000000000Z07:00",
 		EnvironmentOverrideColors: true,
 	})
 }


### PR DESCRIPTION
<img width="445" alt="image" src="https://github.com/user-attachments/assets/c9535b98-bd70-4f34-ad11-b5ab0bc7c01c">
