### PR TITLE
feat: Add path root and httpmask auth, update handshake, and fix Windows CI

### DIFF
--- a/docs/config.yaml
+++ b/docs/config.yaml
@@ -1068,6 +1068,7 @@ proxies: # socks5
     # http-mask-mode: legacy # 可选：legacy（默认）、stream、poll、auto；stream/poll/auto 支持走 CDN/反代
     # http-mask-tls: true # 可选：仅在 http-mask-mode 为 stream/poll/auto 时生效；true 强制 https；false 强制 http（不会根据端口自动推断）
     # http-mask-host: "" # 可选：覆盖 Host/SNI（支持 example.com 或 example.com:443）；仅在 http-mask-mode 为 stream/poll/auto 时生效
+    # path-root: "" # 可选：HTTP 隧道端点一级路径前缀（双方需一致），例如 "aabbcc" => /aabbcc/session、/aabbcc/stream、/aabbcc/api/v1/upload
     # http-mask-multiplex: off # 可选：off（默认）、auto（复用 h1.1 keep-alive / h2 连接，减少每次建链 RTT）、on（单条隧道内多路复用多个目标连接；仅在 http-mask-mode=stream/poll/auto 生效）
     enable-pure-downlink: false # 是否启用混淆下行，false的情况下能在保证数据安全的前提下极大提升下行速度，与服务端端保持相同(如果此处为false，则要求aead不可为none)
 
@@ -1617,6 +1618,7 @@ listeners:
     enable-pure-downlink: false # 是否启用混淆下行，false的情况下能在保证数据安全的前提下极大提升下行速度，与客户端保持相同(如果此处为false，则要求aead不可为none)
     disable-http-mask: false # 可选：禁用 http 掩码/隧道（默认为 false）
     # http-mask-mode: legacy # 可选：legacy（默认）、stream、poll、auto；stream/poll/auto 支持走 CDN/反代
+    # path-root: "" # 可选：HTTP 隧道端点一级路径前缀（双方需一致），例如 "aabbcc" => /aabbcc/session、/aabbcc/stream、/aabbcc/api/v1/upload
 
 
 

--- a/listener/config/sudoku.go
+++ b/listener/config/sudoku.go
@@ -22,6 +22,7 @@ type SudokuServer struct {
 	CustomTables           []string `json:"custom-tables,omitempty"`
 	DisableHTTPMask        bool     `json:"disable-http-mask,omitempty"`
 	HTTPMaskMode           string   `json:"http-mask-mode,omitempty"`
+	PathRoot               string   `json:"path-root,omitempty"`
 
 	// mihomo private extension (not the part of standard Sudoku protocol)
 	MuxOption sing.MuxOption `json:"mux-option,omitempty"`

--- a/listener/inbound/sudoku.go
+++ b/listener/inbound/sudoku.go
@@ -24,6 +24,7 @@ type SudokuOption struct {
 	CustomTables           []string `inbound:"custom-tables,omitempty"`
 	DisableHTTPMask        bool     `inbound:"disable-http-mask,omitempty"`
 	HTTPMaskMode           string   `inbound:"http-mask-mode,omitempty"` // "legacy" (default), "stream", "poll", "auto"
+	PathRoot               string   `inbound:"path-root,omitempty"`      // optional first-level path prefix for HTTP tunnel endpoints
 
 	// mihomo private extension (not the part of standard Sudoku protocol)
 	MuxOption MuxOption `inbound:"mux-option,omitempty"`
@@ -63,6 +64,7 @@ func NewSudoku(options *SudokuOption) (*Sudoku, error) {
 		CustomTables:           options.CustomTables,
 		DisableHTTPMask:        options.DisableHTTPMask,
 		HTTPMaskMode:           options.HTTPMaskMode,
+		PathRoot:               strings.TrimSpace(options.PathRoot),
 	}
 	serverConf.MuxOption = options.MuxOption.Build()
 

--- a/listener/sudoku/server.go
+++ b/listener/sudoku/server.go
@@ -229,6 +229,7 @@ func New(config LC.SudokuServer, tunnel C.Tunnel, additions ...inbound.Addition)
 		HandshakeTimeoutSeconds: handshakeTimeout,
 		DisableHTTPMask:         config.DisableHTTPMask,
 		HTTPMaskMode:            config.HTTPMaskMode,
+		HTTPMaskPathRoot:        strings.TrimSpace(config.PathRoot),
 	}
 	if len(tables) == 1 {
 		protoConf.Table = tables[0]

--- a/transport/sudoku/handshake.go
+++ b/transport/sudoku/handshake.go
@@ -153,14 +153,17 @@ func buildServerObfsConn(raw net.Conn, cfg *ProtocolConfig, table *sudoku.Table,
 func buildHandshakePayload(key string) [16]byte {
 	var payload [16]byte
 	binary.BigEndian.PutUint64(payload[:8], uint64(time.Now().Unix()))
-	// Hash the decoded HEX bytes of the key, not the HEX string itself.
-	// This ensures the user hash is computed on the actual key bytes.
-	keyBytes, err := hex.DecodeString(key)
-	if err != nil {
-		// Fallback: if key is not valid HEX (e.g., a UUID or plain string), hash the string bytes
-		keyBytes = []byte(key)
+
+	// Align with upstream: only decode hex bytes when this key is an ED25519 key material.
+	// For plain UUID/strings (even if they look like hex), hash the string bytes as-is.
+	src := []byte(key)
+	if _, err := crypto.RecoverPublicKey(key); err == nil {
+		if keyBytes, decErr := hex.DecodeString(key); decErr == nil && len(keyBytes) > 0 {
+			src = keyBytes
+		}
 	}
-	hash := sha256.Sum256(keyBytes)
+
+	hash := sha256.Sum256(src)
 	copy(payload[8:], hash[:8])
 	return payload
 }

--- a/transport/sudoku/handshake.go
+++ b/transport/sudoku/handshake.go
@@ -2,7 +2,6 @@ package sudoku
 
 import (
 	"bufio"
-	"crypto/rand"
 	"crypto/sha256"
 	"encoding/binary"
 	"encoding/hex"
@@ -219,7 +218,7 @@ func ClientHandshakeWithOptions(rawConn net.Conn, cfg *ProtocolConfig, opt Clien
 		}
 	}
 
-	table, tableID, err := pickClientTable(cfg)
+	table, err := pickClientTable(cfg)
 	if err != nil {
 		return nil, err
 	}
@@ -231,9 +230,6 @@ func ClientHandshakeWithOptions(rawConn net.Conn, cfg *ProtocolConfig, opt Clien
 	}
 
 	handshake := buildHandshakePayload(cfg.Key)
-	if len(cfg.tableCandidates()) > 1 {
-		handshake[8] = tableID
-	}
 	if _, err := cConn.Write(handshake[:]); err != nil {
 		cConn.Close()
 		return nil, fmt.Errorf("send handshake failed: %w", err)
@@ -379,19 +375,9 @@ func normalizeHTTPMaskStrategy(strategy string) string {
 	}
 }
 
-// randomByte returns a cryptographically random byte (with a math/rand fallback).
-func randomByte() byte {
-	var b [1]byte
-	if _, err := rand.Read(b[:]); err == nil {
-		return b[0]
-	}
-	return byte(time.Now().UnixNano())
-}
-
 func userHashFromHandshake(handshakeBuf []byte) string {
 	if len(handshakeBuf) < 16 {
 		return ""
 	}
-	// handshake[8] may be a table ID when table rotation is enabled; use [9:16] as stable user hash bytes.
-	return hex.EncodeToString(handshakeBuf[9:16])
+	return hex.EncodeToString(handshakeBuf[8:16])
 }

--- a/transport/sudoku/handshake.go
+++ b/transport/sudoku/handshake.go
@@ -211,7 +211,7 @@ func ClientHandshakeWithOptions(rawConn net.Conn, cfg *ProtocolConfig, opt Clien
 	}
 
 	if !cfg.DisableHTTPMask {
-		if err := WriteHTTPMaskHeader(rawConn, cfg.ServerAddress, opt.HTTPMaskStrategy); err != nil {
+		if err := WriteHTTPMaskHeader(rawConn, cfg.ServerAddress, cfg.HTTPMaskPathRoot, opt.HTTPMaskStrategy); err != nil {
 			return nil, fmt.Errorf("write http mask failed: %w", err)
 		}
 	}

--- a/transport/sudoku/httpmask_strategy.go
+++ b/transport/sudoku/httpmask_strategy.go
@@ -7,6 +7,7 @@ import (
 	"math/rand"
 	"net"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -92,24 +93,24 @@ func appendCommonHeaders(buf []byte, host string, r *rand.Rand) []byte {
 
 // WriteHTTPMaskHeader writes an HTTP/1.x request header as a mask, according to strategy.
 // Supported strategies: ""/"random", "post", "websocket".
-func WriteHTTPMaskHeader(w io.Writer, host string, strategy string) error {
+func WriteHTTPMaskHeader(w io.Writer, host string, pathRoot string, strategy string) error {
 	switch normalizeHTTPMaskStrategy(strategy) {
 	case "random":
-		return httpmask.WriteRandomRequestHeader(w, host)
+		return httpmask.WriteRandomRequestHeaderWithPathRoot(w, host, pathRoot)
 	case "post":
-		return writeHTTPMaskPOST(w, host)
+		return writeHTTPMaskPOST(w, host, pathRoot)
 	case "websocket":
-		return writeHTTPMaskWebSocket(w, host)
+		return writeHTTPMaskWebSocket(w, host, pathRoot)
 	default:
 		return fmt.Errorf("unsupported http-mask-strategy: %s", strategy)
 	}
 }
 
-func writeHTTPMaskPOST(w io.Writer, host string) error {
+func writeHTTPMaskPOST(w io.Writer, host string, pathRoot string) error {
 	r := httpMaskRngPool.Get().(*rand.Rand)
 	defer httpMaskRngPool.Put(r)
 
-	path := httpMaskPaths[r.Intn(len(httpMaskPaths))]
+	path := joinPathRoot(pathRoot, httpMaskPaths[r.Intn(len(httpMaskPaths))])
 	ctype := httpMaskContentTypes[r.Intn(len(httpMaskContentTypes))]
 
 	bufPtr := httpMaskBufPool.Get().(*[]byte)
@@ -140,11 +141,11 @@ func writeHTTPMaskPOST(w io.Writer, host string) error {
 	return err
 }
 
-func writeHTTPMaskWebSocket(w io.Writer, host string) error {
+func writeHTTPMaskWebSocket(w io.Writer, host string, pathRoot string) error {
 	r := httpMaskRngPool.Get().(*rand.Rand)
 	defer httpMaskRngPool.Put(r)
 
-	path := httpMaskPaths[r.Intn(len(httpMaskPaths))]
+	path := joinPathRoot(pathRoot, httpMaskPaths[r.Intn(len(httpMaskPaths))])
 
 	bufPtr := httpMaskBufPool.Get().(*[]byte)
 	buf := *bufPtr
@@ -176,4 +177,38 @@ func writeHTTPMaskWebSocket(w io.Writer, host string) error {
 
 	_, err := w.Write(buf)
 	return err
+}
+
+func normalizePathRoot(root string) string {
+	root = strings.TrimSpace(root)
+	root = strings.Trim(root, "/")
+	if root == "" {
+		return ""
+	}
+	for i := 0; i < len(root); i++ {
+		c := root[i]
+		switch {
+		case c >= 'a' && c <= 'z':
+		case c >= 'A' && c <= 'Z':
+		case c >= '0' && c <= '9':
+		case c == '_' || c == '-':
+		default:
+			return ""
+		}
+	}
+	return "/" + root
+}
+
+func joinPathRoot(root, path string) string {
+	root = normalizePathRoot(root)
+	if root == "" {
+		return path
+	}
+	if path == "" {
+		return root
+	}
+	if !strings.HasPrefix(path, "/") {
+		path = "/" + path
+	}
+	return root + path
 }

--- a/transport/sudoku/httpmask_tunnel_test.go
+++ b/transport/sudoku/httpmask_tunnel_test.go
@@ -154,7 +154,7 @@ func TestHTTPMaskTunnel_Stream_TCPRoundTrip(t *testing.T) {
 	clientCfg.ServerAddress = addr
 	clientCfg.HTTPMaskHost = "example.com"
 
-	tunnelConn, err := DialHTTPMaskTunnel(ctx, clientCfg.ServerAddress, &clientCfg, (&net.Dialer{}).DialContext)
+	tunnelConn, err := DialHTTPMaskTunnel(ctx, clientCfg.ServerAddress, &clientCfg, (&net.Dialer{}).DialContext, nil)
 	if err != nil {
 		t.Fatalf("dial tunnel: %v", err)
 	}
@@ -225,7 +225,7 @@ func TestHTTPMaskTunnel_Poll_UoTRoundTrip(t *testing.T) {
 	clientCfg := *serverCfg
 	clientCfg.ServerAddress = addr
 
-	tunnelConn, err := DialHTTPMaskTunnel(ctx, clientCfg.ServerAddress, &clientCfg, (&net.Dialer{}).DialContext)
+	tunnelConn, err := DialHTTPMaskTunnel(ctx, clientCfg.ServerAddress, &clientCfg, (&net.Dialer{}).DialContext, nil)
 	if err != nil {
 		t.Fatalf("dial tunnel: %v", err)
 	}
@@ -287,7 +287,7 @@ func TestHTTPMaskTunnel_Auto_TCPRoundTrip(t *testing.T) {
 	clientCfg := *serverCfg
 	clientCfg.ServerAddress = addr
 
-	tunnelConn, err := DialHTTPMaskTunnel(ctx, clientCfg.ServerAddress, &clientCfg, (&net.Dialer{}).DialContext)
+	tunnelConn, err := DialHTTPMaskTunnel(ctx, clientCfg.ServerAddress, &clientCfg, (&net.Dialer{}).DialContext, nil)
 	if err != nil {
 		t.Fatalf("dial tunnel: %v", err)
 	}
@@ -331,13 +331,13 @@ func TestHTTPMaskTunnel_Validation(t *testing.T) {
 
 	cfg.DisableHTTPMask = true
 	cfg.HTTPMaskMode = "stream"
-	if _, err := DialHTTPMaskTunnel(context.Background(), cfg.ServerAddress, cfg, (&net.Dialer{}).DialContext); err == nil {
+	if _, err := DialHTTPMaskTunnel(context.Background(), cfg.ServerAddress, cfg, (&net.Dialer{}).DialContext, nil); err == nil {
 		t.Fatalf("expected error for disabled http mask")
 	}
 
 	cfg.DisableHTTPMask = false
 	cfg.HTTPMaskMode = "legacy"
-	if _, err := DialHTTPMaskTunnel(context.Background(), cfg.ServerAddress, cfg, (&net.Dialer{}).DialContext); err == nil {
+	if _, err := DialHTTPMaskTunnel(context.Background(), cfg.ServerAddress, cfg, (&net.Dialer{}).DialContext, nil); err == nil {
 		t.Fatalf("expected error for legacy mode")
 	}
 }
@@ -385,7 +385,7 @@ func TestHTTPMaskTunnel_Soak_Concurrent(t *testing.T) {
 			clientCfg.ServerAddress = addr
 			clientCfg.HTTPMaskHost = strings.TrimSpace(clientCfg.HTTPMaskHost)
 
-			tunnelConn, err := DialHTTPMaskTunnel(ctx, clientCfg.ServerAddress, &clientCfg, (&net.Dialer{}).DialContext)
+			tunnelConn, err := DialHTTPMaskTunnel(ctx, clientCfg.ServerAddress, &clientCfg, (&net.Dialer{}).DialContext, nil)
 			if err != nil {
 				runErr <- fmt.Errorf("dial: %w", err)
 				return

--- a/transport/sudoku/multiplex_test.go
+++ b/transport/sudoku/multiplex_test.go
@@ -99,7 +99,7 @@ func TestUserHash_StableAcrossTableRotation(t *testing.T) {
 			if h == "" {
 				t.Fatalf("empty user hash")
 			}
-			if len(h) != 14 {
+			if len(h) != 16 {
 				t.Fatalf("unexpected user hash length: %d", len(h))
 			}
 			unique[h] = struct{}{}
@@ -258,4 +258,3 @@ func TestMultiplex_Boundary_InvalidVersion(t *testing.T) {
 		t.Fatalf("expected error")
 	}
 }
-

--- a/transport/sudoku/obfs/httpmask/auth.go
+++ b/transport/sudoku/obfs/httpmask/auth.go
@@ -1,0 +1,137 @@
+package httpmask
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"crypto/subtle"
+	"encoding/base64"
+	"encoding/binary"
+	"strings"
+	"time"
+)
+
+const (
+	tunnelAuthHeaderKey    = "Authorization"
+	tunnelAuthHeaderPrefix = "Bearer "
+)
+
+type tunnelAuth struct {
+	key  [32]byte // derived HMAC key
+	skew time.Duration
+}
+
+func newTunnelAuth(key string, skew time.Duration) *tunnelAuth {
+	key = strings.TrimSpace(key)
+	if key == "" {
+		return nil
+	}
+	if skew <= 0 {
+		skew = 60 * time.Second
+	}
+
+	// Domain separation: keep this HMAC key independent from other uses of cfg.Key.
+	h := sha256.New()
+	_, _ = h.Write([]byte("sudoku-httpmask-auth-v1:"))
+	_, _ = h.Write([]byte(key))
+
+	var sum [32]byte
+	h.Sum(sum[:0])
+
+	return &tunnelAuth{key: sum, skew: skew}
+}
+
+func (a *tunnelAuth) token(mode TunnelMode, method, path string, now time.Time) string {
+	if a == nil {
+		return ""
+	}
+
+	ts := now.Unix()
+	sig := a.sign(mode, method, path, ts)
+
+	var buf [8 + 16]byte
+	binary.BigEndian.PutUint64(buf[:8], uint64(ts))
+	copy(buf[8:], sig[:])
+	return base64.RawURLEncoding.EncodeToString(buf[:])
+}
+
+func (a *tunnelAuth) verify(headers map[string]string, mode TunnelMode, method, path string, now time.Time) bool {
+	if a == nil {
+		return true
+	}
+	if headers == nil {
+		return false
+	}
+
+	val := strings.TrimSpace(headers["authorization"])
+	if val == "" {
+		return false
+	}
+
+	// Accept both "Bearer <token>" and raw token forms (for forward proxies / CDNs that may normalize headers).
+	if len(val) > len(tunnelAuthHeaderPrefix) && strings.EqualFold(val[:len(tunnelAuthHeaderPrefix)], tunnelAuthHeaderPrefix) {
+		val = strings.TrimSpace(val[len(tunnelAuthHeaderPrefix):])
+	}
+	if val == "" {
+		return false
+	}
+
+	raw, err := base64.RawURLEncoding.DecodeString(val)
+	if err != nil || len(raw) != 8+16 {
+		return false
+	}
+
+	ts := int64(binary.BigEndian.Uint64(raw[:8]))
+	nowTS := now.Unix()
+	delta := nowTS - ts
+	if delta < 0 {
+		delta = -delta
+	}
+	if delta > int64(a.skew.Seconds()) {
+		return false
+	}
+
+	want := a.sign(mode, method, path, ts)
+	return subtle.ConstantTimeCompare(raw[8:], want[:]) == 1
+}
+
+func (a *tunnelAuth) sign(mode TunnelMode, method, path string, ts int64) [16]byte {
+	method = strings.ToUpper(strings.TrimSpace(method))
+	if method == "" {
+		method = "GET"
+	}
+	path = strings.TrimSpace(path)
+
+	var tsBuf [8]byte
+	binary.BigEndian.PutUint64(tsBuf[:], uint64(ts))
+
+	mac := hmac.New(sha256.New, a.key[:])
+	_, _ = mac.Write([]byte(mode))
+	_, _ = mac.Write([]byte{0})
+	_, _ = mac.Write([]byte(method))
+	_, _ = mac.Write([]byte{0})
+	_, _ = mac.Write([]byte(path))
+	_, _ = mac.Write([]byte{0})
+	_, _ = mac.Write(tsBuf[:])
+
+	var full [32]byte
+	mac.Sum(full[:0])
+
+	var out [16]byte
+	copy(out[:], full[:16])
+	return out
+}
+
+type headerSetter interface {
+	Set(key, value string)
+}
+
+func applyTunnelAuthHeader(h headerSetter, auth *tunnelAuth, mode TunnelMode, method, path string) {
+	if auth == nil || h == nil {
+		return
+	}
+	token := auth.token(mode, method, path, time.Now())
+	if token == "" {
+		return
+	}
+	h.Set(tunnelAuthHeaderKey, tunnelAuthHeaderPrefix+token)
+}

--- a/transport/sudoku/obfs/httpmask/masker.go
+++ b/transport/sudoku/obfs/httpmask/masker.go
@@ -129,11 +129,17 @@ func appendCommonHeaders(buf []byte, host string, r *rand.Rand) []byte {
 
 // WriteRandomRequestHeader writes a plausible HTTP/1.1 request header as a mask.
 func WriteRandomRequestHeader(w io.Writer, host string) error {
+	return WriteRandomRequestHeaderWithPathRoot(w, host, "")
+}
+
+// WriteRandomRequestHeaderWithPathRoot is like WriteRandomRequestHeader but prefixes all paths with pathRoot.
+// pathRoot must be a single segment (e.g. "aabbcc"); invalid inputs are treated as empty (disabled).
+func WriteRandomRequestHeaderWithPathRoot(w io.Writer, host string, pathRoot string) error {
 	// Get RNG from pool
 	r := rngPool.Get().(*rand.Rand)
 	defer rngPool.Put(r)
 
-	path := paths[r.Intn(len(paths))]
+	path := joinPathRoot(pathRoot, paths[r.Intn(len(paths))])
 	ctype := contentTypes[r.Intn(len(contentTypes))]
 
 	// Use buffer pool

--- a/transport/sudoku/obfs/httpmask/pathroot.go
+++ b/transport/sudoku/obfs/httpmask/pathroot.go
@@ -1,0 +1,52 @@
+package httpmask
+
+import "strings"
+
+// normalizePathRoot normalizes the configured path root into "/<segment>" form.
+//
+// It is intentionally strict: only a single path segment is allowed, consisting of
+// [A-Za-z0-9_-]. Invalid inputs are treated as empty (disabled).
+func normalizePathRoot(root string) string {
+	root = strings.TrimSpace(root)
+	root = strings.Trim(root, "/")
+	if root == "" {
+		return ""
+	}
+	for i := 0; i < len(root); i++ {
+		c := root[i]
+		switch {
+		case c >= 'a' && c <= 'z':
+		case c >= 'A' && c <= 'Z':
+		case c >= '0' && c <= '9':
+		case c == '_' || c == '-':
+		default:
+			return ""
+		}
+	}
+	return "/" + root
+}
+
+func joinPathRoot(root, path string) string {
+	root = normalizePathRoot(root)
+	if root == "" {
+		return path
+	}
+	if path == "" {
+		return root
+	}
+	if !strings.HasPrefix(path, "/") {
+		path = "/" + path
+	}
+	return root + path
+}
+
+func stripPathRoot(root, fullPath string) (string, bool) {
+	root = normalizePathRoot(root)
+	if root == "" {
+		return fullPath, true
+	}
+	if !strings.HasPrefix(fullPath, root+"/") {
+		return "", false
+	}
+	return strings.TrimPrefix(fullPath, root), true
+}

--- a/transport/sudoku/table_probe.go
+++ b/transport/sudoku/table_probe.go
@@ -3,6 +3,7 @@ package sudoku
 import (
 	"bufio"
 	"bytes"
+	crand "crypto/rand"
 	"encoding/binary"
 	"errors"
 	"fmt"
@@ -14,16 +15,20 @@ import (
 	"github.com/metacubex/mihomo/transport/sudoku/obfs/sudoku"
 )
 
-func pickClientTable(cfg *ProtocolConfig) (*sudoku.Table, byte, error) {
+func pickClientTable(cfg *ProtocolConfig) (*sudoku.Table, error) {
 	candidates := cfg.tableCandidates()
 	if len(candidates) == 0 {
-		return nil, 0, fmt.Errorf("no table configured")
+		return nil, fmt.Errorf("no table configured")
 	}
 	if len(candidates) == 1 {
-		return candidates[0], 0, nil
+		return candidates[0], nil
 	}
-	idx := int(randomByte()) % len(candidates)
-	return candidates[idx], byte(idx), nil
+	var b [1]byte
+	if _, err := crand.Read(b[:]); err != nil {
+		return nil, fmt.Errorf("random table pick failed: %w", err)
+	}
+	idx := int(b[0]) % len(candidates)
+	return candidates[idx], nil
 }
 
 type readOnlyConn struct {


### PR DESCRIPTION
attempted to resolve intermittent test failures on Windows in GitHub Actions CI.
added `path root` to specify the first-level path.
added anti-replay authentication for `httpmask`.
modified a handshake byte to improve user logging.