### PR TITLE
fix: skip IPv6 resolution when ipv6=false configured

### DIFF
--- a/adapter/outboundgroup/groupbase.go
+++ b/adapter/outboundgroup/groupbase.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/netip"
 	"strings"
 	"sync"
 	"time"
@@ -11,6 +12,7 @@ import (
 	"github.com/metacubex/mihomo/adapter/outbound"
 	"github.com/metacubex/mihomo/common/atomic"
 	"github.com/metacubex/mihomo/common/utils"
+	"github.com/metacubex/mihomo/component/resolver"
 	C "github.com/metacubex/mihomo/constant"
 	P "github.com/metacubex/mihomo/constant/provider"
 	"github.com/metacubex/mihomo/log"
@@ -210,6 +212,28 @@ func (gb *GroupBase) GetProxies(touch bool) []C.Proxy {
 			for _, excludeType := range gb.excludeTypeArray {
 				if strings.EqualFold(mType, excludeType) {
 					continue LOOP2
+				}
+			}
+			newProxies = append(newProxies, p)
+		}
+		proxies = newProxies
+	}
+
+	if resolver.DisableIPv6 {
+		var newProxies []C.Proxy
+		for _, p := range proxies {
+			addr := p.Addr()
+			if addr != "" {
+				if addrPort, err := netip.ParseAddrPort(addr); err == nil {
+					if addrPort.Addr().Is6() {
+						continue
+					}
+				} else {
+					if ip, err := netip.ParseAddr(addr); err == nil {
+						if ip.Is6() {
+							continue
+						}
+					}
 				}
 			}
 			newProxies = append(newProxies, p)

--- a/component/resolver/resolver.go
+++ b/component/resolver/resolver.go
@@ -154,7 +154,13 @@ func ResolveIPv6(ctx context.Context, host string) (netip.Addr, error) {
 // LookupIPWithResolver same as LookupIP, but with a resolver
 func LookupIPWithResolver(ctx context.Context, host string, r Resolver) ([]netip.Addr, error) {
 	if node, ok := DefaultHosts.Search(host, false); ok {
-		return node.IPs, nil
+		ips := node.IPs
+		if DisableIPv6 {
+			ips = utils.Filter(ips, func(ip netip.Addr) bool {
+				return ip.Is4()
+			})
+		}
+		return ips, nil
 	}
 
 	if r != nil && r.Invalid() {
@@ -168,6 +174,9 @@ func LookupIPWithResolver(ctx context.Context, host string, r Resolver) ([]netip
 
 	if ip, err := netip.ParseAddr(host); err == nil {
 		ip = ip.Unmap()
+		if DisableIPv6 && ip.Is6() {
+			return []netip.Addr{}, ErrIPVersion
+		}
 		return []netip.Addr{ip}, nil
 	}
 

--- a/dns/resolver.go
+++ b/dns/resolver.go
@@ -50,6 +50,15 @@ type Resolver struct {
 }
 
 func (r *Resolver) LookupIPPrimaryIPv4(ctx context.Context, host string) (ips []netip.Addr, err error) {
+	ips, err = r.lookupIP(ctx, host, D.TypeA)
+	if err == nil {
+		return ips, nil
+	}
+
+	if !r.ipv6 {
+		return nil, err
+	}
+
 	ch := make(chan []netip.Addr, 1)
 	go func() {
 		defer close(ch)
@@ -59,11 +68,6 @@ func (r *Resolver) LookupIPPrimaryIPv4(ctx context.Context, host string) (ips []
 		}
 		ch <- ip
 	}()
-
-	ips, err = r.lookupIP(ctx, host, D.TypeA)
-	if err == nil {
-		return
-	}
 
 	ip, open := <-ch
 	if !open {
@@ -74,33 +78,40 @@ func (r *Resolver) LookupIPPrimaryIPv4(ctx context.Context, host string) (ips []
 }
 
 func (r *Resolver) LookupIP(ctx context.Context, host string) (ips []netip.Addr, err error) {
-	ch := make(chan []netip.Addr, 1)
-	go func() {
-		defer close(ch)
-		ip, err := r.lookupIP(ctx, host, D.TypeAAAA)
-		if err != nil {
-			return
+	if r.ipv6 {
+		ch := make(chan []netip.Addr, 1)
+		go func() {
+			defer close(ch)
+			ip, err := r.lookupIP(ctx, host, D.TypeAAAA)
+			if err != nil {
+				return
+			}
+
+			ch <- ip
+		}()
+
+		ips, err = r.lookupIP(ctx, host, D.TypeA)
+		var waitIPv6 *time.Timer
+		if r != nil && r.ipv6Timeout > 0 {
+			waitIPv6 = time.NewTimer(r.ipv6Timeout)
+		} else {
+			waitIPv6 = time.NewTimer(100 * time.Millisecond)
 		}
-
-		ch <- ip
-	}()
-
-	ips, err = r.lookupIP(ctx, host, D.TypeA)
-	var waitIPv6 *time.Timer
-	if r != nil && r.ipv6Timeout > 0 {
-		waitIPv6 = time.NewTimer(r.ipv6Timeout)
+		defer waitIPv6.Stop()
+		select {
+		case ipv6s, open := <-ch:
+			if !open && err != nil {
+				return nil, resolver.ErrIPNotFound
+			}
+			ips = append(ips, ipv6s...)
+		case <-waitIPv6.C:
+			// wait ipv6 result
+		}
 	} else {
-		waitIPv6 = time.NewTimer(100 * time.Millisecond)
-	}
-	defer waitIPv6.Stop()
-	select {
-	case ipv6s, open := <-ch:
-		if !open && err != nil {
-			return nil, resolver.ErrIPNotFound
+		ips, err = r.lookupIP(ctx, host, D.TypeA)
+		if err != nil {
+			return nil, err
 		}
-		ips = append(ips, ipv6s...)
-	case <-waitIPv6.C:
-		// wait ipv6 result
 	}
 
 	return ips, nil


### PR DESCRIPTION
当配置 ipv6=false 时，完整跳过 IPv6 相关处理：

1. DNS 解析层 (dns/resolver.go):
   - LookupIP: 当 dns.ipv6=false 时跳过 AAAA 记录查询
   - LookupIPPrimaryIPv4: 同样跳过 AAAA 查询，避免不必要的 DNS 请求

2. 组件解析层 (component/resolver/resolver.go):
   - LookupIPWithResolver: 从 Hosts 查找时过滤 IPv6 地址
   - 当 host 是 IP 地址时检查是否是 IPv6，若是则返回错误

3. 代理组层 (adapter/outboundgroup/groupbase.go):
   - GetProxies: 当全局 ipv6=false 时，自动过滤掉 IPv6 代理
   - 检查代理地址是否为 IPv6，若是则排除该代理

修复了配置 ipv6=false 后仍出现 IPv6 地址解析和连接的问题。