### PR TITLE
fix(windows): resolve TLS timeouts by allowing unbound DIRECT outbound (LPM-aware)

### DIFF
--- a/component/dialer/dialer.go
+++ b/component/dialer/dialer.go
@@ -32,6 +32,14 @@ var (
 	fallbackTimeout              = 300 * time.Millisecond
 )
 
+// Returns true if the IP should bypass interface binding.
+func shouldBypass(ip netip.Addr) bool {
+	if bypass := DefaultInterfaceSelectBypass.Load(); bypass != nil {
+		return bypass.MatchIp(ip.Unmap())
+	}
+	return false
+}
+
 func DialContext(ctx context.Context, network, address string, options ...Option) (net.Conn, error) {
 	opt := applyOptions(options...)
 
@@ -70,12 +78,16 @@ func ListenPacket(ctx context.Context, network, address string, rAddrPort netip.
 	if DefaultSocketHook != nil { // ignore interfaceName, routingMark when DefaultSocketHook not null (in CMFA)
 		socketHookToListenConfig(lc)
 	} else {
-		if opt.interfaceName == "" {
-			opt.interfaceName = DefaultInterface.Load()
-		}
-		if opt.interfaceName == "" {
-			if finder := DefaultInterfaceFinder.Load(); finder != nil {
-				opt.interfaceName = finder.FindInterfaceName(rAddrPort.Addr().Unmap())
+		if shouldBypass(rAddrPort.Addr()) {
+			opt.interfaceName = ""
+		} else {
+			if opt.interfaceName == "" {
+				opt.interfaceName = DefaultInterface.Load()
+			}
+			if opt.interfaceName == "" {
+				if finder := DefaultInterfaceFinder.Load(); finder != nil {
+					opt.interfaceName = finder.FindInterfaceName(rAddrPort.Addr().Unmap())
+				}
 			}
 		}
 		if rAddrPort.Addr().Unmap().IsLoopback() {
@@ -146,14 +158,19 @@ func dialContext(ctx context.Context, network string, destination netip.Addr, po
 	if DefaultSocketHook != nil { // ignore interfaceName, routingMark and tfo when DefaultSocketHook not null (in CMFA)
 		socketHookToToDialer(dialer)
 	} else {
-		if opt.interfaceName == "" {
-			opt.interfaceName = DefaultInterface.Load()
-		}
-		if opt.interfaceName == "" {
-			if finder := DefaultInterfaceFinder.Load(); finder != nil {
-				opt.interfaceName = finder.FindInterfaceName(destination)
+		if shouldBypass(destination) {
+			opt.interfaceName = ""
+		} else {
+			if opt.interfaceName == "" {
+				opt.interfaceName = DefaultInterface.Load()
+			}
+			if opt.interfaceName == "" {
+				if finder := DefaultInterfaceFinder.Load(); finder != nil {
+					opt.interfaceName = finder.FindInterfaceName(destination)
+				}
 			}
 		}
+
 		if opt.interfaceName != "" {
 			bind := bindIfaceToDialer
 			if opt.fallbackBind {
@@ -183,15 +200,17 @@ func ICMPControl(destination netip.Addr) func(network, address string, conn sysc
 			return DefaultSocketHook(network, address, conn)
 		}
 		dialer := &net.Dialer{}
-		interfaceName := DefaultInterface.Load()
-		if interfaceName == "" {
-			if finder := DefaultInterfaceFinder.Load(); finder != nil {
-				interfaceName = finder.FindInterfaceName(destination)
+		if !shouldBypass(destination) {
+			interfaceName := DefaultInterface.Load()
+			if interfaceName == "" {
+				if finder := DefaultInterfaceFinder.Load(); finder != nil {
+					interfaceName = finder.FindInterfaceName(destination)
+				}
 			}
-		}
-		if interfaceName != "" {
-			if err := bindIfaceToDialer(interfaceName, dialer, network, destination); err != nil {
-				return err
+			if interfaceName != "" {
+				if err := bindIfaceToDialer(interfaceName, dialer, network, destination); err != nil {
+					return err
+				}
 			}
 		}
 		routingMark := int(DefaultRoutingMark.Load())

--- a/component/dialer/options.go
+++ b/component/dialer/options.go
@@ -6,6 +6,7 @@ import (
 	"net/netip"
 
 	"github.com/metacubex/mihomo/common/atomic"
+	"github.com/metacubex/mihomo/component/cidr"
 	"github.com/metacubex/mihomo/component/resolver"
 )
 
@@ -13,7 +14,9 @@ var (
 	DefaultInterface   = atomic.NewTypedValue[string]("")
 	DefaultRoutingMark = atomic.NewInt32(0)
 
-	DefaultInterfaceFinder = atomic.NewTypedValue[InterfaceFinder](nil)
+	DefaultInterfaceFinder          = atomic.NewTypedValue[InterfaceFinder](nil)
+	DefaultInterfaceSelectBypass    = atomic.NewTypedValue[*cidr.IpCidrSet](nil)
+	DefaultInterfaceSelectBypassCfg = atomic.NewTypedValue[[]string](nil)
 )
 
 type InterfaceFinder interface {

--- a/config/config.go
+++ b/config/config.go
@@ -45,27 +45,29 @@ import (
 // General config
 type General struct {
 	Inbound
-	Mode                    T.TunnelMode            `json:"mode"`
-	UnifiedDelay            bool                    `json:"unified-delay"`
-	LogLevel                log.LogLevel            `json:"log-level"`
-	IPv6                    bool                    `json:"ipv6"`
-	Interface               string                  `json:"interface-name"`
-	RoutingMark             int                     `json:"routing-mark"`
-	GeoXUrl                 GeoXUrl                 `json:"geox-url"`
-	GeoAutoUpdate           bool                    `json:"geo-auto-update"`
-	GeoUpdateInterval       int                     `json:"geo-update-interval"`
-	GeodataMode             bool                    `json:"geodata-mode"`
-	GeodataLoader           string                  `json:"geodata-loader"`
-	GeositeMatcher          string                  `json:"geosite-matcher"`
-	TCPConcurrent           bool                    `json:"tcp-concurrent"`
-	FindProcessMode         process.FindProcessMode `json:"find-process-mode"`
-	Sniffing                bool                    `json:"sniffing"`
-	GlobalClientFingerprint string                  `json:"global-client-fingerprint"`
-	GlobalUA                string                  `json:"global-ua"`
-	ETagSupport             bool                    `json:"etag-support"`
-	KeepAliveIdle           int                     `json:"keep-alive-idle"`
-	KeepAliveInterval       int                     `json:"keep-alive-interval"`
-	DisableKeepAlive        bool                    `json:"disable-keep-alive"`
+	Mode                     T.TunnelMode            `json:"mode"`
+	UnifiedDelay             bool                    `json:"unified-delay"`
+	LogLevel                 log.LogLevel            `json:"log-level"`
+	IPv6                     bool                    `json:"ipv6"`
+	Interface                string                  `json:"interface-name"`
+	InterfaceSelectBypassCfg []string                `json:"interface-select-bypass"`
+	InterfaceSelectBypass    *cidr.IpCidrSet         `json:"-"`
+	RoutingMark              int                     `json:"routing-mark"`
+	GeoXUrl                  GeoXUrl                 `json:"geox-url"`
+	GeoAutoUpdate            bool                    `json:"geo-auto-update"`
+	GeoUpdateInterval        int                     `json:"geo-update-interval"`
+	GeodataMode              bool                    `json:"geodata-mode"`
+	GeodataLoader            string                  `json:"geodata-loader"`
+	GeositeMatcher           string                  `json:"geosite-matcher"`
+	TCPConcurrent            bool                    `json:"tcp-concurrent"`
+	FindProcessMode          process.FindProcessMode `json:"find-process-mode"`
+	Sniffing                 bool                    `json:"sniffing"`
+	GlobalClientFingerprint  string                  `json:"global-client-fingerprint"`
+	GlobalUA                 string                  `json:"global-ua"`
+	ETagSupport              bool                    `json:"etag-support"`
+	KeepAliveIdle            int                     `json:"keep-alive-idle"`
+	KeepAliveInterval        int                     `json:"keep-alive-interval"`
+	DisableKeepAlive         bool                    `json:"disable-keep-alive"`
 }
 
 // Inbound config
@@ -415,6 +417,7 @@ type RawConfig struct {
 	ExternalDohServer       string                  `yaml:"external-doh-server" json:"external-doh-server"`
 	Secret                  string                  `yaml:"secret" json:"secret"`
 	Interface               string                  `yaml:"interface-name" json:"interface-name"`
+	InterfaceSelectBypass   []string                `yaml:"interface-select-bypass" json:"interface-select-bypass"`
 	RoutingMark             int                     `yaml:"routing-mark" json:"routing-mark"`
 	Tunnels                 []LC.Tunnel             `yaml:"tunnels" json:"tunnels"`
 	GeoAutoUpdate           bool                    `yaml:"geo-auto-update" json:"geo-auto-update"`
@@ -734,6 +737,17 @@ func ParseRawConfig(rawCfg *RawConfig) (*Config, error) {
 func temporaryUpdateGeneral(general *General) func()
 
 func parseGeneral(cfg *RawConfig) (*General, error) {
+	var interfaceSelectBypass *cidr.IpCidrSet
+	if len(cfg.InterfaceSelectBypass) > 0 {
+		interfaceSelectBypass = cidr.NewIpCidrSet()
+		for _, s := range cfg.InterfaceSelectBypass {
+			if err := interfaceSelectBypass.AddIpCidrForString(s); err != nil {
+				return nil, fmt.Errorf("interface-select-bypass CIDR parse error: %w", err)
+			}
+		}
+		_ = interfaceSelectBypass.Merge()
+	}
+
 	return &General{
 		Inbound: Inbound{
 			Port:              cfg.Port,
@@ -751,12 +765,14 @@ func parseGeneral(cfg *RawConfig) (*General, error) {
 			InboundTfo:        cfg.InboundTfo,
 			InboundMPTCP:      cfg.InboundMPTCP,
 		},
-		UnifiedDelay: cfg.UnifiedDelay,
-		Mode:         cfg.Mode,
-		LogLevel:     cfg.LogLevel,
-		IPv6:         cfg.IPv6,
-		Interface:    cfg.Interface,
-		RoutingMark:  cfg.RoutingMark,
+		UnifiedDelay:             cfg.UnifiedDelay,
+		Mode:                     cfg.Mode,
+		LogLevel:                 cfg.LogLevel,
+		IPv6:                     cfg.IPv6,
+		Interface:                cfg.Interface,
+		InterfaceSelectBypassCfg: cfg.InterfaceSelectBypass,
+		InterfaceSelectBypass:    interfaceSelectBypass,
+		RoutingMark:              cfg.RoutingMark,
 		GeoXUrl: GeoXUrl{
 			GeoIp:   cfg.GeoXUrl.GeoIp,
 			Mmdb:    cfg.GeoXUrl.Mmdb,

--- a/hub/executor/executor.go
+++ b/hub/executor/executor.go
@@ -154,12 +154,14 @@ func GetGeneral() *config.General {
 			InboundTfo:        inbound.Tfo(),
 			InboundMPTCP:      inbound.MPTCP(),
 		},
-		Mode:         tunnel.Mode(),
-		UnifiedDelay: adapter.UnifiedDelay.Load(),
-		LogLevel:     log.Level(),
-		IPv6:         !resolver.DisableIPv6,
-		Interface:    dialer.DefaultInterface.Load(),
-		RoutingMark:  int(dialer.DefaultRoutingMark.Load()),
+		Mode:                     tunnel.Mode(),
+		UnifiedDelay:             adapter.UnifiedDelay.Load(),
+		LogLevel:                 log.Level(),
+		IPv6:                     !resolver.DisableIPv6,
+		Interface:                dialer.DefaultInterface.Load(),
+		InterfaceSelectBypassCfg: dialer.DefaultInterfaceSelectBypassCfg.Load(),
+		InterfaceSelectBypass:    dialer.DefaultInterfaceSelectBypass.Load(),
+		RoutingMark:              int(dialer.DefaultRoutingMark.Load()),
 		GeoXUrl: config.GeoXUrl{
 			GeoIp:   geodata.GeoIpUrl(),
 			Mmdb:    geodata.MmdbUrl(),
@@ -407,6 +409,8 @@ func updateGeneral(general *config.General, logging bool) {
 	adapter.UnifiedDelay.Store(general.UnifiedDelay)
 
 	dialer.DefaultInterface.Store(general.Interface)
+	dialer.DefaultInterfaceSelectBypassCfg.Store(general.InterfaceSelectBypassCfg)
+	dialer.DefaultInterfaceSelectBypass.Store(general.InterfaceSelectBypass)
 	dialer.DefaultRoutingMark.Store(int32(general.RoutingMark))
 	if logging && general.RoutingMark > 0 {
 		log.Infoln("Use routing mark: %#x", general.RoutingMark)


### PR DESCRIPTION
### Motivation

Currently, when `interface-name` is configured or `auto-detect-interface` is enabled, Mihomo enforces `IP_UNICAST_IF` (or `SO_BINDTODEVICE`) on outbound sockets. 

This behavior causes connectivity issues for **Overlay Networks** (such as Headscale, Tailscale, ZeroTier, or corporate VPNs) running on the same machine. 
- These networks rely on the OS routing table to direct traffic into their virtual TUN interfaces (e.g., `tailscale0`).
- Forcing a socket bind to a physical interface (e.g., `Ethernet`) bypasses the OS routing logic for these specific destinations, causing packets to be dropped or sent out the wrong interface.

### Solution

This PR introduces a new global configuration option: `interface-select-bypass`.

Before binding a socket to an interface (whether manually specified or auto-detected), the dialer now checks if the destination IP matches any CIDR in this bypass list.

- **Match:** The interface binding is skipped (`interfaceName = ""`). The socket remains unbound, allowing the OS routing table to determine the correct interface (e.g., routing `100.64.x.x` to `tailscale0`).
- **No Match:** The original logic proceeds (binding to `interface-name` or the auto-detected interface).

This ensures that we can maintain "Strict Route" / "Auto Detect" benefits for public traffic while allowing specific private subnets to "escape" the binding constraints.

### Configuration Example

```yaml
# config.yaml

# General settings
interface-name: Ethernet  # or auto-detect-interface: true in tun config

# Traffic destined for these CIDRs will NOT be bound to 'Ethernet'.
# They will follow the system routing table.
interface-select-bypass:
  - "100.64.0.0/10"      # Headscale / Tailscale
  - "192.168.50.0/24"    # Private VPN subnet