### PR TITLE
fix: crash due to nil net.Conn from mieru inbound

### DIFF
--- a/listener/inbound/mieru.go
+++ b/listener/inbound/mieru.go
@@ -90,6 +90,8 @@ func (m *Mieru) Listen(tunnel C.Tunnel) error {
 			if err != nil {
 				if !m.server.IsRunning() {
 					break
+				} else {
+					continue
 				}
 			}
 			go mieru.Handle(c, tunnel, req, additions...)


### PR DESCRIPTION
When Accept() returns an err, net.Conn can be nil and it must not be passed to Handle().