### PR TITLE
feat: support mieru UDP outbound

### DIFF
--- a/adapter/outbound/mieru_test.go
+++ b/adapter/outbound/mieru_test.go
@@ -34,7 +34,7 @@ func TestNewMieru(t *testing.T) {
 				Name:      "test",
 				Server:    "example.com",
 				Port:      10003,
-				Transport: "TCP",
+				Transport: "UDP",
 				UserName:  "test",
 				Password:  "test",
 			},

--- a/docs/config.yaml
+++ b/docs/config.yaml
@@ -1027,7 +1027,7 @@ proxies: # socks5
     server: 1.2.3.4
     port: 2999
     # port-range: 2090-2099 #（不可同时填写 port 和 port-range）
-    transport: TCP # 只支持 TCP
+    transport: TCP # 支持 TCP 或者 UDP
     udp: true # 支持 UDP over TCP
     username: user
     password: password

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/bahlo/generic-list-go v0.2.0
 	github.com/coreos/go-iptables v0.8.0
 	github.com/dlclark/regexp2 v1.11.5
-	github.com/enfein/mieru/v3 v3.22.1
+	github.com/enfein/mieru/v3 v3.23.0
 	github.com/go-chi/chi/v5 v5.2.3
 	github.com/go-chi/render v1.0.3
 	github.com/gobwas/ws v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -23,8 +23,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dlclark/regexp2 v1.11.5 h1:Q/sSnsKerHeCkc/jSTNq1oCm7KiVgUMZRDUoRu0JQZQ=
 github.com/dlclark/regexp2 v1.11.5/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
-github.com/enfein/mieru/v3 v3.22.1 h1:/XGYYXpEhEJlxosmtbpEJkhtRLHB8IToG7LB8kU2ZDY=
-github.com/enfein/mieru/v3 v3.22.1/go.mod h1:zJBUCsi5rxyvHM8fjFf+GLaEl4OEjjBXr1s5F6Qd3hM=
+github.com/enfein/mieru/v3 v3.23.0 h1:f/dd3UAoi36FD9DZ9x49t6Ps0oHeSjrVSgWzvEstn0E=
+github.com/enfein/mieru/v3 v3.23.0/go.mod h1:zJBUCsi5rxyvHM8fjFf+GLaEl4OEjjBXr1s5F6Qd3hM=
 github.com/ericlagergren/aegis v0.0.0-20250325060835-cd0defd64358 h1:kXYqH/sL8dS/FdoFjr12ePjnLPorPo2FsnrHNuXSDyo=
 github.com/ericlagergren/aegis v0.0.0-20250325060835-cd0defd64358/go.mod h1:hkIFzoiIPZYxdFOOLyDho59b7SrDfo+w3h+yWdlg45I=
 github.com/ericlagergren/polyval v0.0.0-20220411101811-e25bc10ba391 h1:8j2RH289RJplhA6WfdaPqzg1MjH2K8wX5e0uhAxrw2g=

--- a/listener/inbound/mieru_test.go
+++ b/listener/inbound/mieru_test.go
@@ -149,11 +149,17 @@ func TestNewMieru(t *testing.T) {
 }
 
 func TestInboundMieru(t *testing.T) {
-	t.Run("HANDSHAKE_STANDARD", func(t *testing.T) {
+	t.Run("TCP_HANDSHAKE_STANDARD", func(t *testing.T) {
 		testInboundMieruTCP(t, "HANDSHAKE_STANDARD")
 	})
-	t.Run("HANDSHAKE_NO_WAIT", func(t *testing.T) {
+	t.Run("TCP_HANDSHAKE_NO_WAIT", func(t *testing.T) {
 		testInboundMieruTCP(t, "HANDSHAKE_NO_WAIT")
+	})
+	t.Run("UDP_HANDSHAKE_STANDARD", func(t *testing.T) {
+		testInboundMieruUDP(t, "HANDSHAKE_STANDARD")
+	})
+	t.Run("UDP_HANDSHAKE_NO_WAIT", func(t *testing.T) {
+		testInboundMieruUDP(t, "HANDSHAKE_NO_WAIT")
 	})
 }
 
@@ -168,7 +174,7 @@ func testInboundMieruTCP(t *testing.T, handshakeMode string) {
 
 	inboundOptions := inbound.MieruOption{
 		BaseOption: inbound.BaseOption{
-			NameStr: "mieru_inbound",
+			NameStr: "mieru_inbound_tcp",
 			Listen:  "127.0.0.1",
 			Port:    strconv.Itoa(port),
 		},
@@ -194,7 +200,7 @@ func testInboundMieruTCP(t *testing.T, handshakeMode string) {
 		return
 	}
 	outboundOptions := outbound.MieruOption{
-		Name:          "mieru_outbound",
+		Name:          "mieru_outbound_tcp",
 		Server:        addrPort.Addr().String(),
 		Port:          int(addrPort.Port()),
 		Transport:     "TCP",
@@ -209,4 +215,58 @@ func testInboundMieruTCP(t *testing.T, handshakeMode string) {
 	defer out.Close()
 
 	tunnel.DoTest(t, out)
+}
+
+func testInboundMieruUDP(t *testing.T, handshakeMode string) {
+	t.Parallel()
+	l, err := net.ListenPacket("udp", "127.0.0.1:0")
+	if !assert.NoError(t, err) {
+		return
+	}
+	port := l.LocalAddr().(*net.UDPAddr).Port
+	l.Close()
+
+	inboundOptions := inbound.MieruOption{
+		BaseOption: inbound.BaseOption{
+			NameStr: "mieru_inbound_udp",
+			Listen:  "127.0.0.1",
+			Port:    strconv.Itoa(port),
+		},
+		Transport: "UDP",
+		Users:     map[string]string{"test": "password"},
+	}
+	in, err := inbound.NewMieru(&inboundOptions)
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	tunnel := NewHttpTestTunnel()
+	defer tunnel.Close()
+
+	err = in.Listen(tunnel)
+	if !assert.NoError(t, err) {
+		return
+	}
+	defer in.Close()
+
+	addrPort, err := netip.ParseAddrPort(in.Address())
+	if !assert.NoError(t, err) {
+		return
+	}
+	outboundOptions := outbound.MieruOption{
+		Name:          "mieru_outbound_udp",
+		Server:        addrPort.Addr().String(),
+		Port:          int(addrPort.Port()),
+		Transport:     "UDP",
+		UserName:      "test",
+		Password:      "password",
+		HandshakeMode: handshakeMode,
+	}
+	out, err := outbound.NewMieru(outboundOptions)
+	if !assert.NoError(t, err) {
+		return
+	}
+	defer out.Close()
+
+	tunnel.DoSequentialTest(t, out)
 }


### PR DESCRIPTION
Note: because UDP transport uses a single goroutine to handle all incoming packets to the same destination port, it is slow and can't survive stress test. We may fix that in the future.