### PR TITLE
feat: add raw rules payload support for rule provider API

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -109,6 +109,7 @@ type Controller struct {
 	ExternalDohServer      string
 	Secret                 string
 	Cors                   Cors
+	ExternalIncludeRules   bool
 }
 
 type Cors struct {
@@ -412,6 +413,7 @@ type RawConfig struct {
 	ExternalControllerUnix  string                  `yaml:"external-controller-unix" json:"external-controller-unix"`
 	ExternalControllerTLS   string                  `yaml:"external-controller-tls" json:"external-controller-tls"`
 	ExternalControllerCors  RawCors                 `yaml:"external-controller-cors" json:"external-controller-cors"`
+	ExternalIncludeRules    bool                    `yaml:"external-include-rules" json:"external-include-rules"`
 	ExternalUI              string                  `yaml:"external-ui" json:"external-ui"`
 	ExternalUIURL           string                  `yaml:"external-ui-url" json:"external-ui-url"`
 	ExternalUIName          string                  `yaml:"external-ui-name" json:"external-ui-name"`
@@ -799,6 +801,7 @@ func parseController(cfg *RawConfig) (*Controller, error) {
 		ExternalControllerUnix: cfg.ExternalControllerUnix,
 		ExternalControllerTLS:  cfg.ExternalControllerTLS,
 		ExternalDohServer:      cfg.ExternalDohServer,
+		ExternalIncludeRules:   cfg.ExternalIncludeRules,
 		Cors: Cors{
 			AllowOrigins:        cfg.ExternalControllerCors.AllowOrigins,
 			AllowPrivateNetwork: cfg.ExternalControllerCors.AllowPrivateNetwork,

--- a/constant/provider/interface.go
+++ b/constant/provider/interface.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/metacubex/mihomo/common/utils"
 	"github.com/metacubex/mihomo/constant"
@@ -93,6 +94,8 @@ type RuleProvider interface {
 	Count() int
 	Match(metadata *constant.Metadata, helper constant.RuleMatchHelper) bool
 	Strategy() any
+	RawRules() []string
+	UpdatedAt() time.Time
 }
 
 // Rule Behavior

--- a/hub/hub.go
+++ b/hub/hub.go
@@ -62,6 +62,7 @@ func applyRoute(cfg *config.Config) {
 		EchKey:         cfg.TLS.EchKey,
 		DohServer:      cfg.Controller.ExternalDohServer,
 		IsDebug:        cfg.General.LogLevel == log.DEBUG,
+		IncludeRules:   cfg.Controller.ExternalIncludeRules,
 		Cors: route.Cors{
 			AllowOrigins:        cfg.Controller.Cors.AllowOrigins,
 			AllowPrivateNetwork: cfg.Controller.Cors.AllowPrivateNetwork,

--- a/hub/route/provider.go
+++ b/hub/route/provider.go
@@ -115,6 +115,7 @@ func ruleProviderRouter() http.Handler {
 	r.Get("/", getRuleProviders)
 	r.Route("/{name}", func(r chi.Router) {
 		r.Use(parseRuleProviderName, findRuleProviderByName)
+		r.Get("/", getRuleProvider)
 		r.Put("/", updateRuleProvider)
 	})
 	return r
@@ -122,9 +123,46 @@ func ruleProviderRouter() http.Handler {
 
 func getRuleProviders(w http.ResponseWriter, r *http.Request) {
 	ruleProviders := tunnel.RuleProviders()
+	includeRules := r.URL.Query().Get("includeRules")
+	if includeRules == "true" || (includeRules == "" && externalIncludeRules) {
+		providers := make(map[string]any)
+		for name, provider := range ruleProviders {
+			providers[name] = render.M{
+				"behavior":    provider.Behavior().String(),
+				"name":        name,
+				"ruleCount":   provider.Count(),
+				"type":        provider.Type().String(),
+				"vehicleType": provider.VehicleType().String(),
+				"updatedAt":   provider.UpdatedAt(),
+				"payload":     provider.RawRules(),
+			}
+		}
+		render.JSON(w, r, render.M{
+			"providers": providers,
+		})
+		return
+	}
 	render.JSON(w, r, render.M{
 		"providers": ruleProviders,
 	})
+}
+
+func getRuleProvider(w http.ResponseWriter, r *http.Request) {
+	provider := r.Context().Value(CtxKeyProvider).(P.RuleProvider)
+	includeRules := r.URL.Query().Get("includeRules")
+	if includeRules == "true" || (includeRules == "" && externalIncludeRules) {
+		render.JSON(w, r, render.M{
+			"behavior":    provider.Behavior().String(),
+			"name":        provider.Name(),
+			"ruleCount":   provider.Count(),
+			"type":        provider.Type().String(),
+			"vehicleType": provider.VehicleType().String(),
+			"updatedAt":   provider.UpdatedAt(),
+			"payload":     provider.RawRules(),
+		})
+		return
+	}
+	render.JSON(w, r, provider)
 }
 
 func updateRuleProvider(w http.ResponseWriter, r *http.Request) {

--- a/hub/route/server.go
+++ b/hub/route/server.go
@@ -37,7 +37,8 @@ var (
 	unixServer *http.Server
 	pipeServer *http.Server
 
-	embedMode = false
+	embedMode            = false
+	externalIncludeRules = false
 )
 
 func SetEmbedMode(embed bool) {
@@ -70,6 +71,7 @@ type Config struct {
 	DohServer      string
 	IsDebug        bool
 	Cors           Cors
+	IncludeRules   bool
 }
 
 type Cors struct {
@@ -88,6 +90,7 @@ func (c Cors) Apply(r chi.Router) {
 }
 
 func ReCreateServer(cfg *Config) {
+	externalIncludeRules = cfg.IncludeRules
 	go start(cfg)
 	go startTLS(cfg)
 	go startUnix(cfg)

--- a/rules/provider/classical_strategy.go
+++ b/rules/provider/classical_strategy.go
@@ -10,9 +10,10 @@ import (
 )
 
 type classicalStrategy struct {
-	rules []C.Rule
-	count int
-	parse common.ParseRuleFunc
+	rules    []C.Rule
+	rawRules []string
+	count    int
+	parse    common.ParseRuleFunc
 }
 
 func (c *classicalStrategy) Behavior() P.RuleBehavior {
@@ -35,6 +36,7 @@ func (c *classicalStrategy) Count() int {
 
 func (c *classicalStrategy) Reset() {
 	c.rules = nil
+	c.rawRules = nil
 	c.count = 0
 }
 
@@ -44,6 +46,7 @@ func (c *classicalStrategy) Insert(rule string) {
 		log.Warnln("parse classical rule [%s] error: %s", rule, err.Error())
 	} else {
 		c.rules = append(c.rules, r)
+		c.rawRules = append(c.rawRules, rule)
 		c.count++
 	}
 }
@@ -59,6 +62,10 @@ func (c *classicalStrategy) payloadToRule(rule string) (C.Rule, error) {
 
 func (c *classicalStrategy) FinishInsert() {}
 
+func (c *classicalStrategy) RawRules() []string {
+	return c.rawRules
+}
+
 func NewClassicalStrategy(parse common.ParseRuleFunc) *classicalStrategy {
-	return &classicalStrategy{rules: []C.Rule{}, parse: parse}
+	return &classicalStrategy{rules: []C.Rule{}, rawRules: []string{}, parse: parse}
 }

--- a/rules/provider/domain_strategy.go
+++ b/rules/provider/domain_strategy.go
@@ -55,6 +55,18 @@ func (d *domainStrategy) FinishInsert() {
 	d.domainTrie = nil
 }
 
+func (d *domainStrategy) RawRules() []string {
+	if d.domainSet == nil {
+		return nil
+	}
+	var raw []string
+	d.DumpMrs(func(key string) bool {
+		raw = append(raw, key)
+		return true
+	})
+	return raw
+}
+
 func (d *domainStrategy) FromMrs(r io.Reader, count int) error {
 	domainSet, err := trie.ReadDomainSetBin(r)
 	if err != nil {

--- a/rules/provider/ipcidr_strategy.go
+++ b/rules/provider/ipcidr_strategy.go
@@ -84,6 +84,18 @@ func (i *ipcidrStrategy) ToIpCidr() *netipx.IPSet {
 	return i.cidrSet.ToIPSet()
 }
 
+func (i *ipcidrStrategy) RawRules() []string {
+	if i.cidrSet == nil {
+		return nil
+	}
+	var raw []string
+	i.DumpMrs(func(key string) bool {
+		raw = append(raw, key)
+		return true
+	})
+	return raw
+}
+
 func NewIPCidrStrategy() *ipcidrStrategy {
 	return &ipcidrStrategy{}
 }

--- a/rules/provider/provider.go
+++ b/rules/provider/provider.go
@@ -50,6 +50,7 @@ type ruleStrategy interface {
 	Reset()
 	Insert(rule string)
 	FinishInsert()
+	RawRules() []string
 }
 
 type mrsRuleStrategy interface {
@@ -82,6 +83,13 @@ func (bp *baseProvider) Match(metadata *C.Metadata, helper C.RuleMatchHelper) bo
 
 func (bp *baseProvider) Strategy() any {
 	return bp.strategy
+}
+
+func (bp *baseProvider) RawRules() []string {
+	if bp.strategy == nil {
+		return nil
+	}
+	return bp.strategy.RawRules()
 }
 
 type ruleSetProvider struct {
@@ -304,6 +312,10 @@ func (i *inlineProvider) Update() error {
 
 func (i *inlineProvider) VehicleType() P.VehicleType {
 	return P.Inline
+}
+
+func (i *inlineProvider) UpdatedAt() time.Time {
+	return i.updateAt
 }
 
 func (i *inlineProvider) MarshalJSON() ([]byte, error) {


### PR DESCRIPTION
## 功能概述

为规则提供者 API 添加返回原始规则列表的功能。

## 新增配置

```yaml
external-include-rules: true  # 默认 false
```

## API 变更

| 接口 | 变更 |
|------|------|
| `GET /providers/rules?includeRules=true` | 返回包含 `payload` 字段的规则列表 |
| `GET /providers/rules/{name}` | 新增单个规则提供者查询接口 |

当 `includeRules=true` 或全局配置启用时，响应包含原始规则：

```json
{
  "name": "reject",
  "behavior": "classical",
  "ruleCount": 100,
  "type": "http",
  "vehicleType": "HTTP",
  "updatedAt": "2024-01-01T00:00:00Z",
  "payload": ["DOMAIN-SUFFIX,ad.com,REJECT"]
}
```

## 文件变更

- `config/config.go` - 新增配置项
- `constant/provider/interface.go` - 接口新增 `RawRules()` / `UpdatedAt()`
- `hub/route/provider.go` - 新增 API 端点
- `rules/provider/*.go` - 三种策略实现 `RawRules()`