### PR TITLE
fix(vless): remove incomplete xhttp config options

### DIFF
--- a/adapter/outbound/vless.go
+++ b/adapter/outbound/vless.go
@@ -77,8 +77,6 @@ type XHTTPOptions struct {
 	Mode                 string            `proxy:"mode,omitempty"`
 	Headers              map[string]string `proxy:"headers,omitempty"`
 	ScMaxConcurrentPosts int               `proxy:"sc-max-concurrent-posts,omitempty"`
-	ScMaxEachPostBytes   int               `proxy:"sc-max-each-post-bytes,omitempty"`
-	ScMinPostsIntervalMs int               `proxy:"sc-min-posts-interval-ms,omitempty"`
 	NoGRPCHeader         bool              `proxy:"no-grpc-header,omitempty"`
 	XPaddingBytes        string            `proxy:"x-padding-bytes,omitempty"`
 }
@@ -255,14 +253,12 @@ func (v *Vless) dialXHTTPConn(ctx context.Context) (net.Conn, error) {
 	}
 
 	cfg := &xhttp.Config{
-		Host:                 requestHost,
-		Path:                 v.option.XHTTPOpts.Path,
-		Mode:                 v.option.XHTTPOpts.Mode,
-		Headers:              v.option.XHTTPOpts.Headers,
-		ScMaxEachPostBytes:   v.option.XHTTPOpts.ScMaxEachPostBytes,
-		ScMinPostsIntervalMs: v.option.XHTTPOpts.ScMinPostsIntervalMs,
-		NoGRPCHeader:         v.option.XHTTPOpts.NoGRPCHeader,
-		XPaddingBytes:        v.option.XHTTPOpts.XPaddingBytes,
+		Host:          requestHost,
+		Path:          v.option.XHTTPOpts.Path,
+		Mode:          v.option.XHTTPOpts.Mode,
+		Headers:       v.option.XHTTPOpts.Headers,
+		NoGRPCHeader:  v.option.XHTTPOpts.NoGRPCHeader,
+		XPaddingBytes: v.option.XHTTPOpts.XPaddingBytes,
 	}
 
 	mode := cfg.EffectiveMode(v.realityConfig != nil)

--- a/transport/xhttp/config.go
+++ b/transport/xhttp/config.go
@@ -12,14 +12,12 @@ import (
 )
 
 type Config struct {
-	Host                 string
-	Path                 string
-	Mode                 string
-	Headers              map[string]string
-	ScMaxEachPostBytes   int
-	ScMinPostsIntervalMs int
-	NoGRPCHeader         bool
-	XPaddingBytes        string
+	Host          string
+	Path          string
+	Mode          string
+	Headers       map[string]string
+	NoGRPCHeader  bool
+	XPaddingBytes string
 }
 
 func (c *Config) NormalizedMode() string {


### PR DESCRIPTION
## Summary

Remove `sc-max-each-post-bytes` and `sc-min-posts-interval-ms` from xhttp config.

These options were only declared but not actually implemented, which could be misleading. 

## Verification

- `go build ./...`
- `go test ./listener/inbound -run XHTTP -v`