### PR TITLE
fix: make User-Agent check case-insensitive

### DIFF
--- a/component/http/http.go
+++ b/component/http/http.go
@@ -50,7 +50,7 @@ func HttpRequest(ctx context.Context, url, method string, header map[string][]st
 		}
 	}
 
-	if _, ok := header["User-Agent"]; !ok {
+	if _, ok := req.Header["User-Agent"]; !ok {
 		req.Header.Set("User-Agent", UA())
 	}
 


### PR DESCRIPTION
This pull request contains a fix in checking the User-Agent installation. 

If you set the user-agent in lowercase in the proxy-providers header, it was not used.