### PR TITLE
fix(convert): normalize VLESS share-link transport mapping

### DIFF
--- a/common/convert/converter_test.go
+++ b/common/convert/converter_test.go
@@ -129,3 +129,52 @@ func TestConvertsV2RayMieruFragment(t *testing.T) {
 	assert.Len(t, proxies, 1)
 	assert.Equal(t, "myproxy:443/TCP", proxies[0]["name"])
 }
+
+func TestConvertsV2RayVlessRealityVisionTCPWithoutHeaderType(t *testing.T) {
+	vlessTest := "vless://a1b2c3d4-eacc-4433-981b-7e5f9a8b@142.98.76.54:34888?encryption=none&security=reality&type=tcp&sni=github.io&fp=chrome&pbk=TifX9kL2mPqRsTuVwXyZ_JdUWw&sid=6ba85179f3a2b4c5&flow=xtls-rprx-vision#My-VLESS-Reality-Vision"
+
+	proxies, err := ConvertsV2Ray([]byte(vlessTest))
+
+	assert.Nil(t, err)
+	assert.Len(t, proxies, 1)
+	assert.Equal(t, "tcp", proxies[0]["network"])
+	assert.Equal(t, "xtls-rprx-vision", proxies[0]["flow"])
+	assert.Equal(t, "none", proxies[0]["encryption"])
+	assert.Equal(t, "github.io", proxies[0]["servername"])
+	assert.NotContains(t, proxies[0], "http-opts")
+	assert.NotContains(t, proxies[0], "h2-opts")
+}
+
+func TestConvertsV2RayVlessTCPHTTPHeaderType(t *testing.T) {
+	vlessTest := "vless://uuid@example.com:443?security=tls&type=tcp&headerType=http&host=cdn.example.com&path=%2Fedge&method=POST#vless-http"
+
+	proxies, err := ConvertsV2Ray([]byte(vlessTest))
+
+	assert.Nil(t, err)
+	assert.Len(t, proxies, 1)
+	assert.Equal(t, "http", proxies[0]["network"])
+	assert.Equal(t, map[string]any{
+		"method": "POST",
+		"path":   []string{"/edge"},
+		"headers": map[string]any{
+			"Host": []string{"cdn.example.com"},
+		},
+	}, proxies[0]["http-opts"])
+	assert.NotContains(t, proxies[0], "h2-opts")
+}
+
+func TestConvertsV2RayVlessHTTPTransportUsesH2Opts(t *testing.T) {
+	vlessTest := "vless://uuid@example.com:443?security=tls&type=http&host=cdn.example.com&path=%2Fgrpc#vless-h2"
+
+	proxies, err := ConvertsV2Ray([]byte(vlessTest))
+
+	assert.Nil(t, err)
+	assert.Len(t, proxies, 1)
+	assert.Equal(t, "h2", proxies[0]["network"])
+	assert.Equal(t, map[string]any{
+		"host":    []string{"cdn.example.com"},
+		"path":    []string{"/grpc"},
+		"headers": map[string]any{},
+	}, proxies[0]["h2-opts"])
+	assert.NotContains(t, proxies[0], "http-opts")
+}

--- a/common/convert/v.go
+++ b/common/convert/v.go
@@ -63,7 +63,7 @@ func handleVShareLink(names map[string]int, url *url.URL, scheme string, proxy m
 		network = "tcp"
 	}
 	fakeType := strings.ToLower(query.Get("headerType"))
-	if fakeType == "http" {
+	if network == "tcp" && fakeType == "http" {
 		network = "http"
 	} else if network == "http" {
 		network = "h2"
@@ -71,27 +71,26 @@ func handleVShareLink(names map[string]int, url *url.URL, scheme string, proxy m
 	proxy["network"] = network
 	switch network {
 	case "tcp":
-		if fakeType != "none" {
-			headers := make(map[string]any)
-			httpOpts := make(map[string]any)
-			httpOpts["path"] = []string{"/"}
+	case "http":
+		headers := make(map[string]any)
+		httpOpts := make(map[string]any)
+		httpOpts["path"] = []string{"/"}
 
-			if host := query.Get("host"); host != "" {
-				headers["Host"] = []string{host}
-			}
-
-			if method := query.Get("method"); method != "" {
-				httpOpts["method"] = method
-			}
-
-			if path := query.Get("path"); path != "" {
-				httpOpts["path"] = []string{path}
-			}
-			httpOpts["headers"] = headers
-			proxy["http-opts"] = httpOpts
+		if host := query.Get("host"); host != "" {
+			headers["Host"] = []string{host}
 		}
 
-	case "http":
+		if method := query.Get("method"); method != "" {
+			httpOpts["method"] = method
+		}
+
+		if path := query.Get("path"); path != "" {
+			httpOpts["path"] = []string{path}
+		}
+		httpOpts["headers"] = headers
+		proxy["http-opts"] = httpOpts
+
+	case "h2":
 		headers := make(map[string]any)
 		h2Opts := make(map[string]any)
 		h2Opts["path"] = []string{"/"}


### PR DESCRIPTION
## Summary

This change fixes VLESS share-link transport normalization in the converter.

- keep omitted headerType on plain tcp
- map type=tcp&headerType=http to network=http with http-opts
- map type=http to network=h2 with h2-opts
- add regression coverage for all three cases

## Root Cause

The share-link parser mixed transport normalization with option generation.

That caused two problems:
- plain tcp links with no headerType could still synthesize default http-opts
- transport aliases were not normalized consistently, so HTTP camouflage and HTTP/2 handling were not mapped to the correct option blocks

## Validation

- go test ./common/convert -run 'TestConvertsV2RayVless' -count=1