### PR TITLE
chore: align with trusttunnel's official session reuse logic

### DIFF
--- a/docs/config.yaml
+++ b/docs/config.yaml
@@ -1218,8 +1218,8 @@ proxies: # socks5
     # quic: true # 默认为false
     # congestion-controller: bbr
     ### reuse options
-    # max-connections: 1 # Maximum connections. Conflict with max-streams.
-    # min-streams: 0 # Minimum multiplexed streams in a connection before opening a new connection. Conflict with max-streams.
+    # max-connections: 8 # Maximum connections. Conflict with max-streams.
+    # min-streams: 5 # Minimum multiplexed streams in a connection before opening a new connection. Conflict with max-streams.
     # max-streams: 0 # Maximum multiplexed streams in a connection before opening a new connection. Conflict with max-connections and min-streams.
 
 # dns 出站会将请求劫持到内部 dns 模块，所有请求均在内部处理

--- a/transport/trusttunnel/client.go
+++ b/transport/trusttunnel/client.go
@@ -173,10 +173,10 @@ func (c *Client) newConnectRequest(host, userAgent string) *http.Request {
 		Method: http.MethodConnect,
 		URL: &url.URL{
 			Scheme: "https",
-			Host:   c.server,
+			Host:   c.server, // Use the proxy server authority so the pool keys reuse against the actual proxy endpoint.
 		},
 		Header: make(http.Header),
-		Host:   host,
+		Host:   host, // Send the actual CONNECT target as the Host header (:authority).
 	}
 	request.Header.Add("User-Agent", userAgent)
 	request.Header.Add("Proxy-Authorization", c.auth)

--- a/transport/trusttunnel/client.go
+++ b/transport/trusttunnel/client.go
@@ -246,7 +246,8 @@ func NewPoolClient(ctx context.Context, options ClientOptions) (*PoolClient, err
 	minStreams := options.MinStreams
 	maxStreams := options.MaxStreams
 	if maxConnections == 0 && minStreams == 0 && maxStreams == 0 {
-		maxConnections = 1
+		maxConnections = 8
+		minStreams = 5
 	}
 	client, err := NewClient(ctx, options) // reserve one client and verify the configuration
 	if err != nil {

--- a/transport/trusttunnel/client.go
+++ b/transport/trusttunnel/client.go
@@ -168,52 +168,37 @@ func (c *Client) roundTrip(request *http.Request, conn *httpConn) {
 	}()
 }
 
-func (c *Client) Dial(ctx context.Context, host string) (net.Conn, error) {
+func (c *Client) newConnectRequest(host, userAgent string) *http.Request {
 	request := &http.Request{
 		Method: http.MethodConnect,
 		URL: &url.URL{
 			Scheme: "https",
-			Host:   host,
+			Host:   c.server,
 		},
 		Header: make(http.Header),
 		Host:   host,
 	}
-	request.Header.Add("User-Agent", TCPUserAgent)
+	request.Header.Add("User-Agent", userAgent)
 	request.Header.Add("Proxy-Authorization", c.auth)
+	return request
+}
+
+func (c *Client) Dial(ctx context.Context, host string) (net.Conn, error) {
+	request := c.newConnectRequest(host, TCPUserAgent)
 	conn := &tcpConn{}
 	c.roundTrip(request, &conn.httpConn)
 	return conn, nil
 }
 
 func (c *Client) ListenPacket(ctx context.Context) (net.PacketConn, error) {
-	request := &http.Request{
-		Method: http.MethodConnect,
-		URL: &url.URL{
-			Scheme: "https",
-			Host:   UDPMagicAddress,
-		},
-		Header: make(http.Header),
-		Host:   UDPMagicAddress,
-	}
-	request.Header.Add("User-Agent", UDPUserAgent)
-	request.Header.Add("Proxy-Authorization", c.auth)
+	request := c.newConnectRequest(UDPMagicAddress, UDPUserAgent)
 	conn := &clientPacketConn{}
 	c.roundTrip(request, &conn.httpConn)
 	return conn, nil
 }
 
 func (c *Client) ListenICMP(ctx context.Context) (*IcmpConn, error) {
-	request := &http.Request{
-		Method: http.MethodConnect,
-		URL: &url.URL{
-			Scheme: "https",
-			Host:   ICMPMagicAddress,
-		},
-		Header: make(http.Header),
-		Host:   ICMPMagicAddress,
-	}
-	request.Header.Add("User-Agent", ICMPUserAgent)
-	request.Header.Add("Proxy-Authorization", c.auth)
+	request := c.newConnectRequest(ICMPMagicAddress, ICMPUserAgent)
 	conn := &IcmpConn{}
 	c.roundTrip(request, &conn.httpConn)
 	return conn, nil
@@ -234,17 +219,7 @@ func (c *Client) ResetConnections() {
 
 func (c *Client) HealthCheck(ctx context.Context) error {
 	defer c.resetHealthCheckTimer()
-	request := &http.Request{
-		Method: http.MethodConnect,
-		URL: &url.URL{
-			Scheme: "https",
-			Host:   HealthCheckMagicAddress,
-		},
-		Header: make(http.Header),
-		Host:   HealthCheckMagicAddress,
-	}
-	request.Header.Add("User-Agent", HealthCheckUserAgent)
-	request.Header.Add("Proxy-Authorization", c.auth)
+	request := c.newConnectRequest(HealthCheckMagicAddress, HealthCheckUserAgent)
 	response, err := c.roundTripper.RoundTrip(request.WithContext(ctx))
 	if err != nil {
 		return err


### PR DESCRIPTION
Build CONNECT requests against the proxy server while keeping the target host in the Host header. 

This lets us pool sessions by the actual upstream proxy authority instead of opening separate connections for each destination host so the "max-connections" setting works as expected.