### PR TITLE
feat: make HttpRequest return more accurate error

### DIFF
--- a/common/net/sing.go
+++ b/common/net/sing.go
@@ -66,7 +66,7 @@ func closeWrite(writer io.Closer) error {
 
 // Relay copies between left and right bidirectionally.
 // like [bufio.CopyConn] but remove unneeded [context.Context] handle and the cost of [task.Group]
-func Relay(leftConn, rightConn net.Conn) {
+func Relay(leftConn, rightConn net.Conn, onError func(err error)) {
 	defer func() {
 		_ = leftConn.Close()
 		_ = rightConn.Close()
@@ -78,6 +78,9 @@ func Relay(leftConn, rightConn net.Conn) {
 		if err == nil {
 			_ = closeWrite(leftConn)
 		} else {
+			if onError != nil {
+				onError(err)
+			}
 			_ = leftConn.Close()
 		}
 		close(ch)
@@ -87,6 +90,9 @@ func Relay(leftConn, rightConn net.Conn) {
 	if err == nil {
 		_ = closeWrite(rightConn)
 	} else {
+		if onError != nil {
+			onError(err)
+		}
 		_ = rightConn.Close()
 	}
 	<-ch

--- a/component/http/http.go
+++ b/component/http/http.go
@@ -74,7 +74,7 @@ func HttpRequest(ctx context.Context, url, method string, header map[string][]st
 		TLSHandshakeTimeout:   10 * time.Second,
 		ExpectContinueTimeout: 1 * time.Second,
 		DialContext: func(ctx context.Context, network, address string) (net.Conn, error) {
-			if conn, err := inner.HandleTcp(inner.GetTunnel(), address, opt.specialProxy); err == nil {
+			if conn, err := inner.HandleTcp(inner.GetTunnel(), address, opt.specialProxy, true); err == nil {
 				return conn, nil
 			} else {
 				return dialer.DialContext(ctx, network, address)

--- a/constant/tunnel.go
+++ b/constant/tunnel.go
@@ -6,7 +6,7 @@ type Tunnel interface {
 	// HandleTCPConn will handle a tcp connection blocking
 	HandleTCPConn(conn net.Conn, metadata *Metadata)
 	// HandleTCPConnWithError will handle a tcp connection blocking, and return a more accurate error.
-	HandleTCPConnWithError(conn net.Conn, metadata *Metadata) error
+	HandleTCPConnWithError(conn net.Conn, metadata *Metadata, closeBeforeReturn bool) error
 	// HandleUDPPacket will handle a udp packet nonblocking
 	HandleUDPPacket(packet UDPPacket, metadata *Metadata)
 	// NatTable return nat table

--- a/constant/tunnel.go
+++ b/constant/tunnel.go
@@ -5,6 +5,8 @@ import "net"
 type Tunnel interface {
 	// HandleTCPConn will handle a tcp connection blocking
 	HandleTCPConn(conn net.Conn, metadata *Metadata)
+	// HandleTCPConnWithError will handle a tcp connection blocking, and return a more accurate error.
+	HandleTCPConnWithError(conn net.Conn, metadata *Metadata) error
 	// HandleUDPPacket will handle a udp packet nonblocking
 	HandleUDPPacket(packet UDPPacket, metadata *Metadata)
 	// NatTable return nat table

--- a/listener/http/upgrade.go
+++ b/listener/http/upgrade.go
@@ -85,6 +85,6 @@ func handleUpgrade(conn net.Conn, request *http.Request, tunnel C.Tunnel, additi
 	}
 
 	if resp.StatusCode == http.StatusSwitchingProtocols {
-		N.Relay(bufferedLeft, conn)
+		N.Relay(bufferedLeft, conn, nil)
 	}
 }

--- a/listener/inbound/common_test.go
+++ b/listener/inbound/common_test.go
@@ -57,17 +57,26 @@ func init() {
 }
 
 type TestTunnel struct {
-	HandleTCPConnFn    func(conn net.Conn, metadata *C.Metadata)
-	HandleUDPPacketFn  func(packet C.UDPPacket, metadata *C.Metadata)
-	NatTableFn         func() C.NatTable
-	CloseFn            func() error
-	DoTestFn           func(t *testing.T, proxy C.ProxyAdapter)
-	DoSequentialTestFn func(t *testing.T, proxy C.ProxyAdapter)
-	DoConcurrentTestFn func(t *testing.T, proxy C.ProxyAdapter)
+	HandleTCPConnFn          func(conn net.Conn, metadata *C.Metadata)
+	HandleTCPConnWithErrorFn func(conn net.Conn, metadata *C.Metadata) error
+	HandleUDPPacketFn        func(packet C.UDPPacket, metadata *C.Metadata)
+	NatTableFn               func() C.NatTable
+	CloseFn                  func() error
+	DoTestFn                 func(t *testing.T, proxy C.ProxyAdapter)
+	DoSequentialTestFn       func(t *testing.T, proxy C.ProxyAdapter)
+	DoConcurrentTestFn       func(t *testing.T, proxy C.ProxyAdapter)
 }
 
 func (tt *TestTunnel) HandleTCPConn(conn net.Conn, metadata *C.Metadata) {
 	tt.HandleTCPConnFn(conn, metadata)
+}
+
+func (tt *TestTunnel) HandleTCPConnWithError(conn net.Conn, metadata *C.Metadata) error {
+	if tt.HandleTCPConnWithErrorFn != nil {
+		return tt.HandleTCPConnWithErrorFn(conn, metadata)
+	}
+	tt.HandleTCPConn(conn, metadata)
+	return nil
 }
 
 func (tt *TestTunnel) HandleUDPPacket(packet C.UDPPacket, metadata *C.Metadata) {

--- a/listener/inbound/common_test.go
+++ b/listener/inbound/common_test.go
@@ -276,7 +276,7 @@ func NewHttpTestTunnel() *TestTunnel {
 						if err != nil {
 							panic(err)
 						}
-						N.Relay(rconn, conn)
+						N.Relay(rconn, conn, nil)
 						return
 					}
 				}

--- a/listener/inbound/common_test.go
+++ b/listener/inbound/common_test.go
@@ -58,7 +58,7 @@ func init() {
 
 type TestTunnel struct {
 	HandleTCPConnFn          func(conn net.Conn, metadata *C.Metadata)
-	HandleTCPConnWithErrorFn func(conn net.Conn, metadata *C.Metadata) error
+	HandleTCPConnWithErrorFn func(conn net.Conn, metadata *C.Metadata, closeBeforeReturn bool) error
 	HandleUDPPacketFn        func(packet C.UDPPacket, metadata *C.Metadata)
 	NatTableFn               func() C.NatTable
 	CloseFn                  func() error
@@ -71,9 +71,9 @@ func (tt *TestTunnel) HandleTCPConn(conn net.Conn, metadata *C.Metadata) {
 	tt.HandleTCPConnFn(conn, metadata)
 }
 
-func (tt *TestTunnel) HandleTCPConnWithError(conn net.Conn, metadata *C.Metadata) error {
+func (tt *TestTunnel) HandleTCPConnWithError(conn net.Conn, metadata *C.Metadata, closeBeforeReturn bool) error {
 	if tt.HandleTCPConnWithErrorFn != nil {
-		return tt.HandleTCPConnWithErrorFn(conn, metadata)
+		return tt.HandleTCPConnWithErrorFn(conn, metadata, closeBeforeReturn)
 	}
 	tt.HandleTCPConn(conn, metadata)
 	return nil

--- a/listener/inner/tcp.go
+++ b/listener/inner/tcp.go
@@ -3,6 +3,7 @@ package inner
 import (
 	"errors"
 	"net"
+	"sync"
 
 	N "github.com/metacubex/mihomo/common/net"
 	C "github.com/metacubex/mihomo/constant"
@@ -18,7 +19,66 @@ func GetTunnel() C.Tunnel {
 	return tunnel
 }
 
-func HandleTcp(tunnel C.Tunnel, address string, proxy string) (conn net.Conn, err error) {
+type errConn struct {
+	net.Conn
+	errOnce sync.Once
+	errMu   sync.RWMutex
+	err     error
+}
+
+func newErrConn(conn net.Conn, errCh <-chan error) net.Conn {
+	c := &errConn{Conn: conn}
+	go func() {
+		if err, ok := <-errCh; ok && err != nil {
+			c.setErr(err)
+			_ = c.Conn.Close()
+		}
+	}()
+	return c
+}
+
+func (c *errConn) setErr(err error) {
+	if err == nil {
+		return
+	}
+	c.errOnce.Do(func() {
+		c.errMu.Lock()
+		c.err = err
+		c.errMu.Unlock()
+	})
+}
+
+func (c *errConn) getErr() error {
+	c.errMu.RLock()
+	defer c.errMu.RUnlock()
+	return c.err
+}
+
+func (c *errConn) Read(b []byte) (int, error) {
+	if err := c.getErr(); err != nil {
+		return 0, err
+	}
+	n, err := c.Conn.Read(b)
+	if err != nil {
+		if err2 := c.getErr(); err2 != nil {
+			return n, err2
+		}
+	}
+	return n, err
+}
+
+func (c *errConn) Write(b []byte) (int, error) {
+	if err := c.getErr(); err != nil {
+		return 0, err
+	}
+	n, err := c.Conn.Write(b)
+	if err2 := c.getErr(); err2 != nil {
+		return n, err2
+	}
+	return n, err
+}
+
+func HandleTcp(tunnel C.Tunnel, address string, proxy string, withAccurateError bool) (conn net.Conn, err error) {
 	if tunnel == nil {
 		return nil, errors.New("tunnel uninitialized")
 	}
@@ -35,6 +95,15 @@ func HandleTcp(tunnel C.Tunnel, address string, proxy string) (conn net.Conn, er
 	}
 	if err = metadata.SetRemoteAddress(address); err != nil {
 		return nil, err
+	}
+
+	if withAccurateError {
+		errCh := make(chan error, 1)
+		go func() {
+			errCh <- tunnel.HandleTCPConnWithError(conn2, metadata)
+			close(errCh)
+		}()
+		return newErrConn(conn1, errCh), nil
 	}
 
 	go tunnel.HandleTCPConn(conn2, metadata)

--- a/listener/inner/tcp.go
+++ b/listener/inner/tcp.go
@@ -21,31 +21,23 @@ func GetTunnel() C.Tunnel {
 
 type errConn struct {
 	net.Conn
-	errOnce sync.Once
-	errMu   sync.RWMutex
-	err     error
+	errMu sync.RWMutex
+	err   error
 }
 
-func newErrConn(conn net.Conn, errCh <-chan error) net.Conn {
-	c := &errConn{Conn: conn}
-	go func() {
-		if err, ok := <-errCh; ok && err != nil {
-			c.setErr(err)
-			_ = c.Conn.Close()
-		}
-	}()
-	return c
+func newErrConn(conn net.Conn) *errConn {
+	return &errConn{Conn: conn}
 }
 
 func (c *errConn) setErr(err error) {
 	if err == nil {
 		return
 	}
-	c.errOnce.Do(func() {
-		c.errMu.Lock()
+	c.errMu.Lock()
+	if c.err == nil {
 		c.err = err
-		c.errMu.Unlock()
-	})
+	}
+	c.errMu.Unlock()
 }
 
 func (c *errConn) getErr() error {
@@ -98,12 +90,14 @@ func HandleTcp(tunnel C.Tunnel, address string, proxy string, withAccurateError 
 	}
 
 	if withAccurateError {
-		errCh := make(chan error, 1)
+		c := newErrConn(conn1)
 		go func() {
-			errCh <- tunnel.HandleTCPConnWithError(conn2, metadata)
-			close(errCh)
+			if err := tunnel.HandleTCPConnWithError(conn2, metadata); err != nil {
+				c.setErr(err)
+				_ = c.Conn.Close()
+			}
 		}()
-		return newErrConn(conn1, errCh), nil
+		return c, nil
 	}
 
 	go tunnel.HandleTCPConn(conn2, metadata)

--- a/listener/inner/tcp.go
+++ b/listener/inner/tcp.go
@@ -92,9 +92,9 @@ func HandleTcp(tunnel C.Tunnel, address string, proxy string, withAccurateError 
 	if withAccurateError {
 		c := newErrConn(conn1)
 		go func() {
-			if err := tunnel.HandleTCPConnWithError(conn2, metadata); err != nil {
+			defer conn2.Close()
+			if err := tunnel.HandleTCPConnWithError(conn2, metadata, false); err != nil {
 				c.setErr(err)
-				_ = c.Conn.Close()
 			}
 		}()
 		return c, nil

--- a/listener/reality/reality.go
+++ b/listener/reality/reality.go
@@ -74,7 +74,7 @@ func (c Config) Build(tunnel C.Tunnel) (*Builder, error) {
 	}
 
 	realityConfig.DialContext = func(ctx context.Context, network, address string) (net.Conn, error) {
-		return inner.HandleTcp(tunnel, address, c.Proxy)
+		return inner.HandleTcp(tunnel, address, c.Proxy, false)
 	}
 
 	realityConfig.LimitFallbackUpload = c.LimitFallbackUpload

--- a/listener/sing/dialer.go
+++ b/listener/sing/dialer.go
@@ -21,7 +21,7 @@ func (d Dialer) DialContext(ctx context.Context, network string, destination M.S
 	if network != "tcp" && network != "tcp4" && network != "tcp6" {
 		return nil, fmt.Errorf("unsupported network %s", network)
 	}
-	return inner.HandleTcp(d.t, destination.String(), d.proxy)
+	return inner.HandleTcp(d.t, destination.String(), d.proxy, false)
 }
 
 func (d Dialer) ListenPacket(ctx context.Context, destination M.Socksaddr) (net.PacketConn, error) {

--- a/tunnel/connection.go
+++ b/tunnel/connection.go
@@ -217,6 +217,13 @@ func closeAllLocalCoon(lAddr string) {
 	})
 }
 
-func handleSocket(inbound, outbound net.Conn) {
-	N.Relay(inbound, outbound)
+func handleSocket(inbound, outbound net.Conn) error {
+	var once sync.Once
+	var finalError error
+	N.Relay(inbound, outbound, func(err error) {
+		once.Do(func() {
+			finalError = err
+		})
+	})
+	return finalError
 }

--- a/tunnel/tunnel.go
+++ b/tunnel/tunnel.go
@@ -78,9 +78,9 @@ func (t tunnel) HandleTCPConn(conn net.Conn, metadata *C.Metadata) {
 	handleTCPConn(connCtx)
 }
 
-func (t tunnel) HandleTCPConnWithError(conn net.Conn, metadata *C.Metadata) error {
+func (t tunnel) HandleTCPConnWithError(conn net.Conn, metadata *C.Metadata, closeBeforeReturn bool) error {
 	connCtx := icontext.NewConnContext(conn, metadata)
-	return handleTCPConnWithError(connCtx)
+	return handleTCPConnWithError(connCtx, closeBeforeReturn)
 }
 
 func initUDP() {
@@ -485,18 +485,20 @@ func handleUDPConn(packet C.PacketAdapter) {
 }
 
 func handleTCPConn(connCtx C.ConnContext) {
-	_ = handleTCPConnWithError(connCtx)
+	_ = handleTCPConnWithError(connCtx, true)
 }
 
-func handleTCPConnWithError(connCtx C.ConnContext) error {
+func handleTCPConnWithError(connCtx C.ConnContext, closeBeforeReturn bool) error {
 	if !isHandle(connCtx.Metadata().Type) {
 		_ = connCtx.Conn().Close()
 		return errors.New("tunnel not running")
 	}
 
-	defer func(conn net.Conn) {
-		_ = conn.Close()
-	}(connCtx.Conn())
+	if closeBeforeReturn {
+		defer func(conn net.Conn) {
+			_ = conn.Close()
+		}(connCtx.Conn())
+	}
 
 	metadata := connCtx.Metadata()
 	if !metadata.Valid() {

--- a/tunnel/tunnel.go
+++ b/tunnel/tunnel.go
@@ -78,6 +78,11 @@ func (t tunnel) HandleTCPConn(conn net.Conn, metadata *C.Metadata) {
 	handleTCPConn(connCtx)
 }
 
+func (t tunnel) HandleTCPConnWithError(conn net.Conn, metadata *C.Metadata) error {
+	connCtx := icontext.NewConnContext(conn, metadata)
+	return handleTCPConnWithError(connCtx)
+}
+
 func initUDP() {
 	numUDPWorkers := 4
 	if num := runtime.GOMAXPROCS(0); num > numUDPWorkers {
@@ -480,9 +485,13 @@ func handleUDPConn(packet C.PacketAdapter) {
 }
 
 func handleTCPConn(connCtx C.ConnContext) {
+	_ = handleTCPConnWithError(connCtx)
+}
+
+func handleTCPConnWithError(connCtx C.ConnContext) error {
 	if !isHandle(connCtx.Metadata().Type) {
 		_ = connCtx.Conn().Close()
-		return
+		return errors.New("tunnel not running")
 	}
 
 	defer func(conn net.Conn) {
@@ -492,14 +501,16 @@ func handleTCPConn(connCtx C.ConnContext) {
 	metadata := connCtx.Metadata()
 	if !metadata.Valid() {
 		log.Warnln("[Metadata] not valid: %#v", metadata)
-		return
+		return errors.New("metadata invalid")
 	}
 	fixMetadata(metadata) // fix some metadata not set via metadata.SetRemoteAddr or metadata.SetRemoteAddress
 
 	preHandleFailed := false
+	preHandleErr := error(nil)
 	if err := preHandleMetadata(metadata); err != nil {
 		log.Debugln("[Metadata PreHandle] error: %s", err)
 		preHandleFailed = true
+		preHandleErr = err
 	}
 
 	conn := connCtx.Conn()
@@ -517,7 +528,10 @@ func handleTCPConn(connCtx C.ConnContext) {
 	if preHandleFailed {
 		log.Debugln("[Metadata PreHandle] failed to sniff a domain for connection %s --> %s, give up",
 			metadata.SourceDetail(), metadata.RemoteAddress())
-		return
+		if preHandleErr != nil {
+			return preHandleErr
+		}
+		return errors.New("metadata prehandle failed")
 	}
 
 	peekMutex := sync.Mutex{}
@@ -534,7 +548,7 @@ func handleTCPConn(connCtx C.ConnContext) {
 	proxy, rule, err := resolveMetadata(metadata)
 	if err != nil {
 		log.Warnln("[Metadata] parse failed: %s", err.Error())
-		return
+		return err
 	}
 
 	dialMetadata := metadata
@@ -587,7 +601,7 @@ func handleTCPConn(connCtx C.ConnContext) {
 		logMetadataErr(metadata, rule, proxy, err)
 	})
 	if err != nil {
-		return
+		return err
 	}
 	logMetadata(metadata, rule, remoteConn)
 
@@ -601,6 +615,7 @@ func handleTCPConn(connCtx C.ConnContext) {
 	defer peekMutex.Unlock()
 	_ = conn.SetReadDeadline(time.Time{}) // reset
 	handleSocket(conn, remoteConn)
+	return nil
 }
 
 func logMetadataErr(metadata *C.Metadata, rule C.Rule, proxy C.ProxyAdapter, err error) {

--- a/tunnel/tunnel.go
+++ b/tunnel/tunnel.go
@@ -614,8 +614,7 @@ func handleTCPConnWithError(connCtx C.ConnContext) error {
 	peekMutex.Lock()
 	defer peekMutex.Unlock()
 	_ = conn.SetReadDeadline(time.Time{}) // reset
-	handleSocket(conn, remoteConn)
-	return nil
+	return handleSocket(conn, remoteConn)
 }
 
 func logMetadataErr(metadata *C.Metadata, rule C.Rule, proxy C.ProxyAdapter, err error) {


### PR DESCRIPTION
修改前：订阅请求依赖的 `HttpRequest` 由于读写的是Pipe，如果有网络错误，经常返回 `EOF` 和 `io: read/write on closed pipe`，对用户排除故障极其不友好。

修改后：读写Pipe时可以返回创建连接/中继时产生的第一个错误。