### PR TITLE
fix: auto update local file provider

### DIFF
--- a/component/resource/fetcher.go
+++ b/component/resource/fetcher.go
@@ -183,7 +183,6 @@ func (f *Fetcher[V]) startPullLoop(forceUpdate bool) (err error) {
 	if f.vehicle.Type() == types.File {
 		f.watcher, err = fswatch.NewWatcher(fswatch.Options{
 			Path:     []string{f.vehicle.Path()},
-			Direct:   true,
 			Callback: f.updateCallback,
 		})
 		if err != nil {


### PR DESCRIPTION
Using `Direct: true` will ignore the changes when the file was modified using replace method. Which is a common method used by ftp software.