### PR TITLE
feat(dns): nameserver policy add static records

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1235,6 +1235,9 @@ func parseNameServer(servers []string, respectRules bool, preferH3 bool) ([]dns.
 			default:
 				err = fmt.Errorf("unsupported RCode type: %s", addr)
 			}
+		case "records":
+			dnsNetType = "records"
+			addr, err = checkRecords(u.Host)
 		default:
 			return nil, fmt.Errorf("DNS NameServer[%d] unsupport scheme: %s", idx, u.Scheme)
 		}
@@ -1261,6 +1264,31 @@ func parseNameServer(servers []string, respectRules bool, preferH3 bool) ([]dns.
 		nameservers = append(nameservers, nameserver)
 	}
 	return nameservers, nil
+}
+
+// checkRecords check host is '[ip4],[ip6]', ip4 is required
+func checkRecords(host string) (string, error) {
+	ips := strings.Split(host+",", ",")
+	ip4 := ips[0]
+	ip6 := ips[1]
+
+	log.Debugln("ns-policy records check format => [%s]", host)
+
+	// check ip4 format
+	ip4Addr, err := netip.ParseAddr(ip4)
+	if err != nil || !ip4Addr.Is4() {
+		return "", fmt.Errorf("ns-policy records[0] format error: records://%s", host)
+	}
+
+	// if ip6 not empty, check ip6
+	if len(ip6) > 0 {
+		ip6Addr, err := netip.ParseAddr(ip6)
+		if err != nil || !ip6Addr.Is6() {
+			return "", fmt.Errorf("ns-policy records[1] format error: records://%s", host)
+		}
+	}
+
+	return host, nil
 }
 
 func init() {

--- a/dns/records.go
+++ b/dns/records.go
@@ -1,0 +1,69 @@
+package dns
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"strings"
+
+	"github.com/metacubex/mihomo/log"
+	D "github.com/miekg/dns"
+)
+
+func newRecordsClient(addr string) recordsClient {
+	return recordsClient{
+		rcode: D.RcodeSuccess,
+		addr:  "records://" + addr,
+	}
+}
+
+type recordsClient struct {
+	rcode int
+	addr  string
+}
+
+var _ dnsClient = (*recordsClient)(nil)
+
+func (r recordsClient) ExchangeContext(ctx context.Context, m *D.Msg) (*D.Msg, error) {
+	m.Response = true
+	m.Rcode = r.rcode
+
+	// split ip
+	ips := strings.Split(r.addr[len("records://"):]+",", ",")
+	ip4 := ips[0]
+	ip6 := ips[1]
+
+	var q *D.Question
+	if len(m.Question) > 0 {
+		q = &m.Question[0]
+	} else {
+		return nil, fmt.Errorf("[DNS] ns-policy records resolve failed: no Question")
+	}
+
+	// queryType A/AAAA return ip4/6 records
+	if q.Qtype == D.TypeA {
+		rr := &D.A{
+			Hdr: D.RR_Header{Name: q.Name, Rrtype: D.TypeA, Class: D.ClassINET, Ttl: 60},
+			A:   net.ParseIP(ip4),
+		}
+		m.Answer = append(m.Answer, rr)
+	}
+
+	if q.Qtype == D.TypeAAAA {
+		rr := &D.AAAA{
+			Hdr:  D.RR_Header{Name: q.Name, Rrtype: D.TypeAAAA, Class: D.ClassINET, Ttl: 60},
+			AAAA: net.ParseIP(ip6),
+		}
+		m.Answer = append(m.Answer, rr)
+	}
+
+	log.Debugln("[DNS] ns-policy %s --> %s from %s", msgToDomain(m), msgToLogString(m), r.Address())
+
+	return m, nil
+}
+
+func (r recordsClient) Address() string {
+	return r.addr
+}
+
+func (r recordsClient) ResetConnection() {}

--- a/dns/records_test.go
+++ b/dns/records_test.go
@@ -1,0 +1,61 @@
+package dns
+
+import (
+	"net"
+	"testing"
+
+	D "github.com/miekg/dns"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExchangeContextTypeA(t *testing.T) {
+	// new recordsClient
+	ip4 := "127.0.0.1"
+	recordsCli := newRecordsClient(ip4 + ",2001:0db8:85a3:0000:0000:8a2e:0370:7334")
+
+	// new D.Msg
+	question := D.Question{
+		Name:   "android-gateway.com.cn",
+		Qtype:  D.TypeA,
+		Qclass: D.ClassANY,
+	}
+
+	msg := &D.Msg{
+		Question: []D.Question{question},
+	}
+
+	// test get answer [A]
+	replyMsg, _ := recordsCli.ExchangeContext(nil, msg)
+
+	a, ok := replyMsg.Answer[0].(*D.A)
+
+	assert.Equal(t, true, ok)
+	assert.Equal(t, ip4, a.A.String())
+	assert.Implements(t, (*D.RR)(nil), replyMsg.Answer[0])
+}
+
+func TestExchangeContextTypeAAAA(t *testing.T) {
+	// new recordsClient
+	ip6 := "2001:0db8:85a3:0000:0000:8a2e:0370:7334"
+	recordsCli := newRecordsClient("127.0.0.1," + ip6)
+
+	// new D.Msg
+	question := D.Question{
+		Name:   "android-gateway.com.cn",
+		Qtype:  D.TypeAAAA,
+		Qclass: D.ClassANY,
+	}
+
+	msg := &D.Msg{
+		Question: []D.Question{question},
+	}
+
+	// test get answer [AAAA]
+	replyMsg, _ := recordsCli.ExchangeContext(nil, msg)
+
+	reply, ok := replyMsg.Answer[0].(*D.AAAA)
+
+	assert.Equal(t, true, ok)
+	assert.Equal(t, net.ParseIP(ip6).String(), reply.AAAA.String())
+	assert.Implements(t, (*D.RR)(nil), replyMsg.Answer[0])
+}

--- a/dns/util.go
+++ b/dns/util.go
@@ -107,6 +107,8 @@ func transform(servers []NameServer, resolver *Resolver) []dnsClient {
 			c = newRCodeClient(s.Addr)
 		case "quic":
 			c = newDoQ(s.Addr, resolver, s.Params, s.ProxyAdapter, s.ProxyName)
+		case "records":
+			c = newRecordsClient(s.Addr)
 		default:
 			c = newClient(s.Addr, resolver, s.Net, s.Params, s.ProxyAdapter, s.ProxyName)
 		}

--- a/docs/config.yaml
+++ b/docs/config.yaml
@@ -355,6 +355,8 @@ dns:
     ## global，dns 为 rule-providers 中的名为 global 和 dns 规则订阅，
     ## 且 behavior 必须为 domain/classical，当为 classical 时仅会生效域名类规则
     # "rule-set:global,dns": 8.8.8.8
+    # 配置自定义返回记录, 通过配合fake-ip可透明访问代理网关, 格式(ip4必须): records://{ip4},{ip6}
+    "+.android-gateway.com.cn": records://127.0.0.1,::1
 
 proxies: # socks5
   - name: "socks"


### PR DESCRIPTION
# 背景

> Use CMFA VPN hotspot as a transparent soft router proxy while enabling specific services on the Termux app on the mobile device to facilitate seamless access from other LAN devices. Initially planning to configure hosts pointing to the mobile device, we encountered IP address fluctuations from hotspot hotspots. To avoid modifying hosts for all connected devices each time, we implemented a configuration using fake IP addresses and nameserver policy. This setup provides LAN devices with fake IP addresses while configuring the nameserver policy to return record 127.0.0.1 (the IP address of other connected devices) during connection attempts. This configuration enables LAN devices to access mobile services through a fixed domain name.


使用cmfa+vpn hotspot用作软路由进行透明代理，同时手机上termux还开启了一些服务，希望能方便的在局域网其他设备内访问，本想配置hosts指向手机，但是手机热点的ip会变更，不希望每次改所有链接设备的hosts，所以通过fakeip加nameserver-policy进行配置，给局域网设备返回fakeip，但是mihomo建立连接时nameserver-policy返回记录127.0.0.1(其他手机所在局域网ip)进行连接，即可让局域网设备以一固定域名访问手机服务

# pr目标

添加对nameserver-policy策略中静态记录的支持，允许通过配置直接指定IPv4和IPv6地址，而不需要通过真实DNS查询。


# 功能说明
- **新增字段**: 支持 records:// 模式，格式为 records://{ip4},{ip6}
- **用途**: 可配合fake-ip实现透明代理网关访问
- **示例**: "+.android-gateway.com.cn": records://127.0.0.1,::1

# 修改文件说明

> **遵守修改最小化原则，很多逻辑依照现有rcode处理方式编写**

| 文件 | 更改行数 | 说明 |
| :--- | :--- | :--- |
| **config/config.go** | +31 | 新增 `checkRecords()` 函数用于验证记录格式；在 `parseNameServer` 中识别并处理 `records://` scheme。 |
| **dns/records.go** | +69 (新增) | 实现 `recordsClient` 类型，支持根据查询类型动态返回静态 A 和 AAAA 记录。 |
| **dns/records_test.go** | +61 (新增) | 添加单元测试，验证不同查询类型（A/AAAA）下的静态记录返回逻辑及解析准确性。 |
| **dns/util.go** | +2 | 在 `transform` 函数中注册 `records` 客户端，使其正式接入 DNS 处理流程。 |
| **docs/config.yaml** | +2 | 在配置样例文档中添加 `records://` 的使用示例。 |

# 测试 

| 环境 | 测试说明 |
| :--- | :--- |
| **windows/linux** | 使用自己fork的mihomo构建后测试dns解析和链接行为和预期一致 |
| **CMFA (android)** | 使用自己fork的mihomo和cmfa构建feat版本测试，行为和预期一致 |

| fork构建 | 链接 |
| :--- | :--- |
| **mihomo** |  https://github.com/yutianhui/mihomo/releases/tag/v260319.static-ns-policy |
| **CMFA (android)** | https://github.com/yutianhui/ClashMetaForAndroidMyCustom/releases/tag/v2.11.25.ns-policy |



