### PR TITLE
Fix the issue where TLS Sniffer fails when the length of the ClientHello packet exceeds the TCP MSS

### DIFF
--- a/component/sniffer/dispatcher.go
+++ b/component/sniffer/dispatcher.go
@@ -145,9 +145,9 @@ func (sd *Dispatcher) Enable() bool {
 }
 
 func (sd *Dispatcher) sniffDomain(conn *N.BufferedConn, metadata *C.Metadata) (string, error) {
-	defer func(start time.Time) {
-		log.Debugln("[Sniffer] [%s] Sniffing took %s", metadata.DstIP, time.Since(start))
-	}(time.Now())
+	//defer func(start time.Time) {
+	//	log.Debugln("[Sniffer] [%s] Sniffing took %s", metadata.DstIP, time.Since(start))
+	//}(time.Now())
 
 	for s := range sd.sniffers {
 		if s.SupportNetwork() == C.TCP && s.SupportPort(metadata.DstPort) {
@@ -175,11 +175,11 @@ func (sd *Dispatcher) sniffDomain(conn *N.BufferedConn, metadata *C.Metadata) (s
 			host, err := s.SniffData(bytes)
 			var e *errNeedAtLeastData
 			if errors.As(err, &e) {
-				log.Debugln("[Sniffer] [%s] [%s] %v, got length: %d", metadata.DstIP, s.Protocol(), e, len(bytes))
+				//log.Debugln("[Sniffer] [%s] [%s] %v, got length: %d", metadata.DstIP, s.Protocol(), e, len(bytes))
 				_ = conn.SetReadDeadline(time.Now().Add(1 * time.Second))
 				bytes, err = conn.Peek(e.length)
 				_ = conn.SetReadDeadline(time.Time{})
-				log.Debugln("[Sniffer] [%s] [%s] try again, got length: %d", metadata.DstIP, s.Protocol(), len(bytes))
+				//log.Debugln("[Sniffer] [%s] [%s] try again, got length: %d", metadata.DstIP, s.Protocol(), len(bytes))
 				if err != nil {
 					log.Debugln("[Sniffer] [%s] [%s] the data length not enough, error: %v", metadata.DstIP, s.Protocol(), err)
 					continue
@@ -187,17 +187,17 @@ func (sd *Dispatcher) sniffDomain(conn *N.BufferedConn, metadata *C.Metadata) (s
 				host, err = s.SniffData(bytes)
 			}
 			if err != nil {
-				log.Debugln("[Sniffer] [%s] [%s] Sniff data failed, error: %v", metadata.DstIP, s.Protocol(), err)
+				//log.Debugln("[Sniffer] [%s] [%s] Sniff data failed, error: %v", metadata.DstIP, s.Protocol(), err)
 				continue
 			}
 
 			_, err = netip.ParseAddr(host)
 			if err == nil {
-				log.Debugln("[Sniffer] [%s] [%s] Sniff data failed, got host [%s]", metadata.DstIP, s.Protocol(), host)
+				//log.Debugln("[Sniffer] [%s] [%s] Sniff data failed, got host [%s]", metadata.DstIP, s.Protocol(), host)
 				continue
 			}
 
-			log.Debugln("[Sniffer] [%s] [%s] Sniffed [%s]", metadata.DstIP, s.Protocol(), host)
+			//log.Debugln("[Sniffer] [%s] [%s] Sniffed [%s]", metadata.DstIP, s.Protocol(), host)
 			return host, nil
 		}
 	}

--- a/component/sniffer/dispatcher.go
+++ b/component/sniffer/dispatcher.go
@@ -145,6 +145,10 @@ func (sd *Dispatcher) Enable() bool {
 }
 
 func (sd *Dispatcher) sniffDomain(conn *N.BufferedConn, metadata *C.Metadata) (string, error) {
+	defer func(start time.Time) {
+		log.Debugln("[Sniffer] [%s] Sniffing took %s", metadata.DstIP, time.Since(start))
+	}(time.Now())
+
 	for s := range sd.sniffers {
 		if s.SupportNetwork() == C.TCP && s.SupportPort(metadata.DstPort) {
 			_ = conn.SetReadDeadline(time.Now().Add(1 * time.Second))
@@ -154,7 +158,7 @@ func (sd *Dispatcher) sniffDomain(conn *N.BufferedConn, metadata *C.Metadata) (s
 				_, ok := err.(*net.OpError)
 				if ok {
 					sd.cacheSniffFailed(metadata)
-					log.Errorln("[Sniffer] [%s] may not have any sent data, Consider adding skip", metadata.DstIP.String())
+					log.Errorln("[Sniffer] [%s] [%s] may not have any sent data, Consider adding skip", metadata.DstIP, s.Protocol())
 					_ = conn.Close()
 				}
 
@@ -164,22 +168,23 @@ func (sd *Dispatcher) sniffDomain(conn *N.BufferedConn, metadata *C.Metadata) (s
 			bufferedLen := conn.Buffered()
 			bytes, err := conn.Peek(bufferedLen)
 			if err != nil {
-				log.Debugln("[Sniffer] the data length not enough")
+				log.Debugln("[Sniffer] [%s] [%s] the data length not enough, error: %v", metadata.DstIP, s.Protocol(), err)
 				continue
 			}
 
 			host, err := s.SniffData(bytes)
 			if err != nil {
-				//log.Debugln("[Sniffer] [%s] Sniff data failed %s", s.Protocol(), metadata.DstIP)
+				log.Debugln("[Sniffer] [%s] [%s] Sniff data failed, error: %v", metadata.DstIP, s.Protocol(), err)
 				continue
 			}
 
 			_, err = netip.ParseAddr(host)
 			if err == nil {
-				//log.Debugln("[Sniffer] [%s] Sniff data failed %s", s.Protocol(), metadata.DstIP)
+				log.Debugln("[Sniffer] [%s] [%s] Sniff data failed, got host [%s]", metadata.DstIP, s.Protocol(), host)
 				continue
 			}
 
+			log.Debugln("[Sniffer] [%s] [%s] Sniffed [%s]", metadata.DstIP, s.Protocol(), host)
 			return host, nil
 		}
 	}


### PR DESCRIPTION
Problem:

When the length of the ClientHello message exceeds the TCP MSS (usually 1460 or 1448), due to the fragmentation of the ClientHello message during transmission, it may prevent TLSSniffer from obtaining sufficient data in first peek to parse the packet, leading to parsing failure.

Solution: 

During the TLS Sniffer parsing process, the required packet length can be determined. If the first parsing attempt fails, a retry can be initiated. Within a timeout period, once the data of the corresponding length is obtained, re-parsing can be performed.
