### PR TITLE
feat(proxy-group): optional persistent pin with long-failure auto-unfix

### DIFF
--- a/adapter/outboundgroup/fallback.go
+++ b/adapter/outboundgroup/fallback.go
@@ -248,6 +248,8 @@ func (f *Fallback) observePersistentPinnedResult(selected string, pinned C.Proxy
 	autoUnfixed := false
 	reachedCount := 0
 	resetByHealthy := false
+	resetReason := ""
+	resetFrom := 0
 
 	f.stateMux.Lock()
 	if f.selected != selected || !lastTestAt.After(f.pinAutoUnfixLastTest) {
@@ -263,9 +265,17 @@ func (f *Fallback) observePersistentPinnedResult(selected string, pinned C.Proxy
 	}
 	f.pinAutoUnfixLastTest = lastTestAt
 	if resetByHealthy {
+		if f.pinAutoUnfixCount > 0 {
+			resetReason = "pinned proxy has successful test records"
+			resetFrom = f.pinAutoUnfixCount
+		}
 		f.pinAutoUnfixCount = 0
 	}
 	if lastHealthy {
+		if f.pinAutoUnfixCount > 0 {
+			resetReason = "pinned proxy recovered"
+			resetFrom = f.pinAutoUnfixCount
+		}
 		f.pinAutoUnfixCount = 0
 	} else if hasOtherAlive {
 		f.pinAutoUnfixCount++
@@ -276,10 +286,17 @@ func (f *Fallback) observePersistentPinnedResult(selected string, pinned C.Proxy
 			autoUnfixed = true
 		}
 	} else {
+		if f.pinAutoUnfixCount > 0 {
+			resetReason = "no alternative alive proxies in group"
+			resetFrom = f.pinAutoUnfixCount
+		}
 		f.pinAutoUnfixCount = 0
 	}
 	f.stateMux.Unlock()
 
+	if resetReason != "" {
+		log.Warnln("group [%s] reset persistent pin auto-unfix counter for proxy [%s] from %d to 0 (%s)", f.Name(), selected, resetFrom, resetReason)
+	}
 	if autoUnfixed {
 		log.Warnln("group [%s] auto-unfixed persistent pin on proxy [%s] after %d consecutive unhealthy checks with alternative alive proxies", f.Name(), selected, reachedCount)
 	}
@@ -293,6 +310,11 @@ func (f *Fallback) warnPersistentPinnedProxy(selected, reason string) {
 	}
 
 	shouldLog := false
+	counter := 0
+	threshold := f.pinAutoUnfixThreshold
+	if threshold <= 0 {
+		threshold = defaultPersistentPinAutoUnfixThreshold
+	}
 	f.stateMux.Lock()
 	now := time.Now()
 	if f.lastPinWarnFor != selected || f.lastPinWarnMsg != reason || now.Sub(f.lastPinWarnAt) >= interval {
@@ -301,6 +323,7 @@ func (f *Fallback) warnPersistentPinnedProxy(selected, reason string) {
 		f.lastPinWarnAt = now
 		shouldLog = true
 	}
+	counter = f.pinAutoUnfixCount
 	f.stateMux.Unlock()
 	if !shouldLog {
 		return
@@ -310,7 +333,7 @@ func (f *Fallback) warnPersistentPinnedProxy(selected, reason string) {
 	case "missing":
 		log.Warnln("group [%s] cleared persistent pin because proxy [%s] no longer exists in current members", f.Name(), selected)
 	default:
-		log.Warnln("group [%s] keeps persistent pin on unhealthy proxy [%s]; traffic remains pinned until manual unfix", f.Name(), selected)
+		log.Warnln("group [%s] keeps persistent pin on unhealthy proxy [%s]; traffic remains pinned until manual unfix (auto-unfix counter %d/%d)", f.Name(), selected, counter, threshold)
 	}
 }
 

--- a/adapter/outboundgroup/fallback.go
+++ b/adapter/outboundgroup/fallback.go
@@ -12,17 +12,23 @@ import (
 	"github.com/metacubex/mihomo/common/utils"
 	C "github.com/metacubex/mihomo/constant"
 	P "github.com/metacubex/mihomo/constant/provider"
+	"github.com/metacubex/mihomo/log"
 )
 
 type Fallback struct {
 	*GroupBase
-	stateMux       sync.RWMutex
-	disableUDP     bool
-	testUrl        string
-	selected       string
-	expectedStatus string
-	Hidden         bool
-	Icon           string
+	stateMux        sync.RWMutex
+	disableUDP      bool
+	testUrl         string
+	selected        string
+	expectedStatus  string
+	persistentPin   bool
+	pinWarnInterval time.Duration
+	lastPinWarnAt   time.Time
+	lastPinWarnFor  string
+	lastPinWarnMsg  string
+	Hidden          bool
+	Icon            string
 }
 
 func (f *Fallback) Now() string {
@@ -86,14 +92,16 @@ func (f *Fallback) MarshalJSON() ([]byte, error) {
 		all = append(all, proxy.Name())
 	}
 	return json.Marshal(map[string]any{
-		"type":           f.Type().String(),
-		"now":            f.Now(),
-		"all":            all,
-		"testUrl":        f.testUrl,
-		"expectedStatus": f.expectedStatus,
-		"fixed":          f.getSelected(),
-		"hidden":         f.Hidden,
-		"icon":           f.Icon,
+		"type":                    f.Type().String(),
+		"now":                     f.Now(),
+		"all":                     all,
+		"testUrl":                 f.testUrl,
+		"expectedStatus":          f.expectedStatus,
+		"fixed":                   f.getSelected(),
+		"persistentPin":           f.persistentPin,
+		"pinUnhealthyLogInterval": int(f.pinWarnInterval / time.Second),
+		"hidden":                  f.Hidden,
+		"icon":                    f.Icon,
 	})
 }
 
@@ -108,15 +116,27 @@ func (f *Fallback) findAliveProxy(touch bool) C.Proxy {
 	selected := f.getSelected()
 
 	if len(selected) != 0 {
+		foundSelected := false
 		for _, proxy := range proxies {
 			if proxy.Name() != selected {
 				continue
+			}
+			foundSelected = true
+			if f.persistentPin {
+				if !proxy.AliveForTestUrl(f.testUrl) {
+					f.warnPersistentPinnedProxy(selected, "unhealthy")
+				}
+				return proxy
 			}
 			if proxy.AliveForTestUrl(f.testUrl) {
 				return proxy
 			}
 			f.clearSelectedIf(selected)
 			break
+		}
+		if f.persistentPin && !foundSelected {
+			f.clearSelectedIf(selected)
+			f.warnPersistentPinnedProxy(selected, "missing")
 		}
 	}
 
@@ -157,6 +177,10 @@ func (f *Fallback) ForceSet(name string) {
 	f.setSelected(name)
 }
 
+func (f *Fallback) PersistentPin() bool {
+	return f.persistentPin
+}
+
 func (f *Fallback) getSelected() string {
 	f.stateMux.RLock()
 	defer f.stateMux.RUnlock()
@@ -178,6 +202,34 @@ func (f *Fallback) clearSelectedIf(selected string) {
 	f.stateMux.Unlock()
 }
 
+func (f *Fallback) warnPersistentPinnedProxy(selected, reason string) {
+	interval := f.pinWarnInterval
+	if interval <= 0 {
+		interval = 10 * time.Second
+	}
+
+	shouldLog := false
+	f.stateMux.Lock()
+	now := time.Now()
+	if f.lastPinWarnFor != selected || f.lastPinWarnMsg != reason || now.Sub(f.lastPinWarnAt) >= interval {
+		f.lastPinWarnFor = selected
+		f.lastPinWarnMsg = reason
+		f.lastPinWarnAt = now
+		shouldLog = true
+	}
+	f.stateMux.Unlock()
+	if !shouldLog {
+		return
+	}
+
+	switch reason {
+	case "missing":
+		log.Warnln("group [%s] cleared persistent pin because proxy [%s] no longer exists in current members", f.Name(), selected)
+	default:
+		log.Warnln("group [%s] keeps persistent pin on unhealthy proxy [%s]; traffic remains pinned until manual unfix", f.Name(), selected)
+	}
+}
+
 func (f *Fallback) Providers() []P.ProxyProvider {
 	return f.providers
 }
@@ -187,6 +239,11 @@ func (f *Fallback) Proxies() []C.Proxy {
 }
 
 func NewFallback(option *GroupCommonOption, providers []P.ProxyProvider) *Fallback {
+	pinWarnInterval := 10 * time.Second
+	if option.PinUnhealthyLogInterval > 0 {
+		pinWarnInterval = time.Duration(option.PinUnhealthyLogInterval) * time.Second
+	}
+
 	return &Fallback{
 		GroupBase: NewGroupBase(GroupBaseOption{
 			Name:           option.Name,
@@ -198,10 +255,12 @@ func NewFallback(option *GroupCommonOption, providers []P.ProxyProvider) *Fallba
 			MaxFailedTimes: option.MaxFailedTimes,
 			Providers:      providers,
 		}),
-		disableUDP:     option.DisableUDP,
-		testUrl:        option.URL,
-		expectedStatus: option.ExpectedStatus,
-		Hidden:         option.Hidden,
-		Icon:           option.Icon,
+		disableUDP:      option.DisableUDP,
+		testUrl:         option.URL,
+		expectedStatus:  option.ExpectedStatus,
+		persistentPin:   option.PersistentPin,
+		pinWarnInterval: pinWarnInterval,
+		Hidden:          option.Hidden,
+		Icon:            option.Icon,
 	}
 }

--- a/adapter/outboundgroup/fallback.go
+++ b/adapter/outboundgroup/fallback.go
@@ -17,18 +17,21 @@ import (
 
 type Fallback struct {
 	*GroupBase
-	stateMux        sync.RWMutex
-	disableUDP      bool
-	testUrl         string
-	selected        string
-	expectedStatus  string
-	persistentPin   bool
-	pinWarnInterval time.Duration
-	lastPinWarnAt   time.Time
-	lastPinWarnFor  string
-	lastPinWarnMsg  string
-	Hidden          bool
-	Icon            string
+	stateMux              sync.RWMutex
+	disableUDP            bool
+	testUrl               string
+	selected              string
+	expectedStatus        string
+	persistentPin         bool
+	pinWarnInterval       time.Duration
+	pinAutoUnfixThreshold int
+	pinAutoUnfixCount     int
+	pinAutoUnfixLastTest  time.Time
+	lastPinWarnAt         time.Time
+	lastPinWarnFor        string
+	lastPinWarnMsg        string
+	Hidden                bool
+	Icon                  string
 }
 
 func (f *Fallback) Now() string {
@@ -92,16 +95,17 @@ func (f *Fallback) MarshalJSON() ([]byte, error) {
 		all = append(all, proxy.Name())
 	}
 	return json.Marshal(map[string]any{
-		"type":                    f.Type().String(),
-		"now":                     f.Now(),
-		"all":                     all,
-		"testUrl":                 f.testUrl,
-		"expectedStatus":          f.expectedStatus,
-		"fixed":                   f.getSelected(),
-		"persistentPin":           f.persistentPin,
-		"pinUnhealthyLogInterval": int(f.pinWarnInterval / time.Second),
-		"hidden":                  f.Hidden,
-		"icon":                    f.Icon,
+		"type":                            f.Type().String(),
+		"now":                             f.Now(),
+		"all":                             all,
+		"testUrl":                         f.testUrl,
+		"expectedStatus":                  f.expectedStatus,
+		"fixed":                           f.getSelected(),
+		"persistentPin":                   f.persistentPin,
+		"pinUnhealthyLogInterval":         int(f.pinWarnInterval / time.Second),
+		"persistentPinAutoUnfixThreshold": f.pinAutoUnfixThreshold,
+		"hidden":                          f.Hidden,
+		"icon":                            f.Icon,
 	})
 }
 
@@ -123,6 +127,9 @@ func (f *Fallback) findAliveProxy(touch bool) C.Proxy {
 			}
 			foundSelected = true
 			if f.persistentPin {
+				if f.observePersistentPinnedResult(selected, proxy, proxies) {
+					break
+				}
 				if !proxy.AliveForTestUrl(f.testUrl) {
 					f.warnPersistentPinnedProxy(selected, "unhealthy")
 				}
@@ -191,6 +198,7 @@ func (f *Fallback) getSelected() string {
 func (f *Fallback) setSelected(name string) {
 	f.stateMux.Lock()
 	f.selected = name
+	f.resetPersistentPinStateLocked()
 	f.stateMux.Unlock()
 }
 
@@ -198,8 +206,84 @@ func (f *Fallback) clearSelectedIf(selected string) {
 	f.stateMux.Lock()
 	if f.selected == selected {
 		f.selected = ""
+		f.resetPersistentPinStateLocked()
 	}
 	f.stateMux.Unlock()
+}
+
+func (f *Fallback) resetPersistentPinStateLocked() {
+	f.pinAutoUnfixCount = 0
+	f.pinAutoUnfixLastTest = time.Time{}
+	f.lastPinWarnAt = time.Time{}
+	f.lastPinWarnFor = ""
+	f.lastPinWarnMsg = ""
+}
+
+func (f *Fallback) observePersistentPinnedResult(selected string, pinned C.Proxy, proxies []C.Proxy) bool {
+	history, ok := proxyTestHistory(pinned, f.testUrl)
+	if !ok {
+		return false
+	}
+	lastRecord := history[len(history)-1]
+	lastTestAt := lastRecord.Time
+	lastHealthy := lastRecord.Delay != 0
+	hasOtherAlive := false
+	if !lastHealthy {
+		for _, proxy := range proxies {
+			if proxy.Name() == selected {
+				continue
+			}
+			if proxy.AliveForTestUrl(f.testUrl) {
+				hasOtherAlive = true
+				break
+			}
+		}
+	}
+
+	threshold := f.pinAutoUnfixThreshold
+	if threshold <= 0 {
+		threshold = defaultPersistentPinAutoUnfixThreshold
+	}
+
+	autoUnfixed := false
+	reachedCount := 0
+	resetByHealthy := false
+
+	f.stateMux.Lock()
+	if f.selected != selected || !lastTestAt.After(f.pinAutoUnfixLastTest) {
+		f.stateMux.Unlock()
+		return false
+	}
+
+	for _, record := range history {
+		if record.Time.After(f.pinAutoUnfixLastTest) && record.Delay != 0 {
+			resetByHealthy = true
+			break
+		}
+	}
+	f.pinAutoUnfixLastTest = lastTestAt
+	if resetByHealthy {
+		f.pinAutoUnfixCount = 0
+	}
+	if lastHealthy {
+		f.pinAutoUnfixCount = 0
+	} else if hasOtherAlive {
+		f.pinAutoUnfixCount++
+		if f.pinAutoUnfixCount >= threshold {
+			reachedCount = f.pinAutoUnfixCount
+			f.selected = ""
+			f.resetPersistentPinStateLocked()
+			autoUnfixed = true
+		}
+	} else {
+		f.pinAutoUnfixCount = 0
+	}
+	f.stateMux.Unlock()
+
+	if autoUnfixed {
+		log.Warnln("group [%s] auto-unfixed persistent pin on proxy [%s] after %d consecutive unhealthy checks with alternative alive proxies", f.Name(), selected, reachedCount)
+	}
+	return autoUnfixed
 }
 
 func (f *Fallback) warnPersistentPinnedProxy(selected, reason string) {
@@ -243,6 +327,10 @@ func NewFallback(option *GroupCommonOption, providers []P.ProxyProvider) *Fallba
 	if option.PinUnhealthyLogInterval > 0 {
 		pinWarnInterval = time.Duration(option.PinUnhealthyLogInterval) * time.Second
 	}
+	pinAutoUnfixThreshold := defaultPersistentPinAutoUnfixThreshold
+	if option.PersistentPinAutoUnfixThreshold > 0 {
+		pinAutoUnfixThreshold = option.PersistentPinAutoUnfixThreshold
+	}
 
 	return &Fallback{
 		GroupBase: NewGroupBase(GroupBaseOption{
@@ -255,12 +343,13 @@ func NewFallback(option *GroupCommonOption, providers []P.ProxyProvider) *Fallba
 			MaxFailedTimes: option.MaxFailedTimes,
 			Providers:      providers,
 		}),
-		disableUDP:      option.DisableUDP,
-		testUrl:         option.URL,
-		expectedStatus:  option.ExpectedStatus,
-		persistentPin:   option.PersistentPin,
-		pinWarnInterval: pinWarnInterval,
-		Hidden:          option.Hidden,
-		Icon:            option.Icon,
+		disableUDP:            option.DisableUDP,
+		testUrl:               option.URL,
+		expectedStatus:        option.ExpectedStatus,
+		persistentPin:         option.PersistentPin,
+		pinWarnInterval:       pinWarnInterval,
+		pinAutoUnfixThreshold: pinAutoUnfixThreshold,
+		Hidden:                option.Hidden,
+		Icon:                  option.Icon,
 	}
 }

--- a/adapter/outboundgroup/fallback.go
+++ b/adapter/outboundgroup/fallback.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"sync"
 	"time"
 
 	"github.com/metacubex/mihomo/common/callback"
@@ -15,6 +16,7 @@ import (
 
 type Fallback struct {
 	*GroupBase
+	stateMux       sync.RWMutex
 	disableUDP     bool
 	testUrl        string
 	selected       string
@@ -89,7 +91,7 @@ func (f *Fallback) MarshalJSON() ([]byte, error) {
 		"all":            all,
 		"testUrl":        f.testUrl,
 		"expectedStatus": f.expectedStatus,
-		"fixed":          f.selected,
+		"fixed":          f.getSelected(),
 		"hidden":         f.Hidden,
 		"icon":           f.Icon,
 	})
@@ -103,19 +105,24 @@ func (f *Fallback) Unwrap(metadata *C.Metadata, touch bool) C.Proxy {
 
 func (f *Fallback) findAliveProxy(touch bool) C.Proxy {
 	proxies := f.GetProxies(touch)
-	for _, proxy := range proxies {
-		if len(f.selected) == 0 {
+	selected := f.getSelected()
+
+	if len(selected) != 0 {
+		for _, proxy := range proxies {
+			if proxy.Name() != selected {
+				continue
+			}
 			if proxy.AliveForTestUrl(f.testUrl) {
 				return proxy
 			}
-		} else {
-			if proxy.Name() == f.selected {
-				if proxy.AliveForTestUrl(f.testUrl) {
-					return proxy
-				} else {
-					f.selected = ""
-				}
-			}
+			f.clearSelectedIf(selected)
+			break
+		}
+	}
+
+	for _, proxy := range proxies {
+		if proxy.AliveForTestUrl(f.testUrl) {
+			return proxy
 		}
 	}
 
@@ -135,7 +142,7 @@ func (f *Fallback) Set(name string) error {
 		return errors.New("proxy not exist")
 	}
 
-	f.selected = name
+	f.setSelected(name)
 	if !p.AliveForTestUrl(f.testUrl) {
 		ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond*time.Duration(5000))
 		defer cancel()
@@ -147,7 +154,28 @@ func (f *Fallback) Set(name string) error {
 }
 
 func (f *Fallback) ForceSet(name string) {
+	f.setSelected(name)
+}
+
+func (f *Fallback) getSelected() string {
+	f.stateMux.RLock()
+	defer f.stateMux.RUnlock()
+
+	return f.selected
+}
+
+func (f *Fallback) setSelected(name string) {
+	f.stateMux.Lock()
 	f.selected = name
+	f.stateMux.Unlock()
+}
+
+func (f *Fallback) clearSelectedIf(selected string) {
+	f.stateMux.Lock()
+	if f.selected == selected {
+		f.selected = ""
+	}
+	f.stateMux.Unlock()
 }
 
 func (f *Fallback) Providers() []P.ProxyProvider {

--- a/adapter/outboundgroup/groupbase.go
+++ b/adapter/outboundgroup/groupbase.go
@@ -224,7 +224,7 @@ func (gb *GroupBase) URLTest(ctx context.Context, url string, expectedStatus uti
 		wg.Add(1)
 		go func() {
 			delay, err := proxy.URLTest(ctx, url, expectedStatus)
-			if err == nil {
+			if err == nil && proxy.AliveForTestUrl(url) {
 				lock.Lock()
 				mp[proxy.Name()] = delay
 				lock.Unlock()

--- a/adapter/outboundgroup/parser.go
+++ b/adapter/outboundgroup/parser.go
@@ -23,25 +23,27 @@ var (
 )
 
 type GroupCommonOption struct {
-	Name                string   `group:"name"`
-	Type                string   `group:"type"`
-	Proxies             []string `group:"proxies,omitempty"`
-	Use                 []string `group:"use,omitempty"`
-	URL                 string   `group:"url,omitempty"`
-	Interval            int      `group:"interval,omitempty"`
-	TestTimeout         int      `group:"timeout,omitempty"`
-	MaxFailedTimes      int      `group:"max-failed-times,omitempty"`
-	Lazy                bool     `group:"lazy,omitempty"`
-	DisableUDP          bool     `group:"disable-udp,omitempty"`
-	Filter              string   `group:"filter,omitempty"`
-	ExcludeFilter       string   `group:"exclude-filter,omitempty"`
-	ExcludeType         string   `group:"exclude-type,omitempty"`
-	ExpectedStatus      string   `group:"expected-status,omitempty"`
-	IncludeAll          bool     `group:"include-all,omitempty"`
-	IncludeAllProxies   bool     `group:"include-all-proxies,omitempty"`
-	IncludeAllProviders bool     `group:"include-all-providers,omitempty"`
-	Hidden              bool     `group:"hidden,omitempty"`
-	Icon                string   `group:"icon,omitempty"`
+	Name                    string   `group:"name"`
+	Type                    string   `group:"type"`
+	Proxies                 []string `group:"proxies,omitempty"`
+	Use                     []string `group:"use,omitempty"`
+	URL                     string   `group:"url,omitempty"`
+	Interval                int      `group:"interval,omitempty"`
+	TestTimeout             int      `group:"timeout,omitempty"`
+	MaxFailedTimes          int      `group:"max-failed-times,omitempty"`
+	Lazy                    bool     `group:"lazy,omitempty"`
+	DisableUDP              bool     `group:"disable-udp,omitempty"`
+	Filter                  string   `group:"filter,omitempty"`
+	ExcludeFilter           string   `group:"exclude-filter,omitempty"`
+	ExcludeType             string   `group:"exclude-type,omitempty"`
+	ExpectedStatus          string   `group:"expected-status,omitempty"`
+	PersistentPin           bool     `group:"persistent-pin,omitempty"`
+	PinUnhealthyLogInterval int      `group:"pin-unhealthy-log-interval,omitempty"`
+	IncludeAll              bool     `group:"include-all,omitempty"`
+	IncludeAllProxies       bool     `group:"include-all-proxies,omitempty"`
+	IncludeAllProviders     bool     `group:"include-all-providers,omitempty"`
+	Hidden                  bool     `group:"hidden,omitempty"`
+	Icon                    string   `group:"icon,omitempty"`
 }
 
 func ParseProxyGroup(config map[string]any, proxyMap map[string]C.Proxy, providersMap map[string]P.ProxyProvider, AllProxies []string, AllProviders []string) (C.ProxyAdapter, error) {
@@ -69,6 +71,10 @@ func ParseProxyGroup(config map[string]any, proxyMap map[string]C.Proxy, provide
 	}
 
 	groupName := groupOption.Name
+	if groupOption.PinUnhealthyLogInterval < 0 {
+		log.Warnln("group [%s] has invalid pin-unhealthy-log-interval=%d, fallback to default 10s", groupName, groupOption.PinUnhealthyLogInterval)
+		groupOption.PinUnhealthyLogInterval = 10
+	}
 
 	providers := []P.ProxyProvider{}
 

--- a/adapter/outboundgroup/parser.go
+++ b/adapter/outboundgroup/parser.go
@@ -22,28 +22,34 @@ var (
 	errDuplicateProvider = errors.New("duplicate provider name")
 )
 
+const (
+	defaultPinUnhealthyLogIntervalSeconds  = 10
+	defaultPersistentPinAutoUnfixThreshold = 10
+)
+
 type GroupCommonOption struct {
-	Name                    string   `group:"name"`
-	Type                    string   `group:"type"`
-	Proxies                 []string `group:"proxies,omitempty"`
-	Use                     []string `group:"use,omitempty"`
-	URL                     string   `group:"url,omitempty"`
-	Interval                int      `group:"interval,omitempty"`
-	TestTimeout             int      `group:"timeout,omitempty"`
-	MaxFailedTimes          int      `group:"max-failed-times,omitempty"`
-	Lazy                    bool     `group:"lazy,omitempty"`
-	DisableUDP              bool     `group:"disable-udp,omitempty"`
-	Filter                  string   `group:"filter,omitempty"`
-	ExcludeFilter           string   `group:"exclude-filter,omitempty"`
-	ExcludeType             string   `group:"exclude-type,omitempty"`
-	ExpectedStatus          string   `group:"expected-status,omitempty"`
-	PersistentPin           bool     `group:"persistent-pin,omitempty"`
-	PinUnhealthyLogInterval int      `group:"pin-unhealthy-log-interval,omitempty"`
-	IncludeAll              bool     `group:"include-all,omitempty"`
-	IncludeAllProxies       bool     `group:"include-all-proxies,omitempty"`
-	IncludeAllProviders     bool     `group:"include-all-providers,omitempty"`
-	Hidden                  bool     `group:"hidden,omitempty"`
-	Icon                    string   `group:"icon,omitempty"`
+	Name                            string   `group:"name"`
+	Type                            string   `group:"type"`
+	Proxies                         []string `group:"proxies,omitempty"`
+	Use                             []string `group:"use,omitempty"`
+	URL                             string   `group:"url,omitempty"`
+	Interval                        int      `group:"interval,omitempty"`
+	TestTimeout                     int      `group:"timeout,omitempty"`
+	MaxFailedTimes                  int      `group:"max-failed-times,omitempty"`
+	Lazy                            bool     `group:"lazy,omitempty"`
+	DisableUDP                      bool     `group:"disable-udp,omitempty"`
+	Filter                          string   `group:"filter,omitempty"`
+	ExcludeFilter                   string   `group:"exclude-filter,omitempty"`
+	ExcludeType                     string   `group:"exclude-type,omitempty"`
+	ExpectedStatus                  string   `group:"expected-status,omitempty"`
+	PersistentPin                   bool     `group:"persistent-pin,omitempty"`
+	PinUnhealthyLogInterval         int      `group:"pin-unhealthy-log-interval,omitempty"`
+	PersistentPinAutoUnfixThreshold int      `group:"persistent-pin-auto-unfix-threshold,omitempty"`
+	IncludeAll                      bool     `group:"include-all,omitempty"`
+	IncludeAllProxies               bool     `group:"include-all-proxies,omitempty"`
+	IncludeAllProviders             bool     `group:"include-all-providers,omitempty"`
+	Hidden                          bool     `group:"hidden,omitempty"`
+	Icon                            string   `group:"icon,omitempty"`
 }
 
 func ParseProxyGroup(config map[string]any, proxyMap map[string]C.Proxy, providersMap map[string]P.ProxyProvider, AllProxies []string, AllProviders []string) (C.ProxyAdapter, error) {
@@ -73,7 +79,11 @@ func ParseProxyGroup(config map[string]any, proxyMap map[string]C.Proxy, provide
 	groupName := groupOption.Name
 	if groupOption.PinUnhealthyLogInterval < 0 {
 		log.Warnln("group [%s] has invalid pin-unhealthy-log-interval=%d, fallback to default 10s", groupName, groupOption.PinUnhealthyLogInterval)
-		groupOption.PinUnhealthyLogInterval = 10
+		groupOption.PinUnhealthyLogInterval = defaultPinUnhealthyLogIntervalSeconds
+	}
+	if _, ok := config["persistent-pin-auto-unfix-threshold"]; ok && groupOption.PersistentPinAutoUnfixThreshold <= 0 {
+		log.Warnln("group [%s] has invalid persistent-pin-auto-unfix-threshold=%d, fallback to default %d", groupName, groupOption.PersistentPinAutoUnfixThreshold, defaultPersistentPinAutoUnfixThreshold)
+		groupOption.PersistentPinAutoUnfixThreshold = defaultPersistentPinAutoUnfixThreshold
 	}
 
 	providers := []P.ProxyProvider{}

--- a/adapter/outboundgroup/urltest.go
+++ b/adapter/outboundgroup/urltest.go
@@ -26,21 +26,24 @@ func urlTestWithTolerance(tolerance uint16) urlTestOption {
 
 type URLTest struct {
 	*GroupBase
-	stateMux        sync.RWMutex
-	selected        string
-	testUrl         string
-	expectedStatus  string
-	tolerance       uint16
-	disableUDP      bool
-	persistentPin   bool
-	pinWarnInterval time.Duration
-	lastPinWarnAt   time.Time
-	lastPinWarnFor  string
-	lastPinWarnMsg  string
-	Hidden          bool
-	Icon            string
-	fastNode        C.Proxy
-	fastSingle      *singledo.Single[C.Proxy]
+	stateMux              sync.RWMutex
+	selected              string
+	testUrl               string
+	expectedStatus        string
+	tolerance             uint16
+	disableUDP            bool
+	persistentPin         bool
+	pinWarnInterval       time.Duration
+	pinAutoUnfixThreshold int
+	pinAutoUnfixCount     int
+	pinAutoUnfixLastTest  time.Time
+	lastPinWarnAt         time.Time
+	lastPinWarnFor        string
+	lastPinWarnMsg        string
+	Hidden                bool
+	Icon                  string
+	fastNode              C.Proxy
+	fastSingle            *singledo.Single[C.Proxy]
 }
 
 func (u *URLTest) Now() string {
@@ -125,6 +128,9 @@ func (u *URLTest) fast(touch bool) C.Proxy {
 				if proxy.Name() == selected {
 					foundSelected = true
 					if u.persistentPin {
+						if u.observePersistentPinnedResult(selected, proxy, proxies) {
+							break
+						}
 						if !proxy.AliveForTestUrl(u.testUrl) {
 							u.warnPersistentPinnedProxy(selected, "unhealthy")
 						}
@@ -211,6 +217,7 @@ func (u *URLTest) setFastNode(proxy C.Proxy) {
 func (u *URLTest) setSelected(name string) {
 	u.stateMux.Lock()
 	u.selected = name
+	u.resetPersistentPinStateLocked()
 	u.stateMux.Unlock()
 }
 
@@ -218,6 +225,7 @@ func (u *URLTest) clearSelectedIf(selected string) {
 	u.stateMux.Lock()
 	if u.selected == selected {
 		u.selected = ""
+		u.resetPersistentPinStateLocked()
 	}
 	u.stateMux.Unlock()
 }
@@ -254,6 +262,81 @@ func (u *URLTest) warnPersistentPinnedProxy(selected, reason string) {
 	}
 }
 
+func (u *URLTest) resetPersistentPinStateLocked() {
+	u.pinAutoUnfixCount = 0
+	u.pinAutoUnfixLastTest = time.Time{}
+	u.lastPinWarnAt = time.Time{}
+	u.lastPinWarnFor = ""
+	u.lastPinWarnMsg = ""
+}
+
+func (u *URLTest) observePersistentPinnedResult(selected string, pinned C.Proxy, proxies []C.Proxy) bool {
+	history, ok := proxyTestHistory(pinned, u.testUrl)
+	if !ok {
+		return false
+	}
+	lastRecord := history[len(history)-1]
+	lastTestAt := lastRecord.Time
+	lastHealthy := lastRecord.Delay != 0
+	hasOtherAlive := false
+	if !lastHealthy {
+		for _, proxy := range proxies {
+			if proxy.Name() == selected {
+				continue
+			}
+			if proxy.AliveForTestUrl(u.testUrl) {
+				hasOtherAlive = true
+				break
+			}
+		}
+	}
+
+	threshold := u.pinAutoUnfixThreshold
+	if threshold <= 0 {
+		threshold = defaultPersistentPinAutoUnfixThreshold
+	}
+
+	autoUnfixed := false
+	reachedCount := 0
+	resetByHealthy := false
+
+	u.stateMux.Lock()
+	if u.selected != selected || !lastTestAt.After(u.pinAutoUnfixLastTest) {
+		u.stateMux.Unlock()
+		return false
+	}
+
+	for _, record := range history {
+		if record.Time.After(u.pinAutoUnfixLastTest) && record.Delay != 0 {
+			resetByHealthy = true
+			break
+		}
+	}
+	u.pinAutoUnfixLastTest = lastTestAt
+	if resetByHealthy {
+		u.pinAutoUnfixCount = 0
+	}
+	if lastHealthy {
+		u.pinAutoUnfixCount = 0
+	} else if hasOtherAlive {
+		u.pinAutoUnfixCount++
+		if u.pinAutoUnfixCount >= threshold {
+			reachedCount = u.pinAutoUnfixCount
+			u.selected = ""
+			u.resetPersistentPinStateLocked()
+			autoUnfixed = true
+		}
+	} else {
+		u.pinAutoUnfixCount = 0
+	}
+	u.stateMux.Unlock()
+
+	if autoUnfixed {
+		log.Warnln("group [%s] auto-unfixed persistent pin on proxy [%s] after %d consecutive unhealthy checks with alternative alive proxies", u.Name(), selected, reachedCount)
+	}
+	return autoUnfixed
+}
+
 // SupportUDP implements C.ProxyAdapter
 func (u *URLTest) SupportUDP() bool {
 	if u.disableUDP {
@@ -274,16 +357,17 @@ func (u *URLTest) MarshalJSON() ([]byte, error) {
 		all = append(all, proxy.Name())
 	}
 	return json.Marshal(map[string]any{
-		"type":                    u.Type().String(),
-		"now":                     u.Now(),
-		"all":                     all,
-		"testUrl":                 u.testUrl,
-		"expectedStatus":          u.expectedStatus,
-		"fixed":                   u.getSelected(),
-		"persistentPin":           u.persistentPin,
-		"pinUnhealthyLogInterval": int(u.pinWarnInterval / time.Second),
-		"hidden":                  u.Hidden,
-		"icon":                    u.Icon,
+		"type":                            u.Type().String(),
+		"now":                             u.Now(),
+		"all":                             all,
+		"testUrl":                         u.testUrl,
+		"expectedStatus":                  u.expectedStatus,
+		"fixed":                           u.getSelected(),
+		"persistentPin":                   u.persistentPin,
+		"pinUnhealthyLogInterval":         int(u.pinWarnInterval / time.Second),
+		"persistentPinAutoUnfixThreshold": u.pinAutoUnfixThreshold,
+		"hidden":                          u.Hidden,
+		"icon":                            u.Icon,
 	})
 }
 
@@ -321,6 +405,10 @@ func NewURLTest(option *GroupCommonOption, providers []P.ProxyProvider, options 
 	if option.PinUnhealthyLogInterval > 0 {
 		pinWarnInterval = time.Duration(option.PinUnhealthyLogInterval) * time.Second
 	}
+	pinAutoUnfixThreshold := defaultPersistentPinAutoUnfixThreshold
+	if option.PersistentPinAutoUnfixThreshold > 0 {
+		pinAutoUnfixThreshold = option.PersistentPinAutoUnfixThreshold
+	}
 
 	urlTest := &URLTest{
 		GroupBase: NewGroupBase(GroupBaseOption{
@@ -333,14 +421,15 @@ func NewURLTest(option *GroupCommonOption, providers []P.ProxyProvider, options 
 			MaxFailedTimes: option.MaxFailedTimes,
 			Providers:      providers,
 		}),
-		fastSingle:      singledo.NewSingle[C.Proxy](time.Second * 10),
-		disableUDP:      option.DisableUDP,
-		testUrl:         option.URL,
-		expectedStatus:  option.ExpectedStatus,
-		persistentPin:   option.PersistentPin,
-		pinWarnInterval: pinWarnInterval,
-		Hidden:          option.Hidden,
-		Icon:            option.Icon,
+		fastSingle:            singledo.NewSingle[C.Proxy](time.Second * 10),
+		disableUDP:            option.DisableUDP,
+		testUrl:               option.URL,
+		expectedStatus:        option.ExpectedStatus,
+		persistentPin:         option.PersistentPin,
+		pinWarnInterval:       pinWarnInterval,
+		pinAutoUnfixThreshold: pinAutoUnfixThreshold,
+		Hidden:                option.Hidden,
+		Icon:                  option.Icon,
 	}
 
 	for _, option := range options {

--- a/adapter/outboundgroup/urltest.go
+++ b/adapter/outboundgroup/urltest.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"sync"
 	"time"
 
 	"github.com/metacubex/mihomo/common/callback"
@@ -24,6 +25,7 @@ func urlTestWithTolerance(tolerance uint16) urlTestOption {
 
 type URLTest struct {
 	*GroupBase
+	stateMux       sync.RWMutex
 	selected       string
 	testUrl        string
 	expectedStatus string
@@ -55,7 +57,9 @@ func (u *URLTest) Set(name string) error {
 }
 
 func (u *URLTest) ForceSet(name string) {
+	u.stateMux.Lock()
 	u.selected = name
+	u.stateMux.Unlock()
 	u.fastSingle.Reset()
 }
 
@@ -109,24 +113,29 @@ func (u *URLTest) healthCheck() {
 func (u *URLTest) fast(touch bool) C.Proxy {
 	elm, _, shared := u.fastSingle.Do(func() (C.Proxy, error) {
 		proxies := u.GetProxies(touch)
-		if u.selected != "" {
+		selected, fastNode := u.snapshotState()
+
+		if selected != "" {
 			for _, proxy := range proxies {
 				if !proxy.AliveForTestUrl(u.testUrl) {
 					continue
 				}
-				if proxy.Name() == u.selected {
-					u.fastNode = proxy
+				if proxy.Name() == selected {
+					u.setFastNode(proxy)
 					return proxy, nil
 				}
 			}
 		}
 
-		fast := proxies[0]
-		minDelay := fast.LastDelayForTestUrl(u.testUrl)
-		fastNotExist := true
+		var (
+			fast         C.Proxy
+			fastDelay    uint16
+			hasAliveFast bool
+			fastNotExist = true
+		)
 
-		for _, proxy := range proxies[1:] {
-			if u.fastNode != nil && proxy.Name() == u.fastNode.Name() {
+		for _, proxy := range proxies {
+			if fastNode != nil && proxy.Name() == fastNode.Name() {
 				fastNotExist = false
 			}
 
@@ -135,23 +144,51 @@ func (u *URLTest) fast(touch bool) C.Proxy {
 			}
 
 			delay := proxy.LastDelayForTestUrl(u.testUrl)
-			if delay < minDelay {
+			if !hasAliveFast || delay < fastDelay {
 				fast = proxy
-				minDelay = delay
+				fastDelay = delay
+				hasAliveFast = true
 			}
+		}
 
+		// Do not fall back to timeout nodes when at least one alive node exists.
+		if hasAliveFast {
+			// tolerance
+			if fastNode == nil || fastNotExist || !fastNode.AliveForTestUrl(u.testUrl) || fastNode.LastDelayForTestUrl(u.testUrl) > fastDelay+u.tolerance {
+				fastNode = fast
+			}
+		} else if fastNode == nil || fastNotExist || !fastNode.AliveForTestUrl(u.testUrl) {
+			fastNode = proxies[0]
 		}
-		// tolerance
-		if u.fastNode == nil || fastNotExist || !u.fastNode.AliveForTestUrl(u.testUrl) || u.fastNode.LastDelayForTestUrl(u.testUrl) > fast.LastDelayForTestUrl(u.testUrl)+u.tolerance {
-			u.fastNode = fast
-		}
-		return u.fastNode, nil
+
+		u.setFastNode(fastNode)
+		return fastNode, nil
 	})
 	if shared && touch { // a shared fastSingle.Do() may cause providers untouched, so we touch them again
 		u.Touch()
 	}
 
 	return elm
+}
+
+func (u *URLTest) snapshotState() (string, C.Proxy) {
+	u.stateMux.RLock()
+	defer u.stateMux.RUnlock()
+
+	return u.selected, u.fastNode
+}
+
+func (u *URLTest) getSelected() string {
+	u.stateMux.RLock()
+	defer u.stateMux.RUnlock()
+
+	return u.selected
+}
+
+func (u *URLTest) setFastNode(proxy C.Proxy) {
+	u.stateMux.Lock()
+	u.fastNode = proxy
+	u.stateMux.Unlock()
 }
 
 // SupportUDP implements C.ProxyAdapter
@@ -179,7 +216,7 @@ func (u *URLTest) MarshalJSON() ([]byte, error) {
 		"all":            all,
 		"testUrl":        u.testUrl,
 		"expectedStatus": u.expectedStatus,
-		"fixed":          u.selected,
+		"fixed":          u.getSelected(),
 		"hidden":         u.Hidden,
 		"icon":           u.Icon,
 	})
@@ -194,7 +231,11 @@ func (u *URLTest) Proxies() []C.Proxy {
 }
 
 func (u *URLTest) URLTest(ctx context.Context, url string, expectedStatus utils.IntRanges[uint16]) (map[string]uint16, error) {
-	return u.GroupBase.URLTest(ctx, u.testUrl, expectedStatus)
+	delays, err := u.GroupBase.URLTest(ctx, u.testUrl, expectedStatus)
+	// URL tests update alive/delay history; reset cache so next routing picks fresh best node.
+	u.fastSingle.Reset()
+	_ = u.fast(false)
+	return delays, err
 }
 
 func parseURLTestOption(config map[string]any) []urlTestOption {

--- a/adapter/outboundgroup/urltest.go
+++ b/adapter/outboundgroup/urltest.go
@@ -13,6 +13,7 @@ import (
 	"github.com/metacubex/mihomo/common/utils"
 	C "github.com/metacubex/mihomo/constant"
 	P "github.com/metacubex/mihomo/constant/provider"
+	"github.com/metacubex/mihomo/log"
 )
 
 type urlTestOption func(*URLTest)
@@ -25,16 +26,21 @@ func urlTestWithTolerance(tolerance uint16) urlTestOption {
 
 type URLTest struct {
 	*GroupBase
-	stateMux       sync.RWMutex
-	selected       string
-	testUrl        string
-	expectedStatus string
-	tolerance      uint16
-	disableUDP     bool
-	Hidden         bool
-	Icon           string
-	fastNode       C.Proxy
-	fastSingle     *singledo.Single[C.Proxy]
+	stateMux        sync.RWMutex
+	selected        string
+	testUrl         string
+	expectedStatus  string
+	tolerance       uint16
+	disableUDP      bool
+	persistentPin   bool
+	pinWarnInterval time.Duration
+	lastPinWarnAt   time.Time
+	lastPinWarnFor  string
+	lastPinWarnMsg  string
+	Hidden          bool
+	Icon            string
+	fastNode        C.Proxy
+	fastSingle      *singledo.Single[C.Proxy]
 }
 
 func (u *URLTest) Now() string {
@@ -57,9 +63,7 @@ func (u *URLTest) Set(name string) error {
 }
 
 func (u *URLTest) ForceSet(name string) {
-	u.stateMux.Lock()
-	u.selected = name
-	u.stateMux.Unlock()
+	u.setSelected(name)
 	u.fastSingle.Reset()
 }
 
@@ -116,14 +120,27 @@ func (u *URLTest) fast(touch bool) C.Proxy {
 		selected, fastNode := u.snapshotState()
 
 		if selected != "" {
+			foundSelected := false
 			for _, proxy := range proxies {
-				if !proxy.AliveForTestUrl(u.testUrl) {
-					continue
-				}
 				if proxy.Name() == selected {
+					foundSelected = true
+					if u.persistentPin {
+						if !proxy.AliveForTestUrl(u.testUrl) {
+							u.warnPersistentPinnedProxy(selected, "unhealthy")
+						}
+						u.setFastNode(proxy)
+						return proxy, nil
+					}
+					if !proxy.AliveForTestUrl(u.testUrl) {
+						continue
+					}
 					u.setFastNode(proxy)
 					return proxy, nil
 				}
+			}
+			if u.persistentPin && !foundSelected {
+				u.clearSelectedIf(selected)
+				u.warnPersistentPinnedProxy(selected, "missing")
 			}
 		}
 
@@ -191,6 +208,52 @@ func (u *URLTest) setFastNode(proxy C.Proxy) {
 	u.stateMux.Unlock()
 }
 
+func (u *URLTest) setSelected(name string) {
+	u.stateMux.Lock()
+	u.selected = name
+	u.stateMux.Unlock()
+}
+
+func (u *URLTest) clearSelectedIf(selected string) {
+	u.stateMux.Lock()
+	if u.selected == selected {
+		u.selected = ""
+	}
+	u.stateMux.Unlock()
+}
+
+func (u *URLTest) PersistentPin() bool {
+	return u.persistentPin
+}
+
+func (u *URLTest) warnPersistentPinnedProxy(selected, reason string) {
+	interval := u.pinWarnInterval
+	if interval <= 0 {
+		interval = 10 * time.Second
+	}
+
+	shouldLog := false
+	u.stateMux.Lock()
+	now := time.Now()
+	if u.lastPinWarnFor != selected || u.lastPinWarnMsg != reason || now.Sub(u.lastPinWarnAt) >= interval {
+		u.lastPinWarnFor = selected
+		u.lastPinWarnMsg = reason
+		u.lastPinWarnAt = now
+		shouldLog = true
+	}
+	u.stateMux.Unlock()
+	if !shouldLog {
+		return
+	}
+
+	switch reason {
+	case "missing":
+		log.Warnln("group [%s] cleared persistent pin because proxy [%s] no longer exists in current members", u.Name(), selected)
+	default:
+		log.Warnln("group [%s] keeps persistent pin on unhealthy proxy [%s]; traffic remains pinned until manual unfix", u.Name(), selected)
+	}
+}
+
 // SupportUDP implements C.ProxyAdapter
 func (u *URLTest) SupportUDP() bool {
 	if u.disableUDP {
@@ -211,14 +274,16 @@ func (u *URLTest) MarshalJSON() ([]byte, error) {
 		all = append(all, proxy.Name())
 	}
 	return json.Marshal(map[string]any{
-		"type":           u.Type().String(),
-		"now":            u.Now(),
-		"all":            all,
-		"testUrl":        u.testUrl,
-		"expectedStatus": u.expectedStatus,
-		"fixed":          u.getSelected(),
-		"hidden":         u.Hidden,
-		"icon":           u.Icon,
+		"type":                    u.Type().String(),
+		"now":                     u.Now(),
+		"all":                     all,
+		"testUrl":                 u.testUrl,
+		"expectedStatus":          u.expectedStatus,
+		"fixed":                   u.getSelected(),
+		"persistentPin":           u.persistentPin,
+		"pinUnhealthyLogInterval": int(u.pinWarnInterval / time.Second),
+		"hidden":                  u.Hidden,
+		"icon":                    u.Icon,
 	})
 }
 
@@ -252,6 +317,11 @@ func parseURLTestOption(config map[string]any) []urlTestOption {
 }
 
 func NewURLTest(option *GroupCommonOption, providers []P.ProxyProvider, options ...urlTestOption) *URLTest {
+	pinWarnInterval := 10 * time.Second
+	if option.PinUnhealthyLogInterval > 0 {
+		pinWarnInterval = time.Duration(option.PinUnhealthyLogInterval) * time.Second
+	}
+
 	urlTest := &URLTest{
 		GroupBase: NewGroupBase(GroupBaseOption{
 			Name:           option.Name,
@@ -263,12 +333,14 @@ func NewURLTest(option *GroupCommonOption, providers []P.ProxyProvider, options 
 			MaxFailedTimes: option.MaxFailedTimes,
 			Providers:      providers,
 		}),
-		fastSingle:     singledo.NewSingle[C.Proxy](time.Second * 10),
-		disableUDP:     option.DisableUDP,
-		testUrl:        option.URL,
-		expectedStatus: option.ExpectedStatus,
-		Hidden:         option.Hidden,
-		Icon:           option.Icon,
+		fastSingle:      singledo.NewSingle[C.Proxy](time.Second * 10),
+		disableUDP:      option.DisableUDP,
+		testUrl:         option.URL,
+		expectedStatus:  option.ExpectedStatus,
+		persistentPin:   option.PersistentPin,
+		pinWarnInterval: pinWarnInterval,
+		Hidden:          option.Hidden,
+		Icon:            option.Icon,
 	}
 
 	for _, option := range options {

--- a/adapter/outboundgroup/urltest.go
+++ b/adapter/outboundgroup/urltest.go
@@ -241,6 +241,11 @@ func (u *URLTest) warnPersistentPinnedProxy(selected, reason string) {
 	}
 
 	shouldLog := false
+	counter := 0
+	threshold := u.pinAutoUnfixThreshold
+	if threshold <= 0 {
+		threshold = defaultPersistentPinAutoUnfixThreshold
+	}
 	u.stateMux.Lock()
 	now := time.Now()
 	if u.lastPinWarnFor != selected || u.lastPinWarnMsg != reason || now.Sub(u.lastPinWarnAt) >= interval {
@@ -249,6 +254,7 @@ func (u *URLTest) warnPersistentPinnedProxy(selected, reason string) {
 		u.lastPinWarnAt = now
 		shouldLog = true
 	}
+	counter = u.pinAutoUnfixCount
 	u.stateMux.Unlock()
 	if !shouldLog {
 		return
@@ -258,7 +264,7 @@ func (u *URLTest) warnPersistentPinnedProxy(selected, reason string) {
 	case "missing":
 		log.Warnln("group [%s] cleared persistent pin because proxy [%s] no longer exists in current members", u.Name(), selected)
 	default:
-		log.Warnln("group [%s] keeps persistent pin on unhealthy proxy [%s]; traffic remains pinned until manual unfix", u.Name(), selected)
+		log.Warnln("group [%s] keeps persistent pin on unhealthy proxy [%s]; traffic remains pinned until manual unfix (auto-unfix counter %d/%d)", u.Name(), selected, counter, threshold)
 	}
 }
 
@@ -299,6 +305,8 @@ func (u *URLTest) observePersistentPinnedResult(selected string, pinned C.Proxy,
 	autoUnfixed := false
 	reachedCount := 0
 	resetByHealthy := false
+	resetReason := ""
+	resetFrom := 0
 
 	u.stateMux.Lock()
 	if u.selected != selected || !lastTestAt.After(u.pinAutoUnfixLastTest) {
@@ -314,9 +322,17 @@ func (u *URLTest) observePersistentPinnedResult(selected string, pinned C.Proxy,
 	}
 	u.pinAutoUnfixLastTest = lastTestAt
 	if resetByHealthy {
+		if u.pinAutoUnfixCount > 0 {
+			resetReason = "pinned proxy has successful test records"
+			resetFrom = u.pinAutoUnfixCount
+		}
 		u.pinAutoUnfixCount = 0
 	}
 	if lastHealthy {
+		if u.pinAutoUnfixCount > 0 {
+			resetReason = "pinned proxy recovered"
+			resetFrom = u.pinAutoUnfixCount
+		}
 		u.pinAutoUnfixCount = 0
 	} else if hasOtherAlive {
 		u.pinAutoUnfixCount++
@@ -327,10 +343,17 @@ func (u *URLTest) observePersistentPinnedResult(selected string, pinned C.Proxy,
 			autoUnfixed = true
 		}
 	} else {
+		if u.pinAutoUnfixCount > 0 {
+			resetReason = "no alternative alive proxies in group"
+			resetFrom = u.pinAutoUnfixCount
+		}
 		u.pinAutoUnfixCount = 0
 	}
 	u.stateMux.Unlock()
 
+	if resetReason != "" {
+		log.Warnln("group [%s] reset persistent pin auto-unfix counter for proxy [%s] from %d to 0 (%s)", u.Name(), selected, resetFrom, resetReason)
+	}
 	if autoUnfixed {
 		log.Warnln("group [%s] auto-unfixed persistent pin on proxy [%s] after %d consecutive unhealthy checks with alternative alive proxies", u.Name(), selected, reachedCount)
 	}

--- a/adapter/outboundgroup/util.go
+++ b/adapter/outboundgroup/util.go
@@ -2,6 +2,7 @@ package outboundgroup
 
 import (
 	"context"
+	"time"
 
 	"github.com/metacubex/mihomo/common/utils"
 	C "github.com/metacubex/mihomo/constant"
@@ -35,4 +36,23 @@ var _ SelectAble = (*Selector)(nil)
 
 type PersistentPinAware interface {
 	PersistentPin() bool
+}
+
+func latestProxyTestTime(proxy C.Proxy, testURL string) (time.Time, bool) {
+	history, ok := proxyTestHistory(proxy, testURL)
+	if !ok || len(history) == 0 {
+		return time.Time{}, false
+	}
+
+	return history[len(history)-1].Time, true
+}
+
+func proxyTestHistory(proxy C.Proxy, testURL string) ([]C.DelayHistory, bool) {
+	extra := proxy.ExtraDelayHistories()
+	state, ok := extra[testURL]
+	if !ok || len(state.History) == 0 {
+		return nil, false
+	}
+
+	return state.History, true
 }

--- a/adapter/outboundgroup/util.go
+++ b/adapter/outboundgroup/util.go
@@ -32,3 +32,7 @@ type SelectAble interface {
 var _ SelectAble = (*Fallback)(nil)
 var _ SelectAble = (*URLTest)(nil)
 var _ SelectAble = (*Selector)(nil)
+
+type PersistentPinAware interface {
+	PersistentPin() bool
+}

--- a/docs/config.yaml
+++ b/docs/config.yaml
@@ -1177,6 +1177,8 @@ proxy-groups:
       - vmess1
     # tolerance: 150
     # lazy: true
+    # persistent-pin: false # true 时固定节点将不再被自动测速流程释放
+    # pin-unhealthy-log-interval: 10 # persistent-pin=true 且固定节点异常时，日志提醒间隔（秒）
     # expected-status: 204 # 当健康检查返回状态码与期望值不符时，认为节点不可用
     url: "https://cp.cloudflare.com/generate_204"
     interval: 300
@@ -1188,6 +1190,8 @@ proxy-groups:
       - ss1
       - ss2
       - vmess1
+    # persistent-pin: false
+    # pin-unhealthy-log-interval: 10
     url: "https://cp.cloudflare.com/generate_204"
     interval: 300
 

--- a/docs/config.yaml
+++ b/docs/config.yaml
@@ -1179,6 +1179,7 @@ proxy-groups:
     # lazy: true
     # persistent-pin: false # true 时固定节点将不再被自动测速流程释放
     # pin-unhealthy-log-interval: 10 # persistent-pin=true 且固定节点异常时，日志提醒间隔（秒）
+    # persistent-pin-auto-unfix-threshold: 10 # persistent-pin=true 时生效，固定节点连续 N 次异常且每次都有其他可用节点时自动解除固定
     # expected-status: 204 # 当健康检查返回状态码与期望值不符时，认为节点不可用
     url: "https://cp.cloudflare.com/generate_204"
     interval: 300
@@ -1192,6 +1193,7 @@ proxy-groups:
       - vmess1
     # persistent-pin: false
     # pin-unhealthy-log-interval: 10
+    # persistent-pin-auto-unfix-threshold: 10
     url: "https://cp.cloudflare.com/generate_204"
     interval: 300
 

--- a/hub/route/groups.go
+++ b/hub/route/groups.go
@@ -60,8 +60,10 @@ func getGroupDelay(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if selectAble, ok := proxy.Adapter().(outboundgroup.SelectAble); ok && proxy.Type() != C.Selector {
-		selectAble.ForceSet("")
-		cachefile.Cache().SetSelected(proxy.Name(), "")
+		if pinAware, ok := proxy.Adapter().(outboundgroup.PersistentPinAware); !ok || !pinAware.PersistentPin() {
+			selectAble.ForceSet("")
+			cachefile.Cache().SetSelected(proxy.Name(), "")
+		}
 	}
 
 	query := r.URL.Query()


### PR DESCRIPTION
## 背景与动机
关联 issue: https://github.com/MetaCubeX/mihomo/issues/2616

在 `url-test` / `fallback` 场景中，部分用户会在 GUI 中显式 pin/override 某个节点，希望该选择在自动测速周期中保持一致，避免出现“UI 显示仍是 fixed，但实际流量已被自动策略改走”的体验偏差。 (有的gui会处理正常,跟随释放fixed,但是依旧和用户使用预期不符)

这个 PR 的目标是提供一个**可选能力**：
- 允许用户主动显式开启“固定节点持久化”；
- 当固定节点长期异常、且组内持续存在可用替代节点时，再自动解除固定；
- 默认配置下保持原行为不变。

## 兼容性说明（非常重要）
本 PR 新增行为均为**显式参数开启**后才生效：
- `persistent-pin` 默认 `false`
- `pin-unhealthy-log-interval` 默认 `10`
- `persistent-pin-auto-unfix-threshold` 默认 `10`

也就是说，**不配置这些参数时，现有用户逻辑不会被改变**。

## 修改内容与原因
### 1) `url-test` / `fallback`：支持可选 persistent pin
- 文件：
  - `adapter/outboundgroup/urltest.go`
  - `adapter/outboundgroup/fallback.go`
  - `adapter/outboundgroup/parser.go`
  - `hub/route/groups.go`
  - `adapter/outboundgroup/util.go`
  - `docs/config.yaml`
- 原因：
  - 用户显式 pin 的语义应可被保留（在开启选项时）；
  - 同时避免“永久错误 pin 导致长期不可用”，所以增加可控自动解除阈值；
  - 增加日志可观测性，帮助用户和开发者定位状态变化。

### 2) 自动解除 pin 的触发条件（仅 `persistent-pin=true`）
- 固定节点连续 N 次健康检查失败；
- 且这 N 次期间每次都存在其他可用节点；
- 达到阈值后自动 unfix。
- 原因：
  - 保持用户“固定优先”的意图；
  - 仅在“长期异常且有替代方案”的情况下兜底恢复可用性；
  - 避免网络整体抖动/断网时误解除固定。

### 3) 日志补充
- 在 unhealthy pin 提示中输出当前 auto-unfix 计数；
- 在计数清零时输出清零原因；
- 达阈值自动 unfix 时输出明确日志。
- 原因：
  - 这部分行为对运维和排障非常关键，单看“是否 unfix”不足以判断真实状态。

### 4) 本 PR 包含 #2615 的核心修复内容
- 相关 PR: https://github.com/MetaCubeX/mihomo/pull/2615
- 修复点：当组内存在可用节点时，不应继续选择 timeout 节点。
- 说明：
  - 如果维护者暂不考虑本 PR 的 persistent pin 能力，仍希望至少评估 #2615；
  - 因为“有可用节点但仍选 timeout 节点”在部分用户场景中是可复现且具影响的问题。

## 实际验证
我已基于以下版本进行实际高频使用验证：
- https://github.com/lovitus/mihomo/releases/tag/v2026.03.13-persistent-pin.3

验证环境：
- Windows / macOS : Clash Verge Rev 
-  MacOS : ClashBar
- 连续重度使用 4 天

结论：行为与预期一致。

## 额外说明
本 PR 尽量保持变更边界在 `outboundgroup` 相关逻辑与配置文档，未引入默认行为变化。
