### PR TITLE
feat: support parsing mierus subscription link

### DIFF
--- a/common/convert/converter.go
+++ b/common/convert/converter.go
@@ -618,6 +618,75 @@ func ConvertsV2Ray(buf []byte) ([]map[string]any, error) {
 			anytls["udp"] = true
 
 			proxies = append(proxies, anytls)
+
+		case "mierus":
+			urlMieru, err := url.Parse(line)
+			if err != nil {
+				continue
+			}
+
+			query := urlMieru.Query()
+
+			server := urlMieru.Hostname()
+			if server == "" {
+				continue
+			}
+			username := urlMieru.User.Username()
+			password, _ := urlMieru.User.Password()
+
+			baseName := urlMieru.Fragment
+			if baseName == "" {
+				baseName = query.Get("profile")
+			}
+			if baseName == "" {
+				baseName = server
+			}
+
+			multiplexing := query.Get("multiplexing")
+			handshakeMode := query.Get("handshake-mode")
+			trafficPattern := query.Get("traffic-pattern")
+
+			portList := query["port"]
+			protocolList := query["protocol"]
+			if len(portList) == 0 || len(portList) != len(protocolList) {
+				continue
+			}
+
+			for i, port := range portList {
+				protocol := protocolList[i]
+				name := uniqueName(names, fmt.Sprintf("%s:%s/%s", baseName, port, protocol))
+
+				mieru := make(map[string]any, 15)
+				mieru["name"] = name
+				mieru["type"] = "mieru"
+				mieru["server"] = server
+				mieru["transport"] = protocol
+				mieru["udp"] = true
+				mieru["username"] = username
+				mieru["password"] = password
+
+				if strings.Contains(port, "-") {
+					mieru["port-range"] = port
+				} else {
+					portNum, err := strconv.Atoi(port)
+					if err != nil {
+						continue
+					}
+					mieru["port"] = portNum
+				}
+
+				if multiplexing != "" {
+					mieru["multiplexing"] = multiplexing
+				}
+				if handshakeMode != "" {
+					mieru["handshake-mode"] = handshakeMode
+				}
+				if trafficPattern != "" {
+					mieru["traffic-pattern"] = trafficPattern
+				}
+
+				proxies = append(proxies, mieru)
+			}
 		}
 	}
 

--- a/common/convert/converter_test.go
+++ b/common/convert/converter_test.go
@@ -33,3 +33,99 @@ func TestConvertsV2Ray_normal(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, expected, proxies)
 }
+
+func TestConvertsV2RayMieru(t *testing.T) {
+	mierusTest := "mierus://user:pass@1.2.3.4?handshake-mode=HANDSHAKE_NO_WAIT&mtu=1400&multiplexing=MULTIPLEXING_HIGH&port=6666&port=9998-9999&port=6489&port=4896&profile=default&protocol=TCP&protocol=TCP&protocol=UDP&protocol=UDP&traffic-pattern=CCoQAQ"
+
+	expected := []map[string]any{
+		{
+			"name":            "default:6666/TCP",
+			"type":            "mieru",
+			"server":          "1.2.3.4",
+			"port":            6666,
+			"transport":       "TCP",
+			"udp":             true,
+			"username":        "user",
+			"password":        "pass",
+			"multiplexing":    "MULTIPLEXING_HIGH",
+			"handshake-mode":  "HANDSHAKE_NO_WAIT",
+			"traffic-pattern": "CCoQAQ",
+		},
+		{
+			"name":            "default:9998-9999/TCP",
+			"type":            "mieru",
+			"server":          "1.2.3.4",
+			"port-range":      "9998-9999",
+			"transport":       "TCP",
+			"udp":             true,
+			"username":        "user",
+			"password":        "pass",
+			"multiplexing":    "MULTIPLEXING_HIGH",
+			"handshake-mode":  "HANDSHAKE_NO_WAIT",
+			"traffic-pattern": "CCoQAQ",
+		},
+		{
+			"name":            "default:6489/UDP",
+			"type":            "mieru",
+			"server":          "1.2.3.4",
+			"port":            6489,
+			"transport":       "UDP",
+			"udp":             true,
+			"username":        "user",
+			"password":        "pass",
+			"multiplexing":    "MULTIPLEXING_HIGH",
+			"handshake-mode":  "HANDSHAKE_NO_WAIT",
+			"traffic-pattern": "CCoQAQ",
+		},
+		{
+			"name":            "default:4896/UDP",
+			"type":            "mieru",
+			"server":          "1.2.3.4",
+			"port":            4896,
+			"transport":       "UDP",
+			"udp":             true,
+			"username":        "user",
+			"password":        "pass",
+			"multiplexing":    "MULTIPLEXING_HIGH",
+			"handshake-mode":  "HANDSHAKE_NO_WAIT",
+			"traffic-pattern": "CCoQAQ",
+		},
+	}
+
+	proxies, err := ConvertsV2Ray([]byte(mierusTest))
+
+	assert.Nil(t, err)
+	assert.Equal(t, expected, proxies)
+}
+
+func TestConvertsV2RayMieruMinimal(t *testing.T) {
+	mierusTest := "mierus://user:pass@example.com?port=443&protocol=TCP&profile=simple"
+
+	expected := []map[string]any{
+		{
+			"name":      "simple:443/TCP",
+			"type":      "mieru",
+			"server":    "example.com",
+			"port":      443,
+			"transport": "TCP",
+			"udp":       true,
+			"username":  "user",
+			"password":  "pass",
+		},
+	}
+
+	proxies, err := ConvertsV2Ray([]byte(mierusTest))
+
+	assert.Nil(t, err)
+	assert.Equal(t, expected, proxies)
+}
+
+func TestConvertsV2RayMieruFragment(t *testing.T) {
+	mierusTest := "mierus://user:pass@example.com?port=443&protocol=TCP&profile=default#myproxy"
+
+	proxies, err := ConvertsV2Ray([]byte(mierusTest))
+
+	assert.Nil(t, err)
+	assert.Len(t, proxies, 1)
+	assert.Equal(t, "myproxy:443/TCP", proxies[0]["name"])
+}

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/bahlo/generic-list-go v0.2.0
 	github.com/coreos/go-iptables v0.8.0
 	github.com/dlclark/regexp2 v1.11.5
-	github.com/enfein/mieru/v3 v3.29.0
+	github.com/enfein/mieru/v3 v3.30.0
 	github.com/gobwas/ws v1.4.0
 	github.com/gofrs/uuid/v5 v5.4.0
 	github.com/golang/snappy v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -20,8 +20,8 @@ github.com/dlclark/regexp2 v1.11.5 h1:Q/sSnsKerHeCkc/jSTNq1oCm7KiVgUMZRDUoRu0JQZ
 github.com/dlclark/regexp2 v1.11.5/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
 github.com/dunglas/httpsfv v1.0.2 h1:iERDp/YAfnojSDJ7PW3dj1AReJz4MrwbECSSE59JWL0=
 github.com/dunglas/httpsfv v1.0.2/go.mod h1:zID2mqw9mFsnt7YC3vYQ9/cjq30q41W+1AnDwH8TiMg=
-github.com/enfein/mieru/v3 v3.29.0 h1:i5Hwl5spEWg4ydvYW86zWSYVJ2uGTf5sLYQmFXHdulQ=
-github.com/enfein/mieru/v3 v3.29.0/go.mod h1:zJBUCsi5rxyvHM8fjFf+GLaEl4OEjjBXr1s5F6Qd3hM=
+github.com/enfein/mieru/v3 v3.30.0 h1:g7v0TuK7y0ZMn6TOdjOs8WEUQk8bvs6WYPBJ16SKdBU=
+github.com/enfein/mieru/v3 v3.30.0/go.mod h1:zJBUCsi5rxyvHM8fjFf+GLaEl4OEjjBXr1s5F6Qd3hM=
 github.com/ericlagergren/aegis v0.0.0-20250325060835-cd0defd64358 h1:kXYqH/sL8dS/FdoFjr12ePjnLPorPo2FsnrHNuXSDyo=
 github.com/ericlagergren/aegis v0.0.0-20250325060835-cd0defd64358/go.mod h1:hkIFzoiIPZYxdFOOLyDho59b7SrDfo+w3h+yWdlg45I=
 github.com/ericlagergren/polyval v0.0.0-20220411101811-e25bc10ba391 h1:8j2RH289RJplhA6WfdaPqzg1MjH2K8wX5e0uhAxrw2g=


### PR DESCRIPTION
`mierus://` URL can be generated with `mieru export config simple` command. The URL allow any number of port & port-range combination, so it may generate multiple proxies.

A detailed description of the URL schema can be found in https://github.com/enfein/mieru/blob/main/docs/client-install.md#simple-sharing-link

This PR also bumps mieru version which supports traffic-pattern in the URL.