### PR TITLE
feat(sniffer): ensure forced domains are always sniffed

### DIFF
--- a/component/sniffer/dispatcher.go
+++ b/component/sniffer/dispatcher.go
@@ -48,6 +48,10 @@ func (sd *Dispatcher) shouldOverride(metadata *C.Metadata) bool {
 	if metadata.DNSMode == C.DNSMapping && sd.forceDnsMapping {
 		return true
 	}
+	return sd.forceSniff(metadata)
+}
+
+func (sd *Dispatcher) forceSniff(metadata *C.Metadata) bool {
 	for _, matcher := range sd.forceDomain {
 		if matcher.MatchDomain(metadata.Host) {
 			return true
@@ -98,16 +102,21 @@ func (sd *Dispatcher) TCPSniff(conn *N.BufferedConn, metadata *C.Metadata) bool 
 		if !inWhitelist {
 			return false
 		}
+		forceSniffer := sd.forceSniff(metadata)
 
 		dst := metadata.AddrPort()
-		if count, ok := sd.skipList.Get(dst); ok && count > 5 {
-			log.Debugln("[Sniffer] Skip sniffing[%s] due to multiple failures", dst)
-			return false
+		if !forceSniffer {
+			if count, ok := sd.skipList.Get(dst); ok && count > 5 {
+				log.Debugln("[Sniffer] Skip sniffing[%s] due to multiple failures", dst)
+				return false
+			}
 		}
 
 		host, err := sd.sniffDomain(conn, metadata)
 		if err != nil {
+			if !forceSniffer {
 			sd.cacheSniffFailed(metadata)
+			}
 			log.Debugln("[Sniffer] All sniffing sniff failed with from [%s:%d] to [%s:%d]", metadata.SrcIP, metadata.SrcPort, metadata.String(), metadata.DstPort)
 			return false
 		}

--- a/component/sniffer/dispatcher.go
+++ b/component/sniffer/dispatcher.go
@@ -115,7 +115,7 @@ func (sd *Dispatcher) TCPSniff(conn *N.BufferedConn, metadata *C.Metadata) bool 
 		host, err := sd.sniffDomain(conn, metadata)
 		if err != nil {
 			if !forceSniffer {
-			sd.cacheSniffFailed(metadata)
+				sd.cacheSniffFailed(metadata)
 			}
 			log.Debugln("[Sniffer] All sniffing sniff failed with from [%s:%d] to [%s:%d]", metadata.SrcIP, metadata.SrcPort, metadata.String(), metadata.DstPort)
 			return false


### PR DESCRIPTION
When a domain matches forceDomain:
- SkipList is not checked
- Failed attempts are not cached
- Sniffing is attempted every time

This ensures forced domains are always sniffed regardless of previous failures.

优化 SNI 代理的嗅探行为

当使用 tunnel 和 sniffer 功能实现 SNI 代理时，发现一个问题：
- 由于代理目标地址相同，某些未知加密流量在 sniffer 失败几次后会被缓存为失败记录
- 这导致后续相同流量会跳过嗅探，使代理失效

解决方案：
- 使用 forceDomain 参数强制跳过 sniffer 的失败缓存机制
- 确保所有流量都能被正确嗅探，维持代理功能的正常运作

相关配置示例：

```
tunnels: # one line config
  # 80,443 做sni代理隧道
  - tcp,0.0.0.0:443,fake-domain.com:443
  - udp,0.0.0.0:443,fake-domain.com:443
  - tcp,0.0.0.0:80,fake-domain.com:80
  # gihub 的 ssh 协议隧道
  - tcp,192.168.51.1:22,github.com:22
  
sniffer:
  enable: true
  force-dns-mapping: false
  parse-pure-ip: false
  override-destination: true
  sniff:
    HTTP:
      ports: [80]
    TLS:
      ports: [443]
    QUIC:
      ports: [443]
  force-domain:
    - fake-domain.com
  skip-domain:
    - one.one.one.one
  skip-dst-address:
    - 1.1.1.1/32

rules:
  # 白名单模式
  # fake-domain.com 表示没嗅探到域名，拒绝
  - DOMAIN,fake-domain.com,REJECT
```