### PR TITLE
fix(vless): default xhttp padding to 100-1000 when not set

### DIFF
--- a/transport/xhttp/config.go
+++ b/transport/xhttp/config.go
@@ -80,16 +80,17 @@ func (c *Config) RequestHeader() http.Header {
 }
 
 func (c *Config) RandomPadding() (string, error) {
-	if c.XPaddingBytes == "" {
-		return "", nil
+	paddingRange := c.XPaddingBytes
+	if paddingRange == "" {
+		paddingRange = "100-1000"
 	}
 
-	minVal, maxVal, err := parseRange(c.XPaddingBytes)
+	minVal, maxVal, err := parseRange(paddingRange)
 	if err != nil {
 		return "", err
 	}
 	if minVal < 0 || maxVal < minVal {
-		return "", fmt.Errorf("invalid x-padding-bytes range: %s", c.XPaddingBytes)
+		return "", fmt.Errorf("invalid x-padding-bytes range: %s", paddingRange)
 	}
 	if maxVal == 0 {
 		return "", nil


### PR DESCRIPTION
## Summary

Follow-up fix for xhttp padding behavior.

When `x-padding-bytes` is not explicitly set, Mihomo should still use the default Xray-compatible range `100-1000`.

Without this, stream-one mode may return `400 Bad Request` against servers expecting default padding behavior.

## Verification

- `go build ./...`
- `go test ./listener/inbound -run XHTTP -v`
- tested locally using a real VLESS+XHTTP config with `x-padding-bytes` removed
- confirmed that the connection succeeds without explicitly setting padding
- previously this case returned `xhttp stream-one bad status: 400 Bad Request`