### PR TITLE
fix updater: replace running executable atomically on darwin/linux

### DIFF
--- a/component/updater/update_core.go
+++ b/component/updater/update_core.go
@@ -147,6 +147,11 @@ func (u *CoreUpdater) Update(currentExePath string, channel string, force bool) 
 
 	defer u.clean(updateDir)
 
+	err = u.prepareUpdateDir(updateDir)
+	if err != nil {
+		return fmt.Errorf("preparing update dir: %w", err)
+	}
+
 	err = u.download(updateDir, packagePath, packageURL)
 	if err != nil {
 		return fmt.Errorf("downloading: %w", err)
@@ -162,7 +167,11 @@ func (u *CoreUpdater) Update(currentExePath string, channel string, force bool) 
 		return fmt.Errorf("backuping: %w", err)
 	}
 
-	err = u.copyFile(updateExePath, currentExePath)
+	if runtime.GOOS == "windows" {
+		err = u.copyFile(updateExePath, currentExePath)
+	} else {
+		err = u.replaceFileAtomically(updateExePath, currentExePath)
+	}
 	if err != nil {
 		return fmt.Errorf("replacing: %w", err)
 	}
@@ -192,6 +201,18 @@ func (u *CoreUpdater) getLatestVersion(versionURL string) (version string, err e
 	return content, nil
 }
 
+func (u *CoreUpdater) prepareUpdateDir(updateDir string) error {
+	if err := os.RemoveAll(updateDir); err != nil {
+		return fmt.Errorf("os.RemoveAll(%s): %w", updateDir, err)
+	}
+
+	if err := os.MkdirAll(updateDir, 0o755); err != nil {
+		return fmt.Errorf("os.MkdirAll(%s): %w", updateDir, err)
+	}
+
+	return nil
+}
+
 // download package file and save it to disk
 func (u *CoreUpdater) download(updateDir, packagePath, packageURL string) (err error) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*90)
@@ -207,12 +228,6 @@ func (u *CoreUpdater) download(updateDir, packagePath, packageURL string) (err e
 			err = closeErr
 		}
 	}()
-
-	log.Debugln("updateDir %s", updateDir)
-	err = os.Mkdir(updateDir, 0o755)
-	if err != nil {
-		return fmt.Errorf("mkdir error: %w", err)
-	}
 
 	log.Debugln("updater: saving package to file %s", packagePath)
 	// Create the output file
@@ -462,13 +477,78 @@ func (u *CoreUpdater) copyFile(src, dst string) (err error) {
 		return fmt.Errorf("io.Copy(): %w", err)
 	}
 
-	if runtime.GOOS == "darwin" {
-		err = exec.Command("/usr/bin/codesign", "--sign", "-", dst).Run()
+	log.Infoln("updater: copy: %s to %s", src, dst)
+	return nil
+}
+
+func (u *CoreUpdater) replaceFileAtomically(src, dst string) (err error) {
+	rc, err := os.Open(src)
+	if err != nil {
+		return fmt.Errorf("os.Open(%s): %w", src, err)
+	}
+
+	defer func() {
+		closeErr := rc.Close()
+		if closeErr != nil && err == nil {
+			err = closeErr
+		}
+	}()
+
+	info, err := rc.Stat()
+	if err != nil {
+		return fmt.Errorf("rc.Stat(): %w", err)
+	}
+
+	dir := filepath.Dir(dst)
+	tmp, err := os.CreateTemp(dir, "."+filepath.Base(dst)+".tmp-*")
+	if err != nil {
+		return fmt.Errorf("os.CreateTemp(%s): %w", dir, err)
+	}
+
+	tmpPath := tmp.Name()
+	defer func() {
 		if err != nil {
-			log.Warnln("codesign failed: %v", err)
+			_ = os.Remove(tmpPath)
+		}
+	}()
+
+	defer func() {
+		if tmp != nil {
+			closeErr := tmp.Close()
+			if closeErr != nil && err == nil {
+				err = closeErr
+			}
+		}
+	}()
+
+	if err = tmp.Chmod(info.Mode()); err != nil {
+		return fmt.Errorf("tmp.Chmod(%s): %w", tmpPath, err)
+	}
+
+	if _, err = io.Copy(tmp, rc); err != nil {
+		return fmt.Errorf("io.Copy(): %w", err)
+	}
+
+	if err = tmp.Sync(); err != nil {
+		return fmt.Errorf("tmp.Sync(): %w", err)
+	}
+
+	if err = tmp.Close(); err != nil {
+		return fmt.Errorf("tmp.Close(): %w", err)
+	}
+	tmp = nil
+
+	if runtime.GOOS == "darwin" {
+		signErr := exec.Command("/usr/bin/codesign", "--sign", "-", tmpPath).Run()
+		if signErr != nil {
+			log.Warnln("codesign failed: %v", signErr)
 		}
 	}
 
-	log.Infoln("updater: copy: %s to %s", src, dst)
+	if err = os.Rename(tmpPath, dst); err != nil {
+		return fmt.Errorf("os.Rename(%s, %s): %w", tmpPath, dst, err)
+	}
+
+	log.Infoln("updater: replace: %s to %s via %s", src, dst, tmpPath)
 	return nil
 }

--- a/component/updater/update_core.go
+++ b/component/updater/update_core.go
@@ -49,6 +49,11 @@ type CoreUpdater struct {
 
 var DefaultCoreUpdater = CoreUpdater{}
 
+// preservePosixAttrs is set via init() on linux/darwin to copy owner, mode,
+// xattrs and (on darwin) file flags from the existing binary onto the staged
+// replacement. Nil on other platforms.
+var preservePosixAttrs func(src, dst string)
+
 func (u *CoreUpdater) CoreBaseName() string {
 	switch runtime.GOARCH {
 	case "arm":
@@ -482,6 +487,13 @@ func (u *CoreUpdater) copyFile(src, dst string) (err error) {
 }
 
 func (u *CoreUpdater) replaceFileAtomically(src, dst string) (err error) {
+	// Resolve symlinks so deployments that expose a stable path (e.g.
+	// /usr/local/bin/mihomo -> /opt/mihomo/<ver>/mihomo) replace the real
+	// file rather than turning the symlink into a regular file.
+	if resolved, linkErr := filepath.EvalSymlinks(dst); linkErr == nil {
+		dst = resolved
+	}
+
 	rc, err := os.Open(src)
 	if err != nil {
 		return fmt.Errorf("os.Open(%s): %w", src, err)
@@ -494,9 +506,19 @@ func (u *CoreUpdater) replaceFileAtomically(src, dst string) (err error) {
 		}
 	}()
 
-	info, err := rc.Stat()
+	srcInfo, err := rc.Stat()
 	if err != nil {
 		return fmt.Errorf("rc.Stat(): %w", err)
+	}
+
+	// Prefer the existing dst's mode so local chmod survives updates. Fall
+	// back to src's mode on first install.
+	mode := srcInfo.Mode()
+	dstExists := true
+	if dstInfo, statErr := os.Stat(dst); statErr == nil {
+		mode = dstInfo.Mode()
+	} else if os.IsNotExist(statErr) {
+		dstExists = false
 	}
 
 	dir := filepath.Dir(dst)
@@ -521,7 +543,7 @@ func (u *CoreUpdater) replaceFileAtomically(src, dst string) (err error) {
 		}
 	}()
 
-	if err = tmp.Chmod(info.Mode()); err != nil {
+	if err = tmp.Chmod(mode); err != nil {
 		return fmt.Errorf("tmp.Chmod(%s): %w", tmpPath, err)
 	}
 
@@ -537,6 +559,12 @@ func (u *CoreUpdater) replaceFileAtomically(src, dst string) (err error) {
 		return fmt.Errorf("tmp.Close(): %w", err)
 	}
 	tmp = nil
+
+	// Carry over ownership, xattrs (notably Linux security.capability for
+	// cap_net_admin / cap_net_bind_service), setuid/sgid and darwin flags.
+	if dstExists && preservePosixAttrs != nil {
+		preservePosixAttrs(dst, tmpPath)
+	}
 
 	if runtime.GOOS == "darwin" {
 		signErr := exec.Command("/usr/bin/codesign", "--sign", "-", tmpPath).Run()

--- a/component/updater/update_core_darwin.go
+++ b/component/updater/update_core_darwin.go
@@ -1,0 +1,29 @@
+//go:build darwin
+
+package updater
+
+import (
+	"syscall"
+
+	"github.com/metacubex/mihomo/log"
+
+	"golang.org/x/sys/unix"
+)
+
+func init() {
+	flagsHook = preserveDarwinFlags
+}
+
+// preserveDarwinFlags carries over macOS st_flags (uchg/schg/hidden).
+func preserveDarwinFlags(src, dst string) {
+	var st syscall.Stat_t
+	if err := syscall.Stat(src, &st); err != nil {
+		return
+	}
+	if st.Flags == 0 {
+		return
+	}
+	if err := unix.Chflags(dst, int(st.Flags)); err != nil {
+		log.Warnln("updater: chflags %s: %v", dst, err)
+	}
+}

--- a/component/updater/update_core_darwin_test.go
+++ b/component/updater/update_core_darwin_test.go
@@ -1,0 +1,47 @@
+//go:build darwin
+
+package updater
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+
+	"golang.org/x/sys/unix"
+)
+
+func TestReplaceFileAtomicallyPreservesDarwinFlags(t *testing.T) {
+	root := t.TempDir()
+	src := filepath.Join(root, "src")
+	dst := filepath.Join(root, "dst")
+
+	if err := os.WriteFile(src, []byte("new-core"), 0o700); err != nil {
+		t.Fatalf("write src: %v", err)
+	}
+
+	if err := os.WriteFile(dst, []byte("old-core"), 0o755); err != nil {
+		t.Fatalf("write dst: %v", err)
+	}
+
+	if err := unix.Chflags(dst, unix.UF_HIDDEN); err != nil {
+		if errors.Is(err, syscall.EPERM) {
+			t.Skipf("cannot set darwin file flags in test environment: %v", err)
+		}
+		t.Fatalf("set darwin flags on dst: %v", err)
+	}
+
+	if err := DefaultCoreUpdater.replaceFileAtomically(src, dst); err != nil {
+		t.Fatalf("replace file atomically: %v", err)
+	}
+
+	var st syscall.Stat_t
+	if err := syscall.Stat(dst, &st); err != nil {
+		t.Fatalf("stat dst: %v", err)
+	}
+
+	if st.Flags&unix.UF_HIDDEN == 0 {
+		t.Fatalf("expected UF_HIDDEN to be preserved, flags=%#x", st.Flags)
+	}
+}

--- a/component/updater/update_core_test.go
+++ b/component/updater/update_core_test.go
@@ -70,6 +70,86 @@ func TestReplaceFileAtomicallyReplacesDestination(t *testing.T) {
 	}
 }
 
+func TestReplaceFileAtomicallyPreservesDestinationMode(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("replaceFileAtomically is used on non-Windows platforms")
+	}
+
+	root := t.TempDir()
+	src := filepath.Join(root, "src")
+	dst := filepath.Join(root, "dst")
+
+	if err := os.WriteFile(src, []byte("new-core"), 0o700); err != nil {
+		t.Fatalf("write src: %v", err)
+	}
+
+	if err := os.WriteFile(dst, []byte("old-core"), 0o755); err != nil {
+		t.Fatalf("write dst: %v", err)
+	}
+
+	if err := os.Chmod(dst, 0o751); err != nil {
+		t.Fatalf("chmod dst: %v", err)
+	}
+
+	if err := DefaultCoreUpdater.replaceFileAtomically(src, dst); err != nil {
+		t.Fatalf("replace file atomically: %v", err)
+	}
+
+	info, err := os.Stat(dst)
+	if err != nil {
+		t.Fatalf("stat dst: %v", err)
+	}
+
+	if got, want := info.Mode().Perm(), os.FileMode(0o751); got != want {
+		t.Fatalf("unexpected dst mode: got %o want %o", got, want)
+	}
+}
+
+func TestReplaceFileAtomicallyReplacesSymlinkTarget(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("replaceFileAtomically is used on non-Windows platforms")
+	}
+
+	root := t.TempDir()
+	src := filepath.Join(root, "src")
+	realDst := filepath.Join(root, "real-dst")
+	linkDst := filepath.Join(root, "current")
+
+	if err := os.WriteFile(src, []byte("new-core"), 0o755); err != nil {
+		t.Fatalf("write src: %v", err)
+	}
+
+	if err := os.WriteFile(realDst, []byte("old-core"), 0o755); err != nil {
+		t.Fatalf("write real dst: %v", err)
+	}
+
+	if err := os.Symlink(realDst, linkDst); err != nil {
+		t.Fatalf("create symlink: %v", err)
+	}
+
+	if err := DefaultCoreUpdater.replaceFileAtomically(src, linkDst); err != nil {
+		t.Fatalf("replace file atomically via symlink: %v", err)
+	}
+
+	linkInfo, err := os.Lstat(linkDst)
+	if err != nil {
+		t.Fatalf("lstat symlink dst: %v", err)
+	}
+
+	if linkInfo.Mode()&os.ModeSymlink == 0 {
+		t.Fatalf("expected %s to remain a symlink", linkDst)
+	}
+
+	got, err := os.ReadFile(realDst)
+	if err != nil {
+		t.Fatalf("read real dst: %v", err)
+	}
+
+	if string(got) != "new-core" {
+		t.Fatalf("unexpected real dst content: %q", string(got))
+	}
+}
+
 func TestReplaceFileAtomicallyKeepsDestinationOnSourceError(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("replaceFileAtomically is used on non-Windows platforms")

--- a/component/updater/update_core_test.go
+++ b/component/updater/update_core_test.go
@@ -2,9 +2,97 @@ package updater
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
 	"testing"
 )
 
 func TestCoreBaseName(t *testing.T) {
 	fmt.Println("Core base name =", DefaultCoreUpdater.CoreBaseName())
+}
+
+func TestPrepareUpdateDirRemovesStaleContents(t *testing.T) {
+	root := t.TempDir()
+	updateDir := filepath.Join(root, "meta-update")
+
+	if err := os.MkdirAll(updateDir, 0o755); err != nil {
+		t.Fatalf("mkdir update dir: %v", err)
+	}
+
+	staleFile := filepath.Join(updateDir, "stale.txt")
+	if err := os.WriteFile(staleFile, []byte("stale"), 0o644); err != nil {
+		t.Fatalf("write stale file: %v", err)
+	}
+
+	if err := DefaultCoreUpdater.prepareUpdateDir(updateDir); err != nil {
+		t.Fatalf("prepare update dir: %v", err)
+	}
+
+	entries, err := os.ReadDir(updateDir)
+	if err != nil {
+		t.Fatalf("read update dir: %v", err)
+	}
+
+	if len(entries) != 0 {
+		t.Fatalf("expected clean update dir, got %d entries", len(entries))
+	}
+}
+
+func TestReplaceFileAtomicallyReplacesDestination(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("replaceFileAtomically is used on non-Windows platforms")
+	}
+
+	root := t.TempDir()
+	src := filepath.Join(root, "src")
+	dst := filepath.Join(root, "dst")
+
+	if err := os.WriteFile(src, []byte("new-core"), 0o755); err != nil {
+		t.Fatalf("write src: %v", err)
+	}
+
+	if err := os.WriteFile(dst, []byte("old-core"), 0o755); err != nil {
+		t.Fatalf("write dst: %v", err)
+	}
+
+	if err := DefaultCoreUpdater.replaceFileAtomically(src, dst); err != nil {
+		t.Fatalf("replace file atomically: %v", err)
+	}
+
+	got, err := os.ReadFile(dst)
+	if err != nil {
+		t.Fatalf("read dst: %v", err)
+	}
+
+	if string(got) != "new-core" {
+		t.Fatalf("unexpected dst content: %q", string(got))
+	}
+}
+
+func TestReplaceFileAtomicallyKeepsDestinationOnSourceError(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("replaceFileAtomically is used on non-Windows platforms")
+	}
+
+	root := t.TempDir()
+	dst := filepath.Join(root, "dst")
+
+	if err := os.WriteFile(dst, []byte("old-core"), 0o755); err != nil {
+		t.Fatalf("write dst: %v", err)
+	}
+
+	err := DefaultCoreUpdater.replaceFileAtomically(filepath.Join(root, "missing-src"), dst)
+	if err == nil {
+		t.Fatal("expected replaceFileAtomically to fail for missing src")
+	}
+
+	got, readErr := os.ReadFile(dst)
+	if readErr != nil {
+		t.Fatalf("read dst: %v", readErr)
+	}
+
+	if string(got) != "old-core" {
+		t.Fatalf("destination was modified on failure: %q", string(got))
+	}
 }

--- a/component/updater/update_core_unix.go
+++ b/component/updater/update_core_unix.go
@@ -1,0 +1,96 @@
+//go:build linux || darwin
+
+package updater
+
+import (
+	"os"
+	"syscall"
+
+	"github.com/metacubex/mihomo/log"
+
+	"golang.org/x/sys/unix"
+)
+
+func init() {
+	preservePosixAttrs = preservePosixAttrsUnix
+}
+
+// flagsHook is set on darwin to carry over st_flags (chflags).
+var flagsHook func(src, dst string)
+
+// preservePosixAttrsUnix copies owner, mode, file flags and xattrs from src to
+// dst. Best-effort: errors are logged, not returned. Covers Linux file
+// capabilities (security.capability), SELinux labels, POSIX ACLs, setuid/sgid,
+// uid/gid, and macOS com.apple.* xattrs. chown(2) on Linux strips setuid/sgid
+// when non-root, so chmod is reapplied after.
+func preservePosixAttrsUnix(src, dst string) {
+	info, err := os.Stat(src)
+	if err != nil {
+		log.Warnln("updater: stat %s: %v", src, err)
+		return
+	}
+
+	if sys, ok := info.Sys().(*syscall.Stat_t); ok {
+		if chownErr := os.Chown(dst, int(sys.Uid), int(sys.Gid)); chownErr != nil && !os.IsPermission(chownErr) {
+			log.Warnln("updater: chown %s: %v", dst, chownErr)
+		}
+	}
+
+	if chmodErr := os.Chmod(dst, info.Mode()); chmodErr != nil {
+		log.Warnln("updater: chmod %s: %v", dst, chmodErr)
+	}
+
+	if flagsHook != nil {
+		flagsHook(src, dst)
+	}
+
+	copyXattrs(src, dst)
+}
+
+func copyXattrs(src, dst string) {
+	size, err := unix.Llistxattr(src, nil)
+	if err != nil {
+		if err != unix.ENOTSUP {
+			log.Warnln("updater: llistxattr %s: %v", src, err)
+		}
+		return
+	}
+	if size == 0 {
+		return
+	}
+
+	buf := make([]byte, size)
+	size, err = unix.Llistxattr(src, buf)
+	if err != nil {
+		log.Warnln("updater: llistxattr %s: %v", src, err)
+		return
+	}
+
+	for _, name := range splitXattrNames(buf[:size]) {
+		valSize, err := unix.Lgetxattr(src, name, nil)
+		if err != nil {
+			continue
+		}
+		val := make([]byte, valSize)
+		if _, err = unix.Lgetxattr(src, name, val); err != nil {
+			continue
+		}
+		if err = unix.Lsetxattr(dst, name, val, 0); err != nil {
+			log.Warnln("updater: lsetxattr %s %s: %v", dst, name, err)
+		}
+	}
+}
+
+func splitXattrNames(b []byte) []string {
+	var names []string
+	start := 0
+	for i, c := range b {
+		if c == 0 {
+			if i > start {
+				names = append(names, string(b[start:i]))
+			}
+			start = i + 1
+		}
+	}
+	return names
+}

--- a/component/updater/update_core_unix_test.go
+++ b/component/updater/update_core_unix_test.go
@@ -1,0 +1,80 @@
+//go:build linux || darwin
+
+package updater
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+	"syscall"
+	"testing"
+
+	"golang.org/x/sys/unix"
+)
+
+func TestReplaceFileAtomicallyPreservesDestinationXattrs(t *testing.T) {
+	root := t.TempDir()
+	src := filepath.Join(root, "src")
+	dst := filepath.Join(root, "dst")
+	name := testXattrName()
+	want := []byte("preserved")
+
+	if err := os.WriteFile(src, []byte("new-core"), 0o700); err != nil {
+		t.Fatalf("write src: %v", err)
+	}
+
+	if err := os.WriteFile(dst, []byte("old-core"), 0o755); err != nil {
+		t.Fatalf("write dst: %v", err)
+	}
+
+	if err := unix.Lsetxattr(dst, name, want, 0); err != nil {
+		if isUnsupportedXattrErr(err) {
+			t.Skipf("xattrs not supported in test environment: %v", err)
+		}
+		t.Fatalf("set xattr on dst: %v", err)
+	}
+
+	if err := DefaultCoreUpdater.replaceFileAtomically(src, dst); err != nil {
+		t.Fatalf("replace file atomically: %v", err)
+	}
+
+	got, err := readXattr(dst, name)
+	if err != nil {
+		t.Fatalf("read xattr from dst: %v", err)
+	}
+
+	if !bytes.Equal(got, want) {
+		t.Fatalf("unexpected xattr value: got %q want %q", got, want)
+	}
+}
+
+func readXattr(path, name string) ([]byte, error) {
+	size, err := unix.Lgetxattr(path, name, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	value := make([]byte, size)
+	n, err := unix.Lgetxattr(path, name, value)
+	if err != nil {
+		return nil, err
+	}
+
+	return value[:n], nil
+}
+
+func testXattrName() string {
+	if runtime.GOOS == "darwin" {
+		return "com.mihomo.test"
+	}
+
+	return "user.mihomo.test"
+}
+
+func isUnsupportedXattrErr(err error) bool {
+	return errors.Is(err, unix.ENOTSUP) ||
+		errors.Is(err, unix.EOPNOTSUPP) ||
+		errors.Is(err, syscall.EPERM)
+}


### PR DESCRIPTION
## Summary

This changes the core updater on darwin/linux to use a staged file + atomic rename instead of copying the new binary directly onto the currently running executable.

It also makes retries tolerant of stale `meta-update` directories left behind by interrupted updates.

## Problem

The current update flow is:

1. download the archive into `meta-update`
2. unpack the new core
3. back up `currentExePath`
4. copy `updateExePath` directly to `currentExePath`

On darwin/linux, step 4 currently opens `currentExePath` with `os.O_TRUNC` before `io.Copy`.

If the process is interrupted after truncate and before the copy completes, the running executable can be left as a 0-byte file.

On macOS this is especially unsafe because the updater is modifying its own running executable in place. In practice, the process can be interrupted by code-signing / page validation after the on-disk executable changes, which leaves the replacement half-done.

There is also a retry issue: `download()` uses `os.Mkdir(updateDir)`, so a stale `meta-update` directory from a previous interrupted run makes the next retry fail with `file exists`.

## Validation

### 1. Reproduction process on macOS

The following is one continuous failure window from a real Clash Verge Rev 2.4.7 installation with v1.19.23 mihomo kernel.

The first retry fails because `meta-update` already exists:

```text
[2026-04-08 19:26:18.206] level=info msg="start update"
[2026-04-08 19:26:20.727] level=info msg="current version v1.19.21, latest version v1.19.23"
[2026-04-08 19:26:20.728] level=info msg="updater: updating using url: https://github.com/MetaCubeX/mihomo/releases/latest/download/mihomo-darwin-arm64-v1.19.23.gz"
[2026-04-08 19:26:20.728] level=info msg="updateExeName: mihomo-darwin-arm64"
[2026-04-08 19:26:23.134] level=error msg="updater: failed: downloading: mkdir error: mkdir /Applications/Clash Verge.app/Contents/MacOS/meta-update: file exists"
[2026-04-08 19:26:23.134] level=warning msg="downloading: mkdir error: mkdir /Applications/Clash Verge.app/Contents/MacOS/meta-update: file exists"
```

The second retry in the same repro window then proceeds into the dangerous replacement path and stops after backup:

```text
[2026-04-08 19:26:29.896] level=info msg="start update"
[2026-04-08 19:26:32.070] level=info msg="current version v1.19.21, latest version v1.19.23"
[2026-04-08 19:26:32.070] level=info msg="updater: updating using url: https://github.com/MetaCubeX/mihomo/releases/latest/download/mihomo-darwin-arm64-v1.19.23.gz"
[2026-04-08 19:26:32.070] level=info msg="updateExeName: mihomo-darwin-arm64"
[2026-04-08 19:26:43.498] level=info msg="updater: unpacking package"
[2026-04-08 19:26:43.700] level=info msg="updater: backing up current ExecFile:/Applications/Clash Verge.app/Contents/MacOS/verge-mihomo to /Applications/Clash Verge.app/Contents/MacOS/meta-backup/verge-mihomo"
[2026-04-08 19:26:43.761] level=warning msg="codesign failed: exit status 1"
[2026-04-08 19:26:43.762] level=info msg="updater: copy: /Applications/Clash Verge.app/Contents/MacOS/verge-mihomo to /Applications/Clash Verge.app/Contents/MacOS/meta-backup/verge-mihomo"
```

Immediately in the same time window, macOS kernel logs show code-signing/page validation rejecting the running executable:

```text
2026-04-08 19:26:43.762 kernel CODE SIGNING: process 75086[verge-mihomo]: rejecting invalid page at address 0x100c80000 from offset 0x8000 in file "/Applications/Clash Verge.app/Contents/MacOS/verge-mihomo" (cs_mtime:1775647420.563043230 != mtime:1775647603.764889006) (signed:0 validated:0 tainted:0 nx:0 wpmapped:0 dirty:1 depth:1)
2026-04-08 19:26:43.771 kernel verge-mihomo[75086] Corpse allowed 1 of 5
```

After that, Clash Verge can no longer talk to the core:

```text
[2026-04-08 19:26:55.513] WARN [Core] Failed to apply configuration by mihomo api, error msg: Connection failed, I/O error: Connection refused (os error 61)
[2026-04-08 19:27:06.597] WARN [Core] Failed to apply configuration by mihomo api, error msg: Connection failed, I/O error: No such file or directory (os error 2)
```

This gives one aligned failure chain:

1. retry hits stale `meta-update`
2. next retry reaches unpack + backup
3. updater is still modifying the running executable in place
4. macOS rejects the mutated running image
5. process dies before replacement completes
6. the app loses the core

### 2. Single patched reproduction window on macOS

I then applied this patch locally, rebuilt Mihomo, and reran the self-update flow in an isolated directory.

The patched build returned a normal HTTP response:

```text
{"status":"ok"}

HTTP_STATUS:200
```

The patched updater log completed the full update and restart flow in one continuous window:

```text
time="2026-04-08T20:23:56.433558000+08:00" level=info msg="start update"
time="2026-04-08T20:23:58.909983000+08:00" level=info msg="current version test-fix, latest version v1.19.23"
time="2026-04-08T20:23:58.910005000+08:00" level=info msg="updater: updating using url: https://github.com/MetaCubeX/mihomo/releases/latest/download/mihomo-darwin-arm64-v1.19.23.gz"
time="2026-04-08T20:23:58.910024000+08:00" level=info msg="updateExeName: mihomo-darwin-arm64"
time="2026-04-08T20:24:01.333662000+08:00" level=debug msg="updater: saving package to file /tmp/mihomo-patched-prlog2.qI9QSE/meta-update/mihomo-darwin-arm64-v1.19.23.gz"
time="2026-04-08T20:24:07.305561000+08:00" level=debug msg="updater: downloaded package to file /tmp/mihomo-patched-prlog2.qI9QSE/meta-update/mihomo-darwin-arm64-v1.19.23.gz"
time="2026-04-08T20:24:07.307846000+08:00" level=info msg="updater: unpacking package"
time="2026-04-08T20:24:07.540095000+08:00" level=info msg="updater: backing up current ExecFile:/tmp/mihomo-patched-prlog2.qI9QSE/verge-mihomo to /tmp/mihomo-patched-prlog2.qI9QSE/meta-backup/verge-mihomo"
time="2026-04-08T20:24:07.626590000+08:00" level=info msg="updater: copy: /tmp/mihomo-patched-prlog2.qI9QSE/verge-mihomo to /tmp/mihomo-patched-prlog2.qI9QSE/meta-backup/verge-mihomo"
time="2026-04-08T20:24:07.792971000+08:00" level=info msg="updater: replace: /tmp/mihomo-patched-prlog2.qI9QSE/meta-update/mihomo-darwin-arm64 to /tmp/mihomo-patched-prlog2.qI9QSE/verge-mihomo via /tmp/mihomo-patched-prlog2.qI9QSE/.verge-mihomo.tmp-3046210258"
time="2026-04-08T20:24:07.812660000+08:00" level=info msg="updater: finished"
time="2026-04-08T20:24:07.813034000+08:00" level=info msg="restarting: \"/tmp/mihomo-patched-prlog2.qI9QSE/verge-mihomo\" [\"-d\" \"/tmp/mihomo-patched-prlog2.qI9QSE/data\" \"-f\" \"/tmp/mihomo-patched-prlog2.qI9QSE/config.yaml\" \"-ext-ctl-unix\" \"/tmp/mihomo-patched-prlog2.qI9QSE/verge.sock\"]"
time="2026-04-08T20:24:08.736323000+08:00" level=info msg="RESTful API unix listening at: /tmp/mihomo-patched-prlog2.qI9QSE/verge.sock"
```

The updated binary remained intact and reported the new version:

```text
-rwxr-xr-x  1 ... 30M /tmp/mihomo-patched-prlog2.qI9QSE/meta-backup/verge-mihomo
-rwxr-xr-x  1 ... 30M /tmp/mihomo-patched-prlog2.qI9QSE/verge-mihomo
Mihomo Meta v1.19.23 darwin arm64 with go1.26.2 Wed Apr  8 01:07:41 UTC 2026
Use tags: with_gvisor
```

During the patched update window (`2026-04-08 20:23:56` to `2026-04-08 20:24:09`), querying unified kernel logs for `rejecting invalid page`, `cs_mtime`, or `Corpse allowed` returned no match.

This gives one aligned success chain:

1. update request returns `200`
2. package downloads and unpacks
3. current executable is backed up
4. new executable is staged and atomically renamed into place
5. updater logs `finished`
6. process restarts successfully
7. updated binary remains intact and runnable

## Root cause

There are two related issues:

1. The updater performs in-place self-overwrite of the currently running executable on darwin/linux.
2. The replacement path truncates `currentExePath` before the new binary is fully written.

On macOS, modifying a running executable on disk can break later code-signing page validation. Apple defines `errSecCSStaticCodeChanged` as “The code on disk has been modified after the code started running,” and XNU defines `KERN_CODESIGN_ERROR` as a page-fault rejection caused by a signature check. This is why in-place replacement of a live binary can terminate the process before the copy completes. [1], [2]

[1]: https://developer.apple.com/documentation/security/errseccsstaticcodechanged
[2]: https://github.com/apple-oss-distributions/xnu/blob/main/osfmk/mach/kern_return.h

That leaves `currentExePath` truncated or empty.

## Changes

- recreate or clear the staging update directory instead of failing on stale `meta-update`
- on darwin/linux, copy the new core to a temporary sibling file in the destination directory
- only apply ad-hoc signing to the staged replacement file on macOS
- atomically rename the staged file over `currentExePath`
- keep the existing Windows behavior unchanged

## Why this fixes the issue

Atomic rename never truncates the currently running executable in place.

Until the final rename succeeds, the old binary remains intact. If the process exits before that point, `currentExePath` is still usable and retries can continue safely.

## Tests

This patch adds coverage for:

- clearing stale update directories before a retry
- replacing the destination via the staged atomic path
- leaving the destination untouched when staged replacement fails before rename

## Verification

- `go test ./component/updater`
- isolated self-update repro on macOS now returns `200 {"status":"ok"}`
- updater logs `updater: replace ...` and `updater: finished`
- the target executable remains intact and updates successfully to `v1.19.23`
- no `rejecting invalid page` message was observed during the patched update run
```
