### PR TITLE
fix: 修复  v1.19.21 中 gRPC 自定义 UserAgent 不生效的问题

### DIFF
--- a/transport/gun/gun.go
+++ b/transport/gun/gun.go
@@ -33,8 +33,8 @@ var (
 )
 
 var defaultHeader = http.Header{
-	"content-type": []string{"application/grpc"},
-	"user-agent":   []string{"grpc-go/1.36.0"},
+	"Content-Type": []string{"application/grpc"},
+	"User-Agent":   []string{"grpc-go/1.36.0"},
 }
 
 type DialFn = func(ctx context.Context, network, addr string) (net.Conn, error)


### PR DESCRIPTION
mihomo 的配置文件 config.yaml 中 设置了 gRPC 自定义 UserAgent
`grpc-opts.grpc-user-agent: "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"`

在使用 mihomo v1.19.20时，自定义UA生效，在Cloudflare Security后台能看到请求的UA为自定义UA；但是升级到 v1.19.21后，在配置不变的情况下，Cloudflare后台显示UA变回了默认UA`grpc-go/1.36.0`，被Cloudflare视为HTTP DDoS攻击拦截。

对比 v1.19.20 和 v1,19,21 代码发现：
- 默认UA的代码为
```
var defaultHeader = http.Header{
	"content-type": []string{"application/grpc"},
	"user-agent":   []string{"grpc-go/1.36.0"},
}
```

- 在 v1.19.20 中，判断并修改UA的代码为
```
	if cfg.UserAgent != "" {
		header["user-agent"] = []string{cfg.UserAgent}
	}
```
能正常替换`user-agent`的值

- 而在 v1.19.21 中，判断并修改UA的代码为
```
	if cfg.UserAgent != "" {
		header.Set("User-Agent", cfg.UserAgent)
	}
```
此时会新建一个名为`User-Agent`的自定义UA键值，而并不会替换原有的默认UA`user-agent`，所以导致自定义UA失效，修改`defaultHeader`中的`user-agent`为`User-Agent`后才能替换默认UA为自定义UA

我已经在我自己的repo中[编译测试过了](https://github.com/DanAlex121/mihomo/actions/runs/23056544092)，通过Cloudflare后台日志**确定这个pr能修复gRPC自定义UA不生效的问题**。