### PR TITLE
chore: update mieru version

### DIFF
--- a/docs/config.yaml
+++ b/docs/config.yaml
@@ -1768,6 +1768,8 @@ listeners:
       username2: password2
     # 一个 base64 字符串用于微调网络行为
     # traffic-pattern: ""
+    # 如果开启，且客户端不发送用户提示，代理服务器将拒绝连接
+    # user-hint-is-mandatory: false
 
   - name: sudoku-in-1
     type: sudoku

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/bahlo/generic-list-go v0.2.0
 	github.com/coreos/go-iptables v0.8.0
 	github.com/dlclark/regexp2 v1.11.5
-	github.com/enfein/mieru/v3 v3.30.1
+	github.com/enfein/mieru/v3 v3.31.0
 	github.com/gobwas/ws v1.4.0
 	github.com/gofrs/uuid/v5 v5.4.0
 	github.com/golang/snappy v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -20,8 +20,8 @@ github.com/dlclark/regexp2 v1.11.5 h1:Q/sSnsKerHeCkc/jSTNq1oCm7KiVgUMZRDUoRu0JQZ
 github.com/dlclark/regexp2 v1.11.5/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
 github.com/dunglas/httpsfv v1.0.2 h1:iERDp/YAfnojSDJ7PW3dj1AReJz4MrwbECSSE59JWL0=
 github.com/dunglas/httpsfv v1.0.2/go.mod h1:zID2mqw9mFsnt7YC3vYQ9/cjq30q41W+1AnDwH8TiMg=
-github.com/enfein/mieru/v3 v3.30.1 h1:gHHXQfpQO/5d789o9kokVfej7jl795aJwPihUk3gTDU=
-github.com/enfein/mieru/v3 v3.30.1/go.mod h1:zJBUCsi5rxyvHM8fjFf+GLaEl4OEjjBXr1s5F6Qd3hM=
+github.com/enfein/mieru/v3 v3.31.0 h1:Fl2ocRCRXJzMygzdRjBHgqI996ZuIDHUmyQyovSf9sA=
+github.com/enfein/mieru/v3 v3.31.0/go.mod h1:zJBUCsi5rxyvHM8fjFf+GLaEl4OEjjBXr1s5F6Qd3hM=
 github.com/ericlagergren/aegis v0.0.0-20250325060835-cd0defd64358 h1:kXYqH/sL8dS/FdoFjr12ePjnLPorPo2FsnrHNuXSDyo=
 github.com/ericlagergren/aegis v0.0.0-20250325060835-cd0defd64358/go.mod h1:hkIFzoiIPZYxdFOOLyDho59b7SrDfo+w3h+yWdlg45I=
 github.com/ericlagergren/polyval v0.0.0-20220411101811-e25bc10ba391 h1:8j2RH289RJplhA6WfdaPqzg1MjH2K8wX5e0uhAxrw2g=

--- a/listener/inbound/mieru.go
+++ b/listener/inbound/mieru.go
@@ -27,9 +27,10 @@ type Mieru struct {
 
 type MieruOption struct {
 	BaseOption
-	Transport      string            `inbound:"transport"`
-	Users          map[string]string `inbound:"users"`
-	TrafficPattern string            `inbound:"traffic-pattern,omitempty"`
+	Transport           string            `inbound:"transport"`
+	Users               map[string]string `inbound:"users"`
+	TrafficPattern      string            `inbound:"traffic-pattern,omitempty"`
+	UserHintIsMandatory bool              `inbound:"user-hint-is-mandatory,omitempty"`
 }
 
 type mieruListenerFactory struct{}
@@ -158,11 +159,18 @@ func buildMieruServerConfig(option *MieruOption, ports utils.IntRanges[uint16]) 
 	}
 	var trafficPattern *mierupb.TrafficPattern
 	trafficPattern, _ = mierutp.Decode(option.TrafficPattern)
+	var advancedSettings *mierupb.ServerAdvancedSettings
+	if option.UserHintIsMandatory {
+		advancedSettings = &mierupb.ServerAdvancedSettings{
+			UserHintIsMandatory: proto.Bool(true),
+		}
+	}
 	return &mieruserver.ServerConfig{
 		Config: &mierupb.ServerConfig{
-			PortBindings:   portBindings,
-			Users:          users,
-			TrafficPattern: trafficPattern,
+			PortBindings:     portBindings,
+			Users:            users,
+			TrafficPattern:   trafficPattern,
+			AdvancedSettings: advancedSettings,
 		},
 		StreamListenerFactory: mieruListenerFactory{},
 		PacketListenerFactory: mieruListenerFactory{},

--- a/listener/inbound/mieru_test.go
+++ b/listener/inbound/mieru_test.go
@@ -206,8 +206,9 @@ func testInboundMieruTCP(t *testing.T, handshakeMode string) {
 			Listen:  "127.0.0.1",
 			Port:    strconv.Itoa(port),
 		},
-		Transport: "TCP",
-		Users:     map[string]string{"test": "password"},
+		Transport:           "TCP",
+		Users:               map[string]string{"test": "password"},
+		UserHintIsMandatory: true,
 	}
 	in, err := inbound.NewMieru(&inboundOptions)
 	if !assert.NoError(t, err) {
@@ -260,8 +261,9 @@ func testInboundMieruUDP(t *testing.T, handshakeMode string) {
 			Listen:  "127.0.0.1",
 			Port:    strconv.Itoa(port),
 		},
-		Transport: "UDP",
-		Users:     map[string]string{"test": "password"},
+		Transport:           "UDP",
+		Users:               map[string]string{"test": "password"},
+		UserHintIsMandatory: true,
 	}
 	in, err := inbound.NewMieru(&inboundOptions)
 	if !assert.NoError(t, err) {


### PR DESCRIPTION
In order to address https://github.com/enfein/mieru/issues/264 v3.31.0 introduces a user hint to improve the decryption speed when the number of users is large.

Also add an option to only serve the clients who support user hint.