### PR TITLE
fix: handle `geoip:lan` when GetRecodeSize()

### DIFF
--- a/rules/common/geoip.go
+++ b/rules/common/geoip.go
@@ -186,6 +186,11 @@ func (g *GEOIP) getIPMatcher() (router.IPMatcher, error) {
 }
 
 func (g *GEOIP) GetRecodeSize() int {
+	// skip pseudorule lan
+	if g.country == "lan" {
+		return 0
+	}
+
 	if matcher, err := g.GetIPMatcher(); err == nil {
 		return matcher.Count()
 	}


### PR DESCRIPTION
Currently when accessing `/rules` endpoint, `GetRecodeSize()` will be called on `lan` geoip rule, which will leave a warning in logs.

```
INFO[2025-12-23T17:44:25.043445417Z] Load GeoIP rule: lan                         
WARN[2025-12-23T17:44:25.502231761Z] Load GeoIP rule: lan
```

This pr fixes the issue.

Btw, is geoip:lan a recommended approach to handle private addresses or should users prefer to use geoip:private provided by geoip data?