### PR TITLE
fix(dns): fix DNS cache completely invalid due to incorrect OPT RR filter order

### DIFF
--- a/dns/util.go
+++ b/dns/util.go
@@ -64,6 +64,13 @@ func putMsgToCache(c dnsCache, q D.Question, msg *D.Msg) {
 		return
 	}
 
+	msg = msg.Copy() // never modify the original msg
+
+	// OPT RRs MUST NOT be cached, forwarded, or stored in or loaded from master files.
+	msg.Extra = lo.Filter(msg.Extra, func(rr D.RR, index int) bool {
+		return rr.Header().Rrtype != D.TypeOPT
+	})
+
 	var ttl uint32
 	if msg.Rcode == D.RcodeServerFailure {
 		// [...] a resolver MAY cache a server failure response.
@@ -75,13 +82,6 @@ func putMsgToCache(c dnsCache, q D.Question, msg *D.Msg) {
 	if ttl == 0 {
 		return
 	}
-
-	msg = msg.Copy() // never modify the original msg
-
-	// OPT RRs MUST NOT be cached, forwarded, or stored in or loaded from master files.
-	msg.Extra = lo.Filter(msg.Extra, func(rr D.RR, index int) bool {
-		return rr.Header().Rrtype != D.TypeOPT
-	})
 
 	c.SetWithExpire(q.String(), msg, time.Now().Add(time.Duration(ttl)*time.Second))
 }


### PR DESCRIPTION
In commit c9bc2d3, the filtering of OPT RRs was moved inside the putMsgToCache function. However, the filtering is performed **after** the minimalTTL calculation.

Since the Header().Ttl field of an OPT RR (EDNS0) is used to encode extended RCODE, version, and DO flags (almost always resulting in 0), minimalTTL(lo.Concat(msg.Answer, msg.Ns, msg.Extra)) will invariably return 0. Consequently, putMsgToCache hits the if ttl == 0 { return } condition and skips caching for almost all normal DNS responses.

This commit fixes the issue by moving the OPT RR filtering to happen **before** calculating minimalTTL, restoring the expected DNS caching behavior.