### PR TITLE
fix: add base64 decoding for VLESS host in ConvertsV2Ray function

### DIFF
--- a/common/convert/converter.go
+++ b/common/convert/converter.go
@@ -208,14 +208,8 @@ func ConvertsV2Ray(buf []byte) ([]map[string]any, error) {
 			if err != nil {
 				continue
 			}
-			decodedHost, err := tryDecodeBase64([]byte(urlVLess.Host))
-			if err == nil {
-				oldHost := urlVLess.Host
-				line = strings.Replace(line, oldHost, string(decodedHost), 1)
-				urlVLess, err = url.Parse(line)
-				if err != nil {
-					continue
-				}
+			if decodedHost, err := tryDecodeBase64([]byte(urlVLess.Host)); err == nil {
+				urlVLess.Host = string(decodedHost)
 			}
 			query := urlVLess.Query()
 			vless := make(map[string]any, 20)

--- a/common/convert/converter.go
+++ b/common/convert/converter.go
@@ -208,6 +208,15 @@ func ConvertsV2Ray(buf []byte) ([]map[string]any, error) {
 			if err != nil {
 				continue
 			}
+			decodedHost, err := tryDecodeBase64([]byte(urlVLess.Host))
+			if err == nil {
+				oldHost := urlVLess.Host
+				line = strings.Replace(line, oldHost, string(decodedHost), 1)
+				urlVLess, err = url.Parse(line)
+				if err != nil {
+					continue
+				}
+			}
 			query := urlVLess.Query()
 			vless := make(map[string]any, 20)
 			err = handleVShareLink(names, urlVLess, scheme, vless)


### PR DESCRIPTION
```
vless://YXV0bzozOWE0ZmM1Mi04ODVkLTRlYWYtYWRiYS02MTQ3MmMyOGY0N2VAMTcyLjY3LjE2MS4yMTA6MjA4Ng?remarks=%F0%9F%92%A6%2046%20-%20VLESS%20-%20IPv4%20:%202086&obfsParam=jmxoz0htqbvapnx9ruop77vjl6m-k1ze.peige1985.workers.dev&path=/Ayh9EiFCVZSZv2Tm?ed=2560&obfs=websocket
```
处理 vless 链接中 仅 host 部分被编码的情况