### PR TITLE
feat: support proxy-provider priority

### DIFF
--- a/adapter/outboundgroup/groupbase.go
+++ b/adapter/outboundgroup/groupbase.go
@@ -35,9 +35,10 @@ type GroupBase struct {
 	maxFailedTimes    int
 
 	// for GetProxies
-	getProxiesMutex  sync.Mutex
-	providerVersions []uint32
-	providerProxies  []C.Proxy
+	getProxiesMutex     sync.Mutex
+	providerVersions    []uint32
+	providerProxies     []C.Proxy
+	providerProxyOwners []provider.ProxyProvider
 }
 
 type GroupBaseOption struct {
@@ -100,7 +101,7 @@ func (gb *GroupBase) Touch() {
 	}
 }
 
-func (gb *GroupBase) GetProxies(touch bool) []C.Proxy {
+func (gb *GroupBase) getProxiesInternal(touch bool) ([]C.Proxy, []provider.ProxyProvider) {
 	providerVersions := make([]uint32, len(gb.providers))
 	for i, pd := range gb.providers {
 		if touch { // touch first
@@ -115,22 +116,32 @@ func (gb *GroupBase) GetProxies(touch bool) []C.Proxy {
 
 	// return the cached proxies if version not changed
 	if slices.Equal(providerVersions, gb.providerVersions) {
-		return gb.providerProxies
+		return gb.providerProxies, gb.providerProxyOwners
 	}
 
 	var proxies []C.Proxy
+	var owners []provider.ProxyProvider
 	if len(gb.filterRegs) == 0 {
 		for _, pd := range gb.providers {
-			proxies = append(proxies, pd.Proxies()...)
+			pds := pd.Proxies()
+			proxies = append(proxies, pds...)
+			for range pds {
+				owners = append(owners, pd)
+			}
 		}
 	} else {
 		for _, pd := range gb.providers {
 			if pd.VehicleType() == types.Compatible { // compatible provider unneeded filter
-				proxies = append(proxies, pd.Proxies()...)
+				pds := pd.Proxies()
+				proxies = append(proxies, pds...)
+				for range pds {
+					owners = append(owners, pd)
+				}
 				continue
 			}
 
 			var newProxies []C.Proxy
+			var newOwners []provider.ProxyProvider
 			proxiesSet := map[string]struct{}{}
 			for _, filterReg := range gb.filterRegs {
 				for _, p := range pd.Proxies() {
@@ -139,11 +150,13 @@ func (gb *GroupBase) GetProxies(touch bool) []C.Proxy {
 						if _, ok := proxiesSet[name]; !ok {
 							proxiesSet[name] = struct{}{}
 							newProxies = append(newProxies, p)
+							newOwners = append(newOwners, pd)
 						}
 					}
 				}
 			}
 			proxies = append(proxies, newProxies...)
+			owners = append(owners, newOwners...)
 		}
 	}
 
@@ -152,32 +165,37 @@ func (gb *GroupBase) GetProxies(touch bool) []C.Proxy {
 	// when there are multiple providers, the array needs to be reordered as a whole.
 	if len(gb.providers) > 1 && len(gb.filterRegs) > 1 {
 		var newProxies []C.Proxy
+		var newOwners []provider.ProxyProvider
 		proxiesSet := map[string]struct{}{}
 		for _, filterReg := range gb.filterRegs {
-			for _, p := range proxies {
+			for idx, p := range proxies {
 				name := p.Name()
 				if mat, _ := filterReg.MatchString(name); mat {
 					if _, ok := proxiesSet[name]; !ok {
 						proxiesSet[name] = struct{}{}
 						newProxies = append(newProxies, p)
+						newOwners = append(newOwners, owners[idx])
 					}
 				}
 			}
 		}
-		for _, p := range proxies { // add not matched proxies at the end
+		for idx, p := range proxies { // add not matched proxies at the end
 			name := p.Name()
 			if _, ok := proxiesSet[name]; !ok {
 				proxiesSet[name] = struct{}{}
 				newProxies = append(newProxies, p)
+				newOwners = append(newOwners, owners[idx])
 			}
 		}
 		proxies = newProxies
+		owners = newOwners
 	}
 
 	if len(gb.excludeFilterRegs) > 0 {
 		var newProxies []C.Proxy
+		var newOwners []provider.ProxyProvider
 	LOOP1:
-		for _, p := range proxies {
+		for idx, p := range proxies {
 			name := p.Name()
 			for _, excludeFilterReg := range gb.excludeFilterRegs {
 				if mat, _ := excludeFilterReg.MatchString(name); mat {
@@ -185,14 +203,17 @@ func (gb *GroupBase) GetProxies(touch bool) []C.Proxy {
 				}
 			}
 			newProxies = append(newProxies, p)
+			newOwners = append(newOwners, owners[idx])
 		}
 		proxies = newProxies
+		owners = newOwners
 	}
 
 	if gb.excludeTypeArray != nil {
 		var newProxies []C.Proxy
+		var newOwners []provider.ProxyProvider
 	LOOP2:
-		for _, p := range proxies {
+		for idx, p := range proxies {
 			mType := p.Type().String()
 			for _, excludeType := range gb.excludeTypeArray {
 				if strings.EqualFold(mType, excludeType) {
@@ -200,19 +221,31 @@ func (gb *GroupBase) GetProxies(touch bool) []C.Proxy {
 				}
 			}
 			newProxies = append(newProxies, p)
+			newOwners = append(newOwners, owners[idx])
 		}
 		proxies = newProxies
+		owners = newOwners
 	}
 
 	if len(proxies) == 0 {
-		return []C.Proxy{tunnel.Proxies()["COMPATIBLE"]}
+		return []C.Proxy{tunnel.Proxies()["COMPATIBLE"]}, nil
 	}
 
 	// only cache when proxies not empty
 	gb.providerVersions = providerVersions
 	gb.providerProxies = proxies
+	gb.providerProxyOwners = owners
 
+	return proxies, owners
+}
+
+func (gb *GroupBase) GetProxies(touch bool) []C.Proxy {
+	proxies, _ := gb.getProxiesInternal(touch)
 	return proxies
+}
+
+func (gb *GroupBase) GetProxiesWithOwners(touch bool) ([]C.Proxy, []provider.ProxyProvider) {
+	return gb.getProxiesInternal(touch)
 }
 
 func (gb *GroupBase) URLTest(ctx context.Context, url string, expectedStatus utils.IntRanges[uint16]) (map[string]uint16, error) {

--- a/adapter/outboundgroup/parser.go
+++ b/adapter/outboundgroup/parser.go
@@ -164,7 +164,7 @@ func ParseProxyGroup(config map[string]any, proxyMap map[string]C.Proxy, provide
 
 		hc := provider.NewHealthCheck(ps, groupOption.URL, uint(groupOption.TestTimeout), uint(groupOption.Interval), groupOption.Lazy, expectedStatus)
 
-		pd, err := provider.NewCompatibleProvider(groupName, ps, hc)
+		pd, err := provider.NewCompatibleProvider(groupName, ps, hc, 0)
 		if err != nil {
 			return nil, fmt.Errorf("%s: %w", groupName, err)
 		}

--- a/adapter/outboundgroup/urltest.go
+++ b/adapter/outboundgroup/urltest.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"sort"
 	"time"
 
 	"github.com/metacubex/mihomo/common/callback"
@@ -108,7 +109,7 @@ func (u *URLTest) healthCheck() {
 
 func (u *URLTest) fast(touch bool) C.Proxy {
 	elm, _, shared := u.fastSingle.Do(func() (C.Proxy, error) {
-		proxies := u.GetProxies(touch)
+		proxies, owners := u.GetProxiesWithOwners(touch)
 		if u.selected != "" {
 			for _, proxy := range proxies {
 				if !proxy.AliveForTestUrl(u.testUrl) {
@@ -121,11 +122,51 @@ func (u *URLTest) fast(touch bool) C.Proxy {
 			}
 		}
 
-		fast := proxies[0]
+		var candidates []C.Proxy
+		if len(proxies) != 0 {
+			priorityBuckets := map[int][]C.Proxy{}
+			prioritySet := map[int]struct{}{}
+			for idx, proxy := range proxies {
+				var owner provider.ProxyProvider
+				if owners != nil && idx < len(owners) {
+					owner = owners[idx]
+				}
+				priority := 0
+				if owner != nil {
+					priority = owner.Priority()
+				}
+				prioritySet[priority] = struct{}{}
+				if proxy.AliveForTestUrl(u.testUrl) {
+					priorityBuckets[priority] = append(priorityBuckets[priority], proxy)
+				}
+			}
+
+			priorities := make([]int, 0, len(prioritySet))
+			for priority := range prioritySet {
+				priorities = append(priorities, priority)
+			}
+			sort.Sort(sort.Reverse(sort.IntSlice(priorities)))
+
+			for _, priority := range priorities {
+				if bucket := priorityBuckets[priority]; len(bucket) != 0 {
+					candidates = bucket
+					break
+				}
+			}
+		}
+
+		if len(candidates) == 0 {
+			candidates = proxies
+		}
+		if len(candidates) == 0 {
+			return nil, errors.New("proxy not exist")
+		}
+
+		fast := candidates[0]
 		minDelay := fast.LastDelayForTestUrl(u.testUrl)
 		fastNotExist := true
 
-		for _, proxy := range proxies[1:] {
+		for _, proxy := range candidates[1:] {
 			if u.fastNode != nil && proxy.Name() == u.fastNode.Name() {
 				fastNotExist = false
 			}

--- a/adapter/provider/parser.go
+++ b/adapter/provider/parser.go
@@ -67,6 +67,7 @@ type proxyProviderSchema struct {
 	DialerProxy   string           `provider:"dialer-proxy,omitempty"`
 	SizeLimit     int64            `provider:"size-limit,omitempty"`
 	Payload       []map[string]any `provider:"payload,omitempty"`
+	Priority      int              `provider:"priority,omitempty"`
 
 	HealthCheck healthCheckSchema   `provider:"health-check,omitempty"`
 	Override    OverrideSchema      `provider:"override,omitempty"`
@@ -122,12 +123,12 @@ func ParseProxyProvider(name string, mapping map[string]any) (types.ProxyProvide
 		}
 		vehicle = resource.NewHTTPVehicle(schema.URL, path, schema.Proxy, schema.Header, resource.DefaultHttpTimeout, schema.SizeLimit)
 	case "inline":
-		return NewInlineProvider(name, schema.Payload, parser, hc)
+		return NewInlineProvider(name, schema.Payload, parser, hc, schema.Priority)
 	default:
 		return nil, fmt.Errorf("%w: %s", errVehicleType, schema.Type)
 	}
 
 	interval := time.Duration(uint(schema.Interval)) * time.Second
 
-	return NewProxySetProvider(name, interval, schema.Payload, parser, vehicle, hc)
+	return NewProxySetProvider(name, interval, schema.Payload, parser, vehicle, hc, schema.Priority)
 }

--- a/adapter/provider/provider.go
+++ b/adapter/provider/provider.go
@@ -40,6 +40,7 @@ type providerForApi struct {
 	ExpectedStatus   string            `json:"expectedStatus"`
 	UpdatedAt        time.Time         `json:"updatedAt,omitempty"`
 	SubscriptionInfo *SubscriptionInfo `json:"subscriptionInfo,omitempty"`
+	Priority         int               `json:"priority"`
 }
 
 type baseProvider struct {
@@ -47,6 +48,7 @@ type baseProvider struct {
 	proxies     []C.Proxy
 	healthCheck *HealthCheck
 	version     uint32
+	priority    int
 }
 
 func (bp *baseProvider) Name() string {
@@ -55,6 +57,10 @@ func (bp *baseProvider) Name() string {
 
 func (bp *baseProvider) Version() uint32 {
 	return bp.version
+}
+
+func (bp *baseProvider) Priority() int {
+	return bp.priority
 }
 
 func (bp *baseProvider) Initial() error {
@@ -127,6 +133,7 @@ func (pp *proxySetProvider) MarshalJSON() ([]byte, error) {
 		ExpectedStatus:   pp.healthCheck.expectedStatus.String(),
 		UpdatedAt:        pp.UpdatedAt(),
 		SubscriptionInfo: pp.subscriptionInfo,
+		Priority:         pp.Priority(),
 	})
 }
 
@@ -171,12 +178,13 @@ func (pp *proxySetProvider) Close() error {
 	return pp.Fetcher.Close()
 }
 
-func NewProxySetProvider(name string, interval time.Duration, payload []map[string]any, parser resource.Parser[[]C.Proxy], vehicle types.Vehicle, hc *HealthCheck) (*ProxySetProvider, error) {
+func NewProxySetProvider(name string, interval time.Duration, payload []map[string]any, parser resource.Parser[[]C.Proxy], vehicle types.Vehicle, hc *HealthCheck, priority int) (*ProxySetProvider, error) {
 	pd := &proxySetProvider{
 		baseProvider: baseProvider{
 			name:        name,
 			proxies:     []C.Proxy{},
 			healthCheck: hc,
+			priority:    priority,
 		},
 	}
 
@@ -234,6 +242,7 @@ func (ip *inlineProvider) MarshalJSON() ([]byte, error) {
 		Proxies:        ip.Proxies(),
 		TestUrl:        ip.healthCheck.url,
 		ExpectedStatus: ip.healthCheck.expectedStatus.String(),
+		Priority:       ip.Priority(),
 		UpdatedAt:      ip.updateAt,
 	})
 }
@@ -248,7 +257,7 @@ func (ip *inlineProvider) Update() error {
 	return nil
 }
 
-func NewInlineProvider(name string, payload []map[string]any, parser resource.Parser[[]C.Proxy], hc *HealthCheck) (*InlineProvider, error) {
+func NewInlineProvider(name string, payload []map[string]any, parser resource.Parser[[]C.Proxy], hc *HealthCheck, priority int) (*InlineProvider, error) {
 	ps := ProxySchema{Proxies: payload}
 	buf, err := yaml.Marshal(ps)
 	if err != nil {
@@ -266,6 +275,7 @@ func NewInlineProvider(name string, payload []map[string]any, parser resource.Pa
 			name:        name,
 			proxies:     proxies,
 			healthCheck: hc,
+			priority:    priority,
 		},
 		updateAt: time.Now(),
 	}
@@ -296,6 +306,7 @@ func (cp *compatibleProvider) MarshalJSON() ([]byte, error) {
 		Proxies:        cp.Proxies(),
 		TestUrl:        cp.healthCheck.url,
 		ExpectedStatus: cp.healthCheck.expectedStatus.String(),
+		Priority:       cp.Priority(),
 	})
 }
 
@@ -307,7 +318,7 @@ func (cp *compatibleProvider) VehicleType() types.VehicleType {
 	return types.Compatible
 }
 
-func NewCompatibleProvider(name string, proxies []C.Proxy, hc *HealthCheck) (*CompatibleProvider, error) {
+func NewCompatibleProvider(name string, proxies []C.Proxy, hc *HealthCheck, priority int) (*CompatibleProvider, error) {
 	if len(proxies) == 0 {
 		return nil, errors.New("provider need one proxy at least")
 	}
@@ -317,6 +328,7 @@ func NewCompatibleProvider(name string, proxies []C.Proxy, hc *HealthCheck) (*Co
 			name:        name,
 			proxies:     proxies,
 			healthCheck: hc,
+			priority:    priority,
 		},
 	}
 

--- a/config/config.go
+++ b/config/config.go
@@ -927,7 +927,7 @@ func parseProxies(cfg *RawConfig) (proxies map[string]C.Proxy, providersMap map[
 		ps = append(ps, proxies[v])
 	}
 	hc := provider.NewHealthCheck(ps, "", 5000, 0, true, nil)
-	pd, _ := provider.NewCompatibleProvider(provider.ReservedName, ps, hc)
+	pd, _ := provider.NewCompatibleProvider(provider.ReservedName, ps, hc, 0)
 	providersMap[provider.ReservedName] = pd
 
 	if !hasGlobal {

--- a/constant/provider/interface.go
+++ b/constant/provider/interface.go
@@ -84,6 +84,7 @@ type ProxyProvider interface {
 	Version() uint32
 	RegisterHealthCheckTask(url string, expectedStatus utils.IntRanges[uint16], filter string, interval uint)
 	HealthCheckURL() string
+	Priority() int
 }
 
 // RuleProvider interface

--- a/docs/config.yaml
+++ b/docs/config.yaml
@@ -1001,6 +1001,21 @@ proxy-groups:
     url: "https://cp.cloudflare.com/generate_204"
     interval: 300
 
+  # priority 示例：当 provider A/B/C/D 均可用时优先使用 priority 为 4 的 provider A
+  - name: "priority-auto"
+    type: url-test
+    use:
+      - providerA
+      - providerB
+      - providerC
+      - providerD
+    url: "https://cp.cloudflare.com/generate_204"
+    interval: 300
+    # 当 providerA priority=4、providerB priority=3、providerC priority=3、providerD priority=2 时：
+    # 1. 首先从 providerA 的节点中选择延迟最低的；
+    # 2. 若 providerA 全部不可用，则在 providerB 与 providerC 中合并比较延迟；
+    # 3. 若 A/B/C 均不可用，则回退到 providerD。
+
   # fallback 将按照 url 测试结果按照节点顺序选择
   - name: "fallback-auto"
     type: fallback
@@ -1049,6 +1064,7 @@ proxy-providers:
     interval: 3600
     path: ./provider1.yaml # 默认只允许存储在 mihomo 的 Home Dir，如果想存储到其他位置，请通过设置 SAFE_PATHS 环境变量指定额外的安全路径。该环境变量的语法同本操作系统的PATH环境变量解析规则（即Windows下以分号分割，其他系统下以冒号分割）
     proxy: DIRECT
+    priority: 1 # 可选，默认为 0。值越高的 provider 在 url-test 中会被优先选取，只有节点全部不可用，才会选择低优先级的 provider
     # size-limit: 10240 # 限制下载文件最大为10kb，默认为0即不限制文件大小
     header:
       User-Agent:
@@ -1085,6 +1101,7 @@ proxy-providers:
   provider2:
     type: inline
     dialer-proxy: proxy
+    priority: 2
     payload:
       - name: "ss1"
         type: ss
@@ -1559,3 +1576,24 @@ listeners:
 #  alpn:
 #    - h3
 #  max-udp-relay-packet-size: 1500
+  # priority 示例：当 url-test 同时引用多个 provider 时，可通过 priority 控制优先级
+  providerA:
+    type: http
+    url: "https://example.com/providerA.yaml"
+    priority: 4
+    interval: 600
+  providerB:
+    type: http
+    url: "https://example.com/providerB.yaml"
+    priority: 3
+    interval: 600
+  providerC:
+    type: http
+    url: "https://example.com/providerC.yaml"
+    priority: 3
+    interval: 600
+  providerD:
+    type: http
+    url: "https://example.com/providerD.yaml"
+    priority: 2
+    interval: 600


### PR DESCRIPTION
Use case: two proxy providers. The primary is expensive with great quality but occasionally under maintenance; the secondary is cheap with average quality and is only a backup. I want the selector to prefer the higher-priority provider unless **all** of its nodes are unavailable, then fall back to lower-priority providers.

This commit implements that behavior. A new `priority` field on `proxy-provider` controls the selection order for `url-test` proxy groups: nodes from higher-priority providers are chosen first; if none are available, selection proceeds to lower priorities.
