### PR TITLE
feat(log): add log file output support

### DIFF
--- a/log/log.go
+++ b/log/log.go
@@ -102,3 +102,15 @@ func newLog(logLevel LogLevel, format string, v ...any) Event {
 		Payload:  fmt.Sprintf(format, v...),
 	}
 }
+
+func SetOutputFile(path string) error {
+	if path == "" {
+		return nil
+	}
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+	if err != nil {
+		return err
+	}
+	log.SetOutput(file)
+	return nil
+}

--- a/main.go
+++ b/main.go
@@ -41,6 +41,7 @@ var (
 	externalControllerUnix string
 	externalControllerPipe string
 	secret                 string
+	logFile                string
 )
 
 func init() {
@@ -52,6 +53,7 @@ func init() {
 	flag.StringVar(&externalControllerUnix, "ext-ctl-unix", os.Getenv("CLASH_OVERRIDE_EXTERNAL_CONTROLLER_UNIX"), "override external controller unix address")
 	flag.StringVar(&externalControllerPipe, "ext-ctl-pipe", os.Getenv("CLASH_OVERRIDE_EXTERNAL_CONTROLLER_PIPE"), "override external controller pipe address")
 	flag.StringVar(&secret, "secret", os.Getenv("CLASH_OVERRIDE_SECRET"), "override secret for RESTful API")
+	flag.StringVar(&logFile, "log-file", os.Getenv("CLASH_LOG_FILE"), "specify log file path")
 	flag.BoolVar(&geodataMode, "m", false, "set geodata mode")
 	flag.BoolVar(&version, "v", false, "show current version of mihomo")
 	flag.BoolVar(&testConfig, "t", false, "test configuration and exit")
@@ -59,6 +61,12 @@ func init() {
 }
 
 func main() {
+	if logFile != "" {
+		if err := log.SetOutputFile(logFile); err != nil {
+			fmt.Fprintf(os.Stderr, "failed to set log file: %s\n", err.Error())
+		}
+	}
+
 	// Defensive programming: panic when code mistakenly calls net.DefaultResolver
 	net.DefaultResolver.PreferGo = true
 	net.DefaultResolver.Dial = func(ctx context.Context, network, address string) (net.Conn, error) {


### PR DESCRIPTION
添加 SetOutputFile 函数以支持将日志重定向到文件，
通过 CLI flag -log-file 暴露该功能，方便用户持久化日志用于调试和审计目的。