### PR TITLE
Unconditionally allow clients with passwords for password-free socks5 inbound

### DIFF
--- a/component/auth/auth.go
+++ b/component/auth/auth.go
@@ -41,3 +41,11 @@ func NewAuthenticator(users []AuthUser) Authenticator {
 	}
 	return au
 }
+
+var AlwaysValid Authenticator = alwaysValid{}
+
+type alwaysValid struct{}
+
+func (alwaysValid) Verify(string, string) bool { return true }
+
+func (alwaysValid) Users() []string { return nil }

--- a/transport/socks5/socks5.go
+++ b/transport/socks5/socks5.go
@@ -118,6 +118,10 @@ func ServerHandshake(rw net.Conn, authenticator auth.Authenticator) (addr Addr, 
 		return
 	}
 
+	if nmethods == 1 && buf[0] == 0x02 /* will use password */ && authenticator == nil {
+		authenticator = auth.AlwaysValid
+	}
+
 	// write VER METHOD
 	if authenticator != nil {
 		if _, err = rw.Write([]byte{5, 2}); err != nil {


### PR DESCRIPTION
目前的代码，如果inbound没设socks密码，但某些傻逼客户端又传了个密码过来，会因为 if authenticator != nil 条件不命中，导致其中读用户名和密码部分的逻辑没执行，而直接往下走到代理逻辑，但此时又读到了socks认证的内容，导致报错。

这里修改了下，让逻辑正常走完，始终过一遍认证流程。