### PR TITLE
fix(outboundgroup): avoid selecting timeout nodes when alive nodes exist

### DIFF
--- a/adapter/outboundgroup/fallback.go
+++ b/adapter/outboundgroup/fallback.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"sync"
 	"time"
 
 	"github.com/metacubex/mihomo/common/callback"
@@ -15,6 +16,7 @@ import (
 
 type Fallback struct {
 	*GroupBase
+	stateMux       sync.RWMutex
 	disableUDP     bool
 	testUrl        string
 	selected       string
@@ -89,7 +91,7 @@ func (f *Fallback) MarshalJSON() ([]byte, error) {
 		"all":            all,
 		"testUrl":        f.testUrl,
 		"expectedStatus": f.expectedStatus,
-		"fixed":          f.selected,
+		"fixed":          f.getSelected(),
 		"hidden":         f.Hidden,
 		"icon":           f.Icon,
 	})
@@ -103,19 +105,24 @@ func (f *Fallback) Unwrap(metadata *C.Metadata, touch bool) C.Proxy {
 
 func (f *Fallback) findAliveProxy(touch bool) C.Proxy {
 	proxies := f.GetProxies(touch)
-	for _, proxy := range proxies {
-		if len(f.selected) == 0 {
+	selected := f.getSelected()
+
+	if len(selected) != 0 {
+		for _, proxy := range proxies {
+			if proxy.Name() != selected {
+				continue
+			}
 			if proxy.AliveForTestUrl(f.testUrl) {
 				return proxy
 			}
-		} else {
-			if proxy.Name() == f.selected {
-				if proxy.AliveForTestUrl(f.testUrl) {
-					return proxy
-				} else {
-					f.selected = ""
-				}
-			}
+			f.clearSelectedIf(selected)
+			break
+		}
+	}
+
+	for _, proxy := range proxies {
+		if proxy.AliveForTestUrl(f.testUrl) {
+			return proxy
 		}
 	}
 
@@ -135,7 +142,7 @@ func (f *Fallback) Set(name string) error {
 		return errors.New("proxy not exist")
 	}
 
-	f.selected = name
+	f.setSelected(name)
 	if !p.AliveForTestUrl(f.testUrl) {
 		ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond*time.Duration(5000))
 		defer cancel()
@@ -147,7 +154,28 @@ func (f *Fallback) Set(name string) error {
 }
 
 func (f *Fallback) ForceSet(name string) {
+	f.setSelected(name)
+}
+
+func (f *Fallback) getSelected() string {
+	f.stateMux.RLock()
+	defer f.stateMux.RUnlock()
+
+	return f.selected
+}
+
+func (f *Fallback) setSelected(name string) {
+	f.stateMux.Lock()
 	f.selected = name
+	f.stateMux.Unlock()
+}
+
+func (f *Fallback) clearSelectedIf(selected string) {
+	f.stateMux.Lock()
+	if f.selected == selected {
+		f.selected = ""
+	}
+	f.stateMux.Unlock()
 }
 
 func (f *Fallback) Providers() []P.ProxyProvider {

--- a/adapter/outboundgroup/groupbase.go
+++ b/adapter/outboundgroup/groupbase.go
@@ -224,7 +224,7 @@ func (gb *GroupBase) URLTest(ctx context.Context, url string, expectedStatus uti
 		wg.Add(1)
 		go func() {
 			delay, err := proxy.URLTest(ctx, url, expectedStatus)
-			if err == nil {
+			if err == nil && proxy.AliveForTestUrl(url) {
 				lock.Lock()
 				mp[proxy.Name()] = delay
 				lock.Unlock()

--- a/adapter/outboundgroup/urltest.go
+++ b/adapter/outboundgroup/urltest.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"sync"
 	"time"
 
 	"github.com/metacubex/mihomo/common/callback"
@@ -24,6 +25,7 @@ func urlTestWithTolerance(tolerance uint16) urlTestOption {
 
 type URLTest struct {
 	*GroupBase
+	stateMux       sync.RWMutex
 	selected       string
 	testUrl        string
 	expectedStatus string
@@ -55,7 +57,9 @@ func (u *URLTest) Set(name string) error {
 }
 
 func (u *URLTest) ForceSet(name string) {
+	u.stateMux.Lock()
 	u.selected = name
+	u.stateMux.Unlock()
 	u.fastSingle.Reset()
 }
 
@@ -109,24 +113,29 @@ func (u *URLTest) healthCheck() {
 func (u *URLTest) fast(touch bool) C.Proxy {
 	elm, _, shared := u.fastSingle.Do(func() (C.Proxy, error) {
 		proxies := u.GetProxies(touch)
-		if u.selected != "" {
+		selected, fastNode := u.snapshotState()
+
+		if selected != "" {
 			for _, proxy := range proxies {
 				if !proxy.AliveForTestUrl(u.testUrl) {
 					continue
 				}
-				if proxy.Name() == u.selected {
-					u.fastNode = proxy
+				if proxy.Name() == selected {
+					u.setFastNode(proxy)
 					return proxy, nil
 				}
 			}
 		}
 
-		fast := proxies[0]
-		minDelay := fast.LastDelayForTestUrl(u.testUrl)
-		fastNotExist := true
+		var (
+			fast         C.Proxy
+			fastDelay    uint16
+			hasAliveFast bool
+			fastNotExist = true
+		)
 
-		for _, proxy := range proxies[1:] {
-			if u.fastNode != nil && proxy.Name() == u.fastNode.Name() {
+		for _, proxy := range proxies {
+			if fastNode != nil && proxy.Name() == fastNode.Name() {
 				fastNotExist = false
 			}
 
@@ -135,23 +144,51 @@ func (u *URLTest) fast(touch bool) C.Proxy {
 			}
 
 			delay := proxy.LastDelayForTestUrl(u.testUrl)
-			if delay < minDelay {
+			if !hasAliveFast || delay < fastDelay {
 				fast = proxy
-				minDelay = delay
+				fastDelay = delay
+				hasAliveFast = true
 			}
+		}
 
+		// Do not fall back to timeout nodes when at least one alive node exists.
+		if hasAliveFast {
+			// tolerance
+			if fastNode == nil || fastNotExist || !fastNode.AliveForTestUrl(u.testUrl) || fastNode.LastDelayForTestUrl(u.testUrl) > fastDelay+u.tolerance {
+				fastNode = fast
+			}
+		} else if fastNode == nil || fastNotExist || !fastNode.AliveForTestUrl(u.testUrl) {
+			fastNode = proxies[0]
 		}
-		// tolerance
-		if u.fastNode == nil || fastNotExist || !u.fastNode.AliveForTestUrl(u.testUrl) || u.fastNode.LastDelayForTestUrl(u.testUrl) > fast.LastDelayForTestUrl(u.testUrl)+u.tolerance {
-			u.fastNode = fast
-		}
-		return u.fastNode, nil
+
+		u.setFastNode(fastNode)
+		return fastNode, nil
 	})
 	if shared && touch { // a shared fastSingle.Do() may cause providers untouched, so we touch them again
 		u.Touch()
 	}
 
 	return elm
+}
+
+func (u *URLTest) snapshotState() (string, C.Proxy) {
+	u.stateMux.RLock()
+	defer u.stateMux.RUnlock()
+
+	return u.selected, u.fastNode
+}
+
+func (u *URLTest) getSelected() string {
+	u.stateMux.RLock()
+	defer u.stateMux.RUnlock()
+
+	return u.selected
+}
+
+func (u *URLTest) setFastNode(proxy C.Proxy) {
+	u.stateMux.Lock()
+	u.fastNode = proxy
+	u.stateMux.Unlock()
 }
 
 // SupportUDP implements C.ProxyAdapter
@@ -179,7 +216,7 @@ func (u *URLTest) MarshalJSON() ([]byte, error) {
 		"all":            all,
 		"testUrl":        u.testUrl,
 		"expectedStatus": u.expectedStatus,
-		"fixed":          u.selected,
+		"fixed":          u.getSelected(),
 		"hidden":         u.Hidden,
 		"icon":           u.Icon,
 	})
@@ -194,7 +231,11 @@ func (u *URLTest) Proxies() []C.Proxy {
 }
 
 func (u *URLTest) URLTest(ctx context.Context, url string, expectedStatus utils.IntRanges[uint16]) (map[string]uint16, error) {
-	return u.GroupBase.URLTest(ctx, u.testUrl, expectedStatus)
+	delays, err := u.GroupBase.URLTest(ctx, u.testUrl, expectedStatus)
+	// URL tests update alive/delay history; reset cache so next routing picks fresh best node.
+	u.fastSingle.Reset()
+	_ = u.fast(false)
+	return delays, err
 }
 
 func parseURLTestOption(config map[string]any) []urlTestOption {

--- a/transport/sudoku/obfs/httpmask/tunnel.go
+++ b/transport/sudoku/obfs/httpmask/tunnel.go
@@ -1241,6 +1241,7 @@ func (c *pollConn) pullLoop() {
 			payload, err := base64.StdEncoding.DecodeString(line)
 			if err != nil {
 				_ = resp.Body.Close()
+				cancel()
 				_ = c.closeWithError(fmt.Errorf("poll pull decode failed: %w", err))
 				return
 			}
@@ -1248,6 +1249,7 @@ func (c *pollConn) pullLoop() {
 			case c.rxc <- payload:
 			case <-c.closed:
 				_ = resp.Body.Close()
+				cancel()
 				return
 			}
 		}


### PR DESCRIPTION
## Summary

This PR addresses group selection instability when healthy and timeout nodes coexist.

### Changes

- `adapter/outboundgroup/urltest.go`
  - Prefer alive nodes only when at least one alive node exists.
  - Avoid falling back to timeout nodes while healthy options are still available.
  - Reset and refresh cached fast-node decision after group URL tests.
  - Protect `selected` / `fastNode` state with mutex to avoid concurrent read-write races.

- `adapter/outboundgroup/fallback.go`
  - Keep ordered fallback semantics: check selected first; if selected is unavailable, clear it, then iterate in configured order and pick the first alive node.
  - Protect selected state with mutex to avoid races between manual override and auto selection.

- `adapter/outboundgroup/groupbase.go`
  - Record group delay map entries only for proxies still alive for the tested URL.

- `transport/sudoku/obfs/httpmask/tunnel.go`
  - Add missing `cancel()` calls on early return branches in `pullLoop` to avoid context/timer leaks.

## Why

In large deployments (many groups / many proxies), concurrent API operations and periodic checks can leave selection state inconsistent and cause timeout nodes to be chosen even when alive nodes are available.

This patch keeps behavior deterministic, aligns delay output with selection state, and improves long-running stability.

## Validation

- `go test ./...`
- `go vet ./...`
- `go test ./adapter/outboundgroup ./transport/sudoku/obfs/httpmask ./hub/route`
