### PR TITLE
feat: gRPC协议添加自定义UserAgent #2506

### DIFF
--- a/adapter/outbound/trojan.go
+++ b/adapter/outbound/trojan.go
@@ -356,6 +356,7 @@ func NewTrojan(option TrojanOption) (*Trojan, error) {
 		t.gunTLSConfig = tlsConfig
 		t.gunConfig = &gun.Config{
 			ServiceName:       option.GrpcOpts.GrpcServiceName,
+			UserAgent:         option.GrpcOpts.GrpcUserAgent,
 			Host:              option.SNI,
 			ClientFingerprint: option.ClientFingerprint,
 		}

--- a/adapter/outbound/vless.go
+++ b/adapter/outbound/vless.go
@@ -462,6 +462,7 @@ func NewVless(option VlessOption) (*Vless, error) {
 
 		gunConfig := &gun.Config{
 			ServiceName:       v.option.GrpcOpts.GrpcServiceName,
+			UserAgent:         v.option.GrpcOpts.GrpcUserAgent,
 			Host:              v.option.ServerName,
 			ClientFingerprint: v.option.ClientFingerprint,
 		}

--- a/adapter/outbound/vmess.go
+++ b/adapter/outbound/vmess.go
@@ -86,6 +86,7 @@ type HTTP2Options struct {
 
 type GrpcOptions struct {
 	GrpcServiceName string `proxy:"grpc-service-name,omitempty"`
+	GrpcUserAgent   string `proxy:"grpc-user-agent,omitempty"`
 }
 
 type WSOptions struct {
@@ -467,6 +468,7 @@ func NewVmess(option VmessOption) (*Vmess, error) {
 
 		gunConfig := &gun.Config{
 			ServiceName:       v.option.GrpcOpts.GrpcServiceName,
+			UserAgent:         v.option.GrpcOpts.GrpcUserAgent,
 			Host:              v.option.ServerName,
 			ClientFingerprint: v.option.ClientFingerprint,
 		}

--- a/docs/config.yaml
+++ b/docs/config.yaml
@@ -669,6 +669,7 @@ proxies: # socks5
     # skip-cert-verify: true
     grpc-opts:
       grpc-service-name: "example"
+      # grpc-user-agent: "grpc-go/1.36.0"
     # ip-version: ipv4
 
   # vless
@@ -757,6 +758,8 @@ proxies: # socks5
     servername: testingcf.jsdelivr.net
     grpc-opts:
       grpc-service-name: "grpc"
+      # grpc-user-agent: "grpc-go/1.36.0"
+      
     reality-opts:
       public-key: CrrQSjAG_YkHLwvM2M-7XkKJilgL5upBKCp0od0tLhE
       short-id: 10f897e26c4b9478
@@ -825,6 +828,7 @@ proxies: # socks5
     udp: true
     grpc-opts:
       grpc-service-name: "example"
+      # grpc-user-agent: "grpc-go/1.36.0"
 
   - name: trojan-ws
     server: server

--- a/transport/gun/gun.go
+++ b/transport/gun/gun.go
@@ -60,6 +60,7 @@ type Conn struct {
 
 type Config struct {
 	ServiceName       string
+	UserAgent         string
 	Host              string
 	ClientFingerprint string
 }
@@ -347,6 +348,12 @@ func StreamGunWithTransport(transport *TransportWrap, cfg *Config) (net.Conn, er
 	path := ServiceNameToPath(serviceName)
 
 	reader, writer := io.Pipe()
+
+	header := defaultHeader.Clone()
+	if cfg.UserAgent != "" {
+		header["user-agent"] = []string{cfg.UserAgent}
+	}
+
 	request := &http.Request{
 		Method: http.MethodPost,
 		Body:   reader,
@@ -360,7 +367,7 @@ func StreamGunWithTransport(transport *TransportWrap, cfg *Config) (net.Conn, er
 		Proto:      "HTTP/2",
 		ProtoMajor: 2,
 		ProtoMinor: 0,
-		Header:     defaultHeader,
+		Header:     header,
 	}
 	request = request.WithContext(transport.ctx)
 


### PR DESCRIPTION
## 修改内容：
add grpc-user-agent to grpc-opts

## 原因
默认 **UserAgent: grpc-go/1.36.0** 易触发 Cloudflare CDN 风控

## 现象
同一个的xray server，通过xray client可以访问，mihomo无法访问

## 排查
1. 在 Cloudflare 的后台发现大量请求因 HTTP DDos被拦截
2. 在xray-core的issue中发现相关讨论：https://github.com/XTLS/Xray-core/pull/1790

## 复现
### xray-core
1. 在 xray client的配置文件中，设置 chrome ua，请求不被 Cloudflare 拦截
2. 在 xray client的配置文件中，不设置 chrome ua，请求被 Cloudflare 拦截
### mihomo
1. 不设置 UA，请求被 Cloudflare 拦截
2. 合入patch，设置 chrome ua，请求不被 Cloudflare 拦截