### PR TITLE
Fix architecture check for riscv64 in script

### DIFF
--- a/docker/file-name.sh
+++ b/docker/file-name.sh
@@ -13,7 +13,7 @@ case $TARGETPLATFORM in
     "linux/arm/v7")
         arch="armv7"
         ;;
-    "riscv64")
+    "linux/riscv64")
         arch="riscv64"
         ;;
     *)


### PR DESCRIPTION
Fixes an incorrect TARGETPLATFORM match in `docker/file-name.sh`.

Docker BuildKit always sets `TARGETPLATFORM` to values like
`linux/amd64`, `linux/arm64`, or `linux/riscv64`.

The previous `riscv64` case would never be matched and would fall into
the `Unknown architecture` branch.