### PR TITLE
fix: make sure sniffed host will re-resolve

### DIFF
--- a/tunnel/tunnel.go
+++ b/tunnel/tunnel.go
@@ -299,7 +299,7 @@ func fixMetadata(metadata *C.Metadata) {
 }
 
 func needLookupIP(metadata *C.Metadata) bool {
-	return resolver.MappingEnabled() && metadata.Host == "" && metadata.DstIP.IsValid()
+	return resolver.MappingEnabled() && metadata.Host == "" && (!metadata.DstIP.IsValid() || metadata.SniffHost != "")
 }
 
 func preHandleMetadata(metadata *C.Metadata) error {


### PR DESCRIPTION
```yml
rules:
  - IP-CIDR,0.0.0.0/8,REJECT
  - IP-CIDR,::/128,REJECT
  - GEOIP,CN,DIRECT
```

部署 DNS 广告过滤且设置 IP 为 0.0.0.0 :: 的情况下，上面的规则会失效，“部分” 应用使用 HTTP DNS 查询 DNS 并直接发起国内 IP 的请求，最终会命中 GEOIP,CN,DIRECT。需要在有 SniffHost 的情况下，重新解析 IP 地址而不使用原本 DstIP 的数据