### PR TITLE
fix trojan output when sni is not specified

### DIFF
--- a/adapter/outbound/trojan.go
+++ b/adapter/outbound/trojan.go
@@ -102,9 +102,6 @@ func (t *Trojan) StreamConnContext(ctx context.Context, c net.Conn, metadata *C.
 			InsecureSkipVerify: t.option.SkipCertVerify,
 			ServerName:         t.option.SNI,
 		}
-		if tlsConfig.ServerName == "" {
-			tlsConfig.ServerName = host
-		}
 
 		wsOpts.TLSConfig, err = ca.GetSpecifiedFingerprintTLSConfig(tlsConfig, t.option.Fingerprint)
 		if err != nil {
@@ -121,13 +118,8 @@ func (t *Trojan) StreamConnContext(ctx context.Context, c net.Conn, metadata *C.
 		if len(t.option.ALPN) != 0 {
 			alpn = t.option.ALPN
 		}
-
-		sni := t.option.SNI
-		if sni == "" {
-			sni, _, _ = net.SplitHostPort(t.addr)
-		}
 		c, err = vmess.StreamTLSConn(ctx, c, &vmess.TLSConfig{
-			Host:              sni,
+			Host:              t.option.SNI,
 			SkipCertVerify:    t.option.SkipCertVerify,
 			FingerPrint:       t.option.Fingerprint,
 			ClientFingerprint: t.option.ClientFingerprint,
@@ -303,6 +295,10 @@ func (t *Trojan) Close() error {
 func NewTrojan(option TrojanOption) (*Trojan, error) {
 	addr := net.JoinHostPort(option.Server, strconv.Itoa(option.Port))
 
+	if option.SNI == "" {
+		option.SNI = option.Server
+	}
+
 	t := &Trojan{
 		Base: &Base{
 			name:   option.Name,
@@ -356,16 +352,11 @@ func NewTrojan(option TrojanOption) (*Trojan, error) {
 			return c, nil
 		}
 
-		sni := option.SNI
-		if sni == "" {
-			sni = option.Server
-		}
-
 		tlsConfig := &tls.Config{
 			NextProtos:         option.ALPN,
 			MinVersion:         tls.VersionTLS12,
 			InsecureSkipVerify: option.SkipCertVerify,
-			ServerName:         sni,
+			ServerName:         option.SNI,
 		}
 
 		var err error
@@ -379,7 +370,7 @@ func NewTrojan(option TrojanOption) (*Trojan, error) {
 		t.gunTLSConfig = tlsConfig
 		t.gunConfig = &gun.Config{
 			ServiceName:       option.GrpcOpts.GrpcServiceName,
-			Host:              sni,
+			Host:              option.SNI,
 			ClientFingerprint: option.ClientFingerprint,
 		}
 	}

--- a/adapter/outbound/trojan.go
+++ b/adapter/outbound/trojan.go
@@ -102,6 +102,9 @@ func (t *Trojan) StreamConnContext(ctx context.Context, c net.Conn, metadata *C.
 			InsecureSkipVerify: t.option.SkipCertVerify,
 			ServerName:         t.option.SNI,
 		}
+		if tlsConfig.ServerName == "" {
+			tlsConfig.ServerName = host
+		}
 
 		wsOpts.TLSConfig, err = ca.GetSpecifiedFingerprintTLSConfig(tlsConfig, t.option.Fingerprint)
 		if err != nil {
@@ -118,8 +121,13 @@ func (t *Trojan) StreamConnContext(ctx context.Context, c net.Conn, metadata *C.
 		if len(t.option.ALPN) != 0 {
 			alpn = t.option.ALPN
 		}
+
+		sni := t.option.SNI
+		if sni == "" {
+			sni, _, _ = net.SplitHostPort(t.addr)
+		}
 		c, err = vmess.StreamTLSConn(ctx, c, &vmess.TLSConfig{
-			Host:              t.option.SNI,
+			Host:              sni,
 			SkipCertVerify:    t.option.SkipCertVerify,
 			FingerPrint:       t.option.Fingerprint,
 			ClientFingerprint: t.option.ClientFingerprint,
@@ -348,11 +356,16 @@ func NewTrojan(option TrojanOption) (*Trojan, error) {
 			return c, nil
 		}
 
+		sni := option.SNI
+		if sni == "" {
+			sni = option.Server
+		}
+
 		tlsConfig := &tls.Config{
 			NextProtos:         option.ALPN,
 			MinVersion:         tls.VersionTLS12,
 			InsecureSkipVerify: option.SkipCertVerify,
-			ServerName:         option.SNI,
+			ServerName:         sni,
 		}
 
 		var err error
@@ -366,7 +379,7 @@ func NewTrojan(option TrojanOption) (*Trojan, error) {
 		t.gunTLSConfig = tlsConfig
 		t.gunConfig = &gun.Config{
 			ServiceName:       option.GrpcOpts.GrpcServiceName,
-			Host:              option.SNI,
+			Host:              sni,
 			ClientFingerprint: option.ClientFingerprint,
 		}
 	}


### PR DESCRIPTION
In the latest release v1.19.5, trojan outbound will fail with the error

 ```
connect error: tls: either ServerName or InsecureSkipVerify must be specified in the tls.Config
```

when sni is not specified. It used to be servername if it's not specified.