### PR TITLE
fix: the trustcerts not add to globalCerts after ca.ResetCertificate. change the custom-certificates  to use  PEM format instead of DER

### DIFF
--- a/component/ca/config.go
+++ b/component/ca/config.go
@@ -7,8 +7,10 @@ import (
 	"crypto/x509"
 	_ "embed"
 	"encoding/hex"
+	"encoding/pem"
 	"errors"
 	"fmt"
+	"log"
 	"os"
 	"strconv"
 	"strings"
@@ -33,8 +35,16 @@ func AddCertificate(certificate string) error {
 	if certificate == "" {
 		return fmt.Errorf("certificate is empty")
 	}
-	if cert, err := x509.ParseCertificate([]byte(certificate)); err == nil {
+
+	block, _ := pem.Decode([]byte(certificate))
+	if block == nil {
+		log.Fatalln("failed to parse PEM block containing the certificate")
+		return fmt.Errorf("decode certificate failed")
+	}
+
+	if cert, err := x509.ParseCertificate(block.Bytes); err == nil {
 		trustCerts = append(trustCerts, cert)
+		globalCertPool.AddCert(cert)
 		return nil
 	} else {
 		return fmt.Errorf("add certificate failed")


### PR DESCRIPTION
Normally, trustCert will be added to globalCertPool
but after calling ca.ResetCertificate(), trustCerts will be set to nil, and then the initializeCertPool() method will be called inside ca.ResetCertificate. 
At this time, trustCerts is still nil and cannot be added to globalCertPool.

this is issus log now 
```
time="2025-01-20T22:14:28.142774000+08:00" level=warning msg="[TCP] dial hd (match DomainKeyword/google) 127.0.0.1:50885 --> google.com:80 error: tls: failed to verify certificate: x509: “8.8.8.8” certificate is not standards compliant"

```

after fix:
```
time="2025-01-20T22:15:51.637773000+08:00" level=info msg="[TCP] 127.0.0.1:50923 --> google.com:80 match DomainKeyword(google) using hd[🇺🇸us]"

```

On the other hand, I'm not sure.
because the current source code uses the der format certificate read from the configuration file, which is difficult to configure in yaml.
so I changed it to pem format to read from the config