### PR TITLE
feat(xhttp): complete outbound support and add inbound-side runtime tests

### DIFF
--- a/adapter/outbound/trojan.go
+++ b/adapter/outbound/trojan.go
@@ -37,24 +37,26 @@ type Trojan struct {
 
 type TrojanOption struct {
 	BasicOption
-	Name              string         `proxy:"name"`
-	Server            string         `proxy:"server"`
-	Port              int            `proxy:"port"`
-	Password          string         `proxy:"password"`
-	ALPN              []string       `proxy:"alpn,omitempty"`
-	SNI               string         `proxy:"sni,omitempty"`
-	SkipCertVerify    bool           `proxy:"skip-cert-verify,omitempty"`
-	Fingerprint       string         `proxy:"fingerprint,omitempty"`
-	Certificate       string         `proxy:"certificate,omitempty"`
-	PrivateKey        string         `proxy:"private-key,omitempty"`
-	UDP               bool           `proxy:"udp,omitempty"`
-	Network           string         `proxy:"network,omitempty"`
-	ECHOpts           ECHOptions     `proxy:"ech-opts,omitempty"`
-	RealityOpts       RealityOptions `proxy:"reality-opts,omitempty"`
-	GrpcOpts          GrpcOptions    `proxy:"grpc-opts,omitempty"`
-	WSOpts            WSOptions      `proxy:"ws-opts,omitempty"`
-	SSOpts            TrojanSSOption `proxy:"ss-opts,omitempty"`
-	ClientFingerprint string         `proxy:"client-fingerprint,omitempty"`
+	Name              string           `proxy:"name"`
+	Server            string           `proxy:"server"`
+	Port              int              `proxy:"port"`
+	Password          string           `proxy:"password"`
+	ALPN              []string         `proxy:"alpn,omitempty"`
+	SNI               string           `proxy:"sni,omitempty"`
+	SkipCertVerify    bool             `proxy:"skip-cert-verify,omitempty"`
+	Fingerprint       string           `proxy:"fingerprint,omitempty"`
+	Certificate       string           `proxy:"certificate,omitempty"`
+	PrivateKey        string           `proxy:"private-key,omitempty"`
+	UDP               bool             `proxy:"udp,omitempty"`
+	Network           string           `proxy:"network,omitempty"`
+	ECHOpts           ECHOptions       `proxy:"ech-opts,omitempty"`
+	RealityOpts       RealityOptions   `proxy:"reality-opts,omitempty"`
+	GrpcOpts          GrpcOptions      `proxy:"grpc-opts,omitempty"`
+	WSOpts            WSOptions        `proxy:"ws-opts,omitempty"`
+	XHTTPOpts         XHTTPOptions     `proxy:"xhttp-opts,omitempty"`
+	SplitHTTPOpts     SplitHTTPOptions `proxy:"splithttp-opts,omitempty"`
+	SSOpts            TrojanSSOption   `proxy:"ss-opts,omitempty"`
+	ClientFingerprint string           `proxy:"client-fingerprint,omitempty"`
 }
 
 // TrojanSSOption from https://github.com/p4gefau1t/trojan-go/blob/v0.10.6/tunnel/shadowsocks/config.go#L5
@@ -116,6 +118,8 @@ func (t *Trojan) StreamConnContext(ctx context.Context, c net.Conn, metadata *C.
 		c, err = vmess.StreamWebsocketConn(ctx, c, wsOpts)
 	case "grpc":
 		break // already handle in gun transport
+	case "xhttp", "splithttp":
+		break // already handle in dialXHTTPConn
 	default:
 		// default tcp network
 		// handle TLS
@@ -172,8 +176,31 @@ func (t *Trojan) writeHeaderContext(ctx context.Context, c net.Conn, metadata *C
 	return err
 }
 
+func (t *Trojan) dialXHTTPConn(ctx context.Context) (net.Conn, error) {
+	cfg, err := buildXHTTPConfig(t.option.Network, t.addr, t.option.SNI, t.option.ALPN, t.option.XHTTPOpts, t.option.SplitHTTPOpts, t.realityConfig != nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return dialXHTTPConn(ctx, t.dialer, cfg, xhttpTLSOptions{
+		Address:           t.addr,
+		TLSEnabled:        true,
+		ServerName:        t.option.SNI,
+		SkipCertVerify:    t.option.SkipCertVerify,
+		Fingerprint:       t.option.Fingerprint,
+		Certificate:       t.option.Certificate,
+		PrivateKey:        t.option.PrivateKey,
+		ClientFingerprint: t.option.ClientFingerprint,
+		ALPN:              cfg.ALPN,
+		ECH:               t.echConfig,
+		Reality:           t.realityConfig,
+	})
+}
+
 func (t *Trojan) dialContext(ctx context.Context) (c net.Conn, err error) {
 	switch t.option.Network {
+	case "xhttp", "splithttp":
+		return t.dialXHTTPConn(ctx)
 	case "grpc": // gun transport
 		return t.gunTransport.Dial()
 	default:

--- a/adapter/outbound/vless.go
+++ b/adapter/outbound/vless.go
@@ -17,7 +17,6 @@ import (
 	"github.com/metacubex/mihomo/transport/vless"
 	"github.com/metacubex/mihomo/transport/vless/encryption"
 	"github.com/metacubex/mihomo/transport/vmess"
-	"github.com/metacubex/mihomo/transport/xhttp"
 
 	"github.com/metacubex/http"
 	vmessSing "github.com/metacubex/sing-vmess"
@@ -62,6 +61,7 @@ type VlessOption struct {
 	GrpcOpts          GrpcOptions       `proxy:"grpc-opts,omitempty"`
 	WSOpts            WSOptions         `proxy:"ws-opts,omitempty"`
 	XHTTPOpts         XHTTPOptions      `proxy:"xhttp-opts,omitempty"`
+	SplitHTTPOpts     SplitHTTPOptions  `proxy:"splithttp-opts,omitempty"`
 	WSHeaders         map[string]string `proxy:"ws-headers,omitempty"`
 	SkipCertVerify    bool              `proxy:"skip-cert-verify,omitempty"`
 	Fingerprint       string            `proxy:"fingerprint,omitempty"`
@@ -69,15 +69,6 @@ type VlessOption struct {
 	PrivateKey        string            `proxy:"private-key,omitempty"`
 	ServerName        string            `proxy:"servername,omitempty"`
 	ClientFingerprint string            `proxy:"client-fingerprint,omitempty"`
-}
-
-type XHTTPOptions struct {
-	Path          string            `proxy:"path,omitempty"`
-	Host          string            `proxy:"host,omitempty"`
-	Mode          string            `proxy:"mode,omitempty"`
-	Headers       map[string]string `proxy:"headers,omitempty"`
-	NoGRPCHeader  bool              `proxy:"no-grpc-header,omitempty"`
-	XPaddingBytes string            `proxy:"x-padding-bytes,omitempty"`
 }
 
 func (v *Vless) StreamConnContext(ctx context.Context, c net.Conn, metadata *C.Metadata) (_ net.Conn, err error) {
@@ -161,7 +152,7 @@ func (v *Vless) StreamConnContext(ctx context.Context, c net.Conn, metadata *C.M
 		c, err = vmess.StreamH2Conn(ctx, c, h2Opts)
 	case "grpc":
 		break // already handle in gun transport
-	case "xhttp":
+	case "xhttp", "splithttp":
 		break // already handle in dialXHTTPConn
 	default:
 		// default tcp network
@@ -242,57 +233,29 @@ func (v *Vless) streamTLSConn(ctx context.Context, conn net.Conn, isH2 bool) (ne
 }
 
 func (v *Vless) dialXHTTPConn(ctx context.Context) (net.Conn, error) {
-	requestHost := v.option.XHTTPOpts.Host
-	if requestHost == "" {
-		if v.option.ServerName != "" {
-			requestHost = v.option.ServerName
-		} else {
-			requestHost = v.option.Server
-		}
+	cfg, err := buildXHTTPConfig(v.option.Network, v.addr, v.option.ServerName, v.option.ALPN, v.option.XHTTPOpts, v.option.SplitHTTPOpts, v.realityConfig != nil)
+	if err != nil {
+		return nil, err
 	}
 
-	cfg := &xhttp.Config{
-		Host:          requestHost,
-		Path:          v.option.XHTTPOpts.Path,
-		Mode:          v.option.XHTTPOpts.Mode,
-		Headers:       v.option.XHTTPOpts.Headers,
-		NoGRPCHeader:  v.option.XHTTPOpts.NoGRPCHeader,
-		XPaddingBytes: v.option.XHTTPOpts.XPaddingBytes,
-	}
-
-	mode := cfg.EffectiveMode(v.realityConfig != nil)
-
-	switch mode {
-	case "stream-one":
-		return xhttp.DialStreamOne(
-			ctx,
-			cfg,
-			func(ctx context.Context) (net.Conn, error) {
-				return v.dialer.DialContext(ctx, "tcp", v.addr)
-			},
-			func(ctx context.Context, raw net.Conn, isH2 bool) (net.Conn, error) {
-				return v.streamTLSConn(ctx, raw, isH2)
-			},
-		)
-	case "packet-up":
-		return xhttp.DialPacketUp(
-			ctx,
-			cfg,
-			func(ctx context.Context) (net.Conn, error) {
-				return v.dialer.DialContext(ctx, "tcp", v.addr)
-			},
-			func(ctx context.Context, raw net.Conn, isH2 bool) (net.Conn, error) {
-				return v.streamTLSConn(ctx, raw, isH2)
-			},
-		)
-	default:
-		return nil, fmt.Errorf("xhttp mode %s is not implemented yet", mode)
-	}
+	return dialXHTTPConn(ctx, v.dialer, cfg, xhttpTLSOptions{
+		Address:           v.addr,
+		TLSEnabled:        v.option.TLS,
+		ServerName:        v.option.ServerName,
+		SkipCertVerify:    v.option.SkipCertVerify,
+		Fingerprint:       v.option.Fingerprint,
+		Certificate:       v.option.Certificate,
+		PrivateKey:        v.option.PrivateKey,
+		ClientFingerprint: v.option.ClientFingerprint,
+		ALPN:              cfg.ALPN,
+		ECH:               v.echConfig,
+		Reality:           v.realityConfig,
+	})
 }
 
 func (v *Vless) dialContext(ctx context.Context) (c net.Conn, err error) {
 	switch v.option.Network {
-	case "xhttp":
+	case "xhttp", "splithttp":
 		return v.dialXHTTPConn(ctx)
 	case "grpc": // gun transport
 		return v.gunTransport.Dial()

--- a/adapter/outbound/vless.go
+++ b/adapter/outbound/vless.go
@@ -389,7 +389,7 @@ func (v *Vless) dialXHTTPConn() (net.Conn, error) {
 	case "stream-up":
 		return xhttp.DialStreamUp(cfg, transport, downloadTransport)
 	case "packet-up":
-		return xhttp.DialPacketUp(cfg, transport)
+		return xhttp.DialPacketUp(cfg, transport, downloadTransport)
 	default:
 		return nil, fmt.Errorf("xhttp mode %s is not implemented yet", mode)
 	}

--- a/adapter/outbound/vmess.go
+++ b/adapter/outbound/vmess.go
@@ -42,33 +42,35 @@ type Vmess struct {
 
 type VmessOption struct {
 	BasicOption
-	Name                string         `proxy:"name"`
-	Server              string         `proxy:"server"`
-	Port                int            `proxy:"port"`
-	UUID                string         `proxy:"uuid"`
-	AlterID             int            `proxy:"alterId"`
-	Cipher              string         `proxy:"cipher"`
-	UDP                 bool           `proxy:"udp,omitempty"`
-	Network             string         `proxy:"network,omitempty"`
-	TLS                 bool           `proxy:"tls,omitempty"`
-	ALPN                []string       `proxy:"alpn,omitempty"`
-	SkipCertVerify      bool           `proxy:"skip-cert-verify,omitempty"`
-	Fingerprint         string         `proxy:"fingerprint,omitempty"`
-	Certificate         string         `proxy:"certificate,omitempty"`
-	PrivateKey          string         `proxy:"private-key,omitempty"`
-	ServerName          string         `proxy:"servername,omitempty"`
-	ECHOpts             ECHOptions     `proxy:"ech-opts,omitempty"`
-	RealityOpts         RealityOptions `proxy:"reality-opts,omitempty"`
-	HTTPOpts            HTTPOptions    `proxy:"http-opts,omitempty"`
-	HTTP2Opts           HTTP2Options   `proxy:"h2-opts,omitempty"`
-	GrpcOpts            GrpcOptions    `proxy:"grpc-opts,omitempty"`
-	WSOpts              WSOptions      `proxy:"ws-opts,omitempty"`
-	PacketAddr          bool           `proxy:"packet-addr,omitempty"`
-	XUDP                bool           `proxy:"xudp,omitempty"`
-	PacketEncoding      string         `proxy:"packet-encoding,omitempty"`
-	GlobalPadding       bool           `proxy:"global-padding,omitempty"`
-	AuthenticatedLength bool           `proxy:"authenticated-length,omitempty"`
-	ClientFingerprint   string         `proxy:"client-fingerprint,omitempty"`
+	Name                string           `proxy:"name"`
+	Server              string           `proxy:"server"`
+	Port                int              `proxy:"port"`
+	UUID                string           `proxy:"uuid"`
+	AlterID             int              `proxy:"alterId"`
+	Cipher              string           `proxy:"cipher"`
+	UDP                 bool             `proxy:"udp,omitempty"`
+	Network             string           `proxy:"network,omitempty"`
+	TLS                 bool             `proxy:"tls,omitempty"`
+	ALPN                []string         `proxy:"alpn,omitempty"`
+	SkipCertVerify      bool             `proxy:"skip-cert-verify,omitempty"`
+	Fingerprint         string           `proxy:"fingerprint,omitempty"`
+	Certificate         string           `proxy:"certificate,omitempty"`
+	PrivateKey          string           `proxy:"private-key,omitempty"`
+	ServerName          string           `proxy:"servername,omitempty"`
+	ECHOpts             ECHOptions       `proxy:"ech-opts,omitempty"`
+	RealityOpts         RealityOptions   `proxy:"reality-opts,omitempty"`
+	HTTPOpts            HTTPOptions      `proxy:"http-opts,omitempty"`
+	HTTP2Opts           HTTP2Options     `proxy:"h2-opts,omitempty"`
+	GrpcOpts            GrpcOptions      `proxy:"grpc-opts,omitempty"`
+	WSOpts              WSOptions        `proxy:"ws-opts,omitempty"`
+	XHTTPOpts           XHTTPOptions     `proxy:"xhttp-opts,omitempty"`
+	SplitHTTPOpts       SplitHTTPOptions `proxy:"splithttp-opts,omitempty"`
+	PacketAddr          bool             `proxy:"packet-addr,omitempty"`
+	XUDP                bool             `proxy:"xudp,omitempty"`
+	PacketEncoding      string           `proxy:"packet-encoding,omitempty"`
+	GlobalPadding       bool             `proxy:"global-padding,omitempty"`
+	AuthenticatedLength bool             `proxy:"authenticated-length,omitempty"`
+	ClientFingerprint   string           `proxy:"client-fingerprint,omitempty"`
 }
 
 type HTTPOptions struct {
@@ -204,6 +206,8 @@ func (v *Vmess) StreamConnContext(ctx context.Context, c net.Conn, metadata *C.M
 		c, err = mihomoVMess.StreamH2Conn(ctx, c, h2Opts)
 	case "grpc":
 		break // already handle in gun transport
+	case "xhttp", "splithttp":
+		break // already handle in dialXHTTPConn
 	default:
 		// handle TLS
 		if v.option.TLS {
@@ -290,8 +294,31 @@ func (v *Vmess) streamConnContext(ctx context.Context, c net.Conn, metadata *C.M
 	return
 }
 
+func (v *Vmess) dialXHTTPConn(ctx context.Context) (net.Conn, error) {
+	cfg, err := buildXHTTPConfig(v.option.Network, v.addr, v.option.ServerName, v.option.ALPN, v.option.XHTTPOpts, v.option.SplitHTTPOpts, v.realityConfig != nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return dialXHTTPConn(ctx, v.dialer, cfg, xhttpTLSOptions{
+		Address:           v.addr,
+		TLSEnabled:        v.option.TLS,
+		ServerName:        v.option.ServerName,
+		SkipCertVerify:    v.option.SkipCertVerify,
+		Fingerprint:       v.option.Fingerprint,
+		Certificate:       v.option.Certificate,
+		PrivateKey:        v.option.PrivateKey,
+		ClientFingerprint: v.option.ClientFingerprint,
+		ALPN:              cfg.ALPN,
+		ECH:               v.echConfig,
+		Reality:           v.realityConfig,
+	})
+}
+
 func (v *Vmess) dialContext(ctx context.Context) (c net.Conn, err error) {
 	switch v.option.Network {
+	case "xhttp", "splithttp":
+		return v.dialXHTTPConn(ctx)
 	case "grpc": // gun transport
 		return v.gunTransport.Dial()
 	default:

--- a/adapter/outbound/xhttp.go
+++ b/adapter/outbound/xhttp.go
@@ -1,0 +1,421 @@
+package outbound
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/metacubex/mihomo/component/ech"
+	tlsC "github.com/metacubex/mihomo/component/tls"
+	C "github.com/metacubex/mihomo/constant"
+	mihomoVMess "github.com/metacubex/mihomo/transport/vmess"
+	"github.com/metacubex/mihomo/transport/xhttp"
+
+	"github.com/metacubex/http"
+	quic "github.com/metacubex/quic-go"
+	"github.com/metacubex/quic-go/http3"
+	"github.com/metacubex/tls"
+)
+
+type XHTTPOptions struct {
+	Path             string                 `proxy:"path,omitempty"`
+	Host             string                 `proxy:"host,omitempty"`
+	Mode             string                 `proxy:"mode,omitempty"`
+	Headers          map[string]string      `proxy:"headers,omitempty"`
+	NoGRPCHeader     bool                   `proxy:"no-grpc-header,omitempty"`
+	XPaddingBytes    string                 `proxy:"x-padding-bytes,omitempty"`
+	TryQUIC          *bool                  `proxy:"try-quic,omitempty"`
+	DownloadSettings *XHTTPDownloadSettings `proxy:"download-settings,omitempty"`
+}
+
+type XHTTPDownloadSettings struct {
+	Server            string            `proxy:"server,omitempty"`
+	Port              int               `proxy:"port,omitempty"`
+	Network           string            `proxy:"network,omitempty"`
+	TLS               *bool             `proxy:"tls,omitempty"`
+	Headers           map[string]string `proxy:"headers,omitempty"`
+	Host              string            `proxy:"host,omitempty"`
+	Path              string            `proxy:"path,omitempty"`
+	Mode              string            `proxy:"mode,omitempty"`
+	ServerName        string            `proxy:"servername,omitempty"`
+	ClientFingerprint string            `proxy:"client-fingerprint,omitempty"`
+	SkipCertVerify    bool              `proxy:"skip-cert-verify,omitempty"`
+	RealityOpts       RealityOptions    `proxy:"reality-opts,omitempty"`
+}
+
+type SplitHTTPOptions = XHTTPOptions
+
+type xhttpTLSOptions struct {
+	Address           string
+	TLSEnabled        bool
+	ServerName        string
+	SkipCertVerify    bool
+	Fingerprint       string
+	Certificate       string
+	PrivateKey        string
+	ClientFingerprint string
+	ALPN              []string
+	ECH               *ech.Config
+	Reality           *tlsC.RealityConfig
+}
+
+func hasXHTTPOptions(option XHTTPOptions) bool {
+	return option.Path != "" ||
+		option.Host != "" ||
+		option.Mode != "" ||
+		len(option.Headers) != 0 ||
+		option.NoGRPCHeader ||
+		option.XPaddingBytes != "" ||
+		option.TryQUIC != nil ||
+		option.DownloadSettings != nil
+}
+
+func selectXHTTPOptions(network string, primary XHTTPOptions, compat SplitHTTPOptions) XHTTPOptions {
+	switch strings.ToLower(strings.TrimSpace(network)) {
+	case "splithttp":
+		if hasXHTTPOptions(compat) {
+			return compat
+		}
+		return primary
+	case "xhttp":
+		if hasXHTTPOptions(primary) {
+			return primary
+		}
+		return compat
+	default:
+		if hasXHTTPOptions(primary) {
+			return primary
+		}
+		return compat
+	}
+}
+
+func isXHTTPNetwork(network string) bool {
+	switch strings.ToLower(strings.TrimSpace(network)) {
+	case "xhttp", "splithttp":
+		return true
+	default:
+		return false
+	}
+}
+
+func normalizeXHTTPALPN(alpn []string) []string {
+	if len(alpn) == 0 {
+		return []string{"h2"}
+	}
+
+	out := make([]string, 0, len(alpn))
+	seen := make(map[string]struct{}, len(alpn))
+	for _, item := range alpn {
+		token := strings.ToLower(strings.TrimSpace(item))
+		switch token {
+		case "h2", "h3", "http/1.1":
+			if _, ok := seen[token]; ok {
+				continue
+			}
+			seen[token] = struct{}{}
+			out = append(out, token)
+		}
+	}
+
+	if len(out) == 0 {
+		return []string{"h2"}
+	}
+
+	return out
+}
+
+func mergeXHTTPHeaders(base map[string]string, override map[string]string) map[string]string {
+	if len(base) == 0 && len(override) == 0 {
+		return nil
+	}
+
+	headers := make(map[string]string, len(base)+len(override))
+	for key, value := range base {
+		headers[key] = value
+	}
+	for key, value := range override {
+		headers[key] = value
+	}
+	return headers
+}
+
+func buildXHTTPConfig(network string, addr string, serverName string, alpn []string, primary XHTTPOptions, compat SplitHTTPOptions, hasReality bool) (*xhttp.Config, error) {
+	option := selectXHTTPOptions(network, primary, compat)
+
+	host, _, _ := net.SplitHostPort(addr)
+	requestHost := option.Host
+	if requestHost == "" {
+		if serverName != "" {
+			requestHost = serverName
+		} else {
+			requestHost = host
+		}
+	}
+
+	cfg := &xhttp.Config{
+		Host:          requestHost,
+		Path:          option.Path,
+		Mode:          option.Mode,
+		Headers:       option.Headers,
+		NoGRPCHeader:  option.NoGRPCHeader,
+		XPaddingBytes: option.XPaddingBytes,
+		ALPN:          normalizeXHTTPALPN(alpn),
+		HasReality:    hasReality,
+	}
+	if option.TryQUIC == nil {
+		cfg.TryQUIC = true
+	} else {
+		cfg.TryQUIC = *option.TryQUIC
+	}
+
+	if ds := option.DownloadSettings; ds != nil {
+		if ds.Network != "" && !isXHTTPNetwork(ds.Network) {
+			return nil, fmt.Errorf("xhttp download-settings network must be xhttp or splithttp")
+		}
+
+		realityCfg, err := ds.RealityOpts.Parse()
+		if err != nil {
+			return nil, err
+		}
+
+		cfg.DownloadSettings = &xhttp.DownloadConfig{
+			Server:            ds.Server,
+			Port:              ds.Port,
+			TLS:               ds.TLS,
+			Headers:           ds.Headers,
+			Host:              ds.Host,
+			Path:              ds.Path,
+			Mode:              ds.Mode,
+			ServerName:        ds.ServerName,
+			ClientFingerprint: ds.ClientFingerprint,
+			SkipCertVerify:    ds.SkipCertVerify,
+			Reality:           realityCfg,
+		}
+	}
+
+	return cfg, nil
+}
+
+func (o xhttpTLSOptions) normalizedServerName() string {
+	if o.ServerName != "" {
+		return o.ServerName
+	}
+	host, _, _ := net.SplitHostPort(o.Address)
+	return host
+}
+
+func (o xhttpTLSOptions) wrapConn(ctx context.Context, conn net.Conn, forceH2 bool) (net.Conn, error) {
+	if !o.TLSEnabled {
+		return conn, nil
+	}
+
+	nextProtos := o.ALPN
+	if forceH2 {
+		nextProtos = []string{"h2"}
+	}
+
+	return mihomoVMess.StreamTLSConn(ctx, conn, &mihomoVMess.TLSConfig{
+		Host:              o.normalizedServerName(),
+		SkipCertVerify:    o.SkipCertVerify,
+		FingerPrint:       o.Fingerprint,
+		Certificate:       o.Certificate,
+		PrivateKey:        o.PrivateKey,
+		ClientFingerprint: o.ClientFingerprint,
+		NextProtos:        nextProtos,
+		ECH:               o.ECH,
+		Reality:           o.Reality,
+	})
+}
+
+func (o xhttpTLSOptions) standardTLSConfig(ctx context.Context, nextProtos []string) (*tls.Config, error) {
+	if !o.TLSEnabled {
+		return nil, fmt.Errorf("xhttp http/3 requires tls")
+	}
+	if o.Reality != nil {
+		return nil, fmt.Errorf("xhttp http/3 does not support reality")
+	}
+
+	tlsConfig, err := (&mihomoVMess.TLSConfig{
+		Host:           o.normalizedServerName(),
+		SkipCertVerify: o.SkipCertVerify,
+		FingerPrint:    o.Fingerprint,
+		Certificate:    o.Certificate,
+		PrivateKey:     o.PrivateKey,
+		NextProtos:     nextProtos,
+	}).ToStdConfig()
+	if err != nil {
+		return nil, err
+	}
+	if err := o.ECH.ClientHandle(ctx, tlsConfig); err != nil {
+		return nil, err
+	}
+	return tlsConfig, nil
+}
+
+func (o xhttpTLSOptions) cloneForDownload(ds *xhttp.DownloadConfig) (xhttpTLSOptions, error) {
+	if ds == nil {
+		return o, nil
+	}
+
+	clone := o
+	server, port, err := net.SplitHostPort(o.Address)
+	if err != nil {
+		return clone, err
+	}
+
+	if ds.Server != "" {
+		server = ds.Server
+	}
+	if ds.Port != 0 {
+		port = strconv.Itoa(ds.Port)
+	}
+	clone.Address = net.JoinHostPort(server, port)
+
+	if ds.TLS != nil {
+		clone.TLSEnabled = *ds.TLS
+		clone.Reality = nil
+	}
+	if ds.Reality != nil {
+		if ds.TLS != nil && !*ds.TLS {
+			return clone, fmt.Errorf("xhttp download-settings reality-opts requires tls")
+		}
+		clone.TLSEnabled = true
+		clone.Reality = ds.Reality
+	}
+
+	if ds.ServerName != "" {
+		clone.ServerName = ds.ServerName
+	}
+	if ds.ClientFingerprint != "" {
+		clone.ClientFingerprint = ds.ClientFingerprint
+	}
+	if ds.SkipCertVerify {
+		clone.SkipCertVerify = true
+	}
+
+	return clone, nil
+}
+
+func buildHTTP2RoundTripperFactory(dialer C.Dialer, option xhttpTLSOptions) xhttp.RoundTripperFactory {
+	return func(ctx context.Context) (http.RoundTripper, error) {
+		return &http.Http2Transport{
+			DialTLSContext: func(ctx context.Context, network string, addr string, _ *tls.Config) (net.Conn, error) {
+				raw, err := dialer.DialContext(ctx, "tcp", option.Address)
+				if err != nil {
+					return nil, err
+				}
+
+				wrapped, err := option.wrapConn(ctx, raw, true)
+				if err != nil {
+					_ = raw.Close()
+					return nil, err
+				}
+
+				return wrapped, nil
+			},
+		}, nil
+	}
+}
+
+func buildHTTP3RoundTripperFactory(dialer C.Dialer, option xhttpTLSOptions) xhttp.RoundTripperFactory {
+	return func(ctx context.Context) (http.RoundTripper, error) {
+		tlsConfig, err := option.standardTLSConfig(ctx, []string{"h3"})
+		if err != nil {
+			return nil, err
+		}
+
+		return &http3.Transport{
+			TLSClientConfig: tlsConfig,
+			QUICConfig: &quic.Config{
+				KeepAlivePeriod: 15 * time.Second,
+			},
+			Dial: func(ctx context.Context, _ string, tlsCfg *tls.Config, quicCfg *quic.Config) (*quic.Conn, error) {
+				udpAddr, err := net.ResolveUDPAddr("udp", option.Address)
+				if err != nil {
+					return nil, err
+				}
+
+				packetConn, err := dialer.ListenPacket(ctx, "udp", "", udpAddr.AddrPort())
+				if err != nil {
+					return nil, err
+				}
+
+				quicConn, err := quic.DialEarly(ctx, packetConn, udpAddr, tlsCfg, quicCfg)
+				if err != nil {
+					_ = packetConn.Close()
+					return nil, err
+				}
+
+				return quicConn, nil
+			},
+		}, nil
+	}
+}
+
+func dialXHTTPConn(ctx context.Context, dialer C.Dialer, cfg *xhttp.Config, uploadTLS xhttpTLSOptions) (net.Conn, error) {
+	downloadTLS, err := uploadTLS.cloneForDownload(cfg.DownloadSettings)
+	if err != nil {
+		return nil, err
+	}
+
+	mode := cfg.EffectiveMode()
+	if mode == "stream-one" && cfg.DownloadSettings != nil {
+		return nil, fmt.Errorf(`xhttp mode "stream-one" cannot be used with download-settings`)
+	}
+
+	if cfg.ShouldTryHTTP3() {
+		uploadH3 := buildHTTP3RoundTripperFactory(dialer, uploadTLS)
+		downloadH3 := buildHTTP3RoundTripperFactory(dialer, downloadTLS)
+
+		switch mode {
+		case "stream-one":
+			conn, err := xhttp.DialStreamOne(ctx, cfg, uploadH3)
+			if err == nil {
+				return conn, nil
+			}
+			if !cfg.SupportsHTTP2() {
+				return nil, err
+			}
+		case "stream-up":
+			conn, err := xhttp.DialStreamUp(ctx, cfg, uploadH3, downloadH3)
+			if err == nil {
+				return conn, nil
+			}
+			if !cfg.SupportsHTTP2() {
+				return nil, err
+			}
+		case "packet-up":
+			conn, err := xhttp.DialPacketUp(ctx, cfg, uploadH3, downloadH3)
+			if err == nil {
+				return conn, nil
+			}
+			if !cfg.SupportsHTTP2() {
+				return nil, err
+			}
+		default:
+			return nil, fmt.Errorf("xhttp mode %s is not implemented yet", mode)
+		}
+	}
+
+	if !cfg.SupportsHTTP2() {
+		return nil, fmt.Errorf("xhttp requires h2 or h3 transport, got alpn=%v", cfg.ALPN)
+	}
+
+	uploadH2 := buildHTTP2RoundTripperFactory(dialer, uploadTLS)
+	downloadH2 := buildHTTP2RoundTripperFactory(dialer, downloadTLS)
+
+	switch mode {
+	case "stream-one":
+		return xhttp.DialStreamOne(ctx, cfg, uploadH2)
+	case "stream-up":
+		return xhttp.DialStreamUp(ctx, cfg, uploadH2, downloadH2)
+	case "packet-up":
+		return xhttp.DialPacketUp(ctx, cfg, uploadH2, downloadH2)
+	default:
+		return nil, fmt.Errorf("xhttp mode %s is not implemented yet", mode)
+	}
+}

--- a/adapter/outbound/xhttp.go
+++ b/adapter/outbound/xhttp.go
@@ -34,7 +34,6 @@ type XHTTPOptions struct {
 type XHTTPDownloadSettings struct {
 	Server            string            `proxy:"server,omitempty"`
 	Port              int               `proxy:"port,omitempty"`
-	Network           string            `proxy:"network,omitempty"`
 	TLS               *bool             `proxy:"tls,omitempty"`
 	Headers           map[string]string `proxy:"headers,omitempty"`
 	Host              string            `proxy:"host,omitempty"`
@@ -90,15 +89,6 @@ func selectXHTTPOptions(network string, primary XHTTPOptions, compat SplitHTTPOp
 			return primary
 		}
 		return compat
-	}
-}
-
-func isXHTTPNetwork(network string) bool {
-	switch strings.ToLower(strings.TrimSpace(network)) {
-	case "xhttp", "splithttp":
-		return true
-	default:
-		return false
 	}
 }
 
@@ -173,10 +163,6 @@ func buildXHTTPConfig(network string, addr string, serverName string, alpn []str
 	}
 
 	if ds := option.DownloadSettings; ds != nil {
-		if ds.Network != "" && !isXHTTPNetwork(ds.Network) {
-			return nil, fmt.Errorf("xhttp download-settings network must be xhttp or splithttp")
-		}
-
 		realityCfg, err := ds.RealityOpts.Parse()
 		if err != nil {
 			return nil, err

--- a/adapter/outbound/xhttp_test.go
+++ b/adapter/outbound/xhttp_test.go
@@ -67,6 +67,16 @@ func TestXHTTPTLSOptionsCloneForDownload(t *testing.T) {
 		})
 		assert.ErrorContains(t, err, "reality-opts requires tls")
 	})
+
+	t.Run("OverrideServerNameAndFingerprint", func(t *testing.T) {
+		clone, err := base.cloneForDownload(&xhttp.DownloadConfig{
+			ServerName:        "download.example.com",
+			ClientFingerprint: "firefox",
+		})
+		assert.NoError(t, err)
+		assert.Equal(t, "download.example.com", clone.ServerName)
+		assert.Equal(t, "firefox", clone.ClientFingerprint)
+	})
 }
 
 func TestBuildXHTTPConfigUsesNetworkSpecificOptions(t *testing.T) {
@@ -103,15 +113,6 @@ func TestBuildXHTTPConfigUsesNetworkSpecificOptions(t *testing.T) {
 	}
 	assert.Equal(t, "/splithttp", cfg.Path)
 	assert.Equal(t, "split.example.com", cfg.Host)
-}
-
-func TestBuildXHTTPConfigRejectsInvalidDownloadNetwork(t *testing.T) {
-	_, err := buildXHTTPConfig("xhttp", "example.com:443", "", nil, XHTTPOptions{
-		DownloadSettings: &XHTTPDownloadSettings{
-			Network: "grpc",
-		},
-	}, SplitHTTPOptions{}, false)
-	assert.ErrorContains(t, err, "download-settings network must be xhttp or splithttp")
 }
 
 func TestDialXHTTPConnRejectsStreamOneWithDownloadSettings(t *testing.T) {

--- a/adapter/outbound/xhttp_test.go
+++ b/adapter/outbound/xhttp_test.go
@@ -1,0 +1,129 @@
+package outbound
+
+import (
+	"context"
+	"testing"
+
+	tlsC "github.com/metacubex/mihomo/component/tls"
+	"github.com/metacubex/mihomo/transport/xhttp"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestXHTTPTLSOptionsCloneForDownload(t *testing.T) {
+	trueValue := true
+	falseValue := false
+	reality := &tlsC.RealityConfig{}
+
+	base := xhttpTLSOptions{
+		Address:    "upload.example.com:443",
+		TLSEnabled: true,
+		ServerName: "upload.example.com",
+		Reality:    reality,
+	}
+
+	t.Run("Inherit", func(t *testing.T) {
+		clone, err := base.cloneForDownload(&xhttp.DownloadConfig{
+			Server: "download.example.com",
+			Port:   8443,
+		})
+		assert.NoError(t, err)
+		assert.Equal(t, "download.example.com:8443", clone.Address)
+		assert.True(t, clone.TLSEnabled)
+		assert.Same(t, reality, clone.Reality)
+	})
+
+	t.Run("ExplicitTLSClearsReality", func(t *testing.T) {
+		clone, err := base.cloneForDownload(&xhttp.DownloadConfig{
+			TLS: &trueValue,
+		})
+		assert.NoError(t, err)
+		assert.True(t, clone.TLSEnabled)
+		assert.Nil(t, clone.Reality)
+	})
+
+	t.Run("ExplicitPlainDisablesTLS", func(t *testing.T) {
+		clone, err := base.cloneForDownload(&xhttp.DownloadConfig{
+			TLS: &falseValue,
+		})
+		assert.NoError(t, err)
+		assert.False(t, clone.TLSEnabled)
+		assert.Nil(t, clone.Reality)
+	})
+
+	t.Run("RealityImpliesTLS", func(t *testing.T) {
+		clone, err := (xhttpTLSOptions{Address: "download.example.com:80"}).cloneForDownload(&xhttp.DownloadConfig{
+			Reality: reality,
+		})
+		assert.NoError(t, err)
+		assert.True(t, clone.TLSEnabled)
+		assert.Same(t, reality, clone.Reality)
+	})
+
+	t.Run("RealityRequiresTLS", func(t *testing.T) {
+		_, err := base.cloneForDownload(&xhttp.DownloadConfig{
+			TLS:     &falseValue,
+			Reality: reality,
+		})
+		assert.ErrorContains(t, err, "reality-opts requires tls")
+	})
+}
+
+func TestBuildXHTTPConfigUsesNetworkSpecificOptions(t *testing.T) {
+	cfg, err := buildXHTTPConfig("xhttp", "example.com:443", "", nil,
+		XHTTPOptions{
+			Path: "/xhttp",
+			Host: "xhttp.example.com",
+		},
+		SplitHTTPOptions{
+			Path: "/splithttp",
+			Host: "split.example.com",
+		},
+		false,
+	)
+	if !assert.NoError(t, err) {
+		return
+	}
+	assert.Equal(t, "/xhttp", cfg.Path)
+	assert.Equal(t, "xhttp.example.com", cfg.Host)
+
+	cfg, err = buildXHTTPConfig("splithttp", "example.com:443", "", nil,
+		XHTTPOptions{
+			Path: "/xhttp",
+			Host: "xhttp.example.com",
+		},
+		SplitHTTPOptions{
+			Path: "/splithttp",
+			Host: "split.example.com",
+		},
+		false,
+	)
+	if !assert.NoError(t, err) {
+		return
+	}
+	assert.Equal(t, "/splithttp", cfg.Path)
+	assert.Equal(t, "split.example.com", cfg.Host)
+}
+
+func TestBuildXHTTPConfigRejectsInvalidDownloadNetwork(t *testing.T) {
+	_, err := buildXHTTPConfig("xhttp", "example.com:443", "", nil, XHTTPOptions{
+		DownloadSettings: &XHTTPDownloadSettings{
+			Network: "grpc",
+		},
+	}, SplitHTTPOptions{}, false)
+	assert.ErrorContains(t, err, "download-settings network must be xhttp or splithttp")
+}
+
+func TestDialXHTTPConnRejectsStreamOneWithDownloadSettings(t *testing.T) {
+	cfg := &xhttp.Config{
+		Mode: "stream-one",
+		DownloadSettings: &xhttp.DownloadConfig{
+			Host: "download.example.com",
+		},
+	}
+
+	_, err := dialXHTTPConn(context.Background(), nil, cfg, xhttpTLSOptions{
+		Address: "upload.example.com:443",
+	})
+	assert.ErrorContains(t, err, `mode "stream-one" cannot be used with download-settings`)
+}

--- a/docs/config.yaml
+++ b/docs/config.yaml
@@ -672,6 +672,28 @@ proxies: # socks5
       # ping-interval: 0 # 默认关闭，单位为秒
     # ip-version: ipv4
 
+  - name: "vmess-xhttp"
+    type: vmess
+    server: server
+    port: 443
+    uuid: uuid
+    alterId: 0
+    cipher: auto
+    udp: true
+    tls: true
+    network: xhttp
+    alpn:
+      - h2
+    client-fingerprint: chrome
+    servername: xxx.com
+    xhttp-opts:
+      path: "/"
+      host: xxx.com
+      mode: "auto"
+      # headers:
+      #   X-Forwarded-For: ""
+      # x-padding-bytes: "100-1000"
+
   # vless
   - name: "vless-tcp"
     type: vless
@@ -789,6 +811,23 @@ proxies: # socks5
       # v2ray-http-upgrade: false
       # v2ray-http-upgrade-fast-open: false
 
+  # XHTTP / SplitHTTP 使用说明
+  # 1. network 可选 xhttp 或 splithttp
+  # 2. xhttp 默认读取 xhttp-opts；splithttp 默认读取 splithttp-opts
+  #    为兼容旧配置，splithttp 未填写 splithttp-opts 时会回退读取 xhttp-opts
+  # 3. mode:
+  #    - auto: 自动选择
+  #    - stream-one: 单连接上传/下载
+  #    - stream-up: 独立下载连接 + 流式上传
+  #    - packet-up: 独立下载连接 + 分包上传
+  # 4. auto 选择规则：
+  #    - 启用 reality 时优先使用 stream-one
+  #    - 可用 h2 时优先使用 stream-up
+  #    - 仅可用 h3 时使用 packet-up
+  # 5. 如需优先尝试 HTTP/3，请同时设置：
+  #    - alpn: [h3] 或 [h3, h2]
+  #    - try-quic: true
+  # 6. download-settings 用于单独控制下载链路，可覆盖 server/port/tls/servername/host/path/reality-opts
   - name: "vless-xhttp"
     type: vless
     server: server
@@ -796,7 +835,7 @@ proxies: # socks5
     uuid: uuid
     udp: true
     tls: true
-    network: xhttp
+    network: xhttp # or splithttp
     alpn:
       - h2
     client-fingerprint: chrome
@@ -805,11 +844,26 @@ proxies: # socks5
     xhttp-opts:
       path: "/"
       host: xxx.com
-      # mode: "stream-one" # Available: "stream-one" or "packet-up"
+      # mode: "auto" # Available: "auto", "stream-one", "stream-up", "packet-up"
       # headers:
       #   X-Forwarded-For: ""
       # no-grpc-header: false
       # x-padding-bytes: "100-1000"
+      # try-quic: true # Try HTTP/3 first when alpn contains "h3"
+      # download-settings:
+      #   server: download.example.com
+      #   port: 443
+      #   tls: true # omit to inherit outer tls/reality transport
+      #   servername: download.example.com
+      #   host: download.example.com
+      #   path: "/"
+      #   reality-opts:
+      #     public-key: CrrQSjAG_YkHLwvM2M-7XkKJilgL5upBKCp0od0tLhE
+      #     short-id: 10f897e26c4b9478
+    # splithttp-opts:
+    #   path: "/"
+    #   host: xxx.com
+    #   mode: "packet-up"
 
 
   # Trojan
@@ -876,6 +930,24 @@ proxies: # socks5
     #     Host: example.com
     #   v2ray-http-upgrade: false
     #   v2ray-http-upgrade-fast-open: false
+
+  - name: "trojan-splithttp-h3"
+    type: trojan
+    server: server
+    port: 443
+    password: yourpsk
+    udp: true
+    sni: xxx.com
+    network: splithttp
+    alpn:
+      - h3
+      - h2
+    client-fingerprint: chrome
+    splithttp-opts:
+      path: "/"
+      host: xxx.com
+      mode: "auto"
+      try-quic: true
 
   - name: "trojan-xtls"
     type: trojan

--- a/listener/inbound/trojan_test.go
+++ b/listener/inbound/trojan_test.go
@@ -255,3 +255,138 @@ func TestInboundTrojan_Wss_TrojanSS(t *testing.T) {
 	}
 	testInboundTrojanTLS(t, inboundOptions, outboundOptions)
 }
+
+func testOutboundTrojanXHTTP(t *testing.T, outboundOptions outbound.TrojanOption, frontendOption testXHTTPFrontendOption) {
+	t.Parallel()
+
+	tunnel := NewHttpTestTunnel()
+	defer tunnel.Close()
+
+	frontendOption.BackendAddr = startTestTrojanBackend(t, tunnel, userUUID)
+	addrPort, err := netip.ParseAddrPort(startTestXHTTPFrontend(t, frontendOption))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	outboundOptions.Name = "trojan_xhttp_outbound"
+	outboundOptions.Server = addrPort.Addr().String()
+	outboundOptions.Port = int(addrPort.Port())
+	outboundOptions.Password = userUUID
+
+	out, err := outbound.NewTrojan(outboundOptions)
+	if !assert.NoError(t, err) {
+		return
+	}
+	defer out.Close()
+
+	tunnel.DoTest(t, out)
+	testSingMux(t, tunnel, out)
+}
+
+func TestOutboundTrojan_XHTTP(t *testing.T) {
+	testOutboundTrojanXHTTP(t, outbound.TrojanOption{
+		Fingerprint: tlsFingerprint,
+		Network:     "xhttp",
+		ALPN:        []string{"h2"},
+		XHTTPOpts: outbound.XHTTPOptions{
+			Path: "/trojan-xhttp",
+			Host: "example.com",
+			Mode: "auto",
+		},
+	}, testXHTTPFrontendOption{
+		Path: "/trojan-xhttp",
+		Host: "example.com",
+		Mode: "auto",
+	})
+}
+
+func TestOutboundTrojan_XHTTP_StreamOne(t *testing.T) {
+	testOutboundTrojanXHTTP(t, outbound.TrojanOption{
+		Fingerprint: tlsFingerprint,
+		Network:     "xhttp",
+		ALPN:        []string{"h2"},
+		XHTTPOpts: outbound.XHTTPOptions{
+			Path: "/trojan-xhttp-stream-one",
+			Host: "example.com",
+			Mode: "stream-one",
+		},
+	}, testXHTTPFrontendOption{
+		Path: "/trojan-xhttp-stream-one",
+		Host: "example.com",
+		Mode: "stream-one",
+	})
+}
+
+func TestOutboundTrojan_XHTTP_StreamUp(t *testing.T) {
+	testOutboundTrojanXHTTP(t, outbound.TrojanOption{
+		Fingerprint: tlsFingerprint,
+		Network:     "xhttp",
+		ALPN:        []string{"h2"},
+		XHTTPOpts: outbound.XHTTPOptions{
+			Path: "/trojan-xhttp-stream-up",
+			Host: "example.com",
+			Mode: "stream-up",
+		},
+	}, testXHTTPFrontendOption{
+		Path: "/trojan-xhttp-stream-up",
+		Host: "example.com",
+		Mode: "stream-up",
+	})
+}
+
+func TestOutboundTrojan_XHTTP_DownloadSettings(t *testing.T) {
+	testOutboundTrojanXHTTP(t, outbound.TrojanOption{
+		Fingerprint: tlsFingerprint,
+		Network:     "xhttp",
+		ALPN:        []string{"h2"},
+		XHTTPOpts: outbound.XHTTPOptions{
+			Path: "/trojan-xhttp-download",
+			Host: "example.com",
+			Mode: "auto",
+			DownloadSettings: &outbound.XHTTPDownloadSettings{
+				TLS:  boolPtr(true),
+				Host: "example.com",
+				Path: "/trojan-xhttp-download",
+			},
+		},
+	}, testXHTTPFrontendOption{
+		Path: "/trojan-xhttp-download",
+		Host: "example.com",
+		Mode: "auto",
+	})
+}
+
+func TestOutboundTrojan_SplitHTTP_PacketUp(t *testing.T) {
+	testOutboundTrojanXHTTP(t, outbound.TrojanOption{
+		Fingerprint: tlsFingerprint,
+		Network:     "splithttp",
+		ALPN:        []string{"h2"},
+		SplitHTTPOpts: outbound.SplitHTTPOptions{
+			Path: "/trojan-splithttp-packet-up",
+			Host: "example.com",
+			Mode: "packet-up",
+		},
+	}, testXHTTPFrontendOption{
+		Path: "/trojan-splithttp-packet-up",
+		Host: "example.com",
+		Mode: "packet-up",
+	})
+}
+
+func TestOutboundTrojan_SplitHTTP_Auto_H3(t *testing.T) {
+	testOutboundTrojanXHTTP(t, outbound.TrojanOption{
+		Fingerprint: tlsFingerprint,
+		Network:     "splithttp",
+		ALPN:        []string{"h3"},
+		SplitHTTPOpts: outbound.SplitHTTPOptions{
+			Path: "/trojan-splithttp-auto-h3",
+			Host: "example.com",
+			Mode: "auto",
+		},
+	}, testXHTTPFrontendOption{
+		Path:     "/trojan-splithttp-auto-h3",
+		Host:     "example.com",
+		Mode:     "auto",
+		UseHTTP3: true,
+	})
+}

--- a/listener/inbound/trojan_test.go
+++ b/listener/inbound/trojan_test.go
@@ -335,25 +335,61 @@ func TestOutboundTrojan_XHTTP_StreamUp(t *testing.T) {
 }
 
 func TestOutboundTrojan_XHTTP_DownloadSettings(t *testing.T) {
-	testOutboundTrojanXHTTP(t, outbound.TrojanOption{
+	t.Parallel()
+
+	tunnel := NewHttpTestTunnel()
+	defer tunnel.Close()
+
+	addrs := startTestSharedXHTTPFrontends(t, startTestTrojanBackend(t, tunnel, userUUID), "auto",
+		testXHTTPFrontendOption{
+			Path: "/trojan-xhttp-upload",
+			Host: "upload.example.com",
+		},
+		testXHTTPFrontendOption{
+			Path: "/trojan-xhttp-download",
+			Host: "download.example.com",
+		},
+	)
+
+	uploadAddr, err := netip.ParseAddrPort(addrs[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	downloadAddr, err := netip.ParseAddrPort(addrs[1])
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := outbound.NewTrojan(outbound.TrojanOption{
+		Name:        "trojan_xhttp_outbound",
+		Server:      uploadAddr.Addr().String(),
+		Port:        int(uploadAddr.Port()),
+		Password:    userUUID,
 		Fingerprint: tlsFingerprint,
+		SNI:         "upload.example.com",
 		Network:     "xhttp",
 		ALPN:        []string{"h2"},
 		XHTTPOpts: outbound.XHTTPOptions{
-			Path: "/trojan-xhttp-download",
-			Host: "example.com",
+			Path: "/trojan-xhttp-upload",
+			Host: "upload.example.com",
 			Mode: "auto",
 			DownloadSettings: &outbound.XHTTPDownloadSettings{
-				TLS:  boolPtr(true),
-				Host: "example.com",
-				Path: "/trojan-xhttp-download",
+				Server:     downloadAddr.Addr().String(),
+				Port:       int(downloadAddr.Port()),
+				TLS:        boolPtr(true),
+				ServerName: "download.example.com",
+				Host:       "download.example.com",
+				Path:       "/trojan-xhttp-download",
 			},
 		},
-	}, testXHTTPFrontendOption{
-		Path: "/trojan-xhttp-download",
-		Host: "example.com",
-		Mode: "auto",
 	})
+	if !assert.NoError(t, err) {
+		return
+	}
+	defer out.Close()
+
+	tunnel.DoTest(t, out)
+	testSingMux(t, tunnel, out)
 }
 
 func TestOutboundTrojan_SplitHTTP_PacketUp(t *testing.T) {

--- a/listener/inbound/vless_test.go
+++ b/listener/inbound/vless_test.go
@@ -11,6 +11,10 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func boolPtr(v bool) *bool {
+	return &v
+}
+
 func testInboundVless(t *testing.T, inboundOptions inbound.VlessOption, outboundOptions outbound.VlessOption) {
 	t.Parallel()
 	inboundOptions.BaseOption = inbound.BaseOption{
@@ -359,6 +363,107 @@ func TestInboundVless_XHTTP(t *testing.T) {
 			Path: "/vless-xhttp",
 			Host: "example.com",
 			Mode: "auto",
+		},
+	}
+	testInboundVlessTLS(t, inboundOptions, outboundOptions, false)
+}
+
+func TestInboundVless_XHTTP_StreamOne(t *testing.T) {
+	inboundOptions := inbound.VlessOption{
+		Certificate: tlsCertificate,
+		PrivateKey:  tlsPrivateKey,
+		XHTTPConfig: inbound.XHTTPConfig{
+			Path: "/vless-xhttp-stream-one",
+			Host: "example.com",
+			Mode: "stream-one",
+		},
+	}
+	outboundOptions := outbound.VlessOption{
+		TLS:         true,
+		Fingerprint: tlsFingerprint,
+		Network:     "xhttp",
+		ALPN:        []string{"h2"},
+		XHTTPOpts: outbound.XHTTPOptions{
+			Path: "/vless-xhttp-stream-one",
+			Host: "example.com",
+			Mode: "stream-one",
+		},
+	}
+	testInboundVlessTLS(t, inboundOptions, outboundOptions, false)
+}
+
+func TestInboundVless_XHTTP_StreamUp(t *testing.T) {
+	inboundOptions := inbound.VlessOption{
+		Certificate: tlsCertificate,
+		PrivateKey:  tlsPrivateKey,
+		XHTTPConfig: inbound.XHTTPConfig{
+			Path: "/vless-xhttp-stream-up",
+			Host: "example.com",
+			Mode: "stream-up",
+		},
+	}
+	outboundOptions := outbound.VlessOption{
+		TLS:         true,
+		Fingerprint: tlsFingerprint,
+		Network:     "xhttp",
+		ALPN:        []string{"h2"},
+		XHTTPOpts: outbound.XHTTPOptions{
+			Path: "/vless-xhttp-stream-up",
+			Host: "example.com",
+			Mode: "stream-up",
+		},
+	}
+	testInboundVlessTLS(t, inboundOptions, outboundOptions, false)
+}
+
+func TestInboundVless_XHTTP_DownloadSettings(t *testing.T) {
+	inboundOptions := inbound.VlessOption{
+		Certificate: tlsCertificate,
+		PrivateKey:  tlsPrivateKey,
+		XHTTPConfig: inbound.XHTTPConfig{
+			Path: "/vless-xhttp-download",
+			Host: "example.com",
+			Mode: "auto",
+		},
+	}
+	outboundOptions := outbound.VlessOption{
+		TLS:         true,
+		Fingerprint: tlsFingerprint,
+		Network:     "xhttp",
+		ALPN:        []string{"h2"},
+		XHTTPOpts: outbound.XHTTPOptions{
+			Path: "/vless-xhttp-download",
+			Host: "example.com",
+			Mode: "auto",
+			DownloadSettings: &outbound.XHTTPDownloadSettings{
+				TLS:  boolPtr(true),
+				Host: "example.com",
+				Path: "/vless-xhttp-download",
+			},
+		},
+	}
+	testInboundVlessTLS(t, inboundOptions, outboundOptions, false)
+}
+
+func TestInboundVless_SplitHTTP_PacketUp(t *testing.T) {
+	inboundOptions := inbound.VlessOption{
+		Certificate: tlsCertificate,
+		PrivateKey:  tlsPrivateKey,
+		XHTTPConfig: inbound.XHTTPConfig{
+			Path: "/vless-splithttp-packet-up",
+			Host: "example.com",
+			Mode: "packet-up",
+		},
+	}
+	outboundOptions := outbound.VlessOption{
+		TLS:         true,
+		Fingerprint: tlsFingerprint,
+		Network:     "splithttp",
+		ALPN:        []string{"h2"},
+		SplitHTTPOpts: outbound.SplitHTTPOptions{
+			Path: "/vless-splithttp-packet-up",
+			Host: "example.com",
+			Mode: "packet-up",
 		},
 	}
 	testInboundVlessTLS(t, inboundOptions, outboundOptions, false)

--- a/listener/inbound/vless_test.go
+++ b/listener/inbound/vless_test.go
@@ -496,3 +496,180 @@ func TestInboundVless_Reality_XHTTP(t *testing.T) {
 	}
 	testInboundVless(t, inboundOptions, outboundOptions)
 }
+
+func testOutboundVlessXHTTP(t *testing.T, outboundOptions outbound.VlessOption, frontendOption testXHTTPFrontendOption) {
+	t.Parallel()
+
+	tunnel := NewHttpTestTunnel()
+	defer tunnel.Close()
+
+	frontendOption.BackendAddr = startTestVlessBackend(t, tunnel)
+	addrPort, err := netip.ParseAddrPort(startTestXHTTPFrontend(t, frontendOption))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	outboundOptions.Name = "vless_xhttp_outbound"
+	outboundOptions.Server = addrPort.Addr().String()
+	outboundOptions.Port = int(addrPort.Port())
+	outboundOptions.UUID = userUUID
+
+	out, err := outbound.NewVless(outboundOptions)
+	if !assert.NoError(t, err) {
+		return
+	}
+	defer out.Close()
+
+	tunnel.DoTest(t, out)
+	testSingMux(t, tunnel, out)
+}
+
+func TestOutboundVless_XHTTP(t *testing.T) {
+	testOutboundVlessXHTTP(t, outbound.VlessOption{
+		TLS:         true,
+		Fingerprint: tlsFingerprint,
+		Network:     "xhttp",
+		ALPN:        []string{"h2"},
+		XHTTPOpts: outbound.XHTTPOptions{
+			Path: "/vless-outbound-xhttp",
+			Host: "example.com",
+			Mode: "auto",
+		},
+	}, testXHTTPFrontendOption{
+		Path: "/vless-outbound-xhttp",
+		Host: "example.com",
+		Mode: "auto",
+	})
+}
+
+func TestOutboundVless_XHTTP_StreamOne(t *testing.T) {
+	testOutboundVlessXHTTP(t, outbound.VlessOption{
+		TLS:         true,
+		Fingerprint: tlsFingerprint,
+		Network:     "xhttp",
+		ALPN:        []string{"h2"},
+		XHTTPOpts: outbound.XHTTPOptions{
+			Path: "/vless-outbound-xhttp-stream-one",
+			Host: "example.com",
+			Mode: "stream-one",
+		},
+	}, testXHTTPFrontendOption{
+		Path: "/vless-outbound-xhttp-stream-one",
+		Host: "example.com",
+		Mode: "stream-one",
+	})
+}
+
+func TestOutboundVless_XHTTP_StreamUp(t *testing.T) {
+	testOutboundVlessXHTTP(t, outbound.VlessOption{
+		TLS:         true,
+		Fingerprint: tlsFingerprint,
+		Network:     "xhttp",
+		ALPN:        []string{"h2"},
+		XHTTPOpts: outbound.XHTTPOptions{
+			Path: "/vless-outbound-xhttp-stream-up",
+			Host: "example.com",
+			Mode: "stream-up",
+		},
+	}, testXHTTPFrontendOption{
+		Path: "/vless-outbound-xhttp-stream-up",
+		Host: "example.com",
+		Mode: "stream-up",
+	})
+}
+
+func TestOutboundVless_XHTTP_DownloadSettings(t *testing.T) {
+	t.Parallel()
+
+	tunnel := NewHttpTestTunnel()
+	defer tunnel.Close()
+
+	addrs := startTestSharedXHTTPFrontends(t, startTestVlessBackend(t, tunnel), "auto",
+		testXHTTPFrontendOption{
+			Path: "/vless-outbound-xhttp-upload",
+			Host: "upload.example.com",
+		},
+		testXHTTPFrontendOption{
+			Path: "/vless-outbound-xhttp-download",
+			Host: "download.example.com",
+		},
+	)
+
+	uploadAddr, err := netip.ParseAddrPort(addrs[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	downloadAddr, err := netip.ParseAddrPort(addrs[1])
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := outbound.NewVless(outbound.VlessOption{
+		Name:        "vless_xhttp_outbound",
+		Server:      uploadAddr.Addr().String(),
+		Port:        int(uploadAddr.Port()),
+		UUID:        userUUID,
+		TLS:         true,
+		Fingerprint: tlsFingerprint,
+		ServerName:  "upload.example.com",
+		Network:     "xhttp",
+		ALPN:        []string{"h2"},
+		XHTTPOpts: outbound.XHTTPOptions{
+			Path: "/vless-outbound-xhttp-upload",
+			Host: "upload.example.com",
+			Mode: "auto",
+			DownloadSettings: &outbound.XHTTPDownloadSettings{
+				Server:     downloadAddr.Addr().String(),
+				Port:       int(downloadAddr.Port()),
+				TLS:        boolPtr(true),
+				ServerName: "download.example.com",
+				Host:       "download.example.com",
+				Path:       "/vless-outbound-xhttp-download",
+			},
+		},
+	})
+	if !assert.NoError(t, err) {
+		return
+	}
+	defer out.Close()
+
+	tunnel.DoTest(t, out)
+	testSingMux(t, tunnel, out)
+}
+
+func TestOutboundVless_SplitHTTP_PacketUp(t *testing.T) {
+	testOutboundVlessXHTTP(t, outbound.VlessOption{
+		TLS:         true,
+		Fingerprint: tlsFingerprint,
+		Network:     "splithttp",
+		ALPN:        []string{"h2"},
+		SplitHTTPOpts: outbound.SplitHTTPOptions{
+			Path: "/vless-outbound-splithttp-packet-up",
+			Host: "example.com",
+			Mode: "packet-up",
+		},
+	}, testXHTTPFrontendOption{
+		Path: "/vless-outbound-splithttp-packet-up",
+		Host: "example.com",
+		Mode: "packet-up",
+	})
+}
+
+func TestOutboundVless_SplitHTTP_Auto_H3(t *testing.T) {
+	testOutboundVlessXHTTP(t, outbound.VlessOption{
+		TLS:         true,
+		Fingerprint: tlsFingerprint,
+		Network:     "splithttp",
+		ALPN:        []string{"h3"},
+		SplitHTTPOpts: outbound.SplitHTTPOptions{
+			Path: "/vless-outbound-splithttp-auto-h3",
+			Host: "example.com",
+			Mode: "auto",
+		},
+	}, testXHTTPFrontendOption{
+		Path:     "/vless-outbound-splithttp-auto-h3",
+		Host:     "example.com",
+		Mode:     "auto",
+		UseHTTP3: true,
+	})
+}

--- a/listener/inbound/vless_test.go
+++ b/listener/inbound/vless_test.go
@@ -393,29 +393,33 @@ func TestInboundVless_Reality_XHTTP(t *testing.T) {
 }
 
 func TestInboundVless_XHTTP_DownloadSettings(t *testing.T) {
-	inboundOptions := inbound.VlessOption{
-		Certificate: tlsCertificate,
-		PrivateKey:  tlsPrivateKey,
-		XHTTPConfig: inbound.XHTTPConfig{
-			Path: "/vless-xhttp",
-			Host: "example.com",
-			Mode: "auto",
-		},
+	for _, mode := range []string{"stream-up", "packet-up"} {
+		t.Run(mode, func(t *testing.T) {
+			inboundOptions := inbound.VlessOption{
+				Certificate: tlsCertificate,
+				PrivateKey:  tlsPrivateKey,
+				XHTTPConfig: inbound.XHTTPConfig{
+					Path: "/vless-xhttp",
+					Host: "example.com",
+					Mode: mode,
+				},
+			}
+			outboundOptions := outbound.VlessOption{
+				TLS:               true,
+				Fingerprint:       tlsFingerprint,
+				ServerName:        "example.org",
+				ClientFingerprint: "chrome",
+				Network:           "xhttp",
+				XHTTPOpts: outbound.XHTTPOptions{
+					Path:             "/vless-xhttp",
+					Host:             "example.com",
+					Mode:             mode,
+					DownloadSettings: &outbound.XHTTPDownloadSettings{},
+				},
+			}
+			testInboundVlessTLS(t, inboundOptions, outboundOptions, false)
+		})
 	}
-	outboundOptions := outbound.VlessOption{
-		TLS:               true,
-		Fingerprint:       tlsFingerprint,
-		ServerName:        "example.org",
-		ClientFingerprint: "chrome",
-		Network:           "xhttp",
-		XHTTPOpts: outbound.XHTTPOptions{
-			Path:             "/vless-xhttp",
-			Host:             "example.com",
-			Mode:             "stream-up",
-			DownloadSettings: &outbound.XHTTPDownloadSettings{},
-		},
-	}
-	testInboundVlessTLS(t, inboundOptions, outboundOptions, false)
 }
 
 func TestInboundVless_XHTTP_StreamUp(t *testing.T) {

--- a/listener/inbound/vmess_test.go
+++ b/listener/inbound/vmess_test.go
@@ -378,26 +378,64 @@ func TestOutboundVMess_XHTTP_StreamUp(t *testing.T) {
 }
 
 func TestOutboundVMess_XHTTP_DownloadSettings(t *testing.T) {
-	testOutboundVMessXHTTP(t, outbound.VmessOption{
+	t.Parallel()
+
+	tunnel := NewHttpTestTunnel()
+	defer tunnel.Close()
+
+	addrs := startTestSharedXHTTPFrontends(t, startTestVMessBackend(t, tunnel), "auto",
+		testXHTTPFrontendOption{
+			Path: "/vmess-xhttp-upload",
+			Host: "upload.example.com",
+		},
+		testXHTTPFrontendOption{
+			Path: "/vmess-xhttp-download",
+			Host: "download.example.com",
+		},
+	)
+
+	uploadAddr, err := netip.ParseAddrPort(addrs[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	downloadAddr, err := netip.ParseAddrPort(addrs[1])
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := outbound.NewVmess(outbound.VmessOption{
+		Name:        "vmess_xhttp_outbound",
+		Server:      uploadAddr.Addr().String(),
+		Port:        int(uploadAddr.Port()),
+		UUID:        userUUID,
+		AlterID:     0,
+		Cipher:      "auto",
 		TLS:         true,
 		Fingerprint: tlsFingerprint,
+		ServerName:  "upload.example.com",
 		Network:     "xhttp",
 		ALPN:        []string{"h2"},
 		XHTTPOpts: outbound.XHTTPOptions{
-			Path: "/vmess-xhttp-download",
-			Host: "example.com",
+			Path: "/vmess-xhttp-upload",
+			Host: "upload.example.com",
 			Mode: "auto",
 			DownloadSettings: &outbound.XHTTPDownloadSettings{
-				TLS:  boolPtr(true),
-				Host: "example.com",
-				Path: "/vmess-xhttp-download",
+				Server:     downloadAddr.Addr().String(),
+				Port:       int(downloadAddr.Port()),
+				TLS:        boolPtr(true),
+				ServerName: "download.example.com",
+				Host:       "download.example.com",
+				Path:       "/vmess-xhttp-download",
 			},
 		},
-	}, testXHTTPFrontendOption{
-		Path: "/vmess-xhttp-download",
-		Host: "example.com",
-		Mode: "auto",
 	})
+	if !assert.NoError(t, err) {
+		return
+	}
+	defer out.Close()
+
+	tunnel.DoTest(t, out)
+	testSingMux(t, tunnel, out)
 }
 
 func TestOutboundVMess_SplitHTTP_PacketUp(t *testing.T) {

--- a/listener/inbound/vmess_test.go
+++ b/listener/inbound/vmess_test.go
@@ -293,3 +293,146 @@ func TestInboundVMess_Reality_Grpc(t *testing.T) {
 	}
 	testInboundVMess(t, inboundOptions, outboundOptions)
 }
+
+func testOutboundVMessXHTTP(t *testing.T, outboundOptions outbound.VmessOption, frontendOption testXHTTPFrontendOption) {
+	t.Parallel()
+
+	tunnel := NewHttpTestTunnel()
+	defer tunnel.Close()
+
+	frontendOption.BackendAddr = startTestVMessBackend(t, tunnel)
+	addrPort, err := netip.ParseAddrPort(startTestXHTTPFrontend(t, frontendOption))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	outboundOptions.Name = "vmess_xhttp_outbound"
+	outboundOptions.Server = addrPort.Addr().String()
+	outboundOptions.Port = int(addrPort.Port())
+	outboundOptions.UUID = userUUID
+	outboundOptions.AlterID = 0
+	outboundOptions.Cipher = "auto"
+
+	out, err := outbound.NewVmess(outboundOptions)
+	if !assert.NoError(t, err) {
+		return
+	}
+	defer out.Close()
+
+	tunnel.DoTest(t, out)
+	testSingMux(t, tunnel, out)
+}
+
+func TestOutboundVMess_XHTTP(t *testing.T) {
+	testOutboundVMessXHTTP(t, outbound.VmessOption{
+		TLS:         true,
+		Fingerprint: tlsFingerprint,
+		Network:     "xhttp",
+		ALPN:        []string{"h2"},
+		XHTTPOpts: outbound.XHTTPOptions{
+			Path: "/vmess-xhttp",
+			Host: "example.com",
+			Mode: "auto",
+		},
+	}, testXHTTPFrontendOption{
+		Path: "/vmess-xhttp",
+		Host: "example.com",
+		Mode: "auto",
+	})
+}
+
+func TestOutboundVMess_XHTTP_StreamOne(t *testing.T) {
+	testOutboundVMessXHTTP(t, outbound.VmessOption{
+		TLS:         true,
+		Fingerprint: tlsFingerprint,
+		Network:     "xhttp",
+		ALPN:        []string{"h2"},
+		XHTTPOpts: outbound.XHTTPOptions{
+			Path: "/vmess-xhttp-stream-one",
+			Host: "example.com",
+			Mode: "stream-one",
+		},
+	}, testXHTTPFrontendOption{
+		Path: "/vmess-xhttp-stream-one",
+		Host: "example.com",
+		Mode: "stream-one",
+	})
+}
+
+func TestOutboundVMess_XHTTP_StreamUp(t *testing.T) {
+	testOutboundVMessXHTTP(t, outbound.VmessOption{
+		TLS:         true,
+		Fingerprint: tlsFingerprint,
+		Network:     "xhttp",
+		ALPN:        []string{"h2"},
+		XHTTPOpts: outbound.XHTTPOptions{
+			Path: "/vmess-xhttp-stream-up",
+			Host: "example.com",
+			Mode: "stream-up",
+		},
+	}, testXHTTPFrontendOption{
+		Path: "/vmess-xhttp-stream-up",
+		Host: "example.com",
+		Mode: "stream-up",
+	})
+}
+
+func TestOutboundVMess_XHTTP_DownloadSettings(t *testing.T) {
+	testOutboundVMessXHTTP(t, outbound.VmessOption{
+		TLS:         true,
+		Fingerprint: tlsFingerprint,
+		Network:     "xhttp",
+		ALPN:        []string{"h2"},
+		XHTTPOpts: outbound.XHTTPOptions{
+			Path: "/vmess-xhttp-download",
+			Host: "example.com",
+			Mode: "auto",
+			DownloadSettings: &outbound.XHTTPDownloadSettings{
+				TLS:  boolPtr(true),
+				Host: "example.com",
+				Path: "/vmess-xhttp-download",
+			},
+		},
+	}, testXHTTPFrontendOption{
+		Path: "/vmess-xhttp-download",
+		Host: "example.com",
+		Mode: "auto",
+	})
+}
+
+func TestOutboundVMess_SplitHTTP_PacketUp(t *testing.T) {
+	testOutboundVMessXHTTP(t, outbound.VmessOption{
+		TLS:         true,
+		Fingerprint: tlsFingerprint,
+		Network:     "splithttp",
+		ALPN:        []string{"h2"},
+		SplitHTTPOpts: outbound.SplitHTTPOptions{
+			Path: "/vmess-splithttp-packet-up",
+			Host: "example.com",
+			Mode: "packet-up",
+		},
+	}, testXHTTPFrontendOption{
+		Path: "/vmess-splithttp-packet-up",
+		Host: "example.com",
+		Mode: "packet-up",
+	})
+}
+
+func TestOutboundVMess_SplitHTTP_Auto_H3(t *testing.T) {
+	testOutboundVMessXHTTP(t, outbound.VmessOption{
+		TLS:         true,
+		Fingerprint: tlsFingerprint,
+		Network:     "splithttp",
+		ALPN:        []string{"h3"},
+		SplitHTTPOpts: outbound.SplitHTTPOptions{
+			Path: "/vmess-splithttp-auto-h3",
+			Host: "example.com",
+			Mode: "auto",
+		},
+	}, testXHTTPFrontendOption{
+		Path:     "/vmess-splithttp-auto-h3",
+		Host:     "example.com",
+		Mode:     "auto",
+		UseHTTP3: true,
+	})
+}

--- a/listener/inbound/xhttp_helpers_test.go
+++ b/listener/inbound/xhttp_helpers_test.go
@@ -1,0 +1,205 @@
+package inbound_test
+
+import (
+	"io"
+	"net"
+	"testing"
+
+	adapterInbound "github.com/metacubex/mihomo/adapter/inbound"
+	N "github.com/metacubex/mihomo/common/net"
+	C "github.com/metacubex/mihomo/constant"
+	listenerInbound "github.com/metacubex/mihomo/listener/inbound"
+	"github.com/metacubex/mihomo/listener/sing"
+	"github.com/metacubex/mihomo/transport/socks5"
+	transportTrojan "github.com/metacubex/mihomo/transport/trojan"
+	"github.com/metacubex/mihomo/transport/xhttp"
+
+	"github.com/metacubex/http"
+	"github.com/metacubex/quic-go/http3"
+	"github.com/metacubex/tls"
+)
+
+type testXHTTPFrontendOption struct {
+	Path        string
+	Host        string
+	Mode        string
+	BackendAddr string
+	UseHTTP3    bool
+}
+
+// These helpers provide a local xhttp frontend so outbound xhttp modes can be
+// exercised against existing protocol backends without Docker / external cores.
+func startTestXHTTPFrontend(t *testing.T, option testXHTTPFrontendOption) string {
+	t.Helper()
+
+	handler := xhttp.NewServerHandler(xhttp.ServerOption{
+		Path: option.Path,
+		Host: option.Host,
+		Mode: option.Mode,
+		ConnHandler: func(conn net.Conn) {
+			backendConn, err := net.Dial("tcp", option.BackendAddr)
+			if err != nil {
+				_ = conn.Close()
+				return
+			}
+			N.Relay(conn, backendConn)
+		},
+	})
+
+	if option.UseHTTP3 {
+		packetConn, err := net.ListenPacket("udp", "127.0.0.1:0")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		server := &http3.Server{
+			Handler:   handler,
+			TLSConfig: http3.ConfigureTLSConfig(tlsConfig.Clone()),
+		}
+		go func() {
+			_ = server.Serve(packetConn)
+		}()
+
+		t.Cleanup(func() {
+			_ = server.Close()
+			_ = packetConn.Close()
+		})
+
+		return packetConn.LocalAddr().String()
+	}
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	server := &http.Server{Handler: handler}
+	tlsListener := tls.NewListener(ln, tlsConfig.Clone())
+	go func() {
+		_ = server.Serve(tlsListener)
+	}()
+
+	t.Cleanup(func() {
+		_ = server.Close()
+		_ = tlsListener.Close()
+	})
+
+	return ln.Addr().String()
+}
+
+func startTestVMessBackend(t *testing.T, tunnel *TestTunnel) string {
+	t.Helper()
+
+	in, err := listenerInbound.NewVmess(&listenerInbound.VmessOption{
+		BaseOption: listenerInbound.BaseOption{
+			NameStr: "vmess_xhttp_backend",
+			Listen:  "127.0.0.1",
+			Port:    "0",
+		},
+		Users: []listenerInbound.VmessUser{
+			{Username: "test", UUID: userUUID, AlterID: 0},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := in.Listen(tunnel); err != nil {
+		_ = in.Close()
+		t.Fatal(err)
+	}
+
+	t.Cleanup(func() {
+		_ = in.Close()
+	})
+
+	return in.Address()
+}
+
+func startTestTrojanBackend(t *testing.T, tunnel *TestTunnel, password string) string {
+	t.Helper()
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	passwordKey := transportTrojan.Key(password)
+	handler, err := sing.NewListenerHandler(sing.ListenerConfig{
+		Tunnel: tunnel,
+		Type:   C.TROJAN,
+		Additions: []adapterInbound.Addition{
+			adapterInbound.WithInName("DEFAULT-TROJAN"),
+			adapterInbound.WithSpecialRules(""),
+		},
+	})
+	if err != nil {
+		_ = ln.Close()
+		t.Fatal(err)
+	}
+
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+
+			go handleTestTrojanConn(conn, handler, passwordKey)
+		}
+	}()
+
+	t.Cleanup(func() {
+		_ = ln.Close()
+	})
+
+	return ln.Addr().String()
+}
+
+func handleTestTrojanConn(conn net.Conn, handler *sing.ListenerHandler, passwordKey [transportTrojan.KeyLength]byte) {
+	closeConn := true
+	defer func() {
+		if closeConn {
+			_ = conn.Close()
+		}
+	}()
+
+	var key [transportTrojan.KeyLength]byte
+	if _, err := io.ReadFull(conn, key[:]); err != nil {
+		return
+	}
+	if key != passwordKey {
+		return
+	}
+
+	var crlf [2]byte
+	if _, err := io.ReadFull(conn, crlf[:]); err != nil {
+		return
+	}
+	if crlf != [2]byte{'\r', '\n'} {
+		return
+	}
+
+	command, err := socks5.ReadByte(conn)
+	if err != nil {
+		return
+	}
+	if command != transportTrojan.CommandTCP {
+		return
+	}
+
+	target, err := socks5.ReadAddr0(conn)
+	if err != nil {
+		return
+	}
+
+	if _, err := io.ReadFull(conn, crlf[:]); err != nil {
+		return
+	}
+	if crlf != [2]byte{'\r', '\n'} {
+		return
+	}
+
+	closeConn = false
+	handler.HandleSocket(target, conn)
+}

--- a/listener/inbound/xhttp_helpers_test.go
+++ b/listener/inbound/xhttp_helpers_test.go
@@ -1,8 +1,10 @@
 package inbound_test
 
 import (
+	"context"
 	"io"
 	"net"
+	"strings"
 	"testing"
 
 	adapterInbound "github.com/metacubex/mihomo/adapter/inbound"
@@ -10,12 +12,14 @@ import (
 	C "github.com/metacubex/mihomo/constant"
 	listenerInbound "github.com/metacubex/mihomo/listener/inbound"
 	"github.com/metacubex/mihomo/listener/sing"
+	listenerSingVless "github.com/metacubex/mihomo/listener/sing_vless"
 	"github.com/metacubex/mihomo/transport/socks5"
 	transportTrojan "github.com/metacubex/mihomo/transport/trojan"
 	"github.com/metacubex/mihomo/transport/xhttp"
 
 	"github.com/metacubex/http"
 	"github.com/metacubex/quic-go/http3"
+	M "github.com/metacubex/sing/common/metadata"
 	"github.com/metacubex/tls"
 )
 
@@ -25,6 +29,10 @@ type testXHTTPFrontendOption struct {
 	Mode        string
 	BackendAddr string
 	UseHTTP3    bool
+}
+
+type testSharedXHTTPFrontend struct {
+	handler http.Handler
 }
 
 // These helpers provide a local xhttp frontend so outbound xhttp modes can be
@@ -46,7 +54,45 @@ func startTestXHTTPFrontend(t *testing.T, option testXHTTPFrontendOption) string
 		},
 	})
 
-	if option.UseHTTP3 {
+	return startTestXHTTPServer(t, handler, option.UseHTTP3)
+}
+
+func startTestSharedXHTTPFrontends(t *testing.T, backendAddr string, mode string, options ...testXHTTPFrontendOption) []string {
+	t.Helper()
+
+	frontend := &testSharedXHTTPFrontend{
+		handler: xhttp.NewServerHandler(xhttp.ServerOption{
+			Path: "/",
+			Mode: mode,
+			ConnHandler: func(conn net.Conn) {
+				backendConn, err := net.Dial("tcp", backendAddr)
+				if err != nil {
+					_ = conn.Close()
+					return
+				}
+				N.Relay(conn, backendConn)
+			},
+		}),
+	}
+
+	addrs := make([]string, len(options))
+	for idx, option := range options {
+		addrs[idx] = frontend.startAlias(t, option)
+	}
+
+	return addrs
+}
+
+func (f *testSharedXHTTPFrontend) startAlias(t *testing.T, option testXHTTPFrontendOption) string {
+	t.Helper()
+
+	return startTestXHTTPServer(t, wrapTestXHTTPAliasHandler(f.handler, option), option.UseHTTP3)
+}
+
+func startTestXHTTPServer(t *testing.T, handler http.Handler, useHTTP3 bool) string {
+	t.Helper()
+
+	if useHTTP3 {
 		packetConn, err := net.ListenPacket("udp", "127.0.0.1:0")
 		if err != nil {
 			t.Fatal(err)
@@ -87,6 +133,55 @@ func startTestXHTTPFrontend(t *testing.T, option testXHTTPFrontendOption) string
 	return ln.Addr().String()
 }
 
+func wrapTestXHTTPAliasHandler(inner http.Handler, option testXHTTPFrontendOption) http.Handler {
+	path := option.Path
+	if path == "" {
+		path = "/"
+	}
+	if !strings.HasPrefix(path, "/") {
+		path = "/" + path
+	}
+	if !strings.HasSuffix(path, "/") {
+		path += "/"
+	}
+
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if option.Host != "" && !equalTestXHTTPHost(r.Host, option.Host) {
+			http.NotFound(w, r)
+			return
+		}
+		if !strings.HasPrefix(r.URL.Path, path) {
+			http.NotFound(w, r)
+			return
+		}
+
+		cloned := r.Clone(r.Context())
+		suffix := strings.TrimPrefix(r.URL.Path, path)
+		if suffix == "" {
+			cloned.URL.Path = "/"
+		} else {
+			cloned.URL.Path = "/" + suffix
+		}
+		cloned.RequestURI = ""
+
+		inner.ServeHTTP(w, cloned)
+	})
+}
+
+func equalTestXHTTPHost(a string, b string) bool {
+	a = strings.ToLower(a)
+	b = strings.ToLower(b)
+
+	if ah, _, err := net.SplitHostPort(a); err == nil {
+		a = ah
+	}
+	if bh, _, err := net.SplitHostPort(b); err == nil {
+		b = bh
+	}
+
+	return a == b
+}
+
 func startTestVMessBackend(t *testing.T, tunnel *TestTunnel) string {
 	t.Helper()
 
@@ -114,6 +209,60 @@ func startTestVMessBackend(t *testing.T, tunnel *TestTunnel) string {
 	})
 
 	return in.Address()
+}
+
+func startTestVlessBackend(t *testing.T, tunnel *TestTunnel) string {
+	t.Helper()
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	additions := []adapterInbound.Addition{
+		adapterInbound.WithInName("DEFAULT-VLESS"),
+		adapterInbound.WithSpecialRules(""),
+	}
+	handler, err := sing.NewListenerHandler(sing.ListenerConfig{
+		Tunnel:    tunnel,
+		Type:      C.VLESS,
+		Additions: additions,
+	})
+	if err != nil {
+		_ = ln.Close()
+		t.Fatal(err)
+	}
+
+	service := listenerSingVless.NewService[string](handler)
+	service.UpdateUsers([]string{"test"}, []string{userUUID}, []string{""})
+
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+
+			go handleTestVlessConn(conn, service, additions)
+		}
+	}()
+
+	t.Cleanup(func() {
+		_ = ln.Close()
+	})
+
+	return ln.Addr().String()
+}
+
+func handleTestVlessConn(conn net.Conn, service *listenerSingVless.Service[string], additions []adapterInbound.Addition) {
+	ctx := sing.WithAdditions(context.TODO(), additions...)
+	err := service.NewConnection(ctx, conn, M.Metadata{
+		Protocol: "vless",
+		Source:   M.SocksaddrFromNet(conn.RemoteAddr()),
+	})
+	if err != nil {
+		_ = conn.Close()
+	}
 }
 
 func startTestTrojanBackend(t *testing.T, tunnel *TestTunnel, password string) string {

--- a/listener/sing_vless/server.go
+++ b/listener/sing_vless/server.go
@@ -148,7 +148,7 @@ func New(config LC.VlessServer, tunnel C.Tunnel, additions ...inbound.Addition) 
 	}
 	if config.XHTTPConfig.Mode != "" {
 		switch config.XHTTPConfig.Mode {
-		case "auto":
+		case "auto", "stream-one", "stream-up", "packet-up":
 		default:
 			return nil, errors.New("unsupported xhttp mode")
 		}

--- a/listener/sing_vless/server.go
+++ b/listener/sing_vless/server.go
@@ -148,7 +148,7 @@ func New(config LC.VlessServer, tunnel C.Tunnel, additions ...inbound.Addition) 
 	}
 	if config.XHTTPConfig.Mode != "" {
 		switch config.XHTTPConfig.Mode {
-		case "auto", "stream-up":
+		case "auto", "stream-up", "stream-one", "packet-up":
 		default:
 			return nil, errors.New("unsupported xhttp mode")
 		}

--- a/transport/xhttp/client.go
+++ b/transport/xhttp/client.go
@@ -244,13 +244,17 @@ func DialStreamUp(cfg *Config, uploadTransport http.RoundTripper, downloadTransp
 	return conn, nil
 }
 
-func DialPacketUp(cfg *Config, transport http.RoundTripper) (net.Conn, error) {
+func DialPacketUp(cfg *Config, uploadTransport http.RoundTripper, downloadTransport http.RoundTripper) (net.Conn, error) {
+	downloadCfg := cfg
+	if ds := cfg.DownloadConfig; ds != nil {
+		downloadCfg = ds
+	}
 	sessionID := newSessionID()
 
 	downloadURL := url.URL{
 		Scheme: "https",
-		Host:   cfg.Host,
-		Path:   cfg.NormalizedPath(),
+		Host:   downloadCfg.Host,
+		Path:   downloadCfg.NormalizedPath(),
 	}
 
 	ctx := context.Background()
@@ -258,30 +262,34 @@ func DialPacketUp(cfg *Config, transport http.RoundTripper) (net.Conn, error) {
 		ctx:       ctx,
 		cfg:       cfg,
 		sessionID: sessionID,
-		transport: transport,
+		transport: uploadTransport,
 		seq:       0,
 	}
 	conn := &Conn{writer: writer}
 
-	req, err := http.NewRequestWithContext(httputils.NewAddrContext(&conn.NetAddr, ctx), http.MethodGet, downloadURL.String(), nil)
+	downloadReq, err := http.NewRequestWithContext(httputils.NewAddrContext(&conn.NetAddr, ctx), http.MethodGet, downloadURL.String(), nil)
 	if err != nil {
 		return nil, err
 	}
-	if err := cfg.FillDownloadRequest(req, sessionID); err != nil {
+	if err := downloadCfg.FillDownloadRequest(downloadReq, sessionID); err != nil {
 		return nil, err
 	}
-	req.Host = cfg.Host
+	downloadReq.Host = downloadCfg.Host
 
-	resp, err := transport.RoundTrip(req)
+	resp, err := downloadTransport.RoundTrip(downloadReq)
 	if err != nil {
 		return nil, err
 	}
 	if resp.StatusCode != http.StatusOK {
 		_ = resp.Body.Close()
-		httputils.CloseTransport(transport)
+		httputils.CloseTransport(uploadTransport)
+		httputils.CloseTransport(downloadTransport)
 		return nil, fmt.Errorf("xhttp packet-up download bad status: %s", resp.Status)
 	}
 	conn.reader = resp.Body
+	conn.onClose = func() {
+		httputils.CloseTransport(downloadTransport)
+	}
 
 	return conn, nil
 }

--- a/transport/xhttp/client.go
+++ b/transport/xhttp/client.go
@@ -15,11 +15,9 @@ import (
 	"github.com/metacubex/mihomo/common/httputils"
 
 	"github.com/metacubex/http"
-	"github.com/metacubex/tls"
 )
 
-type DialRawFunc func(ctx context.Context) (net.Conn, error)
-type WrapTLSFunc func(ctx context.Context, conn net.Conn, isH2 bool) (net.Conn, error)
+type RoundTripperFactory func(ctx context.Context) (http.RoundTripper, error)
 
 type PacketUpWriter struct {
 	ctx       context.Context
@@ -34,13 +32,13 @@ func (c *PacketUpWriter) Write(b []byte) (int, error) {
 	c.writeMu.Lock()
 	defer c.writeMu.Unlock()
 
-	u := url.URL{
+	requestURL := url.URL{
 		Scheme: "https",
 		Host:   c.cfg.Host,
 		Path:   c.cfg.NormalizedPath(),
 	}
 
-	req, err := http.NewRequestWithContext(c.ctx, http.MethodPost, u.String(), nil)
+	req, err := http.NewRequestWithContext(c.ctx, http.MethodPost, requestURL.String(), nil)
 	if err != nil {
 		return 0, err
 	}
@@ -72,50 +70,34 @@ func (c *PacketUpWriter) Close() error {
 	return nil
 }
 
-func DialStreamOne(
-	ctx context.Context,
-	cfg *Config,
-	dialRaw DialRawFunc,
-	wrapTLS WrapTLSFunc,
-) (net.Conn, error) {
+func DialStreamOne(ctx context.Context, cfg *Config, newTransport RoundTripperFactory) (net.Conn, error) {
+	transport, err := newTransport(ctx)
+	if err != nil {
+		return nil, err
+	}
+
 	requestURL := url.URL{
 		Scheme: "https",
 		Host:   cfg.Host,
 		Path:   cfg.NormalizedPath(),
 	}
 
-	transport := &http.Http2Transport{
-		DialTLSContext: func(ctx context.Context, network, addr string, _ *tls.Config) (net.Conn, error) {
-			raw, err := dialRaw(ctx)
-			if err != nil {
-				return nil, err
-			}
-			wrapped, err := wrapTLS(ctx, raw, true)
-			if err != nil {
-				_ = raw.Close()
-				return nil, err
-			}
-			return wrapped, nil
-		},
-	}
-
 	pr, pw := io.Pipe()
-
-	conn := &Conn{
-		writer: pw,
-	}
+	conn := &Conn{writer: pw}
 
 	req, err := http.NewRequestWithContext(httputils.NewAddrContext(&conn.NetAddr, contextutils.WithoutCancel(ctx)), http.MethodPost, requestURL.String(), pr)
 	if err != nil {
 		_ = pr.Close()
 		_ = pw.Close()
+		httputils.CloseTransport(transport)
 		return nil, err
 	}
 	req.Host = cfg.Host
 
-	if err := cfg.FillStreamRequest(req); err != nil {
+	if err := cfg.FillStreamRequest(req, ""); err != nil {
 		_ = pr.Close()
 		_ = pw.Close()
+		httputils.CloseTransport(transport)
 		return nil, err
 	}
 
@@ -133,6 +115,7 @@ func DialStreamOne(
 		httputils.CloseTransport(transport)
 		return nil, fmt.Errorf("xhttp stream-one bad status: %s", resp.Status)
 	}
+
 	conn.reader = resp.Body
 	conn.onClose = func() {
 		_ = resp.Body.Close()
@@ -143,33 +126,140 @@ func DialStreamOne(
 	return conn, nil
 }
 
-func DialPacketUp(
+func DialStreamUp(
 	ctx context.Context,
 	cfg *Config,
-	dialRaw DialRawFunc,
-	wrapTLS WrapTLSFunc,
+	newUploadTransport RoundTripperFactory,
+	newDownloadTransport RoundTripperFactory,
 ) (net.Conn, error) {
-	transport := &http.Http2Transport{
-		DialTLSContext: func(ctx context.Context, network string, addr string, _ *tls.Config) (net.Conn, error) {
-			raw, err := dialRaw(ctx)
-			if err != nil {
-				return nil, err
-			}
-			wrapped, err := wrapTLS(ctx, raw, true)
-			if err != nil {
-				_ = raw.Close()
-				return nil, err
-			}
-			return wrapped, nil
-		},
+	uploadTransport, err := newUploadTransport(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	downloadTransport, err := newDownloadTransport(ctx)
+	if err != nil {
+		httputils.CloseTransport(uploadTransport)
+		return nil, err
 	}
 
 	sessionID := newSessionID()
+	downloadCfg := cfg.DownloadRequestConfig()
 
 	downloadURL := url.URL{
 		Scheme: "https",
+		Host:   downloadCfg.Host,
+		Path:   downloadCfg.NormalizedPath(),
+	}
+
+	conn := &Conn{}
+
+	downloadReq, err := http.NewRequestWithContext(
+		httputils.NewAddrContext(&conn.NetAddr, contextutils.WithoutCancel(ctx)),
+		http.MethodGet,
+		downloadURL.String(),
+		nil,
+	)
+	if err != nil {
+		httputils.CloseTransport(uploadTransport)
+		httputils.CloseTransport(downloadTransport)
+		return nil, err
+	}
+	if err := downloadCfg.FillDownloadRequest(downloadReq, sessionID); err != nil {
+		httputils.CloseTransport(uploadTransport)
+		httputils.CloseTransport(downloadTransport)
+		return nil, err
+	}
+	downloadReq.Host = downloadCfg.Host
+
+	downloadResp, err := downloadTransport.RoundTrip(downloadReq)
+	if err != nil {
+		httputils.CloseTransport(uploadTransport)
+		httputils.CloseTransport(downloadTransport)
+		return nil, err
+	}
+	if downloadResp.StatusCode != http.StatusOK {
+		_ = downloadResp.Body.Close()
+		httputils.CloseTransport(uploadTransport)
+		httputils.CloseTransport(downloadTransport)
+		return nil, fmt.Errorf("xhttp stream-up download bad status: %s", downloadResp.Status)
+	}
+
+	uploadURL := url.URL{
+		Scheme: "https",
 		Host:   cfg.Host,
 		Path:   cfg.NormalizedPath(),
+	}
+
+	pr, pw := io.Pipe()
+	uploadReq, err := http.NewRequestWithContext(contextutils.WithoutCancel(ctx), http.MethodPost, uploadURL.String(), pr)
+	if err != nil {
+		_ = downloadResp.Body.Close()
+		_ = pr.Close()
+		_ = pw.Close()
+		httputils.CloseTransport(uploadTransport)
+		httputils.CloseTransport(downloadTransport)
+		return nil, err
+	}
+	if err := cfg.FillStreamRequest(uploadReq, sessionID); err != nil {
+		_ = downloadResp.Body.Close()
+		_ = pr.Close()
+		_ = pw.Close()
+		httputils.CloseTransport(uploadTransport)
+		httputils.CloseTransport(downloadTransport)
+		return nil, err
+	}
+	uploadReq.Host = cfg.Host
+
+	go func() {
+		resp, err := uploadTransport.RoundTrip(uploadReq)
+		if err != nil {
+			_ = pw.CloseWithError(err)
+			return
+		}
+		defer resp.Body.Close()
+		_, _ = io.Copy(io.Discard, resp.Body)
+		if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+			_ = pw.CloseWithError(fmt.Errorf("xhttp stream-up upload bad status: %s", resp.Status))
+		}
+	}()
+
+	conn.writer = pw
+	conn.reader = downloadResp.Body
+	conn.onClose = func() {
+		_ = downloadResp.Body.Close()
+		_ = pr.Close()
+		httputils.CloseTransport(uploadTransport)
+		httputils.CloseTransport(downloadTransport)
+	}
+
+	return conn, nil
+}
+
+func DialPacketUp(
+	ctx context.Context,
+	cfg *Config,
+	newUploadTransport RoundTripperFactory,
+	newDownloadTransport RoundTripperFactory,
+) (net.Conn, error) {
+	uploadTransport, err := newUploadTransport(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	downloadTransport, err := newDownloadTransport(ctx)
+	if err != nil {
+		httputils.CloseTransport(uploadTransport)
+		return nil, err
+	}
+
+	sessionID := newSessionID()
+	downloadCfg := cfg.DownloadRequestConfig()
+
+	downloadURL := url.URL{
+		Scheme: "https",
+		Host:   downloadCfg.Host,
+		Path:   downloadCfg.NormalizedPath(),
 	}
 
 	ctx = contextutils.WithoutCancel(ctx)
@@ -177,30 +267,43 @@ func DialPacketUp(
 		ctx:       ctx,
 		cfg:       cfg,
 		sessionID: sessionID,
-		transport: transport,
+		transport: uploadTransport,
 		seq:       0,
 	}
 	conn := &Conn{writer: writer}
 
 	req, err := http.NewRequestWithContext(httputils.NewAddrContext(&conn.NetAddr, ctx), http.MethodGet, downloadURL.String(), nil)
 	if err != nil {
+		httputils.CloseTransport(uploadTransport)
+		httputils.CloseTransport(downloadTransport)
 		return nil, err
 	}
-	if err := cfg.FillDownloadRequest(req, sessionID); err != nil {
+	if err := downloadCfg.FillDownloadRequest(req, sessionID); err != nil {
+		httputils.CloseTransport(uploadTransport)
+		httputils.CloseTransport(downloadTransport)
 		return nil, err
 	}
-	req.Host = cfg.Host
+	req.Host = downloadCfg.Host
 
-	resp, err := transport.RoundTrip(req)
+	resp, err := downloadTransport.RoundTrip(req)
 	if err != nil {
+		httputils.CloseTransport(uploadTransport)
+		httputils.CloseTransport(downloadTransport)
 		return nil, err
 	}
 	if resp.StatusCode != http.StatusOK {
 		_ = resp.Body.Close()
-		httputils.CloseTransport(transport)
+		httputils.CloseTransport(uploadTransport)
+		httputils.CloseTransport(downloadTransport)
 		return nil, fmt.Errorf("xhttp packet-up download bad status: %s", resp.Status)
 	}
+
 	conn.reader = resp.Body
+	conn.onClose = func() {
+		_ = resp.Body.Close()
+		httputils.CloseTransport(uploadTransport)
+		httputils.CloseTransport(downloadTransport)
+	}
 
 	return conn, nil
 }

--- a/transport/xhttp/config.go
+++ b/transport/xhttp/config.go
@@ -8,16 +8,36 @@ import (
 	"strconv"
 	"strings"
 
+	tlsC "github.com/metacubex/mihomo/component/tls"
+
 	"github.com/metacubex/http"
 )
 
 type Config struct {
-	Host          string
-	Path          string
-	Mode          string
-	Headers       map[string]string
-	NoGRPCHeader  bool
-	XPaddingBytes string
+	Host             string
+	Path             string
+	Mode             string
+	Headers          map[string]string
+	NoGRPCHeader     bool
+	XPaddingBytes    string
+	ALPN             []string
+	TryQUIC          bool
+	HasReality       bool
+	DownloadSettings *DownloadConfig
+}
+
+type DownloadConfig struct {
+	Server            string
+	Port              int
+	TLS               *bool
+	Headers           map[string]string
+	Host              string
+	Path              string
+	Mode              string
+	ServerName        string
+	ClientFingerprint string
+	SkipCertVerify    bool
+	Reality           *tlsC.RealityConfig
 }
 
 func (c *Config) NormalizedMode() string {
@@ -27,15 +47,29 @@ func (c *Config) NormalizedMode() string {
 	return c.Mode
 }
 
-func (c *Config) EffectiveMode(hasReality bool) string {
+func (c *Config) EffectiveModeWithReality(hasReality bool) string {
+	return c.effectiveMode(hasReality)
+}
+
+func (c *Config) effectiveMode(hasReality bool) string {
 	mode := c.NormalizedMode()
 	if mode != "auto" {
 		return mode
 	}
+	if c.DownloadSettings != nil {
+		return "stream-up"
+	}
 	if hasReality {
 		return "stream-one"
 	}
+	if c.SupportsHTTP2() {
+		return "stream-up"
+	}
 	return "packet-up"
+}
+
+func (c *Config) EffectiveMode() string {
+	return c.effectiveMode(c.HasReality)
 }
 
 func (c *Config) NormalizedPath() string {
@@ -75,6 +109,30 @@ func (c *Config) RequestHeader() http.Header {
 	}
 
 	return h
+}
+
+func (c *Config) HasALPN(token string) bool {
+	token = strings.ToLower(strings.TrimSpace(token))
+	if token == "" {
+		return false
+	}
+	for _, item := range c.ALPN {
+		if strings.ToLower(strings.TrimSpace(item)) == token {
+			return true
+		}
+	}
+	return false
+}
+
+func (c *Config) SupportsHTTP2() bool {
+	if len(c.ALPN) == 0 {
+		return true
+	}
+	return c.HasALPN("h2")
+}
+
+func (c *Config) ShouldTryHTTP3() bool {
+	return c.TryQUIC && c.HasALPN("h3")
 }
 
 func (c *Config) RandomPadding() (string, error) {
@@ -126,7 +184,7 @@ func parseRange(s string) (int, int, error) {
 	return minVal, maxVal, nil
 }
 
-func (c *Config) FillStreamRequest(req *http.Request) error {
+func (c *Config) FillStreamRequest(req *http.Request, sessionID string) error {
 	req.Header = c.RequestHeader()
 
 	paddingValue, err := c.RandomPadding()
@@ -142,6 +200,8 @@ func (c *Config) FillStreamRequest(req *http.Request) error {
 		}
 		req.Header.Set("Referer", rawURL+sep+"x_padding="+paddingValue)
 	}
+
+	c.ApplyMetaToRequest(req, sessionID, "")
 
 	if req.Body != nil && !c.NoGRPCHeader {
 		req.Header.Set("Content-Type", "application/grpc")
@@ -206,4 +266,37 @@ func (c *Config) FillDownloadRequest(req *http.Request, sessionID string) error 
 
 	c.ApplyMetaToRequest(req, sessionID, "")
 	return nil
+}
+
+func (c *Config) DownloadRequestConfig() *Config {
+	if c.DownloadSettings == nil {
+		return c
+	}
+
+	download := &Config{
+		Host:          c.Host,
+		Path:          c.Path,
+		Mode:          c.Mode,
+		Headers:       c.Headers,
+		NoGRPCHeader:  c.NoGRPCHeader,
+		XPaddingBytes: c.XPaddingBytes,
+		ALPN:          c.ALPN,
+		TryQUIC:       c.TryQUIC,
+		HasReality:    c.HasReality,
+	}
+
+	if c.DownloadSettings.Host != "" {
+		download.Host = c.DownloadSettings.Host
+	}
+	if c.DownloadSettings.Path != "" {
+		download.Path = c.DownloadSettings.Path
+	}
+	if c.DownloadSettings.Mode != "" {
+		download.Mode = c.DownloadSettings.Mode
+	}
+	if len(c.DownloadSettings.Headers) != 0 {
+		download.Headers = c.DownloadSettings.Headers
+	}
+
+	return download
 }

--- a/transport/xhttp/config_test.go
+++ b/transport/xhttp/config_test.go
@@ -1,0 +1,90 @@
+package xhttp
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestConfigEffectiveMode(t *testing.T) {
+	testCases := []struct {
+		name   string
+		config Config
+		want   string
+	}{
+		{
+			name: "DefaultH2AutoUsesStreamUp",
+			config: Config{
+				ALPN: []string{"h2"},
+			},
+			want: "stream-up",
+		},
+		{
+			name: "RealityAutoUsesStreamOne",
+			config: Config{
+				ALPN:       []string{"h2"},
+				HasReality: true,
+			},
+			want: "stream-one",
+		},
+		{
+			name: "DownloadSettingsForceStreamUp",
+			config: Config{
+				ALPN: []string{"h3"},
+				DownloadSettings: &DownloadConfig{
+					Host: "download.example.com",
+				},
+			},
+			want: "stream-up",
+		},
+		{
+			name: "H3OnlyAutoUsesPacketUp",
+			config: Config{
+				ALPN: []string{"h3"},
+			},
+			want: "packet-up",
+		},
+		{
+			name: "ExplicitModeWins",
+			config: Config{
+				Mode: "packet-up",
+				ALPN: []string{"h2"},
+			},
+			want: "packet-up",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			assert.Equal(t, testCase.want, testCase.config.EffectiveMode())
+		})
+	}
+}
+
+func TestConfigDownloadRequestConfig(t *testing.T) {
+	config := &Config{
+		Host:       "upload.example.com",
+		Path:       "/upload",
+		Mode:       "stream-up",
+		Headers:    map[string]string{"X-Test": "upload"},
+		ALPN:       []string{"h2"},
+		TryQUIC:    true,
+		HasReality: true,
+		DownloadSettings: &DownloadConfig{
+			Host:    "download.example.com",
+			Path:    "/download",
+			Mode:    "packet-up",
+			Headers: map[string]string{"X-Test": "download"},
+		},
+	}
+
+	download := config.DownloadRequestConfig()
+	assert.Equal(t, "download.example.com", download.Host)
+	assert.Equal(t, "/download", download.Path)
+	assert.Equal(t, "packet-up", download.Mode)
+	assert.Equal(t, "download", download.Headers["X-Test"])
+	assert.Equal(t, config.ALPN, download.ALPN)
+	assert.Equal(t, config.TryQUIC, download.TryQUIC)
+	assert.Equal(t, config.HasReality, download.HasReality)
+	assert.Nil(t, download.DownloadSettings)
+}

--- a/transport/xhttp/server.go
+++ b/transport/xhttp/server.go
@@ -162,6 +162,49 @@ func (h *requestHandler) getSession(sessionID string) *httpSession {
 	return h.sessions[sessionID]
 }
 
+func (h *requestHandler) normalizedMode() string {
+	if h.mode == "" {
+		return "auto"
+	}
+	return h.mode
+}
+
+func (h *requestHandler) allowStreamOne() bool {
+	switch h.normalizedMode() {
+	case "auto", "stream-one", "stream-up":
+		return true
+	default:
+		return false
+	}
+}
+
+func (h *requestHandler) allowSessionDownload() bool {
+	switch h.normalizedMode() {
+	case "auto", "stream-up", "packet-up":
+		return true
+	default:
+		return false
+	}
+}
+
+func (h *requestHandler) allowStreamUpUpload() bool {
+	switch h.normalizedMode() {
+	case "auto", "stream-up":
+		return true
+	default:
+		return false
+	}
+}
+
+func (h *requestHandler) allowPacketUpUpload() bool {
+	switch h.normalizedMode() {
+	case "auto", "packet-up":
+		return true
+	default:
+		return false
+	}
+}
+
 func (h *requestHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if h.httpHandler != nil && !strings.HasPrefix(r.URL.Path, h.path) {
 		h.httpHandler.ServeHTTP(w, r)
@@ -183,6 +226,11 @@ func (h *requestHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	// stream-one: POST /path
 	if r.Method == http.MethodPost && len(parts) == 0 {
+		if !h.allowStreamOne() {
+			http.NotFound(w, r)
+			return
+		}
+
 		w.Header().Set("X-Accel-Buffering", "no")
 		w.Header().Set("Cache-Control", "no-store")
 		w.WriteHeader(http.StatusOK)
@@ -208,8 +256,13 @@ func (h *requestHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// packet-up download: GET /path/{session}
+	// stream-up/packet-up download: GET /path/{session}
 	if r.Method == http.MethodGet && len(parts) == 1 {
+		if !h.allowSessionDownload() {
+			http.NotFound(w, r)
+			return
+		}
+
 		sessionID := parts[0]
 		session := h.getOrCreateSession(sessionID)
 		session.markConnected()
@@ -242,8 +295,55 @@ func (h *requestHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// stream-up upload: POST /path/{session}
+	if r.Method == http.MethodPost && len(parts) == 1 {
+		if !h.allowStreamUpUpload() {
+			http.NotFound(w, r)
+			return
+		}
+
+		sessionID := parts[0]
+		session := h.getSession(sessionID)
+		if session == nil {
+			http.Error(w, "unknown xhttp session", http.StatusBadRequest)
+			return
+		}
+
+		buf := make([]byte, 32*1024)
+		var seq uint64
+		for {
+			n, err := r.Body.Read(buf)
+			if n > 0 {
+				if pushErr := session.uploadQueue.Push(Packet{
+					Seq:     seq,
+					Payload: buf[:n],
+				}); pushErr != nil {
+					http.Error(w, pushErr.Error(), http.StatusInternalServerError)
+					return
+				}
+				seq++
+			}
+			if err == io.EOF {
+				break
+			}
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
+		}
+
+		w.Header().Set("Cache-Control", "no-store")
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+
 	// packet-up upload: POST /path/{session}/{seq}
 	if r.Method == http.MethodPost && len(parts) == 2 {
+		if !h.allowPacketUpUpload() {
+			http.NotFound(w, r)
+			return
+		}
+
 		sessionID := parts[0]
 		seq, err := strconv.ParseUint(parts[1], 10, 64)
 		if err != nil {

--- a/transport/xhttp/server_test.go
+++ b/transport/xhttp/server_test.go
@@ -1,0 +1,97 @@
+package xhttp
+
+import (
+	"io"
+	"net"
+	"testing"
+
+	"github.com/metacubex/http"
+	"github.com/metacubex/http/httptest"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestServerHandlerModeRestrictions(t *testing.T) {
+	testCases := []struct {
+		name       string
+		mode       string
+		method     string
+		target     string
+		wantStatus int
+	}{
+		{
+			name:       "StreamOneAcceptsStreamOne",
+			mode:       "stream-one",
+			method:     http.MethodPost,
+			target:     "https://example.com/xhttp/",
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "StreamOneRejectsSessionDownload",
+			mode:       "stream-one",
+			method:     http.MethodGet,
+			target:     "https://example.com/xhttp/session",
+			wantStatus: http.StatusNotFound,
+		},
+		{
+			name:       "StreamUpAcceptsStreamOne",
+			mode:       "stream-up",
+			method:     http.MethodPost,
+			target:     "https://example.com/xhttp/",
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "StreamUpAllowsDownloadEndpoint",
+			mode:       "stream-up",
+			method:     http.MethodGet,
+			target:     "https://example.com/xhttp/session",
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "StreamUpRejectsPacketUpload",
+			mode:       "stream-up",
+			method:     http.MethodPost,
+			target:     "https://example.com/xhttp/session/0",
+			wantStatus: http.StatusNotFound,
+		},
+		{
+			name:       "PacketUpAllowsDownloadEndpoint",
+			mode:       "packet-up",
+			method:     http.MethodGet,
+			target:     "https://example.com/xhttp/session",
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "PacketUpRejectsStreamOne",
+			mode:       "packet-up",
+			method:     http.MethodPost,
+			target:     "https://example.com/xhttp/",
+			wantStatus: http.StatusNotFound,
+		},
+		{
+			name:       "PacketUpRejectsStreamUpUpload",
+			mode:       "packet-up",
+			method:     http.MethodPost,
+			target:     "https://example.com/xhttp/session",
+			wantStatus: http.StatusNotFound,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			handler := NewServerHandler(ServerOption{
+				Path: "/xhttp",
+				Mode: testCase.mode,
+				ConnHandler: func(conn net.Conn) {
+					_ = conn.Close()
+				},
+			})
+
+			req := httptest.NewRequest(testCase.method, testCase.target, io.NopCloser(http.NoBody))
+			recorder := httptest.NewRecorder()
+
+			handler.ServeHTTP(recorder, req)
+
+			assert.Equal(t, testCase.wantStatus, recorder.Result().StatusCode)
+		})
+	}
+}


### PR DESCRIPTION
## What

- complete xhttp / splithttp outbound support for VLESS, VMess and Trojan
- add inbound-side runtime tests for xhttp / splithttp combinations
- document xhttp usage and configuration examples in `docs/config.yaml`

## Details

- add a shared outbound xhttp helper to keep stream dialing and transport setup consistent across protocols
- use `xhttp-opts` for `network: xhttp` and `splithttp-opts` for `network: splithttp`, while keeping backward-compatible fallback when only one opts block is provided
- align `download-settings` with mihomo style by reusing top-level `tls` and `reality-opts` instead of introducing a separate security field
- enforce supported inbound xhttp modes and cover `download-settings`, `try-quic`, and h3-related branches
- avoid re-wrapping TLS/default transports after xhttp dialing

## Testing

- `/usr/local/go/bin/go build ./...`
- `/usr/local/go/bin/go test ./...`
- `PATH=/usr/local/go/bin:$PATH /root/go/bin/golangci-lint run --new-from-rev=2d34ecffe8ea262ffcdf7a15f258980cf5c1c3ac ./...`

## Notes

- runtime coverage is provided by inbound-side tests for VLESS / VMess / Trojan across xhttp and splithttp combinations
- full-repo `golangci-lint run ./...` still reports unrelated pre-existing baseline issues, but this PR introduces no new lint findings
