### PR TITLE
fix: correct inverted error check in getTunnelName

### DIFF
--- a/listener/sing_tun/server.go
+++ b/listener/sing_tun/server.go
@@ -155,7 +155,7 @@ func New(options LC.Tun, tunnel C.Tunnel, additions ...inbound.Addition) (l *Lis
 	}
 	forwarderBindInterface := false
 	if options.FileDescriptor > 0 {
-		if tunnelName, err := getTunnelName(int32(options.FileDescriptor)); err != nil {
+		if tunnelName, err := getTunnelName(int32(options.FileDescriptor)); err == nil {
 			tunName = tunnelName // sing-tun must have the truth tun interface name even it from a fd
 			forwarderBindInterface = true
 		}


### PR DESCRIPTION
## Summary

- Fix inverted error condition (`err != nil` → `err == nil`) in `listener/sing_tun/server.go:158`
- The current code assigns `tunName` from `getTunnelName` only when the call **fails**, discarding the correct tunnel name on success
- This causes incorrect `forwarderBindInterface` behavior when `FileDescriptor > 0` (Android/iOS scenarios)

## Change

```diff
- if tunnelName, err := getTunnelName(int32(options.FileDescriptor)); err != nil {
+ if tunnelName, err := getTunnelName(int32(options.FileDescriptor)); err == nil {
```

## Test plan

- [ ] Verify TUN mode works correctly on Android/iOS where `FileDescriptor > 0`
- [ ] Verify `tunName` is correctly set from the fd-based interface name
- [ ] Verify `forwarderBindInterface` is `true` only when `getTunnelName` succeeds

Fixes https://github.com/MetaCubeX/mihomo/issues/2658

🤖 Generated with [Claude Code](https://claude.com/claude-code)