### PR TITLE
chore: update mieru version

### DIFF
--- a/adapter/outbound/mieru.go
+++ b/adapter/outbound/mieru.go
@@ -56,15 +56,28 @@ func (pd mieruPacketDialer) ListenPacket(ctx context.Context, network, laddr, ra
 	return pd.Dialer.ListenPacket(ctx, network, laddr, rAddrPort)
 }
 
-type mieruDNSResolver struct{}
+type mieruDNSResolver struct {
+	prefer C.DNSPrefer
+}
 
 var _ mierucommon.DNSResolver = (*mieruDNSResolver)(nil)
 
-func (dr mieruDNSResolver) LookupIP(ctx context.Context, network, host string) ([]net.IP, error) {
-	ip, err := resolver.ResolveIP(ctx, host)
+func (dr mieruDNSResolver) LookupIP(ctx context.Context, network, host string) (_ []net.IP, err error) {
+	var ip netip.Addr
+	switch dr.prefer {
+	case C.IPv4Only:
+		ip, err = resolver.ResolveIPv4WithResolver(ctx, host, resolver.ProxyServerHostResolver)
+	case C.IPv6Only:
+		ip, err = resolver.ResolveIPv6WithResolver(ctx, host, resolver.ProxyServerHostResolver)
+	case C.IPv6Prefer:
+		ip, err = resolver.ResolveIPPrefer6WithResolver(ctx, host, resolver.ProxyServerHostResolver)
+	default:
+		ip, err = resolver.ResolveIPWithResolver(ctx, host, resolver.ProxyServerHostResolver)
+	}
 	if err != nil {
 		return nil, fmt.Errorf("can't resolve ip: %w", err)
 	}
+	// TODO: handle IP4P (due to interface limitations, it's currently impossible to modify the port here)
 	return []net.IP{ip.AsSlice()}, nil
 }
 
@@ -131,7 +144,7 @@ func (m *Mieru) ensureClientIsRunning() error {
 	}
 	config.Dialer = dialer
 	config.PacketDialer = mieruPacketDialer{Dialer: dialer}
-	config.Resolver = mieruDNSResolver{}
+	config.Resolver = mieruDNSResolver{prefer: m.prefer}
 	if err := m.client.Store(config); err != nil {
 		return err
 	}

--- a/adapter/outbound/mieru.go
+++ b/adapter/outbound/mieru.go
@@ -11,6 +11,7 @@ import (
 	CN "github.com/metacubex/mihomo/common/net"
 	"github.com/metacubex/mihomo/component/dialer"
 	"github.com/metacubex/mihomo/component/proxydialer"
+	"github.com/metacubex/mihomo/component/resolver"
 	C "github.com/metacubex/mihomo/constant"
 
 	mieruclient "github.com/enfein/mieru/v3/apis/client"
@@ -53,6 +54,18 @@ func (pd mieruPacketDialer) ListenPacket(ctx context.Context, network, laddr, ra
 		return nil, fmt.Errorf("invalid address %s: %w", raddr, err)
 	}
 	return pd.Dialer.ListenPacket(ctx, network, laddr, rAddrPort)
+}
+
+type mieruDNSResolver struct{}
+
+var _ mierucommon.DNSResolver = (*mieruDNSResolver)(nil)
+
+func (dr mieruDNSResolver) LookupIP(ctx context.Context, network, host string) ([]net.IP, error) {
+	ip, err := resolver.ResolveIP(ctx, host)
+	if err != nil {
+		return nil, fmt.Errorf("can't resolve ip: %w", err)
+	}
+	return []net.IP{ip.AsSlice()}, nil
 }
 
 // DialContext implements C.ProxyAdapter
@@ -118,6 +131,7 @@ func (m *Mieru) ensureClientIsRunning() error {
 	}
 	config.Dialer = dialer
 	config.PacketDialer = mieruPacketDialer{Dialer: dialer}
+	config.Resolver = mieruDNSResolver{}
 	if err := m.client.Store(config); err != nil {
 		return err
 	}
@@ -259,6 +273,9 @@ func buildMieruClientConfig(option MieruOption) (*mieruclient.ClientConfig, erro
 				Password: proto.String(option.Password),
 			},
 			Servers: []*mierupb.ServerEndpoint{server},
+		},
+		DNSConfig: &mierucommon.ClientDNSConfig{
+			BypassDialerDNS: true,
 		},
 	}
 	if multiplexing, ok := mierupb.MultiplexingLevel_value[option.Multiplexing]; ok {

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/bahlo/generic-list-go v0.2.0
 	github.com/coreos/go-iptables v0.8.0
 	github.com/dlclark/regexp2 v1.11.5
-	github.com/enfein/mieru/v3 v3.24.1
+	github.com/enfein/mieru/v3 v3.26.0
 	github.com/go-chi/chi/v5 v5.2.3
 	github.com/go-chi/render v1.0.3
 	github.com/gobwas/ws v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -25,8 +25,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dlclark/regexp2 v1.11.5 h1:Q/sSnsKerHeCkc/jSTNq1oCm7KiVgUMZRDUoRu0JQZQ=
 github.com/dlclark/regexp2 v1.11.5/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
-github.com/enfein/mieru/v3 v3.24.1 h1:iX9py3+GExxJxLaxjHAEmQmoE1r0y2hDIsliija+jTI=
-github.com/enfein/mieru/v3 v3.24.1/go.mod h1:zJBUCsi5rxyvHM8fjFf+GLaEl4OEjjBXr1s5F6Qd3hM=
+github.com/enfein/mieru/v3 v3.26.0 h1:ZsxCFkh3UfGSu9LL6EQ9+b97uxTJ7/AnJmLMyrbjSDI=
+github.com/enfein/mieru/v3 v3.26.0/go.mod h1:zJBUCsi5rxyvHM8fjFf+GLaEl4OEjjBXr1s5F6Qd3hM=
 github.com/ericlagergren/aegis v0.0.0-20250325060835-cd0defd64358 h1:kXYqH/sL8dS/FdoFjr12ePjnLPorPo2FsnrHNuXSDyo=
 github.com/ericlagergren/aegis v0.0.0-20250325060835-cd0defd64358/go.mod h1:hkIFzoiIPZYxdFOOLyDho59b7SrDfo+w3h+yWdlg45I=
 github.com/ericlagergren/polyval v0.0.0-20220411101811-e25bc10ba391 h1:8j2RH289RJplhA6WfdaPqzg1MjH2K8wX5e0uhAxrw2g=

--- a/listener/mieru/server.go
+++ b/listener/mieru/server.go
@@ -44,7 +44,12 @@ func Handle(conn net.Conn, tunnel C.Tunnel, request *mierumodel.Request, additio
 			metadata.DstIP, _ = netip.AddrFromSlice(request.DstAddr.IP)
 			metadata.DstIP = metadata.DstIP.Unmap()
 		}
-		inbound.ApplyAdditions(metadata, inbound.WithSrcAddr(conn.RemoteAddr()), inbound.WithInAddr(conn.LocalAddr()))
+		inbound.ApplyAdditions(
+			metadata,
+			inbound.WithInName(conn.(mierucommon.UserContext).UserName()),
+			inbound.WithSrcAddr(conn.RemoteAddr()),
+			inbound.WithInAddr(conn.LocalAddr()),
+		)
 		inbound.ApplyAdditions(metadata, additions...)
 		tunnel.HandleTCPConn(conn, metadata)
 	case mieruconstant.Socks5UDPAssociateCmd: // UDP


### PR DESCRIPTION
Changes from the previous release:

- [outbound] `DNSResolver` is now a mandatory field in client config if you want to resolve proxy server domain name. Resolution happens when the underlay connection is created.
- [inbound] Connection returned from `Accept()` is guaranteed to have user name information associated with it.