### PR TITLE
chore: moving disabled and hit/miss counts data to `extra` for restful api

### DIFF
--- a/hub/route/rules.go
+++ b/hub/route/rules.go
@@ -27,12 +27,16 @@ type Rule struct {
 	Proxy   string `json:"proxy"`
 	Size    int    `json:"size"`
 
-	// from RuleWrapper
-	Disabled  bool      `json:"disabled,omitempty"`
-	HitCount  uint64    `json:"hitCount,omitempty"`
-	HitAt     time.Time `json:"hitAt,omitempty"`
-	MissCount uint64    `json:"missCount,omitempty"`
-	MissAt    time.Time `json:"missAt,omitempty"`
+	// Extra contains information from RuleWrapper
+	Extra *RuleExtra `json:"extra,omitempty"`
+}
+
+type RuleExtra struct {
+	Disabled  bool      `json:"disabled"`
+	HitCount  uint64    `json:"hitCount"`
+	HitAt     time.Time `json:"hitAt"`
+	MissCount uint64    `json:"missCount"`
+	MissAt    time.Time `json:"missAt"`
 }
 
 func getRules(w http.ResponseWriter, r *http.Request) {
@@ -47,11 +51,13 @@ func getRules(w http.ResponseWriter, r *http.Request) {
 			Size:    -1,
 		}
 		if ruleWrapper, ok := rule.(constant.RuleWrapper); ok {
-			r.Disabled = ruleWrapper.IsDisabled()
-			r.HitCount = ruleWrapper.HitCount()
-			r.HitAt = ruleWrapper.HitAt()
-			r.MissCount = ruleWrapper.MissCount()
-			r.MissAt = ruleWrapper.MissAt()
+			r.Extra = &RuleExtra{
+				Disabled:  ruleWrapper.IsDisabled(),
+				HitCount:  ruleWrapper.HitCount(),
+				HitAt:     ruleWrapper.HitAt(),
+				MissCount: ruleWrapper.MissCount(),
+				MissAt:    ruleWrapper.MissAt(),
+			}
 			rule = ruleWrapper.Unwrap() // unwrap RuleWrapper
 		}
 		if rule.RuleType() == constant.GEOIP || rule.RuleType() == constant.GEOSITE {


### PR DESCRIPTION
防止 RuleWrapper 的 disabled / hitCount 零值被序列化忽略