### PR TITLE
feat(outboundgroup): add fallback tolerance to treat high latency as timeout

### DIFF
--- a/adapter/outboundgroup/fallback.go
+++ b/adapter/outboundgroup/fallback.go
@@ -13,12 +13,21 @@ import (
 	P "github.com/metacubex/mihomo/constant/provider"
 )
 
+type fallbackOption func(*Fallback)
+
+func fallbackWithTolerance(tolerance uint16) fallbackOption {
+	return func(f *Fallback) {
+		f.tolerance = tolerance
+	}
+}
+
 type Fallback struct {
 	*GroupBase
 	disableUDP     bool
 	testUrl        string
 	selected       string
 	expectedStatus string
+	tolerance      uint16
 	Hidden         bool
 	Icon           string
 }
@@ -105,12 +114,12 @@ func (f *Fallback) findAliveProxy(touch bool) C.Proxy {
 	proxies := f.GetProxies(touch)
 	for _, proxy := range proxies {
 		if len(f.selected) == 0 {
-			if proxy.AliveForTestUrl(f.testUrl) {
+			if f.proxyAlive(proxy) {
 				return proxy
 			}
 		} else {
 			if proxy.Name() == f.selected {
-				if proxy.AliveForTestUrl(f.testUrl) {
+				if f.proxyAlive(proxy) {
 					return proxy
 				} else {
 					f.selected = ""
@@ -136,7 +145,7 @@ func (f *Fallback) Set(name string) error {
 	}
 
 	f.selected = name
-	if !p.AliveForTestUrl(f.testUrl) {
+	if !f.proxyAlive(p) {
 		ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond*time.Duration(5000))
 		defer cancel()
 		expectedStatus, _ := utils.NewUnsignedRanges[uint16](f.expectedStatus)
@@ -158,8 +167,32 @@ func (f *Fallback) Proxies() []C.Proxy {
 	return f.GetProxies(false)
 }
 
-func NewFallback(option *GroupCommonOption, providers []P.ProxyProvider) *Fallback {
-	return &Fallback{
+func (f *Fallback) proxyAlive(proxy C.Proxy) bool {
+	if !proxy.AliveForTestUrl(f.testUrl) {
+		return false
+	}
+
+	if f.tolerance == 0 {
+		return true
+	}
+
+	return proxy.LastDelayForTestUrl(f.testUrl) <= f.tolerance
+}
+
+func parseFallbackOption(config map[string]any) []fallbackOption {
+	opts := []fallbackOption{}
+
+	if elm, ok := config["tolerance"]; ok {
+		if tolerance, ok := elm.(int); ok {
+			opts = append(opts, fallbackWithTolerance(uint16(tolerance)))
+		}
+	}
+
+	return opts
+}
+
+func NewFallback(option *GroupCommonOption, providers []P.ProxyProvider, options ...fallbackOption) *Fallback {
+	fallback := &Fallback{
 		GroupBase: NewGroupBase(GroupBaseOption{
 			Name:           option.Name,
 			Type:           C.Fallback,
@@ -176,4 +209,10 @@ func NewFallback(option *GroupCommonOption, providers []P.ProxyProvider) *Fallba
 		Hidden:         option.Hidden,
 		Icon:           option.Icon,
 	}
+
+	for _, option := range options {
+		option(fallback)
+	}
+
+	return fallback
 }

--- a/adapter/outboundgroup/parser.go
+++ b/adapter/outboundgroup/parser.go
@@ -181,7 +181,8 @@ func ParseProxyGroup(config map[string]any, proxyMap map[string]C.Proxy, provide
 	case "select":
 		group = NewSelector(groupOption, providers)
 	case "fallback":
-		group = NewFallback(groupOption, providers)
+		opts := parseFallbackOption(config)
+		group = NewFallback(groupOption, providers, opts...)
 	case "load-balance":
 		strategy := parseStrategy(config)
 		return NewLoadBalance(groupOption, providers, strategy)

--- a/docs/config.yaml
+++ b/docs/config.yaml
@@ -1156,6 +1156,7 @@ proxy-groups:
       - ss1
       - ss2
       - vmess1
+    # tolerance: 150 # 单位: ms, 延迟超过该值将视为 timeout
     url: "https://cp.cloudflare.com/generate_204"
     interval: 300
 


### PR DESCRIPTION
In real-world usage, the current fallback group only switches when a probe times out or a node becomes unreachable.
This can delay failover in a common case: node A is congested and has very high latency, but is still technically reachable, so traffic keeps using it.

To improve this behavior, this change adds a tolerance option (in milliseconds) to proxy-group type fallback.
When a node’s measured latency exceeds tolerance, it is treated as timed out, allowing fallback to switch to the next healthy node.

This change includes:

- adding tolerance parsing support for fallback
- applying latency-threshold checks in fallback liveness selection (delay > tolerance is considered unavailable)
- updating config examples/docs with tolerance usage