### PR TITLE
fix: empty proxy provider subscription info not omitted

### DIFF
--- a/adapter/provider/provider.go
+++ b/adapter/provider/provider.go
@@ -137,7 +137,7 @@ func (pp *proxySetProvider) Initial() error {
 		return err
 	}
 	if subscriptionInfo := cachefile.Cache().GetSubscriptionInfo(pp.Name()); subscriptionInfo != "" {
-		pp.subscriptionInfo.Update(subscriptionInfo)
+		pp.subscriptionInfo = NewSubscriptionInfo(subscriptionInfo)
 	}
 	pp.closeAllConnections()
 	return nil
@@ -165,14 +165,12 @@ func NewProxySetProvider(name string, interval time.Duration, parser resource.Pa
 		go hc.process()
 	}
 
-	si := new(SubscriptionInfo)
 	pd := &proxySetProvider{
 		baseProvider: baseProvider{
 			name:        name,
 			proxies:     []C.Proxy{},
 			healthCheck: hc,
 		},
-		subscriptionInfo: si,
 	}
 
 	fetcher := resource.NewFetcher[[]C.Proxy](name, interval, vehicle, parser, proxiesOnUpdate(pd))
@@ -181,7 +179,7 @@ func NewProxySetProvider(name string, interval time.Duration, parser resource.Pa
 		httpVehicle.SetInRead(func(resp *http.Response) {
 			if subscriptionInfo := resp.Header.Get("subscription-userinfo"); subscriptionInfo != "" {
 				cachefile.Cache().SetSubscriptionInfo(name, subscriptionInfo)
-				si.Update(subscriptionInfo)
+				pd.subscriptionInfo = NewSubscriptionInfo(subscriptionInfo)
 			}
 		})
 	}

--- a/adapter/provider/subscription_info.go
+++ b/adapter/provider/subscription_info.go
@@ -15,8 +15,9 @@ type SubscriptionInfo struct {
 	Expire   int64
 }
 
-func (info *SubscriptionInfo) Update(userinfo string) {
+func NewSubscriptionInfo(userinfo string) (si *SubscriptionInfo) {
 	userinfo = strings.ReplaceAll(strings.ToLower(userinfo), " ", "")
+	si = new(SubscriptionInfo)
 
 	for _, field := range strings.Split(userinfo, ";") {
 		name, value, ok := strings.Cut(field, "=")
@@ -32,15 +33,16 @@ func (info *SubscriptionInfo) Update(userinfo string) {
 
 		switch name {
 		case "upload":
-			info.Upload = intValue
+			si.Upload = intValue
 		case "download":
-			info.Download = intValue
+			si.Download = intValue
 		case "total":
-			info.Total = intValue
+			si.Total = intValue
 		case "expire":
-			info.Expire = intValue
+			si.Expire = intValue
 		}
 	}
+	return si
 }
 
 func parseValue(value string) (int64, error) {


### PR DESCRIPTION
获取 proxy provider 信息的 API 返回值里 `subscriptionInfo` 没有的情况应该是不发送这个 `field`，而 72a126e5809acae4e9058c51f4e883dc7c8c6e19 之后现在会发送一个里面全 0 的 struct

这个 PR 把这个行为恢复到和 72a126e5809acae4e9058c51f4e883dc7c8c6e19 之前一样
