### PR TITLE
feat: add timestamp to RESTful API responses

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -45,27 +45,28 @@ import (
 // General config
 type General struct {
 	Inbound
-	Mode                    T.TunnelMode            `json:"mode"`
-	UnifiedDelay            bool                    `json:"unified-delay"`
-	LogLevel                log.LogLevel            `json:"log-level"`
-	IPv6                    bool                    `json:"ipv6"`
-	Interface               string                  `json:"interface-name"`
-	RoutingMark             int                     `json:"routing-mark"`
-	GeoXUrl                 GeoXUrl                 `json:"geox-url"`
-	GeoAutoUpdate           bool                    `json:"geo-auto-update"`
-	GeoUpdateInterval       int                     `json:"geo-update-interval"`
-	GeodataMode             bool                    `json:"geodata-mode"`
-	GeodataLoader           string                  `json:"geodata-loader"`
-	GeositeMatcher          string                  `json:"geosite-matcher"`
-	TCPConcurrent           bool                    `json:"tcp-concurrent"`
-	FindProcessMode         process.FindProcessMode `json:"find-process-mode"`
-	Sniffing                bool                    `json:"sniffing"`
-	GlobalClientFingerprint string                  `json:"global-client-fingerprint"`
-	GlobalUA                string                  `json:"global-ua"`
-	ETagSupport             bool                    `json:"etag-support"`
-	KeepAliveIdle           int                     `json:"keep-alive-idle"`
-	KeepAliveInterval       int                     `json:"keep-alive-interval"`
-	DisableKeepAlive        bool                    `json:"disable-keep-alive"`
+	Mode                      T.TunnelMode            `json:"mode"`
+	UnifiedDelay              bool                    `json:"unified-delay"`
+	LogLevel                  log.LogLevel            `json:"log-level"`
+	LogRestfulTimestampFormat string                  `json:"log-restful-timestamp-format"`
+	IPv6                      bool                    `json:"ipv6"`
+	Interface                 string                  `json:"interface-name"`
+	RoutingMark               int                     `json:"routing-mark"`
+	GeoXUrl                   GeoXUrl                 `json:"geox-url"`
+	GeoAutoUpdate             bool                    `json:"geo-auto-update"`
+	GeoUpdateInterval         int                     `json:"geo-update-interval"`
+	GeodataMode               bool                    `json:"geodata-mode"`
+	GeodataLoader             string                  `json:"geodata-loader"`
+	GeositeMatcher            string                  `json:"geosite-matcher"`
+	TCPConcurrent             bool                    `json:"tcp-concurrent"`
+	FindProcessMode           process.FindProcessMode `json:"find-process-mode"`
+	Sniffing                  bool                    `json:"sniffing"`
+	GlobalClientFingerprint   string                  `json:"global-client-fingerprint"`
+	GlobalUA                  string                  `json:"global-ua"`
+	ETagSupport               bool                    `json:"etag-support"`
+	KeepAliveIdle             int                     `json:"keep-alive-idle"`
+	KeepAliveInterval         int                     `json:"keep-alive-interval"`
+	DisableKeepAlive          bool                    `json:"disable-keep-alive"`
 }
 
 // Inbound config
@@ -390,51 +391,52 @@ type RawTLS struct {
 }
 
 type RawConfig struct {
-	Port                    int                     `yaml:"port" json:"port"`
-	SocksPort               int                     `yaml:"socks-port" json:"socks-port"`
-	RedirPort               int                     `yaml:"redir-port" json:"redir-port"`
-	TProxyPort              int                     `yaml:"tproxy-port" json:"tproxy-port"`
-	MixedPort               int                     `yaml:"mixed-port" json:"mixed-port"`
-	ShadowSocksConfig       string                  `yaml:"ss-config" json:"ss-config"`
-	VmessConfig             string                  `yaml:"vmess-config" json:"vmess-config"`
-	InboundTfo              bool                    `yaml:"inbound-tfo" json:"inbound-tfo"`
-	InboundMPTCP            bool                    `yaml:"inbound-mptcp" json:"inbound-mptcp"`
-	Authentication          []string                `yaml:"authentication" json:"authentication"`
-	SkipAuthPrefixes        []netip.Prefix          `yaml:"skip-auth-prefixes" json:"skip-auth-prefixes"`
-	LanAllowedIPs           []netip.Prefix          `yaml:"lan-allowed-ips" json:"lan-allowed-ips"`
-	LanDisAllowedIPs        []netip.Prefix          `yaml:"lan-disallowed-ips" json:"lan-disallowed-ips"`
-	AllowLan                bool                    `yaml:"allow-lan" json:"allow-lan"`
-	BindAddress             string                  `yaml:"bind-address" json:"bind-address"`
-	Mode                    T.TunnelMode            `yaml:"mode" json:"mode"`
-	UnifiedDelay            bool                    `yaml:"unified-delay" json:"unified-delay"`
-	LogLevel                log.LogLevel            `yaml:"log-level" json:"log-level"`
-	IPv6                    bool                    `yaml:"ipv6" json:"ipv6"`
-	ExternalController      string                  `yaml:"external-controller" json:"external-controller"`
-	ExternalControllerPipe  string                  `yaml:"external-controller-pipe" json:"external-controller-pipe"`
-	ExternalControllerUnix  string                  `yaml:"external-controller-unix" json:"external-controller-unix"`
-	ExternalControllerTLS   string                  `yaml:"external-controller-tls" json:"external-controller-tls"`
-	ExternalControllerCors  RawCors                 `yaml:"external-controller-cors" json:"external-controller-cors"`
-	ExternalUI              string                  `yaml:"external-ui" json:"external-ui"`
-	ExternalUIURL           string                  `yaml:"external-ui-url" json:"external-ui-url"`
-	ExternalUIName          string                  `yaml:"external-ui-name" json:"external-ui-name"`
-	ExternalDohServer       string                  `yaml:"external-doh-server" json:"external-doh-server"`
-	Secret                  string                  `yaml:"secret" json:"secret"`
-	Interface               string                  `yaml:"interface-name" json:"interface-name"`
-	RoutingMark             int                     `yaml:"routing-mark" json:"routing-mark"`
-	Tunnels                 []LC.Tunnel             `yaml:"tunnels" json:"tunnels"`
-	GeoAutoUpdate           bool                    `yaml:"geo-auto-update" json:"geo-auto-update"`
-	GeoUpdateInterval       int                     `yaml:"geo-update-interval" json:"geo-update-interval"`
-	GeodataMode             bool                    `yaml:"geodata-mode" json:"geodata-mode"`
-	GeodataLoader           string                  `yaml:"geodata-loader" json:"geodata-loader"`
-	GeositeMatcher          string                  `yaml:"geosite-matcher" json:"geosite-matcher"`
-	TCPConcurrent           bool                    `yaml:"tcp-concurrent" json:"tcp-concurrent"`
-	FindProcessMode         process.FindProcessMode `yaml:"find-process-mode" json:"find-process-mode"`
-	GlobalClientFingerprint string                  `yaml:"global-client-fingerprint" json:"global-client-fingerprint"`
-	GlobalUA                string                  `yaml:"global-ua" json:"global-ua"`
-	ETagSupport             bool                    `yaml:"etag-support" json:"etag-support"`
-	KeepAliveIdle           int                     `yaml:"keep-alive-idle" json:"keep-alive-idle"`
-	KeepAliveInterval       int                     `yaml:"keep-alive-interval" json:"keep-alive-interval"`
-	DisableKeepAlive        bool                    `yaml:"disable-keep-alive" json:"disable-keep-alive"`
+	Port                      int                     `yaml:"port" json:"port"`
+	SocksPort                 int                     `yaml:"socks-port" json:"socks-port"`
+	RedirPort                 int                     `yaml:"redir-port" json:"redir-port"`
+	TProxyPort                int                     `yaml:"tproxy-port" json:"tproxy-port"`
+	MixedPort                 int                     `yaml:"mixed-port" json:"mixed-port"`
+	ShadowSocksConfig         string                  `yaml:"ss-config" json:"ss-config"`
+	VmessConfig               string                  `yaml:"vmess-config" json:"vmess-config"`
+	InboundTfo                bool                    `yaml:"inbound-tfo" json:"inbound-tfo"`
+	InboundMPTCP              bool                    `yaml:"inbound-mptcp" json:"inbound-mptcp"`
+	Authentication            []string                `yaml:"authentication" json:"authentication"`
+	SkipAuthPrefixes          []netip.Prefix          `yaml:"skip-auth-prefixes" json:"skip-auth-prefixes"`
+	LanAllowedIPs             []netip.Prefix          `yaml:"lan-allowed-ips" json:"lan-allowed-ips"`
+	LanDisAllowedIPs          []netip.Prefix          `yaml:"lan-disallowed-ips" json:"lan-disallowed-ips"`
+	AllowLan                  bool                    `yaml:"allow-lan" json:"allow-lan"`
+	BindAddress               string                  `yaml:"bind-address" json:"bind-address"`
+	Mode                      T.TunnelMode            `yaml:"mode" json:"mode"`
+	UnifiedDelay              bool                    `yaml:"unified-delay" json:"unified-delay"`
+	LogLevel                  log.LogLevel            `yaml:"log-level" json:"log-level"`
+	LogRestfulTimestampFormat string                  `yaml:"log-restful-timestamp-format" json:"log-restful-timestamp-format"`
+	IPv6                      bool                    `yaml:"ipv6" json:"ipv6"`
+	ExternalController        string                  `yaml:"external-controller" json:"external-controller"`
+	ExternalControllerPipe    string                  `yaml:"external-controller-pipe" json:"external-controller-pipe"`
+	ExternalControllerUnix    string                  `yaml:"external-controller-unix" json:"external-controller-unix"`
+	ExternalControllerTLS     string                  `yaml:"external-controller-tls" json:"external-controller-tls"`
+	ExternalControllerCors    RawCors                 `yaml:"external-controller-cors" json:"external-controller-cors"`
+	ExternalUI                string                  `yaml:"external-ui" json:"external-ui"`
+	ExternalUIURL             string                  `yaml:"external-ui-url" json:"external-ui-url"`
+	ExternalUIName            string                  `yaml:"external-ui-name" json:"external-ui-name"`
+	ExternalDohServer         string                  `yaml:"external-doh-server" json:"external-doh-server"`
+	Secret                    string                  `yaml:"secret" json:"secret"`
+	Interface                 string                  `yaml:"interface-name" json:"interface-name"`
+	RoutingMark               int                     `yaml:"routing-mark" json:"routing-mark"`
+	Tunnels                   []LC.Tunnel             `yaml:"tunnels" json:"tunnels"`
+	GeoAutoUpdate             bool                    `yaml:"geo-auto-update" json:"geo-auto-update"`
+	GeoUpdateInterval         int                     `yaml:"geo-update-interval" json:"geo-update-interval"`
+	GeodataMode               bool                    `yaml:"geodata-mode" json:"geodata-mode"`
+	GeodataLoader             string                  `yaml:"geodata-loader" json:"geodata-loader"`
+	GeositeMatcher            string                  `yaml:"geosite-matcher" json:"geosite-matcher"`
+	TCPConcurrent             bool                    `yaml:"tcp-concurrent" json:"tcp-concurrent"`
+	FindProcessMode           process.FindProcessMode `yaml:"find-process-mode" json:"find-process-mode"`
+	GlobalClientFingerprint   string                  `yaml:"global-client-fingerprint" json:"global-client-fingerprint"`
+	GlobalUA                  string                  `yaml:"global-ua" json:"global-ua"`
+	ETagSupport               bool                    `yaml:"etag-support" json:"etag-support"`
+	KeepAliveIdle             int                     `yaml:"keep-alive-idle" json:"keep-alive-idle"`
+	KeepAliveInterval         int                     `yaml:"keep-alive-interval" json:"keep-alive-interval"`
+	DisableKeepAlive          bool                    `yaml:"disable-keep-alive" json:"disable-keep-alive"`
 
 	ProxyProvider map[string]map[string]any `yaml:"proxy-providers" json:"proxy-providers"`
 	RuleProvider  map[string]map[string]any `yaml:"rule-providers" json:"rule-providers"`
@@ -470,26 +472,27 @@ func Parse(buf []byte) (*Config, error) {
 
 func DefaultRawConfig() *RawConfig {
 	return &RawConfig{
-		AllowLan:          false,
-		BindAddress:       "*",
-		LanAllowedIPs:     []netip.Prefix{netip.MustParsePrefix("0.0.0.0/0"), netip.MustParsePrefix("::/0")},
-		IPv6:              true,
-		Mode:              T.Rule,
-		GeoAutoUpdate:     false,
-		GeoUpdateInterval: 24,
-		GeodataMode:       geodata.GeodataMode(),
-		GeodataLoader:     "memconservative",
-		UnifiedDelay:      false,
-		Authentication:    []string{},
-		LogLevel:          log.INFO,
-		Hosts:             map[string]any{},
-		Rule:              []string{},
-		Proxy:             []map[string]any{},
-		ProxyGroup:        []map[string]any{},
-		TCPConcurrent:     false,
-		FindProcessMode:   process.FindProcessStrict,
-		GlobalUA:          "clash.meta/" + C.Version,
-		ETagSupport:       true,
+		AllowLan:                  false,
+		BindAddress:               "*",
+		LanAllowedIPs:             []netip.Prefix{netip.MustParsePrefix("0.0.0.0/0"), netip.MustParsePrefix("::/0")},
+		IPv6:                      true,
+		Mode:                      T.Rule,
+		GeoAutoUpdate:             false,
+		GeoUpdateInterval:         24,
+		GeodataMode:               geodata.GeodataMode(),
+		GeodataLoader:             "memconservative",
+		UnifiedDelay:              false,
+		Authentication:            []string{},
+		LogLevel:                  log.INFO,
+		LogRestfulTimestampFormat: "15:04:05.000",
+		Hosts:                     map[string]any{},
+		Rule:                      []string{},
+		Proxy:                     []map[string]any{},
+		ProxyGroup:                []map[string]any{},
+		TCPConcurrent:             false,
+		FindProcessMode:           process.FindProcessStrict,
+		GlobalUA:                  "clash.meta/" + C.Version,
+		ETagSupport:               true,
 		DNS: RawDNS{
 			Enable:         false,
 			IPv6:           false,
@@ -756,12 +759,13 @@ func parseGeneral(cfg *RawConfig) (*General, error) {
 			InboundTfo:        cfg.InboundTfo,
 			InboundMPTCP:      cfg.InboundMPTCP,
 		},
-		UnifiedDelay: cfg.UnifiedDelay,
-		Mode:         cfg.Mode,
-		LogLevel:     cfg.LogLevel,
-		IPv6:         cfg.IPv6,
-		Interface:    cfg.Interface,
-		RoutingMark:  cfg.RoutingMark,
+		UnifiedDelay:              cfg.UnifiedDelay,
+		Mode:                      cfg.Mode,
+		LogLevel:                  cfg.LogLevel,
+		LogRestfulTimestampFormat: cfg.LogRestfulTimestampFormat,
+		IPv6:                      cfg.IPv6,
+		Interface:                 cfg.Interface,
+		RoutingMark:               cfg.RoutingMark,
 		GeoXUrl: GeoXUrl{
 			GeoIp:   cfg.GeoXUrl.GeoIp,
 			Mmdb:    cfg.GeoXUrl.Mmdb,

--- a/docs/config.yaml
+++ b/docs/config.yaml
@@ -42,6 +42,7 @@ geo-update-interval: 24 # 更新间隔，单位：小时
 # geosite-matcher: succinct
 
 log-level: debug # 日志等级 silent/error/warning/info/debug
+log-restful-timestamp-format: "15:04:05.000" # RESTful API 日志时间格式，用于 /logs、/connections、/traffic、/memory 等接口，默认毫秒精度
 
 ipv6: true # 开启 IPv6 总开关，关闭阻断所有 IPv6 链接和屏蔽 DNS 请求 AAAA 记录
 

--- a/hub/executor/executor.go
+++ b/hub/executor/executor.go
@@ -45,6 +45,8 @@ import (
 
 var mux sync.Mutex
 
+var logRestfulTimestampFormat = "15:04:05.000"
+
 func readConfig(path string) ([]byte, error) {
 	if _, err := os.Stat(path); os.IsNotExist(err) {
 		return nil, err
@@ -86,6 +88,10 @@ func ApplyConfig(cfg *config.Config, force bool) {
 	mux.Lock()
 	defer mux.Unlock()
 	log.SetLevel(cfg.General.LogLevel)
+	logRestfulTimestampFormat = cfg.General.LogRestfulTimestampFormat
+	if logRestfulTimestampFormat == "" {
+		logRestfulTimestampFormat = "15:04:05.000"
+	}
 
 	tunnel.OnSuspend()
 
@@ -125,6 +131,10 @@ func ApplyConfig(cfg *config.Config, force bool) {
 
 func initInnerTcp() {
 	inner.New(tunnel.Tunnel)
+}
+
+func GetLogRestfulTimestampFormat() string {
+	return logRestfulTimestampFormat
 }
 
 func GetGeneral() *config.General {

--- a/hub/route/server.go
+++ b/hub/route/server.go
@@ -17,6 +17,7 @@ import (
 	"github.com/metacubex/mihomo/component/ca"
 	"github.com/metacubex/mihomo/component/ech"
 	C "github.com/metacubex/mihomo/constant"
+	"github.com/metacubex/mihomo/hub/executor"
 	"github.com/metacubex/mihomo/log"
 	"github.com/metacubex/mihomo/ntp"
 	"github.com/metacubex/mihomo/tunnel/statistic"
@@ -45,15 +46,17 @@ func SetEmbedMode(embed bool) {
 }
 
 type Traffic struct {
-	Up        int64 `json:"up"`
-	Down      int64 `json:"down"`
-	UpTotal   int64 `json:"upTotal"`
-	DownTotal int64 `json:"downTotal"`
+	Up        int64  `json:"up"`
+	Down      int64  `json:"down"`
+	UpTotal   int64  `json:"upTotal"`
+	DownTotal int64  `json:"downTotal"`
+	Time      string `json:"time"`
 }
 
 type Memory struct {
 	Inuse   uint64 `json:"inuse"`
 	OSLimit uint64 `json:"oslimit"` // maybe we need it in the future
+	Time    string `json:"time"`
 }
 
 type Config struct {
@@ -388,6 +391,7 @@ func traffic(w http.ResponseWriter, r *http.Request) {
 			Down:      down,
 			UpTotal:   upTotal,
 			DownTotal: downTotal,
+			Time:      time.Now().Format(executor.GetLogRestfulTimestampFormat()),
 		}); err != nil {
 			break
 		}
@@ -439,6 +443,7 @@ func memory(w http.ResponseWriter, r *http.Request) {
 		if err := json.NewEncoder(buf).Encode(Memory{
 			Inuse:   inuse,
 			OSLimit: 0,
+			Time:    time.Now().Format(executor.GetLogRestfulTimestampFormat()),
 		}); err != nil {
 			break
 		}
@@ -458,6 +463,7 @@ func memory(w http.ResponseWriter, r *http.Request) {
 type Log struct {
 	Type    string `json:"type"`
 	Payload string `json:"payload"`
+	Time    string `json:"time"`
 }
 type LogStructuredField struct {
 	Key   string `json:"key"`
@@ -528,6 +534,7 @@ func getLogs(w http.ResponseWriter, r *http.Request) {
 			if err := json.NewEncoder(buf).Encode(Log{
 				Type:    logM.Type(),
 				Payload: logM.Payload,
+				Time:    logM.Time.Format(executor.GetLogRestfulTimestampFormat()),
 			}); err != nil {
 				break
 			}
@@ -537,7 +544,7 @@ func getLogs(w http.ResponseWriter, r *http.Request) {
 				newLevel = "warn"
 			}
 			if err := json.NewEncoder(buf).Encode(LogStructured{
-				Time:    time.Now().Format(time.TimeOnly),
+				Time:    logM.Time.Format(executor.GetLogRestfulTimestampFormat()),
 				Level:   newLevel,
 				Message: logM.Payload,
 				Fields:  []LogStructuredField{},

--- a/log/log.go
+++ b/log/log.go
@@ -3,6 +3,7 @@ package log
 import (
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/metacubex/mihomo/common/observable"
 
@@ -28,6 +29,7 @@ func init() {
 type Event struct {
 	LogLevel LogLevel
 	Payload  string
+	Time     time.Time
 }
 
 func (e *Event) Type() string {
@@ -100,5 +102,6 @@ func newLog(logLevel LogLevel, format string, v ...any) Event {
 	return Event{
 		LogLevel: logLevel,
 		Payload:  fmt.Sprintf(format, v...),
+		Time:     time.Now(),
 	}
 }

--- a/tunnel/statistic/manager.go
+++ b/tunnel/statistic/manager.go
@@ -92,6 +92,7 @@ func (m *Manager) Snapshot() *Snapshot {
 		DownloadTotal: m.downloadTotal.Load(),
 		Connections:   connections,
 		Memory:        m.memory,
+		Time:          time.Now().Format("15:04:05.000"),
 	}
 }
 
@@ -126,4 +127,5 @@ type Snapshot struct {
 	UploadTotal   int64          `json:"uploadTotal"`
 	Connections   []*TrackerInfo `json:"connections"`
 	Memory        uint64         `json:"memory"`
+	Time          string         `json:"time"`
 }


### PR DESCRIPTION
## PR 说明


#### English
Add timestamp field to RESTful API responses (/logs, /connections, /traffic, /memory) with configurable format via `log-restful-timestamp-format` option. Defaults to millisecond precision "15:04:05.000".

#### 中文
为 RESTful API 响应添加时间戳字段（/logs、/connections、/traffic、/memory），支持通过 `log-restful-timestamp-format` 配置格式，默认毫秒精度。