### PR TITLE
feat: support TLS certificate pinning without InsecureSkipVerify

### DIFF
--- a/component/ca/config.go
+++ b/component/ca/config.go
@@ -98,11 +98,17 @@ func GetTLSConfig(opt Option) (tlsConfig *tls.Config, err error) {
 	}
 
 	if len(opt.Fingerprint) > 0 {
-		tlsConfig.VerifyPeerCertificate, err = NewFingerprintVerifier(opt.Fingerprint, tlsConfig.Time)
-		if err != nil {
-			return nil, err
+		if tlsConfig.InsecureSkipVerify {
+			tlsConfig.VerifyPeerCertificate, err = NewFingerprintVerifier(opt.Fingerprint, tlsConfig.Time)
+			if err != nil {
+				return nil, err
+			}
+		} else {
+			tlsConfig.VerifyConnection, err = NewConnectionVerifier(opt.Fingerprint)
+			if err != nil {
+				return nil, err
+			}
 		}
-		tlsConfig.InsecureSkipVerify = true
 	}
 
 	if len(opt.Certificate) > 0 || len(opt.PrivateKey) > 0 {

--- a/component/ca/fingerprint.go
+++ b/component/ca/fingerprint.go
@@ -5,9 +5,12 @@ import (
 	"crypto/sha256"
 	"crypto/x509"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
+
+	"github.com/metacubex/tls"
 )
 
 // NewFingerprintVerifier returns a function that verifies whether a certificate's SHA-256 fingerprint matches the given one.
@@ -66,6 +69,35 @@ func NewFingerprintVerifier(fingerprint string, time func() time.Time) (func(raw
 			}
 		}
 		return errNotMatch
+	}, nil
+}
+
+func NewConnectionVerifier(fingerprint string) (func(tls.ConnectionState) error, error) {
+	switch fingerprint {
+	case "chrome", "firefox", "safari", "ios", "android", "edge", "360", "qq", "random", "randomized":
+		return nil, fmt.Errorf("`fingerprint` is used for TLS certificate pinning. If you need to specify the browser fingerprint, use `client-fingerprint`")
+	}
+	fingerprint = strings.TrimSpace(strings.Replace(fingerprint, ":", "", -1))
+	fpByte, err := hex.DecodeString(fingerprint)
+	if err != nil {
+		return nil, fmt.Errorf("fingerprint string decode error: %w", err)
+	}
+
+	if len(fpByte) != 32 {
+		return nil, fmt.Errorf("fingerprint string length error,need sha256 fingerprint")
+	}
+
+	return func(cs tls.ConnectionState) error {
+		for _, chain := range cs.VerifiedChains {
+			for _, cert := range chain {
+				hash := sha256.Sum256(cert.Raw)
+				if bytes.Equal(fpByte, hash[:]) {
+					return nil
+				}
+			}
+		}
+
+		return errors.New("no matching fingerprint found in cert chain")
 	}, nil
 }
 

--- a/component/ca/fingerprint_test.go
+++ b/component/ca/fingerprint_test.go
@@ -1,10 +1,12 @@
 package ca
 
 import (
+	"crypto/x509"
 	"encoding/pem"
 	"testing"
 	"time"
 
+	"github.com/metacubex/tls"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -349,3 +351,64 @@ QnMFlEPVjjxOAToZpR9GTnfQXeWBIiGH/pR9hNiTrdZoQ0iy2+tzJOeRf1SktoA+
 naM8THLCV8Sg1Mw4J87VBp6iSNnpn86CcDaTmjvfliHjWbcM2pE38P1ZWrOZyGls
 QyYBNWNgVYkDOnXYukrZVP/u3oDYLdE41V4tC5h9Pmzb/CaIxw==
 -----END CERTIFICATE-----`
+
+func TestConnectionVerifier(t *testing.T) {
+	leafFingerprint := CalculateFingerprint(leafPEM.Bytes)
+	verifier, err := NewConnectionVerifier(leafFingerprint)
+	require.NoError(t, err)
+
+	// Mock connection state
+	cs := tls.ConnectionState{
+		VerifiedChains: [][]*x509.Certificate{
+			{
+				{Raw: leafPEM.Bytes},
+				{Raw: intermediatePEM.Bytes},
+				{Raw: rootPEM.Bytes},
+			},
+		},
+	}
+
+	err = verifier(cs)
+	assert.NoError(t, err)
+
+	// Test with invalid hash in chain
+	csInvalid := tls.ConnectionState{
+		VerifiedChains: [][]*x509.Certificate{
+			{
+				{Raw: leafWithInvalidHashPEM.Bytes},
+				{Raw: intermediatePEM.Bytes},
+				{Raw: rootPEM.Bytes},
+			},
+		},
+	}
+	err = verifier(csInvalid)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "no matching fingerprint found")
+
+	// Test with different fingerprint
+	otherFingerprint := CalculateFingerprint(intermediatePEM.Bytes)
+	verifier2, err := NewConnectionVerifier(otherFingerprint)
+	require.NoError(t, err)
+
+	// Should pass because intermediate is in the chain
+	err = verifier2(cs)
+	assert.NoError(t, err)
+
+	// Test with random fingerprint strings
+	_, err = NewConnectionVerifier("random")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "client-fingerprint")
+
+	_, err = NewConnectionVerifier("chrome")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "client-fingerprint")
+
+	// Test with invalid hex string
+	_, err = NewConnectionVerifier("not-a-hex-string")
+	assert.Error(t, err)
+
+	// Test with valid hex but wrong length
+	_, err = NewConnectionVerifier("1234")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "sha256 fingerprint")
+}


### PR DESCRIPTION
Currently, when a fingerprint is provided, `InsecureSkipVerify` will be set to `true` and we handle the entire verification procedure manually.
IMO, `InsecureSkipVerify` should only be used if `skip-cert-verify` is explicitly set .

When `InsecureSkipVerify` is not used, a normal certificate verification will be performed first(which should be safer than our custom implemention), and `VerifiedChains` will be populated. We can simply check if there is any certificate in the chains matches the fingerprint provided by the user.