### PR TITLE
fix: implement Tuic.Close to release PoolClient resources

### DIFF
--- a/adapter/outbound/tuic.go
+++ b/adapter/outbound/tuic.go
@@ -125,6 +125,14 @@ func (t *Tuic) ProxyInfo() C.ProxyInfo {
 	return info
 }
 
+// Close implements C.ProxyAdapter
+func (t *Tuic) Close() error {
+	if t.client != nil {
+		return t.client.Close()
+	}
+	return nil
+}
+
 func NewTuic(option TuicOption) (*Tuic, error) {
 	addr := net.JoinHostPort(option.Server, strconv.Itoa(option.Port))
 	serverName := option.Server

--- a/transport/tuic/pool_client.go
+++ b/transport/tuic/pool_client.go
@@ -119,6 +119,27 @@ func (t *PoolClient) getClient(udp bool) Client {
 	}
 }
 
+// Close releases all resources held by the PoolClient by closing every
+// cached clientImpl in both the tcp and udp lists. Each clientImpl owns its
+// own SingleUse *quic.Transport that is auto-closed when the underlying
+// quicConn closes, so no additional cleanup is needed at the pool level.
+// Close is safe to call multiple times.
+func (t *PoolClient) Close() error {
+	closeClients := func(clients *list.List[Client], mu *sync.Mutex) {
+		mu.Lock()
+		defer mu.Unlock()
+		for it := clients.Front(); it != nil; it = it.Next() {
+			if c := it.Value; c != nil {
+				c.Close()
+			}
+		}
+		clients.Init()
+	}
+	closeClients(&t.tcpClients, &t.tcpClientsMutex)
+	closeClients(&t.udpClients, &t.udpClientsMutex)
+	return nil
+}
+
 func NewPoolClientV4(clientOption *ClientOptionV4, dialFn DialFunc) *PoolClient {
 	p := &PoolClient{
 		dialFn: dialFn,


### PR DESCRIPTION
    Tuic outbound inherited the no-op Base.Close, so autoCloseProxyAdapter
    could not cascade cleanup into the PoolClient. Every clientImpl (and its
    SingleUse quic.Transport) then had to wait for its own closeClient
    finalizer to run, a multi-cycle GC chain that delays release of the
    listen/runSendQueue goroutines under rapid create/destroy workloads.

    Add a public PoolClient.Close that closes every cached clientImpl, and
    wire it up from Tuic.Close so the Close path is synchronous and does not
    depend on GC.