### PR TITLE
sniffer replace domain only if domain is valid

### DIFF
--- a/component/sniffer/dispatcher.go
+++ b/component/sniffer/dispatcher.go
@@ -6,6 +6,8 @@ import (
 	"net/netip"
 	"time"
 
+	"github.com/metacubex/sing/common/metadata"
+
 	"github.com/metacubex/mihomo/common/lru"
 	N "github.com/metacubex/mihomo/common/net"
 	C "github.com/metacubex/mihomo/constant"
@@ -164,6 +166,9 @@ func replaceDomain(metadata *C.Metadata, host string, overrideDest bool) {
 }
 
 func (sd *Dispatcher) domainCanReplace(host string) bool {
+	if host == "." || !metadata.IsDomainName(host) {
+		return false
+	}
 	for _, matcher := range sd.skipDomain {
 		if matcher.MatchDomain(host) {
 			return false


### PR DESCRIPTION
目前 https://wiki.metacubex.one/config/sniff/ 文档里示例的`skip-domain: Mijia Cloud`很明显不是一个有效域名，为了避免用户枚举这种无效域名，增加一层判断，仅当是个有效域名时，才在sniff时进行替换，降低配置复杂度