### PR TITLE
cleanup(vless): remove unused sc-max-concurrent-posts option

### DIFF
--- a/adapter/outbound/vless.go
+++ b/adapter/outbound/vless.go
@@ -72,13 +72,12 @@ type VlessOption struct {
 }
 
 type XHTTPOptions struct {
-	Path                 string            `proxy:"path,omitempty"`
-	Host                 string            `proxy:"host,omitempty"`
-	Mode                 string            `proxy:"mode,omitempty"`
-	Headers              map[string]string `proxy:"headers,omitempty"`
-	ScMaxConcurrentPosts int               `proxy:"sc-max-concurrent-posts,omitempty"`
-	NoGRPCHeader         bool              `proxy:"no-grpc-header,omitempty"`
-	XPaddingBytes        string            `proxy:"x-padding-bytes,omitempty"`
+	Path          string            `proxy:"path,omitempty"`
+	Host          string            `proxy:"host,omitempty"`
+	Mode          string            `proxy:"mode,omitempty"`
+	Headers       map[string]string `proxy:"headers,omitempty"`
+	NoGRPCHeader  bool              `proxy:"no-grpc-header,omitempty"`
+	XPaddingBytes string            `proxy:"x-padding-bytes,omitempty"`
 }
 
 func (v *Vless) StreamConnContext(ctx context.Context, c net.Conn, metadata *C.Metadata) (_ net.Conn, err error) {


### PR DESCRIPTION
## What

Removes the unused `sc-max-concurrent-posts` field from VLESS XHTTP options.

## Why

This option is declared in `XHTTPOptions`, but unlike the other XHTTP fields, it is not referenced anywhere in the current implementation.

Verified used fields:

* `path`
* `host`
* `mode`
* `headers`
* `no-grpc-header`
* `x-padding-bytes`

## Scope

Small cleanup only. No behavior changes intended.

## Validation

* `go build ./...`
* `go test ./listener/inbound -run XHTTP -v`