### PR TITLE
chore: align sudoku with upstream v0.2.0

### DIFF
--- a/docs/config.yaml
+++ b/docs/config.yaml
@@ -1082,19 +1082,19 @@ proxies: # socks5
     server: server_ip/domain # 1.2.3.4 or domain
     port: 443 
     key: "<client_key>" # 如果你使用sudoku生成的ED25519密钥对，请填写密钥对中的私钥，否则填入和服务端相同的uuid
-    aead-method: chacha20-poly1305 # 可选值：chacha20-poly1305、aes-128-gcm、none 我们保证在none的情况下sudoku混淆层仍然确保安全
-    padding-min: 2 # 最小填充字节数
-    padding-max: 7 # 最大填充字节数
+    aead-method: chacha20-poly1305 # 可选：chacha20-poly1305、aes-128-gcm、none（不建议；且 enable-pure-downlink=false 时不可用）
+    padding-min: 2 # 最小填充率（0-100）
+    padding-max: 7 # 最大填充率（0-100，必须 >= padding-min）
     table-type: prefer_ascii    # 可选值：prefer_ascii、prefer_entropy 前者全ascii映射，后者保证熵值（汉明1）低于3
     # custom-table: xpxvvpvv    # 可选，自定义字节布局，必须包含2个x、2个p、4个v，可随意组合。启用此处则需配置`table-type`为`prefer_entropy`
     # custom-tables: ["xpxvvpvv", "vxpvxvvp"] # 可选，自定义字节布局列表（x/v/p），用于 xvp 模式轮换；非空时覆盖 custom-table
     http-mask: true # 是否启用http掩码
-    # http-mask-mode: legacy # 可选：legacy（默认）、stream、poll、auto；stream/poll/auto 支持走 CDN/反代
+    # http-mask-mode: legacy # 可选：legacy（默认）、stream（split-stream）、poll、auto（先 stream 再 poll）；stream/poll/auto 支持走 CDN/反代
     # http-mask-tls: true # 可选：仅在 http-mask-mode 为 stream/poll/auto 时生效；true 强制 https；false 强制 http（不会根据端口自动推断）
     # http-mask-host: "" # 可选：覆盖 Host/SNI（支持 example.com 或 example.com:443）；仅在 http-mask-mode 为 stream/poll/auto 时生效
-    # path-root: "" # 可选：HTTP 隧道端点一级路径前缀（双方需一致），例如 "aabbcc" => /aabbcc/session、/aabbcc/stream、/aabbcc/api/v1/upload
-    # http-mask-multiplex: off # 可选：off（默认）、auto（复用 h1.1 keep-alive / h2 连接，减少每次建链 RTT）、on（单条隧道内多路复用多个目标连接；仅在 http-mask-mode=stream/poll/auto 生效）
-    enable-pure-downlink: false # 是否启用混淆下行，false的情况下能在保证数据安全的前提下极大提升下行速度，与服务端端保持相同(如果此处为false，则要求aead不可为none)
+    # path-root: "" # 可选：HTTP 隧道端点一级路径前缀（双方需一致），例如 "aabbcc" 或 "/aabbcc/" => /aabbcc/session、/aabbcc/stream、/aabbcc/api/v1/upload
+    # http-mask-multiplex: off # 可选：off（默认）、auto（复用底层 HTTP 连接，减少建链 RTT）、on（Sudoku mux 单隧道多目标；仅在 http-mask-mode=stream/poll/auto 生效）
+    enable-pure-downlink: false # 可选：false=带宽优化下行（更快，要求 aead-method != none）；true=纯 Sudoku 下行
 
   # anytls
   - name: anytls
@@ -1632,17 +1632,17 @@ listeners:
     port: 8443 # 仅支持单端口
     listen: 0.0.0.0
     key: "<server_key>" # 如果你使用sudoku生成的ED25519密钥对，此处是密钥对中的公钥，当然，你也可以仅仅使用任意uuid充当key
-    aead-method: chacha20-poly1305 # 支持chacha20-poly1305或者aes-128-gcm以及none，sudoku的混淆层可以确保none情况下数据安全
-    padding-min: 1 # 填充最小长度
-    padding-max: 15 # 填充最大长度，均不建议过大
+    aead-method: chacha20-poly1305 # 可选：chacha20-poly1305、aes-128-gcm、none（不建议；且 enable-pure-downlink=false 时不可用）
+    padding-min: 1 # 最小填充率（0-100）
+    padding-max: 15 # 最大填充率（0-100，必须 >= padding-min）
     table-type: prefer_ascii # 可选值：prefer_ascii、prefer_entropy 前者全ascii映射，后者保证熵值（汉明1）低于3
     # custom-table: xpxvvpvv # 可选，自定义字节布局，必须包含2个x、2个p、4个v，可随意组合。启用此处则需配置`table-type`为`prefer_entropy`
     # custom-tables: ["xpxvvpvv", "vxpvxvvp"] # 可选，自定义字节布局列表（x/v/p），用于 xvp 模式轮换；非空时覆盖 custom-table
-    handshake-timeout: 5   # optional
-    enable-pure-downlink: false # 是否启用混淆下行，false的情况下能在保证数据安全的前提下极大提升下行速度，与客户端保持相同(如果此处为false，则要求aead不可为none)
+    handshake-timeout: 5   # 可选（秒）
+    enable-pure-downlink: false # 可选：false=带宽优化下行（更快，要求 aead-method != none）；true=纯 Sudoku 下行
     disable-http-mask: false # 可选：禁用 http 掩码/隧道（默认为 false）
-    # http-mask-mode: legacy # 可选：legacy（默认）、stream、poll、auto；stream/poll/auto 支持走 CDN/反代
-    # path-root: "" # 可选：HTTP 隧道端点一级路径前缀（双方需一致），例如 "aabbcc" => /aabbcc/session、/aabbcc/stream、/aabbcc/api/v1/upload
+    # http-mask-mode: legacy # 可选：legacy（默认）、stream（split-stream）、poll、auto（先 stream 再 poll）；stream/poll/auto 支持走 CDN/反代
+    # path-root: "" # 可选：HTTP 隧道端点一级路径前缀（双方需一致），例如 "aabbcc" 或 "/aabbcc/" => /aabbcc/session、/aabbcc/stream、/aabbcc/api/v1/upload
 
 
 

--- a/transport/sudoku/config.go
+++ b/transport/sudoku/config.go
@@ -32,7 +32,8 @@ type ProtocolConfig struct {
 	PaddingMin int
 	PaddingMax int
 
-	// EnablePureDownlink toggles the bandwidth-optimized downlink mode.
+	// EnablePureDownlink enables the pure Sudoku downlink mode.
+	// When false, the connection uses the bandwidth-optimized packed downlink (requires AEAD).
 	EnablePureDownlink bool
 
 	// Client-only: final target "host:port".
@@ -46,7 +47,7 @@ type ProtocolConfig struct {
 
 	// HTTPMaskMode controls how the HTTP layer behaves:
 	//   - "legacy": write a fake HTTP/1.1 header then switch to raw stream (default, not CDN-compatible)
-	//   - "stream": real HTTP tunnel (stream-one or split), CDN-compatible
+	//   - "stream": real HTTP tunnel (split-stream), CDN-compatible
 	//   - "poll": plain HTTP tunnel (authorize/push/pull), strong restricted-network pass-through
 	//   - "auto": try stream then fall back to poll
 	HTTPMaskMode string
@@ -114,7 +115,8 @@ func (c *ProtocolConfig) Validate() error {
 	}
 
 	if v := strings.TrimSpace(c.HTTPMaskPathRoot); v != "" {
-		if strings.Contains(v, "/") {
+		v = strings.Trim(v, "/")
+		if v == "" || strings.Contains(v, "/") {
 			return fmt.Errorf("invalid http-mask-path-root: must be a single path segment")
 		}
 		for i := 0; i < len(v); i++ {

--- a/transport/sudoku/crypto/aead.go
+++ b/transport/sudoku/crypto/aead.go
@@ -22,6 +22,26 @@ type AEADConn struct {
 	nonceSize int
 }
 
+func (cc *AEADConn) CloseWrite() error {
+	if cc == nil || cc.Conn == nil {
+		return nil
+	}
+	if cw, ok := cc.Conn.(interface{ CloseWrite() error }); ok {
+		return cw.CloseWrite()
+	}
+	return nil
+}
+
+func (cc *AEADConn) CloseRead() error {
+	if cc == nil || cc.Conn == nil {
+		return nil
+	}
+	if cr, ok := cc.Conn.(interface{ CloseRead() error }); ok {
+		return cr.CloseRead()
+	}
+	return nil
+}
+
 func NewAEADConn(c net.Conn, key string, method string) (*AEADConn, error) {
 	if method == "none" {
 		return &AEADConn{Conn: c, aead: nil}, nil

--- a/transport/sudoku/multiplex/session.go
+++ b/transport/sudoku/multiplex/session.go
@@ -383,7 +383,11 @@ func (c *stream) enqueue(payload []byte) {
 		c.mu.Unlock()
 		return
 	}
-	c.queue = append(c.queue, payload)
+	if len(c.readBuf) == 0 && len(c.queue) == 0 {
+		c.readBuf = payload
+	} else {
+		c.queue = append(c.queue, payload)
+	}
 	c.cond.Signal()
 	c.mu.Unlock()
 }
@@ -491,6 +495,9 @@ func (c *stream) Close() error {
 	return nil
 }
 
+func (c *stream) CloseWrite() error { return c.Close() }
+func (c *stream) CloseRead() error  { return c.Close() }
+
 func (c *stream) LocalAddr() net.Addr  { return c.localAddr }
 func (c *stream) RemoteAddr() net.Addr { return c.remoteAddr }
 
@@ -501,4 +508,3 @@ func (c *stream) SetDeadline(t time.Time) error {
 }
 func (c *stream) SetReadDeadline(time.Time) error  { return nil }
 func (c *stream) SetWriteDeadline(time.Time) error { return nil }
-

--- a/transport/sudoku/obfs/httpmask/halfpipe.go
+++ b/transport/sudoku/obfs/httpmask/halfpipe.go
@@ -1,0 +1,229 @@
+package httpmask
+
+import (
+	"io"
+	"net"
+	"os"
+	"sync"
+	"time"
+)
+
+type pipeDeadline struct {
+	mu     sync.Mutex
+	timer  *time.Timer
+	cancel chan struct{}
+}
+
+func makePipeDeadline() pipeDeadline {
+	return pipeDeadline{cancel: make(chan struct{})}
+}
+
+func (d *pipeDeadline) set(t time.Time) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	if d.timer != nil && !d.timer.Stop() {
+		<-d.cancel
+	}
+	d.timer = nil
+
+	closed := isClosedPipeChan(d.cancel)
+	if t.IsZero() {
+		if closed {
+			d.cancel = make(chan struct{})
+		}
+		return
+	}
+
+	if dur := time.Until(t); dur > 0 {
+		if closed {
+			d.cancel = make(chan struct{})
+		}
+		d.timer = time.AfterFunc(dur, func() {
+			close(d.cancel)
+		})
+		return
+	}
+
+	if !closed {
+		close(d.cancel)
+	}
+}
+
+func (d *pipeDeadline) wait() <-chan struct{} {
+	d.mu.Lock()
+	ch := d.cancel
+	d.mu.Unlock()
+	return ch
+}
+
+func isClosedPipeChan(ch <-chan struct{}) bool {
+	select {
+	case <-ch:
+		return true
+	default:
+		return false
+	}
+}
+
+type halfPipeAddr struct{}
+
+func (halfPipeAddr) Network() string { return "pipe" }
+func (halfPipeAddr) String() string  { return "pipe" }
+
+type halfPipeConn struct {
+	wrMu sync.Mutex
+
+	rdRx <-chan []byte
+	rdTx chan<- int
+
+	wrTx chan<- []byte
+	wrRx <-chan int
+
+	readOnce  sync.Once
+	writeOnce sync.Once
+
+	localReadDone  chan struct{}
+	localWriteDone chan struct{}
+
+	remoteReadDone  <-chan struct{}
+	remoteWriteDone <-chan struct{}
+
+	readDeadline  pipeDeadline
+	writeDeadline pipeDeadline
+}
+
+func newHalfPipe() (net.Conn, net.Conn) {
+	cb1 := make(chan []byte)
+	cb2 := make(chan []byte)
+	cn1 := make(chan int)
+	cn2 := make(chan int)
+
+	r1 := make(chan struct{})
+	w1 := make(chan struct{})
+	r2 := make(chan struct{})
+	w2 := make(chan struct{})
+
+	c1 := &halfPipeConn{
+		rdRx: cb1,
+		rdTx: cn1,
+		wrTx: cb2,
+		wrRx: cn2,
+
+		localReadDone:   r1,
+		localWriteDone:  w1,
+		remoteReadDone:  r2,
+		remoteWriteDone: w2,
+
+		readDeadline:  makePipeDeadline(),
+		writeDeadline: makePipeDeadline(),
+	}
+	c2 := &halfPipeConn{
+		rdRx: cb2,
+		rdTx: cn2,
+		wrTx: cb1,
+		wrRx: cn1,
+
+		localReadDone:   r2,
+		localWriteDone:  w2,
+		remoteReadDone:  r1,
+		remoteWriteDone: w1,
+
+		readDeadline:  makePipeDeadline(),
+		writeDeadline: makePipeDeadline(),
+	}
+	return c1, c2
+}
+
+func (*halfPipeConn) LocalAddr() net.Addr  { return halfPipeAddr{} }
+func (*halfPipeConn) RemoteAddr() net.Addr { return halfPipeAddr{} }
+
+func (c *halfPipeConn) Read(p []byte) (int, error) {
+	switch {
+	case isClosedPipeChan(c.localReadDone):
+		return 0, io.ErrClosedPipe
+	case isClosedPipeChan(c.remoteWriteDone):
+		return 0, io.EOF
+	case isClosedPipeChan(c.readDeadline.wait()):
+		return 0, os.ErrDeadlineExceeded
+	}
+
+	select {
+	case b := <-c.rdRx:
+		n := copy(p, b)
+		c.rdTx <- n
+		return n, nil
+	case <-c.localReadDone:
+		return 0, io.ErrClosedPipe
+	case <-c.remoteWriteDone:
+		return 0, io.EOF
+	case <-c.readDeadline.wait():
+		return 0, os.ErrDeadlineExceeded
+	}
+}
+
+func (c *halfPipeConn) Write(p []byte) (int, error) {
+	switch {
+	case isClosedPipeChan(c.localWriteDone):
+		return 0, io.ErrClosedPipe
+	case isClosedPipeChan(c.remoteReadDone):
+		return 0, io.ErrClosedPipe
+	case isClosedPipeChan(c.writeDeadline.wait()):
+		return 0, os.ErrDeadlineExceeded
+	}
+
+	c.wrMu.Lock()
+	defer c.wrMu.Unlock()
+
+	var (
+		total int
+		rest  = p
+	)
+	for once := true; once || len(rest) > 0; once = false {
+		select {
+		case c.wrTx <- rest:
+			n := <-c.wrRx
+			rest = rest[n:]
+			total += n
+		case <-c.localWriteDone:
+			return total, io.ErrClosedPipe
+		case <-c.remoteReadDone:
+			return total, io.ErrClosedPipe
+		case <-c.writeDeadline.wait():
+			return total, os.ErrDeadlineExceeded
+		}
+	}
+	return total, nil
+}
+
+func (c *halfPipeConn) CloseWrite() error {
+	c.writeOnce.Do(func() { close(c.localWriteDone) })
+	return nil
+}
+
+func (c *halfPipeConn) CloseRead() error {
+	c.readOnce.Do(func() { close(c.localReadDone) })
+	return nil
+}
+
+func (c *halfPipeConn) Close() error {
+	_ = c.CloseRead()
+	_ = c.CloseWrite()
+	return nil
+}
+
+func (c *halfPipeConn) SetDeadline(t time.Time) error {
+	c.readDeadline.set(t)
+	c.writeDeadline.set(t)
+	return nil
+}
+
+func (c *halfPipeConn) SetReadDeadline(t time.Time) error {
+	c.readDeadline.set(t)
+	return nil
+}
+
+func (c *halfPipeConn) SetWriteDeadline(t time.Time) error {
+	c.writeDeadline.set(t)
+	return nil
+}

--- a/transport/sudoku/obfs/sudoku/padding_prob.go
+++ b/transport/sudoku/obfs/sudoku/padding_prob.go
@@ -1,0 +1,44 @@
+package sudoku
+
+import "math/rand"
+
+const probOne = uint64(1) << 32
+
+func pickPaddingThreshold(r *rand.Rand, pMin, pMax int) uint64 {
+	if r == nil {
+		return 0
+	}
+	if pMin < 0 {
+		pMin = 0
+	}
+	if pMax < pMin {
+		pMax = pMin
+	}
+	if pMax > 100 {
+		pMax = 100
+	}
+	if pMin > 100 {
+		pMin = 100
+	}
+
+	min := uint64(pMin) * probOne / 100
+	max := uint64(pMax) * probOne / 100
+	if max <= min {
+		return min
+	}
+	u := uint64(r.Uint32())
+	return min + (u * (max - min) >> 32)
+}
+
+func shouldPad(r *rand.Rand, threshold uint64) bool {
+	if threshold == 0 {
+		return false
+	}
+	if threshold >= probOne {
+		return true
+	}
+	if r == nil {
+		return false
+	}
+	return uint64(r.Uint32()) < threshold
+}


### PR DESCRIPTION
The previously occurring "unreachable" code was due to a situation that was overlooked when deprecating a field. This update aligns the handling of authentication with that of HTTP masking, ensuring backward compatibility while preventing the reappearance of "unreachable" code.