### PR TITLE
fix: remove wrong Host header assignment

### DIFF
--- a/listener/http/proxy.go
+++ b/listener/http/proxy.go
@@ -78,11 +78,6 @@ func HandleConn(c net.Conn, tunnel C.Tunnel, store auth.AuthStore, additions ...
 				return // hijack connection
 			}
 
-			host := request.Header.Get("Host")
-			if host != "" {
-				request.Host = host
-			}
-
 			request.RequestURI = ""
 
 			if isUpgradeRequest(request) {


### PR DESCRIPTION
Mihomo was previously assigning request.Host from the client-provided Host header:

This could cause requests to fail when the client sets an unexpected Host (e.g., https://github.com/jawah/niquests/issues/355). Removing this assignment ensures the Host is derived from the absolute-form URL in [readRequest](https://github.com/MetaCubeX/http/blame/57085a02dc1462b08a2a7212ababcc2f4ba7b5e7/request.go#L1144-L1147) 