### PR TITLE
chore: improve HTTPS RR logging

### DIFF
--- a/dns/resolver.go
+++ b/dns/resolver.go
@@ -165,11 +165,9 @@ func (r *Resolver) ExchangeContext(ctx context.Context, m *D.Msg) (msg *D.Msg, e
 
 	q := m.Question[0]
 	domain := msgToDomain(m)
-	_, qTypeStr := msgToQtype(m)
 	cacheM, expireTime, hit := r.cache.GetWithExpire(q.String())
 	if hit {
-		ips := msgToIP(cacheM)
-		log.Debugln("[DNS] cache hit %s --> %s %s, expire at %s", domain, ips, qTypeStr, expireTime.Format("2006-01-02 15:04:05"))
+		log.Debugln("[DNS] cache hit %s --> %s, expire at %s", domain, msgToLogString(cacheM), expireTime.Format("2006-01-02 15:04:05"))
 		now := time.Now()
 		msg = cacheM.Copy()
 		if expireTime.Before(now) {

--- a/dns/util.go
+++ b/dns/util.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/metacubex/mihomo/common/picker"
+	"github.com/metacubex/mihomo/component/ech/echparser"
 	"github.com/metacubex/mihomo/component/resolver"
 	"github.com/metacubex/mihomo/log"
 
@@ -226,6 +227,77 @@ func msgToQtype(msg *D.Msg) (uint16, string) {
 	return 0, ""
 }
 
+func msgToHTTPSRRInfo(msg *D.Msg) string {
+	var alpns []string
+	var publicName string
+	var hasIPv4, hasIPv6 bool
+
+	collect := func(rrs []D.RR) {
+		for _, rr := range rrs {
+			httpsRR, ok := rr.(*D.HTTPS)
+			if !ok {
+				continue
+			}
+
+			for _, kv := range httpsRR.Value {
+				switch v := kv.(type) {
+				case *D.SVCBAlpn:
+					if len(alpns) == 0 && len(v.Alpn) > 0 {
+						alpns = append(alpns, v.Alpn...)
+					}
+				case *D.SVCBIPv4Hint:
+					if len(v.Hint) > 0 {
+						hasIPv4 = true
+					}
+				case *D.SVCBIPv6Hint:
+					if len(v.Hint) > 0 {
+						hasIPv6 = true
+					}
+				case *D.SVCBECHConfig:
+					if publicName == "" && len(v.ECH) > 0 {
+						if cfgs, err := echparser.ParseECHConfigList(v.ECH); err == nil && len(cfgs) > 0 {
+							publicName = string(cfgs[0].PublicName)
+						}
+					}
+				}
+			}
+		}
+	}
+
+	collect(msg.Answer)
+	collect(msg.Extra)
+
+	if len(alpns) == 0 && publicName == "" && !hasIPv4 && !hasIPv6 {
+		return ""
+	}
+
+	var parts []string
+	if len(alpns) > 0 {
+		parts = append(parts, "alpn:"+strings.Join(alpns, ","))
+	}
+	if publicName != "" {
+		parts = append(parts, "pn:"+publicName)
+	}
+	if hasIPv4 {
+		parts = append(parts, "ipv4hint")
+	}
+	if hasIPv6 {
+		parts = append(parts, "ipv6hint")
+	}
+
+	return strings.Join(parts, ";")
+}
+
+func msgToLogString(msg *D.Msg) string {
+	qType, qTypeStr := msgToQtype(msg)
+	switch qType {
+	case D.TypeHTTPS:
+		return fmt.Sprintf("[%s] %s", msgToHTTPSRRInfo(msg), qTypeStr)
+	default:
+		return fmt.Sprintf("%s %s", msgToIP(msg), qTypeStr)
+	}
+}
+
 func batchExchange(ctx context.Context, clients []dnsClient, m *D.Msg) (msg *D.Msg, cache bool, err error) {
 	cache = true
 	fast, ctx := picker.WithTimeout[*D.Msg](ctx, resolver.DefaultDNSTimeout)
@@ -248,8 +320,7 @@ func batchExchange(ctx context.Context, clients []dnsClient, m *D.Msg) (msg *D.M
 				// so we would ignore RCode errors from RCode clients.
 				return nil, errors.New("server failure: " + D.RcodeToString[m.Rcode])
 			}
-			ips := msgToIP(m)
-			log.Debugln("[DNS] %s --> %s %s from %s", domain, ips, qTypeStr, client.Address())
+			log.Debugln("[DNS] %s --> %s from %s", domain, msgToLogString(m), client.Address())
 			return m, nil
 		})
 	}


### PR DESCRIPTION
link #2428

- Add formatHTTPSRRInfo function to parse and format HTTPS RR details
- Enhance DNS logging to show HTTPS RR details (ALPN, public name, hints)

for example.

```diff
mihomo on  Meta [!] via  v1.24.1 on   (auto) took 1m34s at 00:32:34
❯ go run .\main.go -d C:\Users\admin\Downloads\mihomo-windows-amd64-v3-v1.19.17 -f C:\Users\admin\Downloads\mihomo-windows-amd64-v3-v1.19.17\mihoyo-9b68.yaml
time="2025-12-12T00:33:04.887958500+08:00" level=info msg="Start initial configuration in progress"
time="2025-12-12T00:33:04.913846600+08:00" level=info msg="Geodata Loader mode: memconservative"
time="2025-12-12T00:33:04.913846600+08:00" level=info msg="Geosite Matcher implementation: succinct"
time="2025-12-12T00:33:04.943604700+08:00" level=info msg="Initial configuration complete, total time: 30ms"
time="2025-12-12T00:33:04.943604700+08:00" level=info msg="Sniffer is closed"
time="2025-12-12T00:33:04.945494100+08:00" level=info msg="RESTful API listening at: 127.0.0.1:19097"
time="2025-12-12T00:33:04.946035300+08:00" level=info msg="Mixed(http+socks) proxy listening at: 127.0.0.1:7897"
time="2025-12-12T00:33:04.946035300+08:00" level=info msg="Start initial compatible provider default"
time="2025-12-12T00:33:04.946035300+08:00" level=info msg="Start initial compatible provider OUT"
time="2025-12-12T00:33:15.694234400+08:00" level=debug msg="[Rule] use default rules"
time="2025-12-12T00:33:15.694778900+08:00" level=debug msg="[DNS] resolve openai.com A from https://223.5.5.5:443/dns-query"
time="2025-12-12T00:33:15.694778900+08:00" level=debug msg="creating a new http client"
time="2025-12-12T00:33:15.694778900+08:00" level=debug msg="[https://223.5.5.5:443/dns-query] using HTTP/2 for this upstream: <nil>"
time="2025-12-12T00:33:15.694778900+08:00" level=debug msg="[DNS] resolve openai.com A from https://1.12.12.12:443/dns-query"
time="2025-12-12T00:33:15.695325900+08:00" level=debug msg="creating a new http client"
time="2025-12-12T00:33:15.694778900+08:00" level=debug msg="[DNS] resolve openai.com AAAA from https://223.5.5.5:443/dns-query"
time="2025-12-12T00:33:15.694778900+08:00" level=debug msg="[DNS] resolve openai.com AAAA from https://1.12.12.12:443/dns-query"
time="2025-12-12T00:33:15.695325900+08:00" level=debug msg="[https://1.12.12.12:443/dns-query] using HTTP/2 for this upstream: <nil>"
time="2025-12-12T00:33:15.748320800+08:00" level=debug msg="[DNS] openai.com --> [] AAAA from https://223.5.5.5:443/dns-query"
time="2025-12-12T00:33:15.753294300+08:00" level=debug msg="[DNS] openai.com --> [104.18.33.45 172.64.154.211] A from https://223.5.5.5:443/dns-query"
time="2025-12-12T00:33:16.948471400+08:00" level=debug msg="[DNS] resolve example.eu.org HTTPS from https://223.5.5.5:443/dns-query"
time="2025-12-12T00:33:16.948471400+08:00" level=debug msg="[DNS] resolve example.eu.org HTTPS from https://1.12.12.12:443/dns-query"
+time="2025-12-12T00:33:16.954842400+08:00" level=debug msg="[DNS] example.eu.org --> [alpn:h3,h2;pn:cloudflare-ech.com;ipv4hint;ipv6hint] HTTPS from https://223.5.5.5:443/dns-query"
time="2025-12-12T00:33:18.026054100+08:00" level=info msg="[TCP] 127.0.0.1:5289 --> byted.cc:443 match Match using OUT[SG1-openai]"
time="2025-12-12T00:33:25.253409000+08:00" level=debug msg="[Rule] use default rules"
time="2025-12-12T00:33:25.253409000+08:00" level=debug msg="[DNS] cache hit openai.com --> [] AAAA, expire at 2025-12-12 00:35:12"
time="2025-12-12T00:33:25.253409000+08:00" level=debug msg="[DNS] cache hit openai.com --> [104.18.33.45 172.64.154.211] A, expire at 2025-12-12 00:33:20"       
time="2025-12-12T00:33:25.253965300+08:00" level=debug msg="[DNS] resolve openai.com A from https://223.5.5.5:443/dns-query"
time="2025-12-12T00:33:25.253965300+08:00" level=debug msg="[DNS] resolve openai.com A from https://1.12.12.12:443/dns-query"
time="2025-12-12T00:33:25.261854100+08:00" level=debug msg="[DNS] openai.com --> [172.64.154.211 104.18.33.45] A from https://1.12.12.12:443/dns-query"
+time="2025-12-12T00:33:26.445743300+08:00" level=debug msg="[DNS] cache hit example.eu.org --> [alpn:h3,h2;pn:cloudflare-ech.com;ipv4hint;ipv6hint] HTTPS, expire at 2025-12-12 00:35:12"
time="2025-12-12T00:33:27.440355300+08:00" level=info msg="[TCP] 127.0.0.1:7968 --> byted.cc:443 match Match using OUT[SG1-openai]"
time="2025-12-12T00:33:35.123177200+08:00" level=warning msg="Mihomo shutting down"
```