### PR TITLE
chore: add procfs fallback for android findProcess

### DIFF
--- a/component/process/process_linux.go
+++ b/component/process/process_linux.go
@@ -1,14 +1,17 @@
 package process
 
 import (
+	"bufio"
 	"bytes"
 	"encoding/binary"
+	"encoding/hex"
 	"fmt"
 	"net/netip"
 	"os"
 	"path"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 	"syscall"
 	"unicode"
@@ -61,10 +64,29 @@ type inetDiagResponse struct {
 
 func findProcessName(network string, ip netip.Addr, srcPort int) (uint32, string, error) {
 	uid, inode, err := resolveSocketByNetlink(network, ip, srcPort)
+	if runtime.GOOS == "android" {
+		// on Android (especially recent releases), netlink INET_DIAG can fail or return UID 0 / empty process info for some apps
+		// so trying fallback to resolve /proc/net/{tcp,tcp6,udp,udp6}
+		if err != nil {
+			uid, inode, err = resolveSocketByProcFS(network, ip, srcPort)
+		} else if uid == 0 {
+			pUID, pInode, pErr := resolveSocketByProcFS(network, ip, srcPort)
+			if pErr == nil && pUID != 0 {
+				uid, inode, err = pUID, pInode, nil
+			}
+		}
+	}
 	if err != nil {
 		return 0, "", err
 	}
 	pp, err := resolveProcessNameByProcSearch(inode, uid)
+	if runtime.GOOS == "android" {
+		// if inode-based /proc/<pid>/fd resolution fails but UID is known,
+		// fall back to resolving the process/package name by UID (typical on Android where all app processes share one UID).
+		if err != nil && uid != 0 {
+			pp, err = resolveProcessNameByUID(uid)
+		}
+	}
 	return uid, pp, err
 }
 
@@ -180,6 +202,47 @@ func resolveProcessNameByProcSearch(inode, uid uint32) (string, error) {
 	return "", fmt.Errorf("process of uid(%d),inode(%d) not found", uid, inode)
 }
 
+// resolveProcessNameByUID returns a process name for any process with uid.
+// On Android all processes of one app share the same UID; used when inode
+// lookup fails (socket closed / TIME_WAIT).
+func resolveProcessNameByUID(uid uint32) (string, error) {
+	files, err := os.ReadDir("/proc")
+	if err != nil {
+		return "", err
+	}
+
+	for _, f := range files {
+		if !f.IsDir() || !isPid(f.Name()) {
+			continue
+		}
+
+		info, err := f.Info()
+		if err != nil {
+			continue
+		}
+		if info.Sys().(*syscall.Stat_t).Uid != uid {
+			continue
+		}
+
+		processPath := filepath.Join("/proc", f.Name())
+		if runtime.GOOS == "android" {
+			cmdline, err := os.ReadFile(path.Join(processPath, "cmdline"))
+			if err != nil {
+				continue
+			}
+			if name := splitCmdline(cmdline); name != "" {
+				return name, nil
+			}
+		} else {
+			if exe, err := os.Readlink(filepath.Join(processPath, "exe")); err == nil {
+				return exe, nil
+			}
+		}
+	}
+
+	return "", fmt.Errorf("no process found with uid %d", uid)
+}
+
 func splitCmdline(cmdline []byte) string {
 	cmdline = bytes.Trim(cmdline, " ")
 
@@ -198,3 +261,196 @@ func isPid(s string) bool {
 		return !unicode.IsDigit(r)
 	}) == -1
 }
+
+// resolveSocketByProcFS finds UID and inode from /proc/net/{tcp,tcp6,udp,udp6}.
+// In TUN mode metadata sourceIP is often the gateway (e.g. fake-ip range), not
+// the socket's real local address; we match by local port first and prefer
+// exact IP+port when it matches.
+func resolveSocketByProcFS(network string, ip netip.Addr, srcPort int) (uint32, uint32, error) {
+	var proto string
+	switch {
+	case strings.HasPrefix(network, "tcp"):
+		proto = "tcp"
+	case strings.HasPrefix(network, "udp"):
+		proto = "udp"
+	default:
+		return 0, 0, ErrInvalidNetwork
+	}
+
+	targetPort := uint16(srcPort)
+	unmapped := ip.Unmap()
+	files := []string{"/proc/net/" + proto, "/proc/net/" + proto + "6"}
+
+	var bestUID, bestInode uint32
+	found := false
+
+	for _, path := range files {
+		isV6 := strings.HasSuffix(path, "6")
+
+		var matchIP netip.Addr
+		if unmapped.Is4() {
+			if isV6 {
+				matchIP = netip.AddrFrom16(unmapped.As16())
+			} else {
+				matchIP = unmapped
+			}
+		} else {
+			if !isV6 {
+				continue
+			}
+			matchIP = unmapped
+		}
+
+		uid, inode, exact, err := searchProcNetFileByPort(path, matchIP, targetPort)
+		if err != nil {
+			continue
+		}
+
+		if exact {
+			return uid, inode, nil
+		}
+
+		if !found || (bestUID == 0 && uid != 0) {
+			bestUID = uid
+			bestInode = inode
+			found = true
+		}
+	}
+
+	if found {
+		return bestUID, bestInode, nil
+	}
+	return 0, 0, ErrNotFound
+}
+
+// searchProcNetFileByPort scans /proc/net/* for local_address matching targetPort.
+// Exact IP+port wins; else port-only (skips inode==0 entries used by TIME_WAIT).
+func searchProcNetFileByPort(path string, targetIP netip.Addr, targetPort uint16) (uid, inode uint32, exact bool, err error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return 0, 0, false, err
+	}
+	defer f.Close()
+
+	isV6 := strings.HasSuffix(path, "6")
+	scanner := bufio.NewScanner(f)
+
+	if !scanner.Scan() {
+		return 0, 0, false, ErrNotFound
+	}
+
+	var bestUID, bestInode uint32
+	found := false
+
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+
+		fields := strings.Fields(line)
+		if len(fields) < 10 {
+			continue
+		}
+
+		lineIP, linePort, parseErr := parseHexAddrPort(fields[1], isV6)
+		if parseErr != nil {
+			continue
+		}
+		if linePort != targetPort {
+			continue
+		}
+
+		lineUID, parseErr := strconv.ParseUint(fields[7], 10, 32)
+		if parseErr != nil {
+			continue
+		}
+		lineInode, parseErr := strconv.ParseUint(fields[9], 10, 32)
+		if parseErr != nil {
+			continue
+		}
+
+		if lineIP == targetIP {
+			return uint32(lineUID), uint32(lineInode), true, nil
+		}
+
+		if lineInode == 0 {
+			continue
+		}
+
+		if !found || (bestUID == 0 && lineUID != 0) {
+			bestUID = uint32(lineUID)
+			bestInode = uint32(lineInode)
+			found = true
+		}
+	}
+
+	if found {
+		return bestUID, bestInode, false, nil
+	}
+	return 0, 0, false, ErrNotFound
+}
+
+func parseHexAddrPort(s string, isV6 bool) (netip.Addr, uint16, error) {
+	colon := strings.IndexByte(s, ':')
+	if colon < 0 {
+		return netip.Addr{}, 0, fmt.Errorf("invalid addr:port: %s", s)
+	}
+
+	port64, err := strconv.ParseUint(s[colon+1:], 16, 16)
+	if err != nil {
+		return netip.Addr{}, 0, err
+	}
+
+	var addr netip.Addr
+	if isV6 {
+		addr, err = parseHexIPv6(s[:colon])
+	} else {
+		addr, err = parseHexIPv4(s[:colon])
+	}
+	return addr, uint16(port64), err
+}
+
+func parseHexIPv4(s string) (netip.Addr, error) {
+	if len(s) != 8 {
+		return netip.Addr{}, fmt.Errorf("invalid ipv4 hex len: %d", len(s))
+	}
+	b, err := hex.DecodeString(s)
+	if err != nil {
+		return netip.Addr{}, err
+	}
+	var ip [4]byte
+	if littleEndian {
+		ip[0], ip[1], ip[2], ip[3] = b[3], b[2], b[1], b[0]
+	} else {
+		copy(ip[:], b)
+	}
+	return netip.AddrFrom4(ip), nil
+}
+
+func parseHexIPv6(s string) (netip.Addr, error) {
+	if len(s) != 32 {
+		return netip.Addr{}, fmt.Errorf("invalid ipv6 hex len: %d", len(s))
+	}
+	var ip [16]byte
+	for i := 0; i < 4; i++ {
+		b, err := hex.DecodeString(s[i*8 : (i+1)*8])
+		if err != nil {
+			return netip.Addr{}, err
+		}
+		if littleEndian {
+			ip[i*4+0] = b[3]
+			ip[i*4+1] = b[2]
+			ip[i*4+2] = b[1]
+			ip[i*4+3] = b[0]
+		} else {
+			copy(ip[i*4:(i+1)*4], b)
+		}
+	}
+	return netip.AddrFrom16(ip), nil
+}
+
+var littleEndian = func() bool {
+	x := uint32(0x01020304)
+	return *(*byte)(unsafe.Pointer(&x)) == 0x04
+}()


### PR DESCRIPTION
## Summary
- Add `find-process-backend` (`auto` | `netlink` | `procfs`) to control how the local socket owner is resolved for process-based rules.
- On Android (especially recent releases), netlink INET_DIAG can fail or return UID 0 / empty process info for some apps, so process rules become unreliable.
- Procfs path reads `/proc/net/tcp`, `tcp6`, `udp`, `udp6`, matches primarily by local port when TUN metadata source IP does not match the kernel row (e.g. fake-ip / gateway IP).
- Skip `inode == 0` rows for port-only matches to avoid TIME_WAIT false positives.
- If inode-based `/proc/<pid>/fd` resolution fails but UID is known, fall back to resolving the process/package name by UID (typical on Android where all app processes share one UID).

## Problem
On Android 16, users running Mihomo under root (e.g. KernelSU Next, SUSFS, TUN + redirect) observed unstable process identification:

- Netlink sometimes returns errors (e.g. `NLMSG_ERROR`) or UID 0 with no process name, while `ss` still shows the correct UID/PID.
- With TUN + fake-ip, metadata often carries a gateway/fake source IP (e.g. `198.18.0.1`) that does not appear as `local_address` in `/proc/net/tcp` for the real app socket, so naive IP+port matching fails.
- Fast connections can leave only TIME_WAIT rows with misleading UID/inode when lookup runs late.

**Repro / validation environment (reported):** OnePlus 15, Android 16, KernelSU Next + SUSFS, Mihomo in any mode with process-based rules.

## Solution
1. Introduce **`find-process-backend`** in **general** config (same level as `find-process-mode`, not under `tun:`).
2. **`auto` (default):** try netlink first; on error or UID 0, retry via procfs.
3. **`procfs`:** use `/proc/net/*` only (bypass netlink).
4. **`netlink`:** preserve previous behavior (netlink only).
5. After UID/inode resolution, resolve process name by inode; if that fails and UID ≠ 0, resolve by scanning `/proc` for that UID (Android package/cmdline).

## Changes
- `component/process/find_process_backend.go` — `FindProcessBackend` type, defaults, `Get`/`Set`, text unmarshaling.
- `component/process/process_linux_procfs.go` — parse `/proc/net/tcp*` / `udp*`, port-first + exact IP when possible, skip `inode=0` for port-only rows.
- `component/process/process_linux.go` — backend switch, netlink → procfs fallback, `resolveProcessNameByUID`.
- `config/config.go` — `find-process-backend` on `General` / `RawConfig`, default `auto`, wire into parsed general.
- `hub/executor/executor.go` — apply backend on config load / `GetGeneral`.
- `hub/route/configs.go` — REST PATCH support for `find-process-backend`.

## Usage
```yaml
find-process-mode: always   # or strict, as needed
find-process-backend: auto  # auto | netlink | procfs
```

## Testing
- go test ./... and go build -tags with_gvisor pass.
- Manually verified on OnePlus 15 / Android 16 / KernelSU Next + SUSFS: process-based rules match more consistently with auto or procfs; Chrome and other apps no longer randomly appear as UID 0 when procfs path is used.