### PR TITLE
fix: check whether the dst port is within the specified range

### DIFF
--- a/component/sniffer/dispatcher.go
+++ b/component/sniffer/dispatcher.go
@@ -146,7 +146,7 @@ func (sd *Dispatcher) Enable() bool {
 
 func (sd *Dispatcher) sniffDomain(conn *N.BufferedConn, metadata *C.Metadata) (string, error) {
 	for s := range sd.sniffers {
-		if s.SupportNetwork() == C.TCP {
+		if s.SupportNetwork() == C.TCP && s.SupportPort(metadata.DstPort) {
 			_ = conn.SetReadDeadline(time.Now().Add(1 * time.Second))
 			_, err := conn.Peek(1)
 			_ = conn.SetReadDeadline(time.Time{})


### PR DESCRIPTION
After through the sniffers list in `TCPSniff`, if a sniffer that meets the protocol and port requirements is found, then `inWhitelist` is set to true, and the subsequent `sniffDomain` process is initiated. However, within `sniffDomain`, there is no re-check of the port, which results in a scenario where, despite both HTTP and TLS sniffers being configured to sniff different ports (for instance, HTTP is set to sniff only port 80, and TLS is set to sniff only port 443), in practice, HTTP will intercept all requests on port 443 (and similarly, TLS will process all requests on port 80).

Solution: Implement an additional check for the supported ports within sniffDomain.

After iterating the sniffers list in `TCPSniff`, if there is a sniffer that meets the protocol and port requirements, then `inWhitelist` is set to true, and the subsequent `sniffDomain` process is entered. However, in `sniffDomain`, there is no re-check on the port, which leads to a situation where, even though both HTTP and TLS sniffers are configured to sniff different ports (for example, HTTP sniffer only sniffs port 80, and TLS sniffer only sniffs port 443), in practice, HTTP sniffer will sniff all requests on port 443 (and TLS sniffer will sniff all requests on port 80).

Solution: Simply add another check for the supported ports in `sniffDomain`.