### PR TITLE
feat: update ProxyProvider type to use OrderedMap for better management

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -414,7 +414,7 @@ type RawConfig struct {
 	KeepAliveInterval       int               `yaml:"keep-alive-interval" json:"keep-alive-interval"`
 	DisableKeepAlive        bool              `yaml:"disable-keep-alive" json:"disable-keep-alive"`
 
-	ProxyProvider map[string]map[string]any `yaml:"proxy-providers" json:"proxy-providers"`
+	ProxyProvider *orderedmap.OrderedMap[string, map[string]any] `yaml:"proxy-providers" json:"proxy-providers"`
 	RuleProvider  map[string]map[string]any `yaml:"rule-providers" json:"rule-providers"`
 	Proxy         []map[string]any          `yaml:"proxies" json:"proxies"`
 	ProxyGroup    []map[string]any          `yaml:"proxy-groups" json:"proxy-groups"`
@@ -464,6 +464,7 @@ func DefaultRawConfig() *RawConfig {
 		Rule:              []string{},
 		Proxy:             []map[string]any{},
 		ProxyGroup:        []map[string]any{},
+		ProxyProvider:     orderedmap.New[string, map[string]any](),
 		TCPConcurrent:     false,
 		FindProcessMode:   P.FindProcessStrict,
 		GlobalUA:          "clash.meta/" + C.Version,
@@ -884,7 +885,8 @@ func parseProxies(cfg *RawConfig) (proxies map[string]C.Proxy, providersMap map[
 
 	var AllProviders []string
 	// parse and initial providers
-	for name, mapping := range providersConfig {
+	for pair := providersConfig.Oldest(); pair != nil; pair = pair.Next() {
+		name, mapping := pair.Key, pair.Value
 		if name == provider.ReservedName {
 			return nil, nil, fmt.Errorf("can not defined a provider called `%s`", provider.ReservedName)
 		}
@@ -899,7 +901,6 @@ func parseProxies(cfg *RawConfig) (proxies map[string]C.Proxy, providersMap map[
 	}
 
 	slices.Sort(AllProxies)
-	slices.Sort(AllProviders)
 
 	// parse proxy group
 	for idx, mapping := range groupsConfig {


### PR DESCRIPTION
[依照proxy-providers顺序加载各provider，而不是依照名称排列](https://github.com/MetaCubeX/mihomo/discussions/2114)，已在服务器上测试过顺序相关功能，如有需要可以到[这里](https://github.com/5kind/mihomo/actions/runs/15760925956)下载修改后的二进制文件。
已知的问题：
在[webui](https://metacubex.github.io/metacubexd)中`代理`已按文件顺序排列，`代理提供者`依然按照名称排列；
其余可能的问题、功能影响等未测试。
