### PR TITLE
fix: compare authentication scheme case-insensitively

### DIFF
--- a/listener/http/utils.go
+++ b/listener/http/utils.go
@@ -63,7 +63,7 @@ func removeExtraHTTPHostPort(req *http.Request) {
 // parseBasicProxyAuthorization parse header Proxy-Authorization and return base64-encoded credential
 func parseBasicProxyAuthorization(request *http.Request) string {
 	value := request.Header.Get("Proxy-Authorization")
-	if !strings.HasPrefix(value, "Basic ") {
+	if !(len(value) >= 6 && strings.EqualFold(value[:6], "Basic ")) {
 		return ""
 	}
 

--- a/listener/http/utils.go
+++ b/listener/http/utils.go
@@ -63,7 +63,11 @@ func removeExtraHTTPHostPort(req *http.Request) {
 // parseBasicProxyAuthorization parse header Proxy-Authorization and return base64-encoded credential
 func parseBasicProxyAuthorization(request *http.Request) string {
 	value := request.Header.Get("Proxy-Authorization")
-	if !(len(value) >= 6 && strings.EqualFold(value[:6], "Basic ")) {
+	const prefix = "Basic "
+	// According to RFC7617, the scheme should be case-insensitive.
+	// In practice, some implementations do use different case styles, causing authentication to fail
+	// eg: https://github.com/algesten/ureq/blob/381fd42cfcb80a5eb709d64860aa0ae726f17b8e/src/unversioned/transport/connect.rs#L118
+	if len(value) < len(prefix) || !strings.EqualFold(value[:len(prefix)], prefix) {
 		return ""
 	}
 


### PR DESCRIPTION
According to [RFC7617](https://datatracker.ietf.org/doc/html/rfc7617#section-2), the scheme should be case-insensitive. In practice, some implementations do use different case styles ([example in ureq](https://github.com/algesten/ureq/blob/381fd42cfcb80a5eb709d64860aa0ae726f17b8e/src/unversioned/transport/connect.rs#L118)), causing authentication to fail.