### PR TITLE
fix: unix upgrade api 500

### DIFF
--- a/component/updater/update_core.go
+++ b/component/updater/update_core.go
@@ -160,7 +160,14 @@ func (u *CoreUpdater) Update(currentExePath string, channel string, force bool) 
 		return fmt.Errorf("backuping: %w", err)
 	}
 
-	err = u.copyFile(updateExePath, currentExePath)
+	// Replace the current executable with the updated one
+	// On Windows, use copyFile because rename fails with "File in use" error
+	// On other platforms, use rename which can handle running executables
+	if runtime.GOOS == "windows" {
+		err = u.copyFile(updateExePath, currentExePath)
+	} else {
+		err = os.Rename(updateExePath, currentExePath)
+	}
 	if err != nil {
 		return fmt.Errorf("replacing: %w", err)
 	}


### PR DESCRIPTION
01cd7e2c0e22b56a3b94b13e8c20e67605fb78ec 这个提交导致[v1.19.12](https://github.com/MetaCubeX/mihomo/releases/tag/v1.19.12)没法通过upgrade接口升级

```
{
    "message": "replacing: os.OpenFile(/usr/local/bin/mihomo): open /usr/local/bin/mihomo: text file busy"
}
```