### PR TITLE
fix: prevent deadlock in gun.Conn.Close when initReader is in progress

### DIFF
--- a/transport/gun/gun.go
+++ b/transport/gun/gun.go
@@ -363,7 +363,11 @@ func (t *Transport) Dial() (net.Conn, error) {
 	}
 
 	go conn.Init()
-	<-initStarted // ensure g.initOnce.Do has been called before any g.Close
+
+	// ensure conn.initOnce.Do has been called before return
+	// prevent the race caused by the return side immediately calling conn.Close
+	<-initStarted
+
 	return conn, nil
 }
 

--- a/transport/gun/gun.go
+++ b/transport/gun/gun.go
@@ -191,27 +191,37 @@ func (g *Conn) FrontHeadroom() int {
 }
 
 func (g *Conn) Close() error {
-	g.initOnce.Do(func() { // if initReader not called, it should not be run anymore
+	g.closeMutex.Lock()
+	if g.closed {
+		g.closeMutex.Unlock()
+		return nil
+	}
+	g.closed = true
+	g.closeMutex.Unlock()
+
+	var errorArr []error
+
+	// Close writer first to unblock any in-progress initFn (e.g. HTTP2 RoundTrip
+	// waiting on the pipe). This must happen before waiting on initOnce to avoid
+	// a deadlock where Close blocks on initOnce.Do while initReader blocks on
+	// network I/O that will never complete.
+	if closer, ok := g.writer.(io.Closer); ok {
+		if err := closer.Close(); err != nil {
+			errorArr = append(errorArr, err)
+		}
+	}
+
+	// Now safe to wait for initReader to finish — closing the writer above ensures
+	// initFn will fail promptly instead of blocking forever.
+	g.initOnce.Do(func() {
 		g.initErr = net.ErrClosed
 	})
 
 	g.closeMutex.Lock()
 	defer g.closeMutex.Unlock()
-	if g.closed {
-		return nil
-	}
-	g.closed = true
-
-	var errorArr []error
 
 	if reader := g.reader; reader != nil {
 		if err := reader.Close(); err != nil {
-			errorArr = append(errorArr, err)
-		}
-	}
-
-	if closer, ok := g.writer.(io.Closer); ok {
-		if err := closer.Close(); err != nil {
 			errorArr = append(errorArr, err)
 		}
 	}

--- a/transport/gun/gun.go
+++ b/transport/gun/gun.go
@@ -152,8 +152,10 @@ func (g *Conn) Write(b []byte) (n int, err error) {
 	buf.Write(b)
 
 	_, err = g.writer.Write(buf.Bytes())
-	if err == io.ErrClosedPipe && g.initErr != nil {
-		err = g.initErr
+	if err == io.ErrClosedPipe {
+		if initErr := g.Init(); initErr != nil {
+			err = initErr
+		}
 	}
 
 	if flusher, ok := g.writer.(http.Flusher); ok {
@@ -175,8 +177,10 @@ func (g *Conn) WriteBuffer(buffer *buf.Buffer) error {
 	binary.PutUvarint(header[6:], uint64(dataLen))
 	_, err := g.writer.Write(buffer.Bytes())
 
-	if err == io.ErrClosedPipe && g.initErr != nil {
-		err = g.initErr
+	if err == io.ErrClosedPipe {
+		if initErr := g.Init(); initErr != nil {
+			err = initErr
+		}
 	}
 
 	if flusher, ok := g.writer.(http.Flusher); ok {
@@ -192,36 +196,22 @@ func (g *Conn) FrontHeadroom() int {
 
 func (g *Conn) Close() error {
 	g.closeMutex.Lock()
+	defer g.closeMutex.Unlock()
 	if g.closed {
-		g.closeMutex.Unlock()
 		return nil
 	}
 	g.closed = true
-	g.closeMutex.Unlock()
 
 	var errorArr []error
 
-	// Close writer first to unblock any in-progress initFn (e.g. HTTP2 RoundTrip
-	// waiting on the pipe). This must happen before waiting on initOnce to avoid
-	// a deadlock where Close blocks on initOnce.Do while initReader blocks on
-	// network I/O that will never complete.
-	if closer, ok := g.writer.(io.Closer); ok {
-		if err := closer.Close(); err != nil {
+	if reader := g.reader; reader != nil {
+		if err := reader.Close(); err != nil {
 			errorArr = append(errorArr, err)
 		}
 	}
 
-	// Now safe to wait for initReader to finish — closing the writer above ensures
-	// initFn will fail promptly instead of blocking forever.
-	g.initOnce.Do(func() {
-		g.initErr = net.ErrClosed
-	})
-
-	g.closeMutex.Lock()
-	defer g.closeMutex.Unlock()
-
-	if reader := g.reader; reader != nil {
-		if err := reader.Close(); err != nil {
+	if closer, ok := g.writer.(io.Closer); ok {
+		if err := closer.Close(); err != nil {
 			errorArr = append(errorArr, err)
 		}
 	}
@@ -350,9 +340,11 @@ func (t *Transport) Dial() (net.Conn, error) {
 		Header:     header,
 	}
 	request = request.WithContext(t.ctx)
+	initStarted := make(chan struct{})
 
 	conn := &Conn{
 		initFn: func() (io.ReadCloser, NetAddr, error) {
+			close(initStarted)
 			nAddr := NetAddr{}
 			trace := &httptrace.ClientTrace{
 				GotConn: func(connInfo httptrace.GotConnInfo) {
@@ -371,6 +363,7 @@ func (t *Transport) Dial() (net.Conn, error) {
 	}
 
 	go conn.Init()
+	<-initStarted // ensure g.initOnce.Do has been called before any g.Close
 	return conn, nil
 }
 


### PR DESCRIPTION
Close() called initOnce.Do() which blocks if initReader is already running inside initFn (e.g. HTTP2 RoundTrip stuck on network I/O). This caused worker goroutines to hang forever during alive checks.

Fix: close the pipe writer first to unblock initFn, then call initOnce.Do() which is now guaranteed to return promptly.