### PR TITLE
Add basic support for xhttp subscriptions

### DIFF
--- a/common/convert/v.go
+++ b/common/convert/v.go
@@ -90,6 +90,20 @@ func handleVShareLink(names map[string]int, url *url.URL, scheme string, proxy m
 			proxy["http-opts"] = httpOpts
 		}
 
+	case "xhttp":
+		xhttpOpts := make(map[string]any)
+		xhttpOpts["path"] = "/"
+		if path := query.Get("path"); path != "" {
+			xhttpOpts["path"] = path
+		}
+		if host := query.Get("host"); host != "" {
+			xhttpOpts["host"] = host
+		}
+		if mode := query.Get("mode"); mode != "" {
+			xhttpOpts["mode"] = mode
+		}
+		proxy["xhttp-opts"] = xhttpOpts
+
 	case "http":
 		headers := make(map[string]any)
 		h2Opts := make(map[string]any)


### PR DESCRIPTION
Subscriptions, such as those from 3x-ui using specific xhttp parts, are not supported. Let's add basic support for them.