### PR TITLE
fix: remove destructive deadline implementation from xhttp Conn

### DIFF
--- a/transport/xhttp/conn.go
+++ b/transport/xhttp/conn.go
@@ -1,7 +1,6 @@
 package xhttp
 
 import (
-	"errors"
 	"io"
 	"time"
 
@@ -13,9 +12,6 @@ type Conn struct {
 	reader  io.ReadCloser
 	onClose func()
 	httputils.NetAddr
-
-	// deadlines
-	deadline *time.Timer
 }
 
 func (c *Conn) Write(b []byte) (int, error) {
@@ -32,27 +28,12 @@ func (c *Conn) Close() error {
 	if c.onClose != nil {
 		c.onClose()
 	}
-	return errors.Join(err, err2)
+	if err != nil {
+		return err
+	}
+	return err2
 }
 
-func (c *Conn) SetReadDeadline(t time.Time) error  { return c.SetDeadline(t) }
-func (c *Conn) SetWriteDeadline(t time.Time) error { return c.SetDeadline(t) }
-
-func (c *Conn) SetDeadline(t time.Time) error {
-	if t.IsZero() {
-		if c.deadline != nil {
-			c.deadline.Stop()
-			c.deadline = nil
-		}
-		return nil
-	}
-	d := time.Until(t)
-	if c.deadline != nil {
-		c.deadline.Reset(d)
-		return nil
-	}
-	c.deadline = time.AfterFunc(d, func() {
-		c.Close()
-	})
-	return nil
-}
+func (c *Conn) SetReadDeadline(_ time.Time) error  { return nil }
+func (c *Conn) SetWriteDeadline(_ time.Time) error { return nil }
+func (c *Conn) SetDeadline(_ time.Time) error      { return nil }


### PR DESCRIPTION
## Problem

The old `SetDeadline` implementation in `xhttp.Conn` used `time.AfterFunc` to force-close the entire connection on timeout. This permanently destroyed the underlying HTTP stream rather than providing proper deadline semantics (`os.ErrDeadlineExceeded`).

When the `deadline.Conn` wrapper delegated `SetReadDeadline`/`SetWriteDeadline`/`SetDeadline` to the inner conn (via the `disablePipe` fast-path or direct delegation for `SetWriteDeadline`/`SetDeadline`), this caused xhttp connections to be unexpectedly killed during speed tests and delay checks — particularly on Linux where scheduling differences made the timeout more likely to trigger.

## Root Cause

`deadline.Conn` only overrides `SetReadDeadline` — both `SetWriteDeadline` and `SetDeadline` are always delegated to the inner conn. Even `SetReadDeadline` is delegated when `disablePipe=true` or `inRead=true`. The inner conn's destructive `time.AfterFunc → Close()` was then triggered, killing the HTTP stream.

## Fix

Replace the deadline methods with no-op stubs, consistent with other non-TCP transports in this codebase (`sudoku/early_handshake`, `sudoku/multiplex/session`, `sudoku/obfs/httpmask/tunnel`, etc.). The outer `deadline.Conn` wrapper (applied on both server and client paths) provides correct read deadline semantics via its pipe mechanism.

Connection lifecycle is properly managed by:
- `context.Context` cancellation
- HTTP/2 transport timeouts
- Remote peer disconnection / GOAWAY