### PR TITLE
Fix typo in sniffer skip-dst-address config parsing

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1712,7 +1712,7 @@ func parseSniffer(snifferRaw RawSniffer, ruleProviders map[string]P.RuleProvider
 	}
 	snifferConfig.SkipSrcAddress = skipSrcAddress
 
-	skipDstAddress, err := parseIPCIDR(snifferRaw.SkipDstAddress, nil, "sniffer.skip-src-address", ruleProviders)
+	skipDstAddress, err := parseIPCIDR(snifferRaw.SkipDstAddress, nil, "sniffer.skip-dst-address", ruleProviders)
 	if err != nil {
 		return nil, fmt.Errorf("error in skip-dst-address, error:%w", err)
 	}


### PR DESCRIPTION
Corrects the argument name from 'sniffer.skip-src-address' to 'sniffer.skip-dst-address' in the parseIPCIDR call for SkipDstAddress, ensuring the correct configuration key is used.