### PR TITLE
fix: ssr uri decode

### DIFF
--- a/common/convert/base64.go
+++ b/common/convert/base64.go
@@ -2,6 +2,7 @@ package convert
 
 import (
 	"encoding/base64"
+	"fmt"
 	"strings"
 )
 
@@ -42,4 +43,23 @@ func decodeUrlSafe(data string) string {
 		return ""
 	}
 	return string(dcBuf)
+}
+
+func TryDecodeBase64(s string) (decoded []byte, err error) {
+	if len(s)%4 == 0 {
+		if decoded, err = base64.StdEncoding.DecodeString(s); err == nil {
+			return
+		}
+		if decoded, err = base64.URLEncoding.DecodeString(s); err == nil {
+			return
+		}
+	} else {
+		if decoded, err = base64.RawStdEncoding.DecodeString(s); err == nil {
+			return
+		}
+		if decoded, err = base64.RawURLEncoding.DecodeString(s); err == nil {
+			return
+		}
+	}
+	return nil, fmt.Errorf("invalid base64-encoded string")
 }

--- a/common/convert/converter.go
+++ b/common/convert/converter.go
@@ -456,12 +456,12 @@ func ConvertsV2Ray(buf []byte) ([]map[string]any, error) {
 			proxies = append(proxies, ss)
 
 		case "ssr":
-			dcBuf, err := encRaw.DecodeString(body)
+			dcBuf, err := TryDecodeBase64(body)
 			if err != nil {
 				continue
 			}
 
-			// ssr://host:port:protocol:method:obfs:urlsafebase64pass/?obfsparam=urlsafebase64&protoparam=&remarks=urlsafebase64&group=urlsafebase64&udpport=0&uot=1
+			// ssr://host:port:protocol:method:obfs:urlsafebase64pass/?obfsparam=urlsafebase64param&protoparam=urlsafebase64param&remarks=urlsafebase64remarks&group=urlsafebase64group&udpport=0&uot=1
 
 			before, after, ok := strings.Cut(string(dcBuf), "/?")
 			if !ok {
@@ -490,7 +490,7 @@ func ConvertsV2Ray(buf []byte) ([]map[string]any, error) {
 			name := uniqueName(names, remarks)
 
 			obfsParam := decodeUrlSafe(query.Get("obfsparam"))
-			protocolParam := query.Get("protoparam")
+			protocolParam := decodeUrlSafe(query.Get("protoparam"))
 
 			ssr := make(map[string]any, 20)
 


### PR DESCRIPTION
https://github.com/shadowsocksrr/shadowsocks-rss/wiki/SSR-QRcode-scheme

https://github.com/MetaCubeX/mihomo/issues/225 https://github.com/MetaCubeX/mihomo/issues/1530

Compatible Base64 decoding is used to handle inconsistent encoding across tools.

