### PR TITLE
feat: ignore some AI IDE dir (.trae,.codebuddy,.cursor)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,9 @@ test/config/cache*
 /output
 .vscode/
 .fleet/
+
+# AI ide
+.trae/
+.codebuddy/
+.cursor/
+


### PR DESCRIPTION
自动忽略这些AI IDE产生的配置目录, 目的是为了方便AI IDE使用人员,
以防误操作而提交这些项目无关的文件