### PR TITLE
fix: unable to start mieru inbound when traffic-pattern is not set

### DIFF
--- a/listener/inbound/mieru.go
+++ b/listener/inbound/mieru.go
@@ -29,7 +29,7 @@ type MieruOption struct {
 	BaseOption
 	Transport      string            `inbound:"transport"`
 	Users          map[string]string `inbound:"users"`
-	TrafficPattern string            `inbound:"traffic-pattern"`
+	TrafficPattern string            `inbound:"traffic-pattern,omitempty"`
 }
 
 type mieruListenerFactory struct{}


### PR DESCRIPTION
```
time="..." level=fatal msg="Parse config error: proxy 0: '' has unset fields: traffic-pattern"
```