### PR TITLE
feat: network-policy — auto-switch select groups based on network environment

### DIFF
--- a/adapter/outboundgroup/parser.go
+++ b/adapter/outboundgroup/parser.go
@@ -10,6 +10,7 @@ import (
 	"github.com/metacubex/mihomo/adapter/provider"
 	"github.com/metacubex/mihomo/common/structure"
 	"github.com/metacubex/mihomo/common/utils"
+	"github.com/metacubex/mihomo/component/networkpolicy"
 	C "github.com/metacubex/mihomo/constant"
 	P "github.com/metacubex/mihomo/constant/provider"
 	"github.com/metacubex/mihomo/log"
@@ -44,7 +45,7 @@ type GroupCommonOption struct {
 	Icon                string   `group:"icon,omitempty"`
 }
 
-func ParseProxyGroup(config map[string]any, proxyMap map[string]C.Proxy, providersMap map[string]P.ProxyProvider, AllProxies []string, AllProviders []string) (C.ProxyAdapter, error) {
+func ParseProxyGroup(config map[string]any, proxyMap map[string]C.Proxy, providersMap map[string]P.ProxyProvider, AllProxies []string, AllProviders []string, AllNetworks []string, AllProxyNames []string) (C.ProxyAdapter, error) {
 	decoder := structure.NewDecoder(structure.Option{TagName: "group", WeaklyTypedInput: true})
 
 	groupOption := &GroupCommonOption{
@@ -56,6 +57,17 @@ func ParseProxyGroup(config map[string]any, proxyMap map[string]C.Proxy, provide
 
 	if groupOption.Type == "" || groupOption.Name == "" {
 		return nil, errFormat
+	}
+
+	// network-policy is a select-only subfield (architecture §5.8.1).
+	// Presence on any other group type is a parse-time configuration error.
+	// Presence detection is key-based, so `network-policy:` (null value) is
+	// treated the same as a populated field — ParseGroupPolicy will reject
+	// it with "expected map" and users who want "no policy" must omit the
+	// field entirely.
+	_, hasNetworkPolicy := config["network-policy"]
+	if hasNetworkPolicy && groupOption.Type != "select" {
+		return nil, fmt.Errorf("%s: network-policy is only supported on select groups (got %q)", groupOption.Name, groupOption.Type)
 	}
 
 	if _, ok := config["routing-mark"]; ok {
@@ -178,7 +190,46 @@ func ParseProxyGroup(config map[string]any, proxyMap map[string]C.Proxy, provide
 		opts := parseURLTestOption(config)
 		group = NewURLTest(groupOption, providers, opts...)
 	case "select":
-		group = NewSelector(groupOption, providers)
+		selector := NewSelector(groupOption, providers)
+		// Build GroupSource from the post-expansion static proxy set and the
+		// external-provider presence (architecture §5.8.1). StaticProxies
+		// must reflect the runtime-visible candidate set after filtering —
+		// GroupBase.GetProxies applies ExcludeFilter / ExcludeType on top of
+		// the compatible-provider output at runtime, so the parse-time check
+		// must apply the same filters to preserve the "parse-time visible ⇒
+		// runtime reachable" invariant promised by GroupSource's docs.
+		// (Filter itself is already applied in the include-all-proxies
+		// expansion path above, so only the Exclude* side is handled here.)
+		//
+		// The inner CompatibleProvider wrapping Proxies: is not an "external"
+		// provider for validation purposes — tolerant-branch validation
+		// applies only to real providers referenced via `use:` /
+		// include-all-providers.
+		gs := networkpolicy.GroupSource{
+			StaticProxies: filterStaticProxies(groupOption.Proxies, groupOption.ExcludeFilter, groupOption.ExcludeType, proxyMap),
+			HasProvider:   len(groupOption.Use) > 0,
+			Filter:        groupOption.Filter,
+			ExcludeFilter: groupOption.ExcludeFilter,
+			ExcludeType:   groupOption.ExcludeType,
+		}
+		if hasNetworkPolicy {
+			// AllProxyNames is the stable pre-computed global proxy-name set
+			// (all built-ins, top-level `proxies:`, and every declared proxy
+			// group name). It is NOT derived from proxyMap at this moment,
+			// because proxyMap only contains groups parsed so far — using it
+			// would make the §5.8.1 "globally known vs. truly absent"
+			// distinction order-dependent (proxyGroupsDagSort topologically
+			// sorts groups but groups without mutual dependencies can appear
+			// in any order, destabilizing validation across runs).
+			policy, err := networkpolicy.ParseGroupPolicy(config["network-policy"], AllNetworks, AllProxyNames, gs)
+			if err != nil {
+				return nil, fmt.Errorf("%s: %w", groupName, err)
+			}
+			selector.SetNetworkPolicy(policy, gs)
+		} else {
+			selector.SetNetworkPolicy(networkpolicy.GroupPolicy{}, gs)
+		}
+		group = selector
 	case "fallback":
 		group = NewFallback(groupOption, providers)
 	case "load-balance":
@@ -219,6 +270,72 @@ func getProviders(mapping map[string]P.ProxyProvider, list []string) ([]P.ProxyP
 		ps = append(ps, p)
 	}
 	return ps, nil
+}
+
+// filterStaticProxies applies a group's ExcludeFilter / ExcludeType rules to
+// the (already Filter-applied) static proxy name list, producing the
+// parse-time candidate set that the network-policy validator can trust.
+//
+// GroupBase.GetProxies applies ExcludeFilter / ExcludeType unconditionally to
+// both the compatible-provider-wrapped static proxies and external provider
+// output (adapter/outboundgroup/groupbase.go). For the network-policy
+// parse-time check to correctly preserve the "visible at parse time ⇒
+// reachable at runtime" invariant (architecture §5.8.1), the static list
+// must go through the same Exclude* filtering before being recorded as
+// GroupSource.StaticProxies.
+//
+// Note: the regex split + compile logic here intentionally duplicates
+// NewGroupBase in groupbase.go. The two are called independently (NewGroupBase
+// for runtime, this for parse-time validation); keep them aligned by hand
+// when editing either side.
+//
+// ExcludeType matching needs proxy type strings, which are only available
+// via proxyMap. A name missing from proxyMap is kept in the result because
+// a separately-failing lookup downstream (getProxies) will surface the bug
+// on its own channel — the network-policy validator's job is narrow.
+func filterStaticProxies(names []string, excludeFilter, excludeType string, proxyMap map[string]C.Proxy) []string {
+	if len(names) == 0 {
+		return nil
+	}
+
+	var excludeFilterRegs []*regexp2.Regexp
+	if excludeFilter != "" {
+		for _, f := range strings.Split(excludeFilter, "`") {
+			excludeFilterRegs = append(excludeFilterRegs, regexp2.MustCompile(f, regexp2.None))
+		}
+	}
+	var excludeTypeArr []string
+	if excludeType != "" {
+		excludeTypeArr = strings.Split(excludeType, "|")
+	}
+
+	if len(excludeFilterRegs) == 0 && len(excludeTypeArr) == 0 {
+		// Common case: no exclude filters at all. Return a defensive copy so
+		// downstream callers can't mutate the caller's slice.
+		return append([]string(nil), names...)
+	}
+
+	out := make([]string, 0, len(names))
+outer:
+	for _, name := range names {
+		for _, reg := range excludeFilterRegs {
+			if mat, _ := reg.MatchString(name); mat {
+				continue outer
+			}
+		}
+		if len(excludeTypeArr) > 0 {
+			if p, ok := proxyMap[name]; ok {
+				t := p.Type().String()
+				for _, et := range excludeTypeArr {
+					if strings.EqualFold(t, et) {
+						continue outer
+					}
+				}
+			}
+		}
+		out = append(out, name)
+	}
+	return out
 }
 
 func addTestUrlToProviders(providers []P.ProxyProvider, url string, expectedStatus utils.IntRanges[uint16], filter string, interval uint) {

--- a/adapter/outboundgroup/parser_test.go
+++ b/adapter/outboundgroup/parser_test.go
@@ -1,0 +1,253 @@
+package outboundgroup
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/metacubex/mihomo/adapter"
+	"github.com/metacubex/mihomo/adapter/outbound"
+	C "github.com/metacubex/mihomo/constant"
+	P "github.com/metacubex/mihomo/constant/provider"
+)
+
+// baseProxyMap builds a minimal proxyMap covering the built-in outbounds
+// plus any extra names the test passes in. Each "extra" is a Direct proxy
+// under the requested name so the type happens to be C.Direct — tests that
+// need a specific type should build their own proxyMap.
+func baseProxyMap(extra ...string) map[string]C.Proxy {
+	m := map[string]C.Proxy{
+		"DIRECT":      adapter.NewProxy(outbound.NewDirect()),
+		"REJECT":      adapter.NewProxy(outbound.NewReject()),
+		"REJECT-DROP": adapter.NewProxy(outbound.NewRejectDrop()),
+		"PASS":        adapter.NewProxy(outbound.NewPass()),
+	}
+	for _, name := range extra {
+		// NewDirect produces a proxy named "DIRECT"; wrap a proxy with the
+		// desired name by going through the DIRECT template. For validation
+		// tests we only need proxyMap lookup to succeed and the type string
+		// to be stable — the actual dial behavior is irrelevant.
+		m[name] = adapter.NewProxy(outbound.NewDirect())
+	}
+	return m
+}
+
+// --- filterStaticProxies --------------------------------------------------
+
+func TestFilterStaticProxies_NoExclude(t *testing.T) {
+	names := []string{"a", "b", "c"}
+	got := filterStaticProxies(names, "", "", baseProxyMap("a", "b", "c"))
+	if len(got) != 3 || got[0] != "a" || got[1] != "b" || got[2] != "c" {
+		t.Errorf("no-exclude: want [a b c], got %v", got)
+	}
+	// Must be a defensive copy.
+	names[0] = "mutated"
+	if got[0] != "a" {
+		t.Errorf("filterStaticProxies did not copy the input slice; got[0]=%q", got[0])
+	}
+}
+
+func TestFilterStaticProxies_EmptyInput(t *testing.T) {
+	if got := filterStaticProxies(nil, "", "", nil); got != nil {
+		t.Errorf("nil in → nil out, got %v", got)
+	}
+	if got := filterStaticProxies([]string{}, "^x$", "", nil); got != nil {
+		t.Errorf("empty in → nil out, got %v", got)
+	}
+}
+
+func TestFilterStaticProxies_ExcludeFilter(t *testing.T) {
+	names := []string{"hk", "us", "DIRECT"}
+	got := filterStaticProxies(names, "^DIRECT$", "", baseProxyMap("hk", "us"))
+	if len(got) != 2 || got[0] != "hk" || got[1] != "us" {
+		t.Errorf("exclude-filter ^DIRECT$: want [hk us], got %v", got)
+	}
+}
+
+func TestFilterStaticProxies_ExcludeFilterMultiPattern(t *testing.T) {
+	names := []string{"hk", "us", "tokyo", "osaka"}
+	// Backtick-separated regex list: same semantics as GroupBase.
+	got := filterStaticProxies(names, "^hk$`^osaka$", "", baseProxyMap("hk", "us", "tokyo", "osaka"))
+	if len(got) != 2 || got[0] != "us" || got[1] != "tokyo" {
+		t.Errorf("exclude-filter backtick list: want [us tokyo], got %v", got)
+	}
+}
+
+func TestFilterStaticProxies_ExcludeType(t *testing.T) {
+	// Build a proxyMap where "DIRECT" and "REJECT" have distinct types.
+	pm := baseProxyMap()
+	got := filterStaticProxies([]string{"DIRECT", "REJECT"}, "", "Direct", pm)
+	if len(got) != 1 || got[0] != "REJECT" {
+		t.Errorf("exclude-type Direct: want [REJECT], got %v", got)
+	}
+}
+
+func TestFilterStaticProxies_ExcludeTypeCaseInsensitive(t *testing.T) {
+	pm := baseProxyMap()
+	got := filterStaticProxies([]string{"DIRECT"}, "", "direct", pm)
+	if len(got) != 0 {
+		t.Errorf("exclude-type direct (lowercase) should still match Direct type; got %v", got)
+	}
+}
+
+func TestFilterStaticProxies_ExcludeTypeMultiPipe(t *testing.T) {
+	pm := baseProxyMap()
+	got := filterStaticProxies([]string{"DIRECT", "REJECT", "PASS"}, "", "Direct|Reject", pm)
+	// PASS is a "Pass" type, not Direct/Reject → kept.
+	if len(got) != 1 || got[0] != "PASS" {
+		t.Errorf("exclude-type Direct|Reject: want [PASS], got %v", got)
+	}
+}
+
+func TestFilterStaticProxies_NameMissingFromProxyMap(t *testing.T) {
+	// proxy name that proxyMap doesn't resolve: ExcludeType cannot match, so
+	// it should pass through (downstream getProxies will flag the bug).
+	got := filterStaticProxies([]string{"ghost"}, "", "Direct", baseProxyMap())
+	if len(got) != 1 || got[0] != "ghost" {
+		t.Errorf("unresolved name should be preserved; got %v", got)
+	}
+}
+
+// --- ParseProxyGroup ------------------------------------------------------
+
+// parseGroup is a thin wrapper so tests can call ParseProxyGroup with a
+// baseline proxyMap and empty provider/AllProviders/AllNetworks arguments.
+func parseGroup(config map[string]any, opts ...func(*parseGroupArgs)) (C.ProxyAdapter, error) {
+	args := &parseGroupArgs{
+		proxyMap:      baseProxyMap("hk", "us"),
+		providersMap:  map[string]P.ProxyProvider{},
+		allProxies:    []string{"hk", "us"},
+		allProviders:  nil,
+		allNetworks:   nil,
+		allProxyNames: []string{"DIRECT", "REJECT", "REJECT-DROP", "COMPATIBLE", "PASS", "hk", "us"},
+	}
+	for _, opt := range opts {
+		opt(args)
+	}
+	return ParseProxyGroup(config, args.proxyMap, args.providersMap, args.allProxies, args.allProviders, args.allNetworks, args.allProxyNames)
+}
+
+type parseGroupArgs struct {
+	proxyMap      map[string]C.Proxy
+	providersMap  map[string]P.ProxyProvider
+	allProxies    []string
+	allProviders  []string
+	allNetworks   []string
+	allProxyNames []string
+}
+
+func withNetworks(names ...string) func(*parseGroupArgs) {
+	return func(a *parseGroupArgs) { a.allNetworks = names }
+}
+
+// withAllProxyNames overrides the global proxy-name set for tests that want
+// to exercise the "globally known but not reachable from this group" branch.
+func withAllProxyNames(names ...string) func(*parseGroupArgs) {
+	return func(a *parseGroupArgs) { a.allProxyNames = names }
+}
+
+// Non-select group with network-policy is a parse-time error (architecture
+// §5.8.1). Exercising all three non-select group types would be overkill;
+// one representative (url-test) is sufficient — the check is on
+// groupOption.Type alone.
+func TestParseProxyGroup_NetworkPolicyOnNonSelect_Rejected(t *testing.T) {
+	cfg := map[string]any{
+		"name":    "sel",
+		"type":    "url-test",
+		"url":     "http://example.com",
+		"proxies": []any{"hk", "us"},
+		"network-policy": map[string]any{
+			"office": "hk",
+		},
+	}
+	_, err := parseGroup(cfg, withNetworks("office"))
+	if err == nil || !strings.Contains(err.Error(), "only supported on select groups") {
+		t.Errorf("want select-only error, got %v", err)
+	}
+}
+
+// exclude-filter applied to a static proxy makes it unreachable at runtime;
+// the parse-time validator must catch this before the user sees a
+// missing_target at the first PUT. The target DIRECT is a built-in so it
+// lives in the global proxy set — that puts the error on the "globally
+// known but not reachable from this group" branch (§5.8.1 row 4.a),
+// distinct from the "unknown everywhere" branch.
+func TestParseProxyGroup_ExcludeFilter_TargetFailsParseTime(t *testing.T) {
+	cfg := map[string]any{
+		"name":           "sel",
+		"type":           "select",
+		"proxies":        []any{"DIRECT"},
+		"exclude-filter": "^DIRECT$",
+		"network-policy": map[string]any{
+			"office": "DIRECT",
+		},
+	}
+	_, err := parseGroup(cfg, withNetworks("office"))
+	if err == nil || !strings.Contains(err.Error(), "not reachable by this group") {
+		t.Errorf("want parse-time unreachable error after exclude-filter; got %v", err)
+	}
+}
+
+// Happy path: exclude-filter that doesn't hit the target leaves it reachable.
+func TestParseProxyGroup_ExcludeFilter_DoesNotHitTarget(t *testing.T) {
+	cfg := map[string]any{
+		"name":           "sel",
+		"type":           "select",
+		"proxies":        []any{"hk", "us"},
+		"exclude-filter": "^jp$", // doesn't match hk or us
+		"network-policy": map[string]any{
+			"office": "hk",
+		},
+	}
+	if _, err := parseGroup(cfg, withNetworks("office")); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+// Regression: globalProxyNames must be a stable caller-precomputed set,
+// not derived from proxyMap during group iteration. A target that names
+// another group which has not yet been parsed should still be recognized
+// as "globally known but not reachable from this group" (§5.8.1 case 2),
+// never as "not found anywhere" (case 4). This test simulates the
+// situation by supplying allProxyNames that contains a group name which
+// proxyMap does NOT yet know about.
+func TestParseProxyGroup_GlobalButUnreachable_ReferencesLaterGroup(t *testing.T) {
+	cfg := map[string]any{
+		"name":    "sel",
+		"type":    "select",
+		"proxies": []any{"hk"},
+		"network-policy": map[string]any{
+			"office": "some-later-group",
+		},
+	}
+	// proxyMap deliberately does NOT contain some-later-group, but the
+	// caller-supplied allProxyNames does — the validator must still fail
+	// fast with "not reachable by this group".
+	_, err := parseGroup(cfg,
+		withNetworks("office"),
+		withAllProxyNames("DIRECT", "REJECT", "REJECT-DROP", "COMPATIBLE", "PASS", "hk", "us", "some-later-group"),
+	)
+	if err == nil || !strings.Contains(err.Error(), "not reachable by this group") {
+		t.Errorf("want unreachable-from-this-group error for later-group target; got %v", err)
+	}
+}
+
+// Happy path for the common case without network-policy — make sure the
+// new SetNetworkPolicy call path doesn't break existing select groups.
+func TestParseProxyGroup_SelectWithoutNetworkPolicy(t *testing.T) {
+	cfg := map[string]any{
+		"name":    "sel",
+		"type":    "select",
+		"proxies": []any{"hk", "us"},
+	}
+	adapter, err := parseGroup(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	sel, ok := adapter.(*Selector)
+	if !ok {
+		t.Fatalf("expected *Selector, got %T", adapter)
+	}
+	if !sel.NetworkPolicy().IsEmpty() {
+		t.Errorf("selector without network-policy field should report empty policy, got %+v", sel.NetworkPolicy())
+	}
+}

--- a/adapter/outboundgroup/selector.go
+++ b/adapter/outboundgroup/selector.go
@@ -5,15 +5,18 @@ import (
 	"encoding/json"
 	"errors"
 
+	"github.com/metacubex/mihomo/component/networkpolicy"
 	C "github.com/metacubex/mihomo/constant"
 	P "github.com/metacubex/mihomo/constant/provider"
 )
 
 type Selector struct {
 	*GroupBase
-	disableUDP bool
-	selected   string
-	testUrl    string
+	disableUDP  bool
+	selected    string
+	testUrl     string
+	policy      networkpolicy.GroupPolicy
+	groupSource networkpolicy.GroupSource
 }
 
 // DialContext implements C.ProxyAdapter
@@ -108,6 +111,45 @@ func (s *Selector) selectedProxy(touch bool) C.Proxy {
 
 func (s *Selector) Providers() []P.ProxyProvider {
 	return s.providers
+}
+
+// HasProxy reports whether name is currently a visible candidate of this
+// group (either a static member listed under proxies: or a provider-emitted
+// proxy present in the current provider snapshot).
+//
+// The runtime network-policy manager uses this to validate that a resolved
+// target proxy is actually reachable before calling Set; a false return maps
+// to the missing_target reason (architecture §5.8.2).
+func (s *Selector) HasProxy(name string) bool {
+	for _, p := range s.GetProxies(false) {
+		if p.Name() == name {
+			return true
+		}
+	}
+	return false
+}
+
+// NetworkPolicy returns the parsed network-policy: subtree of this select
+// group. Returns a zero-value GroupPolicy (IsEmpty == true) when the group
+// has no network-policy configured.
+func (s *Selector) NetworkPolicy() networkpolicy.GroupPolicy {
+	return s.policy
+}
+
+// GroupSource returns the parse-time candidate-set metadata recorded for
+// this group. Populated even when the group has no network-policy, so the
+// runtime manager can diagnose provider availability uniformly.
+func (s *Selector) GroupSource() networkpolicy.GroupSource {
+	return s.groupSource
+}
+
+// SetNetworkPolicy records the parsed policy and candidate-set metadata.
+// Called once by ParseProxyGroup after the select group has been constructed.
+// Exposed separately from NewSelector to avoid changing the common-case
+// constructor signature (the GLOBAL group and tests never set a policy).
+func (s *Selector) SetNetworkPolicy(policy networkpolicy.GroupPolicy, source networkpolicy.GroupSource) {
+	s.policy = policy
+	s.groupSource = source
 }
 
 func (s *Selector) Proxies() []C.Proxy {

--- a/component/networkpolicy/config_parse.go
+++ b/component/networkpolicy/config_parse.go
@@ -1,0 +1,176 @@
+package networkpolicy
+
+import (
+	"fmt"
+
+	"golang.org/x/exp/slices"
+)
+
+// ParseNetworks parses the top-level YAML `networks:` list into a []Network.
+//
+// Each entry must have exactly these keys:
+//   - `name`: non-empty string; must not equal DefaultKey ("default") or
+//     MatchedNone ("<none>") (both are reserved sentinels); must be unique
+//     within the list.
+//   - `match`: non-empty map, parsed by ParseMatch.
+//
+// Any unknown top-level key, duplicate name, or parse error on match block
+// is fail-fast. Empty / nil input returns (nil, nil) so the top-level may
+// simply omit the field.
+func ParseNetworks(raw []map[string]any) ([]Network, error) {
+	if len(raw) == 0 {
+		return nil, nil
+	}
+	out := make([]Network, 0, len(raw))
+	seen := make(map[string]struct{}, len(raw))
+	for i, entry := range raw {
+		if len(entry) == 0 {
+			return nil, fmt.Errorf("networks[%d]: empty entry", i)
+		}
+		for k := range entry {
+			switch k {
+			case "name", "match":
+			default:
+				return nil, fmt.Errorf("networks[%d]: unknown key %q", i, k)
+			}
+		}
+		nameAny, ok := entry["name"]
+		if !ok {
+			return nil, fmt.Errorf("networks[%d]: missing name", i)
+		}
+		name, ok := nameAny.(string)
+		if !ok {
+			return nil, fmt.Errorf("networks[%d]: name must be string, got %T", i, nameAny)
+		}
+		if name == "" {
+			return nil, fmt.Errorf("networks[%d]: name cannot be empty", i)
+		}
+		if name == DefaultKey || name == MatchedNone {
+			return nil, fmt.Errorf("networks[%d]: name %q is reserved", i, name)
+		}
+		if _, dup := seen[name]; dup {
+			return nil, fmt.Errorf("networks[%d]: duplicate name %q", i, name)
+		}
+		seen[name] = struct{}{}
+
+		matchAny, ok := entry["match"]
+		if !ok {
+			return nil, fmt.Errorf("networks[%d] (%q): missing match block", i, name)
+		}
+		matchMap, ok := matchAny.(map[string]any)
+		if !ok {
+			return nil, fmt.Errorf("networks[%d] (%q): match must be a map, got %T", i, name, matchAny)
+		}
+		m, err := ParseMatch(matchMap)
+		if err != nil {
+			return nil, fmt.Errorf("networks[%d] (%q): %w", i, name, err)
+		}
+
+		out = append(out, Network{Name: name, Matcher: m})
+	}
+	return out, nil
+}
+
+// ParseGroupPolicy parses a select proxy-group's `network-policy:` subtree
+// into a GroupPolicy, validating every key and value against the group's
+// candidate set and the global proxy name set.
+//
+// Arguments:
+//   - raw: the network-policy subtree (expected map[string]any where keys
+//     are network names plus the optional reserved key DefaultKey)
+//   - networkNames: the set of all valid network names defined under the
+//     top-level networks: list (reserved DefaultKey is accepted in addition
+//     and does not need to be in this list)
+//   - globalProxyNames: the set of all parse-time-known proxy names
+//     (built-ins + top-level `proxies:` + proxy group names; anything
+//     resolvable via the kernel's proxyMap at parse time). Used to enforce
+//     architecture §5.8.1 row 4 — "exists globally but not in this group's
+//     sources" and "doesn't exist anywhere" both fail fast, regardless of
+//     HasProvider. Provider expansions contribute names disjoint from this
+//     set, so a target ∉ globalProxyNames is the only case where the
+//     provider-tolerant branch applies.
+//   - source: the group's parse-time candidate-set metadata (see GroupSource).
+//
+// Validation (architecture §5.8.1):
+//   - Each key must either be in networkNames or equal DefaultKey.
+//   - Each value (target proxy name) is non-empty and either:
+//   - in source.StaticProxies (parse-time visible, fail-fast on miss from
+//     the group's own candidate set);
+//   - not in globalProxyNames AND source.HasProvider is true (tolerant:
+//     target may come from a subscription; runtime reports missing_target
+//     if absent on the first PUT);
+//   - any other case (globally known but unreachable from this group; or
+//     unknown everywhere with no provider attached) is a parse-time error.
+//   - Empty raw map is rejected — network-policy: present but empty is a
+//     likely typo; users who want "no policy" should omit the field.
+func ParseGroupPolicy(raw any, networkNames []string, globalProxyNames []string, source GroupSource) (GroupPolicy, error) {
+	m, ok := raw.(map[string]any)
+	if !ok {
+		return GroupPolicy{}, fmt.Errorf("network-policy: expected map, got %T", raw)
+	}
+	if len(m) == 0 {
+		return GroupPolicy{}, fmt.Errorf("network-policy: empty map not allowed (omit the field to disable)")
+	}
+
+	policy := GroupPolicy{Mapping: make(map[string]string, len(m))}
+	for key, v := range m {
+		// Key validation first: reject reserved sentinel and unknown networks
+		// before looking at the target. Ordering matters — if a user writes
+		// `<none>: 42`, the real error is the reserved key, not the non-string
+		// target.  DefaultKey is accepted without appearing in networkNames
+		// since it is the policy-layer fallback key, not a network.
+		isDefault := key == DefaultKey
+		if key == MatchedNone {
+			return GroupPolicy{}, fmt.Errorf("network-policy[%q]: reserved sentinel, not a valid network name", key)
+		}
+		if !isDefault && !slices.Contains(networkNames, key) {
+			return GroupPolicy{}, fmt.Errorf("network-policy[%q]: unknown network (not defined in top-level networks:)", key)
+		}
+
+		// Target shape check.
+		target, ok := v.(string)
+		if !ok {
+			return GroupPolicy{}, fmt.Errorf("network-policy[%q]: target must be string, got %T", key, v)
+		}
+		if target == "" {
+			return GroupPolicy{}, fmt.Errorf("network-policy[%q]: target cannot be empty", key)
+		}
+
+		// Target reachability split (architecture §5.8.1):
+		//   1) target ∈ StaticProxies → parse-time visible → OK
+		//   2) target ∈ globalProxyNames but ∉ StaticProxies → fail-fast:
+		//      the name exists elsewhere in the kernel's proxy namespace but
+		//      this group can't reach it. Architecture treats provider-emitted
+		//      names as disjoint from the global set, so a use-only group
+		//      whose subscription happens to expose a node whose name
+		//      collides with a global proxy still fails here — users must
+		//      either add the target to this group's proxies: or rename the
+		//      colliding global name. The error message flags both options.
+		//   3) target ∉ globalProxyNames && HasProvider → tolerant (may
+		//      be populated by subscription after provider first-load)
+		//   4) target ∉ globalProxyNames && !HasProvider → fail-fast:
+		//      name doesn't exist anywhere and there's no provider that
+		//      could supply it later
+		switch {
+		case slices.Contains(source.StaticProxies, target):
+			// case 1: OK
+		case slices.Contains(globalProxyNames, target):
+			// case 2
+			return GroupPolicy{}, fmt.Errorf("network-policy[%q]: target %q is defined globally but is not reachable by this group (add %q to this group's proxies:, pick a target already in the group, or if you meant a provider node with the same name, rename it to disambiguate)", key, target, target)
+		case source.HasProvider:
+			// case 3: tolerant
+		default:
+			// case 4
+			return GroupPolicy{}, fmt.Errorf("network-policy[%q]: target %q not found anywhere (add %q to proxies:, attach a provider via use:, or set include-all-providers: true)", key, target, target)
+		}
+
+		// All checks passed; commit to the policy only now.
+		if isDefault {
+			policy.HasDefault = true
+			policy.DefaultProxy = target
+		} else {
+			policy.Mapping[key] = target
+		}
+	}
+	return policy, nil
+}

--- a/component/networkpolicy/config_parse_test.go
+++ b/component/networkpolicy/config_parse_test.go
@@ -1,0 +1,318 @@
+package networkpolicy
+
+import (
+	"strings"
+	"testing"
+)
+
+// --- ParseNetworks -------------------------------------------------------
+
+func TestParseNetworks_Empty(t *testing.T) {
+	got, err := ParseNetworks(nil)
+	if err != nil {
+		t.Fatalf("ParseNetworks(nil): unexpected error: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("ParseNetworks(nil): want empty, got %d entries", len(got))
+	}
+
+	got, err = ParseNetworks([]map[string]any{})
+	if err != nil {
+		t.Fatalf("ParseNetworks(empty slice): unexpected error: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("ParseNetworks(empty slice): want empty, got %d", len(got))
+	}
+}
+
+func TestParseNetworks_Happy(t *testing.T) {
+	raw := []map[string]any{
+		{"name": "office", "match": map[string]any{"ssid": "office-5g", "iface-type": "wifi"}},
+		{"name": "home", "match": map[string]any{"gateway-mac": "aa:bb:cc:dd:ee:00"}},
+		{"name": "anywhere", "match": map[string]any{"dns-suffix": "corp.example.com"}},
+	}
+	got, err := ParseNetworks(raw)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("want 3 networks, got %d", len(got))
+	}
+	if got[0].Name != "office" || got[1].Name != "home" || got[2].Name != "anywhere" {
+		t.Errorf("unexpected names: %q %q %q", got[0].Name, got[1].Name, got[2].Name)
+	}
+	for i := range got {
+		if got[i].Matcher == nil {
+			t.Errorf("entry %d has nil matcher", i)
+		}
+	}
+}
+
+func TestParseNetworks_ReservedNames(t *testing.T) {
+	for _, name := range []string{DefaultKey, MatchedNone} {
+		raw := []map[string]any{
+			{"name": name, "match": map[string]any{"ssid": "x"}},
+		}
+		_, err := ParseNetworks(raw)
+		if err == nil || !strings.Contains(err.Error(), "reserved") {
+			t.Errorf("name %q: want reserved error, got %v", name, err)
+		}
+	}
+}
+
+func TestParseNetworks_DuplicateName(t *testing.T) {
+	raw := []map[string]any{
+		{"name": "office", "match": map[string]any{"ssid": "a"}},
+		{"name": "office", "match": map[string]any{"ssid": "b"}},
+	}
+	_, err := ParseNetworks(raw)
+	if err == nil || !strings.Contains(err.Error(), "duplicate name") {
+		t.Errorf("want duplicate-name error, got %v", err)
+	}
+}
+
+func TestParseNetworks_MissingName(t *testing.T) {
+	raw := []map[string]any{
+		{"match": map[string]any{"ssid": "a"}},
+	}
+	_, err := ParseNetworks(raw)
+	if err == nil || !strings.Contains(err.Error(), "missing name") {
+		t.Errorf("want missing-name error, got %v", err)
+	}
+}
+
+func TestParseNetworks_EmptyName(t *testing.T) {
+	raw := []map[string]any{{"name": "", "match": map[string]any{"ssid": "a"}}}
+	_, err := ParseNetworks(raw)
+	if err == nil || !strings.Contains(err.Error(), "cannot be empty") {
+		t.Errorf("want empty-name error, got %v", err)
+	}
+}
+
+func TestParseNetworks_NonStringName(t *testing.T) {
+	raw := []map[string]any{{"name": 42, "match": map[string]any{"ssid": "a"}}}
+	_, err := ParseNetworks(raw)
+	if err == nil || !strings.Contains(err.Error(), "name must be string") {
+		t.Errorf("want string-name error, got %v", err)
+	}
+}
+
+func TestParseNetworks_MissingMatch(t *testing.T) {
+	raw := []map[string]any{{"name": "office"}}
+	_, err := ParseNetworks(raw)
+	if err == nil || !strings.Contains(err.Error(), "missing match") {
+		t.Errorf("want missing-match error, got %v", err)
+	}
+}
+
+func TestParseNetworks_MatchNotMap(t *testing.T) {
+	raw := []map[string]any{{"name": "office", "match": "oops"}}
+	_, err := ParseNetworks(raw)
+	if err == nil || !strings.Contains(err.Error(), "match must be a map") {
+		t.Errorf("want match-not-map error, got %v", err)
+	}
+}
+
+func TestParseNetworks_UnknownTopLevelKey(t *testing.T) {
+	raw := []map[string]any{{"name": "office", "match": map[string]any{"ssid": "a"}, "priority": 1}}
+	_, err := ParseNetworks(raw)
+	if err == nil || !strings.Contains(err.Error(), "unknown key") {
+		t.Errorf("want unknown-key error, got %v", err)
+	}
+}
+
+func TestParseNetworks_EmptyEntry(t *testing.T) {
+	raw := []map[string]any{{}}
+	_, err := ParseNetworks(raw)
+	if err == nil || !strings.Contains(err.Error(), "empty entry") {
+		t.Errorf("want empty-entry error, got %v", err)
+	}
+}
+
+func TestParseNetworks_MeteredRejected(t *testing.T) {
+	// metered matcher is disabled at ParseMatch level; ensure the error
+	// surfaces via ParseNetworks (no silent acceptance).
+	raw := []map[string]any{
+		{"name": "x", "match": map[string]any{"metered": true}},
+	}
+	_, err := ParseNetworks(raw)
+	if err == nil || !strings.Contains(err.Error(), "metered") {
+		t.Errorf("want metered error, got %v", err)
+	}
+}
+
+func TestParseNetworks_UnknownMatchKeyPropagates(t *testing.T) {
+	raw := []map[string]any{
+		{"name": "x", "match": map[string]any{"bogus": "v"}},
+	}
+	_, err := ParseNetworks(raw)
+	if err == nil || !strings.Contains(err.Error(), "unknown match key") {
+		t.Errorf("want propagated unknown-match-key error, got %v", err)
+	}
+}
+
+// --- ParseGroupPolicy ----------------------------------------------------
+
+func TestParseGroupPolicy_Happy_StaticProxy(t *testing.T) {
+	source := GroupSource{StaticProxies: []string{"hk", "us", "DIRECT"}}
+	global := []string{"hk", "us", "DIRECT"}
+	raw := map[string]any{
+		"office":  "hk",
+		"home":    "DIRECT",
+		"default": "us",
+	}
+	p, err := ParseGroupPolicy(raw, []string{"office", "home"}, global, source)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if p.Mapping["office"] != "hk" || p.Mapping["home"] != "DIRECT" {
+		t.Errorf("unexpected mapping: %v", p.Mapping)
+	}
+	// Guard against a future regression that writes the default into Mapping;
+	// TestParseGroupPolicy_DefaultKeyAllowed only covers the default-only case.
+	if len(p.Mapping) != 2 {
+		t.Errorf("mapping should only contain non-default keys, got %v", p.Mapping)
+	}
+	if !p.HasDefault || p.DefaultProxy != "us" {
+		t.Errorf("default not captured: hasDefault=%v defaultProxy=%q", p.HasDefault, p.DefaultProxy)
+	}
+}
+
+func TestParseGroupPolicy_ProviderTolerant(t *testing.T) {
+	// target "auto-fill" is not in StaticProxies AND not in globalProxyNames;
+	// HasProvider=true → parse-time tolerant (target may come from subscription).
+	source := GroupSource{StaticProxies: []string{"DIRECT"}, HasProvider: true}
+	global := []string{"DIRECT"} // auto-fill NOT in globals → tolerant branch
+	raw := map[string]any{"office": "auto-fill"}
+	_, err := ParseGroupPolicy(raw, []string{"office"}, global, source)
+	if err != nil {
+		t.Errorf("provider-backed target should be tolerant; got %v", err)
+	}
+}
+
+// Architecture §5.8.1 row 4: target exists globally but is not reachable
+// from this group is fail-fast regardless of HasProvider. Provider
+// expansions contribute names disjoint from the global proxy set, so any
+// global name this group can't reach is a definite misconfiguration.
+func TestParseGroupPolicy_GlobalButUnreachable_FailsEvenWithProvider(t *testing.T) {
+	source := GroupSource{StaticProxies: []string{"DIRECT"}, HasProvider: true}
+	global := []string{"DIRECT", "someOtherGroup"}
+	raw := map[string]any{"office": "someOtherGroup"}
+	_, err := ParseGroupPolicy(raw, []string{"office"}, global, source)
+	if err == nil || !strings.Contains(err.Error(), "not reachable by this group") {
+		t.Errorf("want global-but-unreachable error even with HasProvider=true; got %v", err)
+	}
+}
+
+func TestParseGroupPolicy_UnknownTargetNoProvider(t *testing.T) {
+	source := GroupSource{StaticProxies: []string{"DIRECT"}, HasProvider: false}
+	global := []string{"DIRECT"}
+	raw := map[string]any{"office": "oops"}
+	_, err := ParseGroupPolicy(raw, []string{"office"}, global, source)
+	if err == nil || !strings.Contains(err.Error(), "not found anywhere") {
+		t.Errorf("want missing-target error, got %v", err)
+	}
+}
+
+func TestParseGroupPolicy_UnknownNetworkName(t *testing.T) {
+	source := GroupSource{StaticProxies: []string{"hk"}}
+	raw := map[string]any{"undefined-net": "hk"}
+	_, err := ParseGroupPolicy(raw, []string{"office"}, []string{"hk"}, source)
+	if err == nil || !strings.Contains(err.Error(), "unknown network") {
+		t.Errorf("want unknown-network error, got %v", err)
+	}
+}
+
+func TestParseGroupPolicy_DefaultKeyAllowed(t *testing.T) {
+	source := GroupSource{StaticProxies: []string{"DIRECT"}}
+	raw := map[string]any{"default": "DIRECT"}
+	p, err := ParseGroupPolicy(raw, []string{}, []string{"DIRECT"}, source)
+	if err != nil {
+		t.Fatalf("default-only policy should parse; got %v", err)
+	}
+	if !p.HasDefault || p.DefaultProxy != "DIRECT" {
+		t.Errorf("default not applied: %+v", p)
+	}
+	if len(p.Mapping) != 0 {
+		t.Errorf("mapping should be empty, got %v", p.Mapping)
+	}
+}
+
+func TestParseGroupPolicy_MatchedNoneReserved(t *testing.T) {
+	source := GroupSource{StaticProxies: []string{"hk"}}
+	raw := map[string]any{"<none>": "hk"}
+	_, err := ParseGroupPolicy(raw, []string{"office"}, []string{"hk"}, source)
+	if err == nil || !strings.Contains(err.Error(), "reserved sentinel") {
+		t.Errorf("want reserved-sentinel error, got %v", err)
+	}
+}
+
+func TestParseGroupPolicy_EmptyMap(t *testing.T) {
+	source := GroupSource{StaticProxies: []string{"hk"}}
+	raw := map[string]any{}
+	_, err := ParseGroupPolicy(raw, []string{"office"}, []string{"hk"}, source)
+	if err == nil || !strings.Contains(err.Error(), "empty map") {
+		t.Errorf("want empty-map error, got %v", err)
+	}
+}
+
+func TestParseGroupPolicy_NonMapRaw(t *testing.T) {
+	source := GroupSource{StaticProxies: []string{"hk"}}
+	_, err := ParseGroupPolicy("oops", []string{"office"}, []string{"hk"}, source)
+	if err == nil || !strings.Contains(err.Error(), "expected map") {
+		t.Errorf("want expected-map error, got %v", err)
+	}
+}
+
+func TestParseGroupPolicy_NonStringTarget(t *testing.T) {
+	source := GroupSource{StaticProxies: []string{"hk"}}
+	raw := map[string]any{"office": 42}
+	_, err := ParseGroupPolicy(raw, []string{"office"}, []string{"hk"}, source)
+	if err == nil || !strings.Contains(err.Error(), "target must be string") {
+		t.Errorf("want string-target error, got %v", err)
+	}
+}
+
+func TestParseGroupPolicy_EmptyTarget(t *testing.T) {
+	source := GroupSource{StaticProxies: []string{"hk"}}
+	raw := map[string]any{"office": ""}
+	_, err := ParseGroupPolicy(raw, []string{"office"}, []string{"hk"}, source)
+	if err == nil || !strings.Contains(err.Error(), "target cannot be empty") {
+		t.Errorf("want empty-target error, got %v", err)
+	}
+}
+
+// When a reserved key (<none>) carries a malformed target, the reserved-key
+// error should win — otherwise users chase the wrong problem first. Regression
+// guard: key validation must run before target shape validation.
+func TestParseGroupPolicy_ReservedKeyTakesPrecedenceOverTargetShape(t *testing.T) {
+	source := GroupSource{StaticProxies: []string{"hk"}}
+	raw := map[string]any{"<none>": 42}
+	_, err := ParseGroupPolicy(raw, []string{"office"}, []string{"hk"}, source)
+	if err == nil || !strings.Contains(err.Error(), "reserved sentinel") {
+		t.Errorf("want reserved-sentinel error to take precedence over target shape; got %v", err)
+	}
+}
+
+// Same ordering guard for unknown-network keys: unknown-network must be
+// reported before a bad target shape.
+func TestParseGroupPolicy_UnknownNetworkTakesPrecedenceOverTargetShape(t *testing.T) {
+	source := GroupSource{StaticProxies: []string{"hk"}}
+	raw := map[string]any{"bogus-net": 42}
+	_, err := ParseGroupPolicy(raw, []string{"office"}, []string{"hk"}, source)
+	if err == nil || !strings.Contains(err.Error(), "unknown network") {
+		t.Errorf("want unknown-network error to take precedence over target shape; got %v", err)
+	}
+}
+
+// Default target itself must pass the reachability check — a default that
+// references a proxy not in the group's candidate set is just as broken
+// as a per-network mapping that does.
+func TestParseGroupPolicy_DefaultTargetReachabilityChecked(t *testing.T) {
+	source := GroupSource{StaticProxies: []string{"DIRECT"}, HasProvider: false}
+	raw := map[string]any{"default": "bogus"}
+	_, err := ParseGroupPolicy(raw, []string{}, []string{"DIRECT"}, source)
+	if err == nil || !strings.Contains(err.Error(), "not found anywhere") {
+		t.Errorf("want default-reachability error, got %v", err)
+	}
+}

--- a/component/networkpolicy/context.go
+++ b/component/networkpolicy/context.go
@@ -1,0 +1,353 @@
+package networkpolicy
+
+import (
+	"encoding/json"
+	"fmt"
+	"hash"
+	"hash/fnv"
+	"net/netip"
+	"strconv"
+	"strings"
+	"unicode"
+
+	"golang.org/x/exp/slices"
+)
+
+// MaxInterfaces is the hard cap on interfaces[] length. PUT bodies with
+// more entries are rejected with HTTP 400 / too_many_interfaces.
+const MaxInterfaces = 32
+
+// NetworkContext is the snapshot host pushes via PUT /network/context.
+//
+// Shape: multi-interface inventory (Interfaces) + top-level global fields
+// (DNSSuffix, TTL). JSON tags use snake_case; Go fields use CamelCase.
+// `version` is required and must equal 1; `interfaces` is required and may
+// be an empty array ("sampler reported no relevant iface" — rare). Missing
+// required fields are rejected at UnmarshalJSON time as malformed_body.
+type NetworkContext struct {
+	Version    int                `json:"version"`
+	Interfaces []InterfaceContext `json:"interfaces"`
+	DNSSuffix  []string           `json:"dns_suffix,omitempty"`
+	TTL        *int               `json:"ttl,omitempty"`
+
+	// normalizeErr carries a field-path-prefixed parse/normalize error so
+	// validate() can surface it as the HTTP 400 cause without depending on
+	// per-field typed error variables (keeping the struct shape minimal).
+	normalizeErr error
+}
+
+// InterfaceContext represents a single active network interface.
+//
+// Field semantics:
+//   - Name: host's iface name (unique within a NetworkContext)
+//   - IfaceType: one of ifaceTypes or empty (unknown)
+//   - SSID/BSSID: populated for Wi-Fi interfaces; BSSID normalized to
+//     lower-case colon form
+//   - GatewayIP: the default-route next-hop the host attributes to this
+//     iface (filled iff the iface is judged to be a user-visible default
+//     route candidate by the sampler policy); GatewayMAC is only filled
+//     when GatewayIP is (validate enforces this)
+//   - Subnets: on-link CIDRs of the iface (interface address ± netmask);
+//     routes carried via the iface (e.g. WireGuard AllowedIPs) are NOT
+//     included by sampler contract
+//   - Metered: tri-state tag (nil = unknown, true/false = explicit)
+type InterfaceContext struct {
+	Name       string   `json:"name"`
+	IfaceType  string   `json:"iface_type,omitempty"`
+	SSID       string   `json:"ssid,omitempty"`
+	BSSID      string   `json:"bssid,omitempty"`
+	GatewayIP  string   `json:"gateway_ip,omitempty"`
+	GatewayMAC string   `json:"gateway_mac,omitempty"`
+	Subnets    []string `json:"subnets,omitempty"`
+	Metered    *bool    `json:"metered,omitempty"`
+
+	// Derived fields cached by normalize() for matcher hot path.
+	gatewayIPParsed netip.Addr
+	subnetsParsed   []netip.Prefix
+}
+
+// ifaceTypes enumerates the valid iface_type values, in alphabetical order
+// so error messages display the set in a stable, easy-to-scan form. The wire
+// deliberately does not carry a distinct "tun" value — the host filters
+// mihomo's own TUN from interfaces[] by name, so the matcher only sees
+// user-installed VPNs as iface_type=vpn.
+var ifaceTypes = []string{"cellular", "ethernet", "loopback", "other", "vpn", "wifi", "wwan"}
+
+// IsValidIfaceType reports whether s is a valid iface_type enum value.
+// Empty string returns true — a host that can't classify may omit the field.
+func IsValidIfaceType(s string) bool {
+	if s == "" {
+		return true
+	}
+	return slices.Contains(ifaceTypes, s)
+}
+
+// UnmarshalJSON enforces presence of the two required top-level wire fields,
+// `version` and `interfaces`. REST handlers translate the returned error to
+// HTTP 400 `malformed_body`. Other JSON decoding errors (non-object body,
+// type mismatches, malformed UTF-8) also surface here and map to the same
+// error code at the handler layer.
+func (c *NetworkContext) UnmarshalJSON(data []byte) error {
+	var raw struct {
+		Version    *int                `json:"version"`
+		Interfaces *[]InterfaceContext `json:"interfaces"`
+		DNSSuffix  []string            `json:"dns_suffix,omitempty"`
+		TTL        *int                `json:"ttl,omitempty"`
+	}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	if raw.Version == nil {
+		return fmt.Errorf("missing required field: version")
+	}
+	if raw.Interfaces == nil {
+		return fmt.Errorf("missing required field: interfaces")
+	}
+	c.Version = *raw.Version
+	c.Interfaces = *raw.Interfaces
+	c.DNSSuffix = raw.DNSSuffix
+	c.TTL = raw.TTL
+	return nil
+}
+
+// NormalizeAndValidate is the single public entry point for preparing a
+// NetworkContext. REST handlers call this after json.Unmarshal. Returns nil
+// when the context is ready for the Manager; returns an error suitable for
+// HTTP 400 passthrough otherwise (mapped to invalid_version / invalid_ttl /
+// too_many_interfaces / invalid_field / invalid_gateway_combo /
+// duplicate_iface_name by the REST handler).
+//
+// MaxInterfaces is checked first to short-circuit DoS-ish inputs before
+// the per-iface MAC / CIDR parsers run. normalize() then canonicalizes the
+// bounded interfaces set so validate() can operate on canonical forms
+// (parsed/lowercased/sorted); validate() also reports any error captured
+// during normalize() via the normalizeErr carrier.
+func (c *NetworkContext) NormalizeAndValidate() error {
+	if len(c.Interfaces) > MaxInterfaces {
+		return fmt.Errorf("invalid interfaces: %d entries (max %d)", len(c.Interfaces), MaxInterfaces)
+	}
+	c.normalize()
+	return c.validate()
+}
+
+// normalize rewrites fields in place. Idempotent: calling twice yields the
+// same result. On first parse error it records the error in c.normalizeErr
+// and stops processing further interfaces; validate() reports it as 400.
+//
+// Does not mutate `Version` — the wire requires version=1 explicitly;
+// deviations are surfaced by validate() as invalid_version.
+func (c *NetworkContext) normalize() {
+	c.normalizeErr = nil
+
+	for i := range c.Interfaces {
+		if err := c.Interfaces[i].normalize(); err != nil {
+			c.normalizeErr = fmt.Errorf("interfaces[%d]: %w", i, err)
+			// Leave already-normalized prefix entries as-is so Fingerprint()
+			// behavior on validated ctx is deterministic even if validate()
+			// later rejects; the error propagates through validate().
+			break
+		}
+	}
+
+	// Canonical ordering: sort by Name. Duplicate-name detection happens in
+	// validate() — we sort first so duplicates land adjacent regardless of
+	// host insertion order, which also gives the matcher ∃iface a
+	// deterministic traversal in tests.
+	slices.SortFunc(c.Interfaces, func(a, b InterfaceContext) int {
+		return strings.Compare(a.Name, b.Name)
+	})
+
+	c.DNSSuffix = normalizeDNSSuffix(c.DNSSuffix)
+}
+
+// validate checks field legality. Must be called after normalize().
+// Returns the first error encountered — REST handlers only need one.
+func (c *NetworkContext) validate() error {
+	if c.Version != 1 {
+		return fmt.Errorf("invalid version: %d (expected 1)", c.Version)
+	}
+	if c.TTL != nil {
+		switch {
+		case *c.TTL <= 0:
+			return fmt.Errorf("invalid ttl: %d (must be > 0 or omitted)", *c.TTL)
+		case *c.TTL > MaxTTLSeconds:
+			return fmt.Errorf("invalid ttl: %d (max %d seconds = 10 years)", *c.TTL, MaxTTLSeconds)
+		}
+	}
+	if len(c.Interfaces) > MaxInterfaces {
+		return fmt.Errorf("invalid interfaces: %d entries (max %d)", len(c.Interfaces), MaxInterfaces)
+	}
+	if c.normalizeErr != nil {
+		return c.normalizeErr
+	}
+
+	// name uniqueness + per-iface field legality.
+	seen := make(map[string]struct{}, len(c.Interfaces))
+	for i := range c.Interfaces {
+		iface := &c.Interfaces[i]
+		if _, ok := seen[iface.Name]; ok {
+			return fmt.Errorf("interfaces[%d]: duplicate name %q", i, iface.Name)
+		}
+		seen[iface.Name] = struct{}{}
+		if err := iface.validate(); err != nil {
+			return fmt.Errorf("interfaces[%d]: %w", i, err)
+		}
+	}
+
+	for i, s := range c.DNSSuffix {
+		if strings.IndexFunc(s, isForbiddenDNSChar) >= 0 {
+			return fmt.Errorf("invalid dns_suffix[%d]: %q (contains comma, whitespace, or control char)", i, s)
+		}
+	}
+	return nil
+}
+
+// normalize rewrites an InterfaceContext in place. Returns an error on first
+// parse failure (prefixed with the field name; caller adds the interfaces[i]
+// prefix).
+func (iface *InterfaceContext) normalize() error {
+	iface.gatewayIPParsed = netip.Addr{}
+	iface.subnetsParsed = nil
+
+	if iface.IfaceType != "" {
+		iface.IfaceType = strings.ToLower(iface.IfaceType)
+	}
+	if iface.BSSID != "" {
+		m, err := normalizeMAC(iface.BSSID)
+		if err != nil {
+			return fmt.Errorf("bssid: %q: %w", iface.BSSID, err)
+		}
+		iface.BSSID = m
+	}
+	if iface.GatewayMAC != "" {
+		m, err := normalizeMAC(iface.GatewayMAC)
+		if err != nil {
+			return fmt.Errorf("gateway_mac: %q: %w", iface.GatewayMAC, err)
+		}
+		iface.GatewayMAC = m
+	}
+	if iface.GatewayIP != "" {
+		addr, err := netip.ParseAddr(iface.GatewayIP)
+		if err != nil {
+			return fmt.Errorf("gateway_ip: %q: %w", iface.GatewayIP, err)
+		}
+		// Strip IPv6 zone so netip.Prefix.Contains works in matcher (zoned
+		// addrs never equal their unzoned siblings).
+		addr = addr.WithZone("")
+		iface.GatewayIP = addr.String()
+		iface.gatewayIPParsed = addr
+	}
+	if len(iface.Subnets) > 0 {
+		parsed := make([]netip.Prefix, 0, len(iface.Subnets))
+		for i, raw := range iface.Subnets {
+			if raw == "" {
+				// Drop empty strings before CIDR parsing.
+				continue
+			}
+			p, err := netip.ParsePrefix(raw)
+			if err != nil {
+				return fmt.Errorf("subnets[%d]: %q: %w", i, raw, err)
+			}
+			parsed = append(parsed, p.Masked())
+		}
+		if len(parsed) == 0 {
+			iface.Subnets = nil
+		} else {
+			// Canonical form: sort by String() then dedupe. Derive the string
+			// slice from parsed so the two representations cannot drift.
+			slices.SortFunc(parsed, func(a, b netip.Prefix) int {
+				return strings.Compare(a.String(), b.String())
+			})
+			parsed = slices.CompactFunc(parsed, func(a, b netip.Prefix) bool {
+				return a.String() == b.String()
+			})
+			normed := make([]string, len(parsed))
+			for i, p := range parsed {
+				normed[i] = p.String()
+			}
+			iface.Subnets = normed
+			iface.subnetsParsed = parsed
+		}
+	}
+	return nil
+}
+
+// validate checks legality of the already-normalized interface.
+func (iface *InterfaceContext) validate() error {
+	if iface.Name == "" {
+		return fmt.Errorf("name: empty (required)")
+	}
+	if len(iface.Name) > 255 {
+		return fmt.Errorf("name: %d bytes (max 255)", len(iface.Name))
+	}
+	if len(iface.SSID) > 32 {
+		return fmt.Errorf("ssid: %d bytes (max 32)", len(iface.SSID))
+	}
+	if iface.IfaceType != "" && !IsValidIfaceType(iface.IfaceType) {
+		return fmt.Errorf("iface_type: %q (expected one of %s)", iface.IfaceType, strings.Join(ifaceTypes, "/"))
+	}
+	// gateway_mac is only meaningful when gateway_ip is also filled; they
+	// must be filled together or both empty.
+	if iface.GatewayMAC != "" && iface.GatewayIP == "" {
+		return fmt.Errorf("gateway_mac: filled but gateway_ip is empty")
+	}
+	return nil
+}
+
+// isForbiddenDNSChar rejects whitespace, control characters, and commas.
+// Comma is forbidden because Fingerprint() joins dns_suffix entries with
+// ","; allowing commas in values would create within-field aliasing
+// (["a,b"] and ["a","b"] would hash to the same fingerprint).
+func isForbiddenDNSChar(r rune) bool {
+	return r == ',' || unicode.IsSpace(r) || unicode.IsControl(r)
+}
+
+// Fingerprint returns a stable hash of the semantic content of c (TTL excluded).
+// Format: 16-char lower-case hex of an fnv64a digest over length-prefixed
+// fields in a deterministic order.
+//
+// Canonical encoding:
+//   - missing / null / empty per-iface scalars → ""
+//   - empty subnets / empty dns_suffix → ""
+//   - metered tri-state → "null" / "true" / "false"
+//   - version → "1" (literal string)
+//
+// Interfaces are iterated in sort-by-name order (normalize() already sorted).
+// Key prefix "iface.{idx}." binds each field to its row so that any
+// cross-language reimplementation of the hasher can reproduce the byte
+// stream exactly given the same canonical context.
+func (c *NetworkContext) Fingerprint() string {
+	h := fnv.New64a()
+	for idx := range c.Interfaces {
+		iface := &c.Interfaces[idx]
+		writeFingerprintField(h, fmt.Sprintf("iface.%d.name", idx), iface.Name)
+		writeFingerprintField(h, fmt.Sprintf("iface.%d.iface_type", idx), iface.IfaceType)
+		writeFingerprintField(h, fmt.Sprintf("iface.%d.ssid", idx), iface.SSID)
+		writeFingerprintField(h, fmt.Sprintf("iface.%d.bssid", idx), iface.BSSID)
+		writeFingerprintField(h, fmt.Sprintf("iface.%d.gateway_ip", idx), iface.GatewayIP)
+		writeFingerprintField(h, fmt.Sprintf("iface.%d.gateway_mac", idx), iface.GatewayMAC)
+		writeFingerprintField(h, fmt.Sprintf("iface.%d.subnets", idx), strings.Join(iface.Subnets, ","))
+		writeFingerprintField(h, fmt.Sprintf("iface.%d.metered", idx), meteredString(iface.Metered))
+	}
+	writeFingerprintField(h, "dns_suffix", strings.Join(c.DNSSuffix, ","))
+	// The version field is encoded as the literal string "1" (not
+	// strconv.Itoa(c.Version)) so Fingerprint stays byte-stable even if
+	// called before a successful NormalizeAndValidate — which would
+	// otherwise leave Version at whatever the wire payload said. This is
+	// also the rule any cross-impl implementation (e.g. the host-side
+	// Rust fingerprint) must follow to keep byte parity.
+	writeFingerprintField(h, "version", "1")
+	return fmt.Sprintf("%016x", h.Sum64())
+}
+
+// writeFingerprintField emits "<name>=<len>:<value>\n". Length prefix defeats
+// cross-field aliasing (e.g. a value containing "name=...\n" can't collide
+// with a context that has those markers as real field values).
+func writeFingerprintField(h hash.Hash64, name, value string) {
+	h.Write([]byte(name))
+	h.Write([]byte{'='})
+	h.Write([]byte(strconv.Itoa(len(value))))
+	h.Write([]byte{':'})
+	h.Write([]byte(value))
+	h.Write([]byte{'\n'})
+}

--- a/component/networkpolicy/context.go
+++ b/component/networkpolicy/context.go
@@ -89,9 +89,9 @@ type InterfaceContext struct {
 // user-installed VPNs as iface_type=vpn.
 var ifaceTypes = []string{"cellular", "ethernet", "loopback", "other", "vpn", "wifi", "wwan"}
 
-// IsValidIfaceType reports whether s is a valid iface_type enum value.
+// isValidIfaceType reports whether s is a valid iface_type enum value.
 // Empty string returns true — a host that can't classify may omit the field.
-func IsValidIfaceType(s string) bool {
+func isValidIfaceType(s string) bool {
 	if s == "" {
 		return true
 	}
@@ -195,8 +195,8 @@ func (c *NetworkContext) validate() error {
 		switch {
 		case *c.TTL <= 0:
 			return fmt.Errorf("%w: %d (must be > 0 or omitted)", ErrInvalidTTL, *c.TTL)
-		case *c.TTL > MaxTTLSeconds:
-			return fmt.Errorf("%w: %d (max %d seconds = 10 years)", ErrInvalidTTL, *c.TTL, MaxTTLSeconds)
+		case *c.TTL > maxTTLSeconds:
+			return fmt.Errorf("%w: %d (max %d seconds = 10 years)", ErrInvalidTTL, *c.TTL, maxTTLSeconds)
 		}
 	}
 	if len(c.Interfaces) > MaxInterfaces {
@@ -384,7 +384,7 @@ func (iface *InterfaceContext) validate() error {
 	if len(iface.SSID) > 32 {
 		return invalidField("ssid", fmt.Sprintf("%d bytes (max 32)", len(iface.SSID)))
 	}
-	if iface.IfaceType != "" && !IsValidIfaceType(iface.IfaceType) {
+	if iface.IfaceType != "" && !isValidIfaceType(iface.IfaceType) {
 		return invalidField("iface_type", fmt.Sprintf("%q not in %s", iface.IfaceType, strings.Join(ifaceTypes, "/")))
 	}
 	// gateway_mac is only meaningful when gateway_ip is also filled; they

--- a/component/networkpolicy/context.go
+++ b/component/networkpolicy/context.go
@@ -2,6 +2,7 @@ package networkpolicy
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"hash"
 	"hash/fnv"
@@ -11,6 +12,21 @@ import (
 	"unicode"
 
 	"golang.org/x/exp/slices"
+)
+
+// Sentinel errors returned (wrapped) by NormalizeAndValidate. REST
+// handlers use errors.Is to route each failure to its §5.4.8 error
+// code without string-matching the human-readable message. Adding a
+// new code in the future is a one-line change here plus one
+// fmt.Errorf("%w: ...") call at the emission site.
+var (
+	ErrMalformedBody       = errors.New("malformed_body")
+	ErrInvalidVersion      = errors.New("invalid_version")
+	ErrInvalidTTL          = errors.New("invalid_ttl")
+	ErrTooManyInterfaces   = errors.New("too_many_interfaces")
+	ErrDuplicateIfaceName  = errors.New("duplicate_iface_name")
+	ErrInvalidGatewayCombo = errors.New("invalid_gateway_combo")
+	ErrInvalidField        = errors.New("invalid_field")
 )
 
 // MaxInterfaces is the hard cap on interfaces[] length. PUT bodies with
@@ -98,10 +114,10 @@ func (c *NetworkContext) UnmarshalJSON(data []byte) error {
 		return err
 	}
 	if raw.Version == nil {
-		return fmt.Errorf("missing required field: version")
+		return fmt.Errorf("%w: missing required field: version", ErrMalformedBody)
 	}
 	if raw.Interfaces == nil {
-		return fmt.Errorf("missing required field: interfaces")
+		return fmt.Errorf("%w: missing required field: interfaces", ErrMalformedBody)
 	}
 	c.Version = *raw.Version
 	c.Interfaces = *raw.Interfaces
@@ -124,15 +140,23 @@ func (c *NetworkContext) UnmarshalJSON(data []byte) error {
 // during normalize() via the normalizeErr carrier.
 func (c *NetworkContext) NormalizeAndValidate() error {
 	if len(c.Interfaces) > MaxInterfaces {
-		return fmt.Errorf("invalid interfaces: %d entries (max %d)", len(c.Interfaces), MaxInterfaces)
+		return fmt.Errorf("%w: %d entries (max %d)", ErrTooManyInterfaces, len(c.Interfaces), MaxInterfaces)
 	}
 	c.normalize()
 	return c.validate()
 }
 
-// normalize rewrites fields in place. Idempotent: calling twice yields the
-// same result. On first parse error it records the error in c.normalizeErr
-// and stops processing further interfaces; validate() reports it as 400.
+// normalize rewrites per-iface fields in place + canonicalizes
+// DNSSuffix. Idempotent. On first parse error it records the error in
+// c.normalizeErr (with the original pre-sort iface index) and stops
+// processing further interfaces; validate() reports it as 400.
+//
+// Note: per-iface validate() and the canonical sort BOTH happen in
+// validate(), not here. Per-iface validate runs BEFORE sort so any
+// "invalid_field" / "invalid_gateway_combo" errors carry the input-order
+// iface index — host can locate the bad iface by the index it sent.
+// Sort happens after per-iface validate so duplicate-name detection +
+// matcher iteration see canonical order.
 //
 // Does not mutate `Version` — the wire requires version=1 explicitly;
 // deviations are surfaced by validate() as invalid_version.
@@ -141,7 +165,9 @@ func (c *NetworkContext) normalize() {
 
 	for i := range c.Interfaces {
 		if err := c.Interfaces[i].normalize(); err != nil {
-			c.normalizeErr = fmt.Errorf("interfaces[%d]: %w", i, err)
+			// Pre-sort original index so the host can map the error
+			// back to the iface they sent.
+			c.normalizeErr = withIfacePrefix(err, i)
 			// Leave already-normalized prefix entries as-is so Fingerprint()
 			// behavior on validated ctx is deterministic even if validate()
 			// later rejects; the error propagates through validate().
@@ -149,57 +175,129 @@ func (c *NetworkContext) normalize() {
 		}
 	}
 
-	// Canonical ordering: sort by Name. Duplicate-name detection happens in
-	// validate() — we sort first so duplicates land adjacent regardless of
-	// host insertion order, which also gives the matcher ∃iface a
-	// deterministic traversal in tests.
-	slices.SortFunc(c.Interfaces, func(a, b InterfaceContext) int {
-		return strings.Compare(a.Name, b.Name)
-	})
-
 	c.DNSSuffix = normalizeDNSSuffix(c.DNSSuffix)
 }
 
 // validate checks field legality. Must be called after normalize().
 // Returns the first error encountered — REST handlers only need one.
+//
+// The per-iface validate loop and the canonical sort BOTH happen
+// here, in this exact order: per-iface validate first (using pre-sort
+// indices), then sort, then duplicate-name detection. This way every
+// invalid_field / invalid_gateway_combo error path carries the
+// input-order iface index, matching what host sent regardless of how
+// many ifaces or what their names happened to be.
 func (c *NetworkContext) validate() error {
 	if c.Version != 1 {
-		return fmt.Errorf("invalid version: %d (expected 1)", c.Version)
+		return fmt.Errorf("%w: got %d (expected 1)", ErrInvalidVersion, c.Version)
 	}
 	if c.TTL != nil {
 		switch {
 		case *c.TTL <= 0:
-			return fmt.Errorf("invalid ttl: %d (must be > 0 or omitted)", *c.TTL)
+			return fmt.Errorf("%w: %d (must be > 0 or omitted)", ErrInvalidTTL, *c.TTL)
 		case *c.TTL > MaxTTLSeconds:
-			return fmt.Errorf("invalid ttl: %d (max %d seconds = 10 years)", *c.TTL, MaxTTLSeconds)
+			return fmt.Errorf("%w: %d (max %d seconds = 10 years)", ErrInvalidTTL, *c.TTL, MaxTTLSeconds)
 		}
 	}
 	if len(c.Interfaces) > MaxInterfaces {
-		return fmt.Errorf("invalid interfaces: %d entries (max %d)", len(c.Interfaces), MaxInterfaces)
+		return fmt.Errorf("%w: %d entries (max %d)", ErrTooManyInterfaces, len(c.Interfaces), MaxInterfaces)
 	}
 	if c.normalizeErr != nil {
 		return c.normalizeErr
 	}
 
-	// name uniqueness + per-iface field legality.
+	// Per-iface field legality, BEFORE canonical sort, so error indices
+	// reflect the host's input order (consistent with normalize()'s
+	// error indexing).
+	for i := range c.Interfaces {
+		if err := c.Interfaces[i].validate(); err != nil {
+			return withIfacePrefix(err, i)
+		}
+	}
+
+	// Canonical sort by Name — gives deterministic iteration order in
+	// the matcher and lets duplicate-name detection use a single pass.
+	slices.SortFunc(c.Interfaces, func(a, b InterfaceContext) int {
+		return strings.Compare(a.Name, b.Name)
+	})
+
+	// Duplicate-name detection (post-sort). The error reports the name
+	// rather than an index because the index would be the post-sort
+	// position, which doesn't match the host's input order.
 	seen := make(map[string]struct{}, len(c.Interfaces))
 	for i := range c.Interfaces {
-		iface := &c.Interfaces[i]
-		if _, ok := seen[iface.Name]; ok {
-			return fmt.Errorf("interfaces[%d]: duplicate name %q", i, iface.Name)
+		if _, ok := seen[c.Interfaces[i].Name]; ok {
+			return fmt.Errorf("%w: name=%q", ErrDuplicateIfaceName, c.Interfaces[i].Name)
 		}
-		seen[iface.Name] = struct{}{}
-		if err := iface.validate(); err != nil {
-			return fmt.Errorf("interfaces[%d]: %w", i, err)
-		}
+		seen[c.Interfaces[i].Name] = struct{}{}
 	}
 
 	for i, s := range c.DNSSuffix {
 		if strings.IndexFunc(s, isForbiddenDNSChar) >= 0 {
-			return fmt.Errorf("invalid dns_suffix[%d]: %q (contains comma, whitespace, or control char)", i, s)
+			return fmt.Errorf("%w: field: dns_suffix[%d], reason: contains comma, whitespace, or control char", ErrInvalidField, i)
 		}
 	}
 	return nil
+}
+
+// invalidField builds an ErrInvalidField error with the canonical
+// "field: <path>, reason: <why>" message format required by §5.4.8.
+// Callers at the top of the tree supply the full path; iface-level
+// callers supply a relative path (like "ssid") and let the outer
+// context.validate / context.normalize prefix the "interfaces[N]."
+// piece.
+func invalidField(path, reason string) error {
+	return fmt.Errorf("%w: field: %s, reason: %s", ErrInvalidField, path, reason)
+}
+
+// invalidGatewayCombo builds an ErrInvalidGatewayCombo error in the
+// same "field: <path>, reason: <why>" shape as invalidField, so host
+// log parsers can handle every code uniformly.
+func invalidGatewayCombo(path string) error {
+	if path == "" {
+		// Defensive: iface.validate calls with "" and the outer
+		// withIfacePrefix fills the path. If a future caller forgets
+		// to wrap, surface a recognizable placeholder rather than
+		// emitting "field: , reason: ...".
+		path = "<unknown>"
+	}
+	return fmt.Errorf("%w: field: %s, reason: gateway_mac filled but gateway_ip empty", ErrInvalidGatewayCombo, path)
+}
+
+// withIfacePrefix rewrites an iface-level error's field path to include
+// the "interfaces[N]." prefix. Preserves the sentinel via the wrapped
+// %w so errors.Is continues to work. Returns the original error
+// unchanged if it isn't one of our field-path errors.
+func withIfacePrefix(err error, idx int) error {
+	// gateway_combo is iface-wide; the inner caller's path is always
+	// "<unknown>" (or the rare degenerate empty-path), so we just stamp
+	// "interfaces[N]" without parsing the message.
+	if errors.Is(err, ErrInvalidGatewayCombo) {
+		return invalidGatewayCombo(fmt.Sprintf("interfaces[%d]", idx))
+	}
+	if !errors.Is(err, ErrInvalidField) {
+		return err
+	}
+	// Field-level error: extract "field: <path>, reason: <why>" and
+	// rebuild with the iface prefix. Search for ": field: " (with
+	// leading colon) to avoid matching the "invalid_field:" sentinel
+	// prefix the %w wrap inserts — that would otherwise double-prefix
+	// the path. Note: this string-based parse depends on the format
+	// invalidField emits — keep both in sync.
+	msg := err.Error()
+	const marker = ": field: "
+	i := strings.Index(msg, marker)
+	if i < 0 {
+		return err
+	}
+	rest := msg[i+len(marker):]
+	j := strings.Index(rest, ", reason: ")
+	if j < 0 {
+		return err
+	}
+	relPath := rest[:j]
+	reason := rest[j+len(", reason: "):]
+	return invalidField(fmt.Sprintf("interfaces[%d].%s", idx, relPath), reason)
 }
 
 // normalize rewrites an InterfaceContext in place. Returns an error on first
@@ -215,21 +313,21 @@ func (iface *InterfaceContext) normalize() error {
 	if iface.BSSID != "" {
 		m, err := normalizeMAC(iface.BSSID)
 		if err != nil {
-			return fmt.Errorf("bssid: %q: %w", iface.BSSID, err)
+			return invalidField("bssid", fmt.Sprintf("%q: %s", iface.BSSID, err.Error()))
 		}
 		iface.BSSID = m
 	}
 	if iface.GatewayMAC != "" {
 		m, err := normalizeMAC(iface.GatewayMAC)
 		if err != nil {
-			return fmt.Errorf("gateway_mac: %q: %w", iface.GatewayMAC, err)
+			return invalidField("gateway_mac", fmt.Sprintf("%q: %s", iface.GatewayMAC, err.Error()))
 		}
 		iface.GatewayMAC = m
 	}
 	if iface.GatewayIP != "" {
 		addr, err := netip.ParseAddr(iface.GatewayIP)
 		if err != nil {
-			return fmt.Errorf("gateway_ip: %q: %w", iface.GatewayIP, err)
+			return invalidField("gateway_ip", fmt.Sprintf("%q: %s", iface.GatewayIP, err.Error()))
 		}
 		// Strip IPv6 zone so netip.Prefix.Contains works in matcher (zoned
 		// addrs never equal their unzoned siblings).
@@ -246,7 +344,7 @@ func (iface *InterfaceContext) normalize() error {
 			}
 			p, err := netip.ParsePrefix(raw)
 			if err != nil {
-				return fmt.Errorf("subnets[%d]: %q: %w", i, raw, err)
+				return invalidField(fmt.Sprintf("subnets[%d]", i), fmt.Sprintf("%q: %s", raw, err.Error()))
 			}
 			parsed = append(parsed, p.Masked())
 		}
@@ -272,24 +370,29 @@ func (iface *InterfaceContext) normalize() error {
 	return nil
 }
 
-// validate checks legality of the already-normalized interface.
+// validate checks legality of the already-normalized interface. All
+// field-level failures emit ErrInvalidField with the relative path
+// ("name" / "ssid" / ...); the caller prefixes "interfaces[N]." before
+// surfacing to the REST layer.
 func (iface *InterfaceContext) validate() error {
 	if iface.Name == "" {
-		return fmt.Errorf("name: empty (required)")
+		return invalidField("name", "empty (required)")
 	}
 	if len(iface.Name) > 255 {
-		return fmt.Errorf("name: %d bytes (max 255)", len(iface.Name))
+		return invalidField("name", fmt.Sprintf("%d bytes (max 255)", len(iface.Name)))
 	}
 	if len(iface.SSID) > 32 {
-		return fmt.Errorf("ssid: %d bytes (max 32)", len(iface.SSID))
+		return invalidField("ssid", fmt.Sprintf("%d bytes (max 32)", len(iface.SSID)))
 	}
 	if iface.IfaceType != "" && !IsValidIfaceType(iface.IfaceType) {
-		return fmt.Errorf("iface_type: %q (expected one of %s)", iface.IfaceType, strings.Join(ifaceTypes, "/"))
+		return invalidField("iface_type", fmt.Sprintf("%q not in %s", iface.IfaceType, strings.Join(ifaceTypes, "/")))
 	}
 	// gateway_mac is only meaningful when gateway_ip is also filled; they
-	// must be filled together or both empty.
+	// must be filled together or both empty. Uses a distinct sentinel so
+	// the REST layer can emit its own error code.
 	if iface.GatewayMAC != "" && iface.GatewayIP == "" {
-		return fmt.Errorf("gateway_mac: filled but gateway_ip is empty")
+		// Path is supplied by the outer context.validate via withIfacePrefix.
+		return invalidGatewayCombo("")
 	}
 	return nil
 }

--- a/component/networkpolicy/context_test.go
+++ b/component/networkpolicy/context_test.go
@@ -1,0 +1,444 @@
+package networkpolicy
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNormalize_Interfaces(t *testing.T) {
+	c := &NetworkContext{
+		Version: 1,
+		Interfaces: []InterfaceContext{
+			{
+				Name:       "wlan0",
+				IfaceType:  "WIFI",
+				BSSID:      "AA-BB-CC-DD-EE-FF",
+				GatewayIP:  "2001:DB8:0::1",
+				GatewayMAC: "aabbccddeeff",
+				Subnets:    []string{"192.168.1.0/24", "10.0.0.0/8", "192.168.1.0/24", ""},
+			},
+			{
+				Name:      "en0", // out-of-order: normalize should sort to front
+				IfaceType: "ethernet",
+			},
+		},
+		DNSSuffix: []string{"CORP.Example.COM", "", "home.example.com", "CORP.Example.COM"},
+	}
+	c.normalize()
+
+	assert.Equal(t, 1, c.Version, "version passes through unchanged")
+	// Sorted by name: en0 < wlan0
+	assert.Equal(t, "en0", c.Interfaces[0].Name)
+	assert.Equal(t, "wlan0", c.Interfaces[1].Name)
+
+	// wlan0 (now index 1) normalized
+	w := &c.Interfaces[1]
+	assert.Equal(t, "wifi", w.IfaceType)
+	assert.Equal(t, "aa:bb:cc:dd:ee:ff", w.BSSID)
+	assert.Equal(t, "aa:bb:cc:dd:ee:ff", w.GatewayMAC)
+	assert.Equal(t, "2001:db8::1", w.GatewayIP)
+	assert.True(t, w.gatewayIPParsed.IsValid())
+	assert.Equal(t, []string{"10.0.0.0/8", "192.168.1.0/24"}, w.Subnets, "sorted, deduped, empty filtered")
+
+	// DNSSuffix normalized: lowercased, empty filtered, sorted, deduped
+	assert.Equal(t, []string{"corp.example.com", "home.example.com"}, c.DNSSuffix)
+}
+
+func TestNormalize_Idempotent(t *testing.T) {
+	c := &NetworkContext{
+		Version: 1,
+		Interfaces: []InterfaceContext{
+			{Name: "wlan0", BSSID: "aa:bb:cc:dd:ee:ff", Subnets: []string{"10.0.0.0/8"}},
+		},
+		DNSSuffix: []string{"corp"},
+	}
+	c.normalize()
+	snapshot := *c
+	c.normalize()
+	assert.Equal(t, snapshot.Interfaces[0].BSSID, c.Interfaces[0].BSSID)
+	assert.Equal(t, snapshot.Interfaces[0].Subnets, c.Interfaces[0].Subnets)
+	assert.Equal(t, snapshot.DNSSuffix, c.DNSSuffix)
+}
+
+func TestNormalize_ClearsStaleDerived(t *testing.T) {
+	// Reused struct must not leak derived state when the sampler edits raw fields.
+	c := &NetworkContext{
+		Interfaces: []InterfaceContext{
+			{Name: "wlan0", Subnets: []string{"10.0.0.0/8"}, GatewayIP: "10.0.0.1"},
+		},
+	}
+	c.normalize()
+	assert.NotEmpty(t, c.Interfaces[0].subnetsParsed)
+	assert.True(t, c.Interfaces[0].gatewayIPParsed.IsValid())
+
+	c.Interfaces[0].Subnets = []string{"not-a-cidr"}
+	c.normalize()
+	assert.NotNil(t, c.normalizeErr)
+	// iface.normalize() resets both derived fields at the top, then processes
+	// GatewayIP (success) and Subnets (failure, returns). Final state:
+	// gatewayIPParsed valid, subnetsParsed nil. This test pins the field
+	// processing order; flipping it without updating here would regress.
+	assert.True(t, c.Interfaces[0].gatewayIPParsed.IsValid(), "GatewayIP normalize ran before Subnets")
+	assert.Nil(t, c.Interfaces[0].subnetsParsed, "Subnets parse failed, derived slice stays nil")
+}
+
+func TestNormalize_IPv6StripsZone(t *testing.T) {
+	// Hosts commonly emit link-local gateway addresses with an interface zone
+	// ("fe80::1%en0"). netip.Prefix.Contains returns false for zoned addrs, so
+	// we strip the zone during normalize so gateway-ip CIDR matchers still hit.
+	c := &NetworkContext{
+		Version: 1,
+		Interfaces: []InterfaceContext{
+			{Name: "wlan0", GatewayIP: "fe80::1%en0"},
+		},
+	}
+	assert.NoError(t, c.NormalizeAndValidate())
+	assert.Equal(t, "fe80::1", c.Interfaces[0].GatewayIP)
+	assert.Equal(t, "", c.Interfaces[0].gatewayIPParsed.Zone())
+}
+
+func TestNormalize_SubnetsDedupAfterMasked(t *testing.T) {
+	// "10.5.0.0/8" and "10.0.0.0/8" mask to the same prefix; dedupe must catch that.
+	c := &NetworkContext{
+		Version: 1,
+		Interfaces: []InterfaceContext{
+			{Name: "wlan0", Subnets: []string{"10.5.0.0/8", "10.0.0.0/8"}},
+		},
+	}
+	assert.NoError(t, c.NormalizeAndValidate())
+	assert.Equal(t, []string{"10.0.0.0/8"}, c.Interfaces[0].Subnets)
+}
+
+func TestValidate(t *testing.T) {
+	ttl0, ttlNeg, ttlBig, ttlOK := 0, -1, MaxTTLSeconds+1, 60
+
+	validIface := InterfaceContext{Name: "wlan0"}
+
+	cases := []struct {
+		name   string
+		ctx    NetworkContext
+		errSub string // "" means no error
+	}{
+		{"valid empty interfaces", NetworkContext{Version: 1}, ""},
+		{"valid single iface", NetworkContext{Version: 1, Interfaces: []InterfaceContext{validIface}}, ""},
+		{"version 0 rejected (no silent promotion)", NetworkContext{Version: 0}, "invalid version"},
+		{"version unsupported", NetworkContext{Version: 2}, "invalid version"},
+		{"ttl nil sticky", NetworkContext{Version: 1}, ""},
+		{"ttl positive", NetworkContext{Version: 1, TTL: &ttlOK}, ""},
+		{"ttl zero", NetworkContext{Version: 1, TTL: &ttl0}, "invalid ttl"},
+		{"ttl negative", NetworkContext{Version: 1, TTL: &ttlNeg}, "invalid ttl"},
+		{"ttl too large", NetworkContext{Version: 1, TTL: &ttlBig}, "invalid ttl"},
+		{"iface name required", NetworkContext{Version: 1, Interfaces: []InterfaceContext{{}}}, "name: empty"},
+		{"iface name too long", NetworkContext{Version: 1, Interfaces: []InterfaceContext{{Name: strings.Repeat("x", 256)}}}, "name: 256 bytes"},
+		{"ssid too long", NetworkContext{Version: 1, Interfaces: []InterfaceContext{{Name: "wlan0", SSID: strings.Repeat("a", 33)}}}, "ssid: 33 bytes"},
+		{"ssid at limit", NetworkContext{Version: 1, Interfaces: []InterfaceContext{{Name: "wlan0", SSID: strings.Repeat("a", 32)}}}, ""},
+		{"bssid invalid", NetworkContext{Version: 1, Interfaces: []InterfaceContext{{Name: "wlan0", BSSID: "xx:yy:zz:11:22:33"}}}, "bssid"},
+		{"gateway_ip invalid", NetworkContext{Version: 1, Interfaces: []InterfaceContext{{Name: "wlan0", GatewayIP: "999.9.9.9"}}}, "gateway_ip"},
+		{"iface_type invalid", NetworkContext{Version: 1, Interfaces: []InterfaceContext{{Name: "wlan0", IfaceType: "wire"}}}, "iface_type"},
+		{"gateway_mac without gateway_ip", NetworkContext{Version: 1, Interfaces: []InterfaceContext{{Name: "wlan0", GatewayMAC: "aa:bb:cc:dd:ee:ff"}}}, "gateway_mac: filled but gateway_ip is empty"},
+		{"gateway_mac+gateway_ip ok", NetworkContext{Version: 1, Interfaces: []InterfaceContext{{Name: "wlan0", GatewayIP: "10.0.0.1", GatewayMAC: "aa:bb:cc:dd:ee:ff"}}}, ""},
+		{"subnets invalid entry", NetworkContext{Version: 1, Interfaces: []InterfaceContext{{Name: "wlan0", Subnets: []string{"10.0.0.0/8", "not-a-cidr"}}}}, "subnets[1]"},
+		{"duplicate iface name", NetworkContext{Version: 1, Interfaces: []InterfaceContext{{Name: "wlan0"}, {Name: "wlan0"}}}, "duplicate name"},
+		{"dns_suffix with space", NetworkContext{Version: 1, DNSSuffix: []string{"corp example"}}, "dns_suffix"},
+		{"dns_suffix with comma rejected", NetworkContext{Version: 1, DNSSuffix: []string{"a,b"}}, "dns_suffix"},
+		{"too many interfaces", NetworkContext{Version: 1, Interfaces: makeIfaces(MaxInterfaces + 1)}, "invalid interfaces: 33 entries"},
+		{"at max interfaces", NetworkContext{Version: 1, Interfaces: makeIfaces(MaxInterfaces)}, ""},
+	}
+	for _, tc := range cases {
+		c := tc.ctx
+		err := c.NormalizeAndValidate()
+		if tc.errSub == "" {
+			assert.NoError(t, err, "case %q", tc.name)
+		} else {
+			assert.ErrorContains(t, err, tc.errSub, "case %q", tc.name)
+		}
+	}
+}
+
+func makeIfaces(n int) []InterfaceContext {
+	out := make([]InterfaceContext, n)
+	for i := range out {
+		out[i].Name = "if" + string(rune('a'+i/26)) + string(rune('a'+i%26))
+	}
+	return out
+}
+
+// TestFingerprint exercises the semantic invariants of the fingerprint algorithm.
+func TestFingerprint(t *testing.T) {
+	ttl := 60
+	base := NetworkContext{
+		Version: 1,
+		Interfaces: []InterfaceContext{
+			{Name: "wlan0", SSID: "office", IfaceType: "wifi"},
+		},
+		DNSSuffix: []string{"corp.example.com"},
+	}
+
+	// TTL must not affect fingerprint.
+	a := base
+	c := base
+	c.TTL = &ttl
+
+	for _, x := range []*NetworkContext{&a, &c} {
+		_ = x.NormalizeAndValidate()
+	}
+	assert.Equal(t, a.Fingerprint(), c.Fingerprint(), "TTL excluded from fingerprint")
+
+	// IPv6 canonicalization: three equivalent forms collapse to one fingerprint.
+	ipForms := []string{"2001:db8::1", "2001:0db8:0000:0000:0000:0000:0000:0001", "2001:DB8:0::1"}
+	var fps []string
+	for _, ip := range ipForms {
+		c := NetworkContext{
+			Version: 1,
+			Interfaces: []InterfaceContext{
+				{Name: "wlan0", GatewayIP: ip},
+			},
+		}
+		_ = c.NormalizeAndValidate()
+		fps = append(fps, c.Fingerprint())
+	}
+	assert.Equal(t, fps[0], fps[1])
+	assert.Equal(t, fps[0], fps[2])
+
+	// Length-prefix in write_kv: a value containing "name=...\n" must not
+	// collide with a context where those markers are real field structure.
+	a1 := NetworkContext{
+		Version: 1,
+		Interfaces: []InterfaceContext{
+			{Name: "wlan0", SSID: "x\ngateway_ip=10.0.0.1"},
+		},
+	}
+	a2 := NetworkContext{
+		Version: 1,
+		Interfaces: []InterfaceContext{
+			{Name: "wlan0", SSID: "x", GatewayIP: "10.0.0.1"},
+		},
+	}
+	_ = a1.NormalizeAndValidate()
+	_ = a2.NormalizeAndValidate()
+	assert.NotEqual(t, a1.Fingerprint(), a2.Fingerprint())
+
+	// Iface order independence: normalize sorts by name, so host insertion
+	// order must not affect the fingerprint.
+	f1 := NetworkContext{
+		Version: 1,
+		Interfaces: []InterfaceContext{
+			{Name: "en0", IfaceType: "ethernet"},
+			{Name: "wlan0", IfaceType: "wifi"},
+		},
+	}
+	f2 := NetworkContext{
+		Version: 1,
+		Interfaces: []InterfaceContext{
+			{Name: "wlan0", IfaceType: "wifi"},
+			{Name: "en0", IfaceType: "ethernet"},
+		},
+	}
+	_ = f1.NormalizeAndValidate()
+	_ = f2.NormalizeAndValidate()
+	assert.Equal(t, f1.Fingerprint(), f2.Fingerprint(), "iface insertion order must not change fingerprint")
+}
+
+// TestFingerprint_Stable checks that the fingerprint output format is 16-char
+// lower-case hex and produces a stable value for a fixed input. Cross-impl
+// byte-parity golden fixtures (validating against any future language-port
+// implementation) are added later once a second implementation exists.
+func TestFingerprint_Stable(t *testing.T) {
+	c := NetworkContext{Version: 1, Interfaces: []InterfaceContext{{Name: "en0"}}}
+	assert.NoError(t, c.NormalizeAndValidate())
+	fp1 := c.Fingerprint()
+	fp2 := c.Fingerprint()
+	assert.Equal(t, fp1, fp2, "fingerprint is deterministic")
+	assert.Len(t, fp1, 16, "fingerprint is 16 hex chars (fnv64a)")
+	for _, ch := range fp1 {
+		assert.True(t, (ch >= '0' && ch <= '9') || (ch >= 'a' && ch <= 'f'), "lowercase hex only: got %q", fp1)
+	}
+}
+
+// TestFingerprint_Pinned locks the current Go implementation against silent
+// algorithm drift (field order swap, hash family change, length-prefix
+// encoding change). If any of these shift, the test breaks loudly — and the
+// operator updating the expected values must consciously accept that they
+// are also breaking any cross-impl byte parity relying on the old hashes.
+//
+// Not a cross-impl golden fixture; that comes when a second implementation
+// lands. These are local self-consistency anchors only.
+func TestFingerprint_Pinned(t *testing.T) {
+	tVal, fVal := true, false
+	cases := []struct {
+		name string
+		ctx  NetworkContext
+		want string
+	}{
+		{
+			"empty",
+			NetworkContext{Version: 1},
+			"e124fe9cbeefe00a",
+		},
+		{
+			"single name only",
+			NetworkContext{Version: 1, Interfaces: []InterfaceContext{{Name: "en0"}}},
+			"209db35aa391d1ab",
+		},
+		{
+			"rich single iface",
+			NetworkContext{
+				Version: 1,
+				Interfaces: []InterfaceContext{
+					{
+						Name:       "wlan0",
+						IfaceType:  "wifi",
+						SSID:       "office",
+						BSSID:      "aa:bb:cc:dd:ee:00",
+						GatewayIP:  "10.0.0.1",
+						GatewayMAC: "11:22:33:44:55:66",
+						Subnets:    []string{"10.0.0.0/24"},
+						Metered:    &fVal,
+					},
+				},
+				DNSSuffix: []string{"corp.example.com"},
+			},
+			"44642fb47eb57a92",
+		},
+		{
+			"two ifaces",
+			NetworkContext{
+				Version: 1,
+				Interfaces: []InterfaceContext{
+					{Name: "en0", IfaceType: "ethernet"},
+					{Name: "wg0", IfaceType: "vpn", Metered: &tVal},
+				},
+			},
+			"f8c3ef1ec380d486",
+		},
+	}
+	for _, tc := range cases {
+		c := tc.ctx
+		assert.NoError(t, c.NormalizeAndValidate(), "case %q", tc.name)
+		assert.Equal(t, tc.want, c.Fingerprint(), "case %q fingerprint drift", tc.name)
+	}
+}
+
+// TestFingerprint_MeteredTriState pins the tri-state metered encoding in
+// the fingerprint. The three distinct values null / true / false must
+// produce three distinct hashes — that's what lets a cross-impl
+// implementation (e.g. host-side Rust) reach byte parity even though JSON
+// can express all three states.
+func TestFingerprint_MeteredTriState(t *testing.T) {
+	tVal, fVal := true, false
+	ctxNull := norm(t, &NetworkContext{Version: 1, Interfaces: []InterfaceContext{{Name: "en0"}}})
+	ctxTrue := norm(t, &NetworkContext{Version: 1, Interfaces: []InterfaceContext{{Name: "en0", Metered: &tVal}}})
+	ctxFalse := norm(t, &NetworkContext{Version: 1, Interfaces: []InterfaceContext{{Name: "en0", Metered: &fVal}}})
+
+	fpNull, fpTrue, fpFalse := ctxNull.Fingerprint(), ctxTrue.Fingerprint(), ctxFalse.Fingerprint()
+	assert.NotEqual(t, fpNull, fpTrue, "metered=null vs metered=true must differ")
+	assert.NotEqual(t, fpNull, fpFalse, "metered=null vs metered=false must differ")
+	assert.NotEqual(t, fpTrue, fpFalse, "metered=true vs metered=false must differ")
+}
+
+// TestFingerprint_Idempotent deep-copies a context, repeats normalize, and
+// verifies both the resulting fingerprint and the canonical stored fields
+// stay identical across repeated calls.
+func TestFingerprint_Idempotent(t *testing.T) {
+	c := NetworkContext{
+		Version: 1,
+		Interfaces: []InterfaceContext{
+			{Name: "wlan0", SSID: "office", Subnets: []string{"10.0.0.0/8"}, BSSID: "AA-BB-CC-DD-EE-FF"},
+		},
+		DNSSuffix: []string{"CORP.example.com"},
+	}
+	assert.NoError(t, c.NormalizeAndValidate())
+	fp1 := c.Fingerprint()
+
+	// Second pass — should be a no-op even after a fresh normalize().
+	c.normalize()
+	assert.NoError(t, c.validate())
+	fp2 := c.Fingerprint()
+	assert.Equal(t, fp1, fp2, "Fingerprint stable across repeated NormalizeAndValidate")
+	assert.Equal(t, "aa:bb:cc:dd:ee:ff", c.Interfaces[0].BSSID, "BSSID stays canonical")
+	assert.Equal(t, []string{"10.0.0.0/8"}, c.Interfaces[0].Subnets)
+	assert.Equal(t, []string{"corp.example.com"}, c.DNSSuffix)
+}
+
+func TestJSONDecoding(t *testing.T) {
+	// JSON null, missing, and zero are three distinct states for TTL and Metered.
+	cases := []struct {
+		name string
+		in   string
+		want func(t *testing.T, c *NetworkContext)
+	}{
+		{"ttl missing → nil", `{"version":1,"interfaces":[]}`, func(t *testing.T, c *NetworkContext) {
+			assert.Nil(t, c.TTL)
+		}},
+		{"ttl null → nil", `{"version":1,"interfaces":[],"ttl":null}`, func(t *testing.T, c *NetworkContext) {
+			assert.Nil(t, c.TTL)
+		}},
+		{"ttl 0 → *0", `{"version":1,"interfaces":[],"ttl":0}`, func(t *testing.T, c *NetworkContext) {
+			assert.NotNil(t, c.TTL)
+			assert.Equal(t, 0, *c.TTL)
+		}},
+		{"iface metered null → nil", `{"version":1,"interfaces":[{"name":"en0","metered":null}]}`, func(t *testing.T, c *NetworkContext) {
+			assert.Len(t, c.Interfaces, 1)
+			assert.Nil(t, c.Interfaces[0].Metered)
+		}},
+		{"iface metered false → *false", `{"version":1,"interfaces":[{"name":"en0","metered":false}]}`, func(t *testing.T, c *NetworkContext) {
+			assert.Len(t, c.Interfaces, 1)
+			assert.NotNil(t, c.Interfaces[0].Metered)
+			assert.False(t, *c.Interfaces[0].Metered)
+		}},
+		{"iface metered true → *true", `{"version":1,"interfaces":[{"name":"en0","metered":true}]}`, func(t *testing.T, c *NetworkContext) {
+			assert.Len(t, c.Interfaces, 1)
+			assert.NotNil(t, c.Interfaces[0].Metered)
+			assert.True(t, *c.Interfaces[0].Metered)
+		}},
+		{"dns_suffix array", `{"version":1,"interfaces":[],"dns_suffix":["corp","home"]}`, func(t *testing.T, c *NetworkContext) {
+			assert.Equal(t, []string{"corp", "home"}, c.DNSSuffix)
+		}},
+	}
+	for _, tc := range cases {
+		var c NetworkContext
+		assert.NoError(t, json.Unmarshal([]byte(tc.in), &c), "case %q", tc.name)
+		tc.want(t, &c)
+	}
+}
+
+func TestJSONDecoding_RejectsMissingRequiredFields(t *testing.T) {
+	// version and interfaces are wire-required. Missing either is a
+	// malformed_body error at the REST layer.
+	cases := []struct {
+		name string
+		in   string
+	}{
+		{"missing version", `{"interfaces":[]}`},
+		{"missing interfaces", `{"version":1}`},
+		{"both missing", `{}`},
+		{"version null", `{"version":null,"interfaces":[]}`},
+		{"interfaces null", `{"version":1,"interfaces":null}`},
+	}
+	for _, tc := range cases {
+		var c NetworkContext
+		err := json.Unmarshal([]byte(tc.in), &c)
+		assert.Error(t, err, "case %q", tc.name)
+	}
+}
+
+func TestJSONDecoding_RejectsScalarDNSSuffix(t *testing.T) {
+	// dns_suffix is wire-required to be []string. A scalar form triggers a
+	// json.Unmarshal type mismatch, which REST handlers surface as
+	// malformed_body.
+	var c NetworkContext
+	err := json.Unmarshal([]byte(`{"version":1,"interfaces":[],"dns_suffix":"corp"}`), &c)
+	assert.Error(t, err)
+}
+
+func TestIsValidIfaceType(t *testing.T) {
+	for _, s := range []string{"", "wifi", "ethernet", "cellular", "wwan", "vpn", "loopback", "other"} {
+		assert.True(t, IsValidIfaceType(s), "want valid for %q", s)
+	}
+	for _, s := range []string{"tun", "wire", "WIFI", "cell"} {
+		assert.False(t, IsValidIfaceType(s), "want invalid for %q", s)
+	}
+}

--- a/component/networkpolicy/context_test.go
+++ b/component/networkpolicy/context_test.go
@@ -118,7 +118,7 @@ func TestNormalize_SubnetsDedupAfterMasked(t *testing.T) {
 }
 
 func TestValidate(t *testing.T) {
-	ttl0, ttlNeg, ttlBig, ttlOK := 0, -1, MaxTTLSeconds+1, 60
+	ttl0, ttlNeg, ttlBig, ttlOK := 0, -1, maxTTLSeconds+1, 60
 
 	validIface := InterfaceContext{Name: "wlan0"}
 
@@ -448,9 +448,9 @@ func TestJSONDecoding_RejectsScalarDNSSuffix(t *testing.T) {
 
 func TestIsValidIfaceType(t *testing.T) {
 	for _, s := range []string{"", "wifi", "ethernet", "cellular", "wwan", "vpn", "loopback", "other"} {
-		assert.True(t, IsValidIfaceType(s), "want valid for %q", s)
+		assert.True(t, isValidIfaceType(s), "want valid for %q", s)
 	}
 	for _, s := range []string{"tun", "wire", "WIFI", "cell"} {
-		assert.False(t, IsValidIfaceType(s), "want invalid for %q", s)
+		assert.False(t, isValidIfaceType(s), "want invalid for %q", s)
 	}
 }

--- a/component/networkpolicy/context_test.go
+++ b/component/networkpolicy/context_test.go
@@ -27,7 +27,12 @@ func TestNormalize_Interfaces(t *testing.T) {
 		},
 		DNSSuffix: []string{"CORP.Example.COM", "", "home.example.com", "CORP.Example.COM"},
 	}
-	c.normalize()
+	// Use NormalizeAndValidate so the canonical sort runs (sort moved
+	// from normalize() into validate() in the M4 round-2 fix that gave
+	// per-iface error paths input-order indices).
+	if err := c.NormalizeAndValidate(); err != nil {
+		t.Fatalf("unexpected: %v", err)
+	}
 
 	assert.Equal(t, 1, c.Version, "version passes through unchanged")
 	// Sorted by name: en0 < wlan0
@@ -124,27 +129,34 @@ func TestValidate(t *testing.T) {
 	}{
 		{"valid empty interfaces", NetworkContext{Version: 1}, ""},
 		{"valid single iface", NetworkContext{Version: 1, Interfaces: []InterfaceContext{validIface}}, ""},
-		{"version 0 rejected (no silent promotion)", NetworkContext{Version: 0}, "invalid version"},
-		{"version unsupported", NetworkContext{Version: 2}, "invalid version"},
+		{"version 0 rejected (no silent promotion)", NetworkContext{Version: 0}, "invalid_version"},
+		{"version unsupported", NetworkContext{Version: 2}, "invalid_version"},
 		{"ttl nil sticky", NetworkContext{Version: 1}, ""},
 		{"ttl positive", NetworkContext{Version: 1, TTL: &ttlOK}, ""},
-		{"ttl zero", NetworkContext{Version: 1, TTL: &ttl0}, "invalid ttl"},
-		{"ttl negative", NetworkContext{Version: 1, TTL: &ttlNeg}, "invalid ttl"},
-		{"ttl too large", NetworkContext{Version: 1, TTL: &ttlBig}, "invalid ttl"},
-		{"iface name required", NetworkContext{Version: 1, Interfaces: []InterfaceContext{{}}}, "name: empty"},
-		{"iface name too long", NetworkContext{Version: 1, Interfaces: []InterfaceContext{{Name: strings.Repeat("x", 256)}}}, "name: 256 bytes"},
-		{"ssid too long", NetworkContext{Version: 1, Interfaces: []InterfaceContext{{Name: "wlan0", SSID: strings.Repeat("a", 33)}}}, "ssid: 33 bytes"},
+		{"ttl zero", NetworkContext{Version: 1, TTL: &ttl0}, "invalid_ttl"},
+		{"ttl negative", NetworkContext{Version: 1, TTL: &ttlNeg}, "invalid_ttl"},
+		{"ttl too large", NetworkContext{Version: 1, TTL: &ttlBig}, "invalid_ttl"},
+		{"iface name required", NetworkContext{Version: 1, Interfaces: []InterfaceContext{{}}}, "field: interfaces[0].name, reason: empty"},
+		{"iface name too long", NetworkContext{Version: 1, Interfaces: []InterfaceContext{{Name: strings.Repeat("x", 256)}}}, "field: interfaces[0].name, reason: 256 bytes"},
+		{"ssid too long", NetworkContext{Version: 1, Interfaces: []InterfaceContext{{Name: "wlan0", SSID: strings.Repeat("a", 33)}}}, "field: interfaces[0].ssid, reason: 33 bytes"},
 		{"ssid at limit", NetworkContext{Version: 1, Interfaces: []InterfaceContext{{Name: "wlan0", SSID: strings.Repeat("a", 32)}}}, ""},
-		{"bssid invalid", NetworkContext{Version: 1, Interfaces: []InterfaceContext{{Name: "wlan0", BSSID: "xx:yy:zz:11:22:33"}}}, "bssid"},
-		{"gateway_ip invalid", NetworkContext{Version: 1, Interfaces: []InterfaceContext{{Name: "wlan0", GatewayIP: "999.9.9.9"}}}, "gateway_ip"},
-		{"iface_type invalid", NetworkContext{Version: 1, Interfaces: []InterfaceContext{{Name: "wlan0", IfaceType: "wire"}}}, "iface_type"},
-		{"gateway_mac without gateway_ip", NetworkContext{Version: 1, Interfaces: []InterfaceContext{{Name: "wlan0", GatewayMAC: "aa:bb:cc:dd:ee:ff"}}}, "gateway_mac: filled but gateway_ip is empty"},
+		{"bssid invalid", NetworkContext{Version: 1, Interfaces: []InterfaceContext{{Name: "wlan0", BSSID: "xx:yy:zz:11:22:33"}}}, "field: interfaces[0].bssid"},
+		{"gateway_ip invalid", NetworkContext{Version: 1, Interfaces: []InterfaceContext{{Name: "wlan0", GatewayIP: "999.9.9.9"}}}, "field: interfaces[0].gateway_ip"},
+		{"iface_type invalid", NetworkContext{Version: 1, Interfaces: []InterfaceContext{{Name: "wlan0", IfaceType: "wire"}}}, "field: interfaces[0].iface_type"},
+		{"gateway_mac without gateway_ip", NetworkContext{Version: 1, Interfaces: []InterfaceContext{{Name: "wlan0", GatewayMAC: "aa:bb:cc:dd:ee:ff"}}}, "invalid_gateway_combo"},
 		{"gateway_mac+gateway_ip ok", NetworkContext{Version: 1, Interfaces: []InterfaceContext{{Name: "wlan0", GatewayIP: "10.0.0.1", GatewayMAC: "aa:bb:cc:dd:ee:ff"}}}, ""},
-		{"subnets invalid entry", NetworkContext{Version: 1, Interfaces: []InterfaceContext{{Name: "wlan0", Subnets: []string{"10.0.0.0/8", "not-a-cidr"}}}}, "subnets[1]"},
-		{"duplicate iface name", NetworkContext{Version: 1, Interfaces: []InterfaceContext{{Name: "wlan0"}, {Name: "wlan0"}}}, "duplicate name"},
-		{"dns_suffix with space", NetworkContext{Version: 1, DNSSuffix: []string{"corp example"}}, "dns_suffix"},
-		{"dns_suffix with comma rejected", NetworkContext{Version: 1, DNSSuffix: []string{"a,b"}}, "dns_suffix"},
-		{"too many interfaces", NetworkContext{Version: 1, Interfaces: makeIfaces(MaxInterfaces + 1)}, "invalid interfaces: 33 entries"},
+		{"subnets invalid entry", NetworkContext{Version: 1, Interfaces: []InterfaceContext{{Name: "wlan0", Subnets: []string{"10.0.0.0/8", "not-a-cidr"}}}}, "field: interfaces[0].subnets[1]"},
+		{"duplicate iface name", NetworkContext{Version: 1, Interfaces: []InterfaceContext{{Name: "wlan0"}, {Name: "wlan0"}}}, "duplicate_iface_name"},
+		{"dns_suffix with space", NetworkContext{Version: 1, DNSSuffix: []string{"corp example"}}, "field: dns_suffix"},
+		{"dns_suffix with comma rejected", NetworkContext{Version: 1, DNSSuffix: []string{"a,b"}}, "field: dns_suffix"},
+		{"too many interfaces", NetworkContext{Version: 1, Interfaces: makeIfaces(MaxInterfaces + 1)}, "too_many_interfaces"},
+		// Regression: per-iface error indices reflect HOST input order
+		// (pre-sort), not post-sort canonical order. With "z0" first and
+		// "a0" second in the input, an error on the second iface should
+		// say interfaces[1] (input position) rather than interfaces[0]
+		// (sorted position).
+		{"input-order index normalize", NetworkContext{Version: 1, Interfaces: []InterfaceContext{{Name: "z0"}, {Name: "a0", BSSID: "xx:yy:zz:11:22:33"}}}, "interfaces[1].bssid"},
+		{"input-order index validate", NetworkContext{Version: 1, Interfaces: []InterfaceContext{{Name: "z0"}, {Name: "a0", IfaceType: "satellite"}}}, "interfaces[1].iface_type"},
 		{"at max interfaces", NetworkContext{Version: 1, Interfaces: makeIfaces(MaxInterfaces)}, ""},
 	}
 	for _, tc := range cases {

--- a/component/networkpolicy/install.go
+++ b/component/networkpolicy/install.go
@@ -1,0 +1,248 @@
+package networkpolicy
+
+import (
+	"sync"
+
+	"github.com/metacubex/mihomo/component/profile/cachefile"
+	"github.com/metacubex/mihomo/log"
+)
+
+// globalManager is the process-wide Manager accessor, installed by
+// hub/executor.ApplyConfig and consumed by REST handlers (PUT /proxies
+// hook that calls HandleManualSet, PUT/DELETE/GET /network/context
+// handlers, and provider-update hooks).
+//
+// Guarded by globalMu so hot reloads that swap the manager don't race
+// against concurrent readers. Readers call Global() which takes the
+// lock briefly; Install() swaps under the lock. Manager itself has
+// internal concurrency — the global mutex only protects the pointer
+// swap.
+//
+// Lock ordering discipline for the REST layer (M4):
+//
+//   - globalMu → m.mu  (Install's inheritFrom acquires both; M4 code
+//     that already holds globalMu via Global() and then acquires m.mu
+//     via a manager method is consistent with this order).
+//   - globalMu → sel.mu  (Install calls newSel.Set inside inheritFrom
+//     while holding globalMu; REST handlers that hold a Selector's
+//     internal mutex MUST NOT call Global() or any networkpolicy
+//     package-level function, to avoid inversion deadlock).
+//
+// Specifically: PUT /proxies/:name handlers that call
+// networkpolicy.Global().HandleManualSet(...) or similar must release
+// the Selector lock BEFORE looking up Global(). The safest pattern is:
+// do the Selector.Set() call as its own statement, then fetch Global()
+// in a separate statement, then call HandleManualSet. If the Selector
+// layer doesn't expose its mutex (and outboundgroup.Selector.Set does
+// take an internal mutex), the ordering is satisfied implicitly
+// because the caller never holds the Selector lock across the
+// HandleManualSet call — they call Set, then call HandleManualSet.
+//
+// Known limitation: retaining a *Manager returned by Global() past the
+// Install call that succeeded it leaves the caller operating on a
+// detached instance. M4 REST handlers must re-fetch Global() at every
+// entry point rather than cache the pointer at server-startup time.
+// Codifying this via package-level PutContext/DeleteContext/etc
+// wrappers is deferred to M4 where the REST dispatch is designed.
+var (
+	globalMu      sync.Mutex
+	globalManager *Manager
+)
+
+// Global returns the currently-installed Manager, or nil if Install has
+// not yet been called in this process. REST handlers and hooks should
+// treat a nil return as "network-policy feature is off / not yet
+// initialized" and skip their network-policy-specific logic.
+func Global() *Manager {
+	globalMu.Lock()
+	defer globalMu.Unlock()
+	return globalManager
+}
+
+// Install constructs a new Manager for the given configuration and
+// publishes it as the global instance. On hot reload (second and later
+// calls), it migrates in-memory state from the previous Manager per
+// §5.8.3:
+//   - groups that exist in both old and new: inherit source,
+//     last_matched_network, startup_eval_pending, missingTargetPending
+//   - groups added in the reload: start fresh per branch A / B init
+//   - groups removed in the reload: state is dropped AND their
+//     cachefile bucketNetworkPolicy entry is GC'd so a future reload
+//     that reuses the same name starts clean
+//
+// Cachefile state is also consulted as a fallback, but in-memory state
+// takes priority per §5.6.1 "内存中的状态与热重载：无论 store-selected
+// 是否开启，进程内内存中的状态在配置热重载时始终保留".
+//
+// Critical: Install performs state migration + barrier release BEFORE
+// atomically swapping the global pointer. Concurrent Global() readers
+// see either the old Manager (fully initialized) or the new Manager
+// (fully initialized) — never a half-migrated one. Without this
+// ordering, a PUT / HandleManualSet / GetStatus racing with the
+// migration could observe a Manager whose ctx / TTL / per-group state
+// was still being copied.
+//
+// After migration (or first install), Install releases the provider
+// barrier for every group. mihomo's executor loads proxy providers
+// synchronously via loadProvider before calling Install, so this marks
+// the cold-start provider wait as complete and runs the branch-B
+// internal matched=<none> evaluation for any group that still has
+// startup_eval_pending=true.
+//
+// Install does NOT call ForceReEvaluate — the caller decides whether
+// the context-replay step of §5.8.3 is appropriate (e.g., on hot
+// reload with a cached ctx). On a first-time cold start, ForceReEvaluate
+// is a no-op so unconditional calls are safe.
+func Install(networks []Network, groups []SelectorWithPolicy, cache *cachefile.CacheFile) *Manager {
+	newMgr := NewManager(groups, networks, cache)
+
+	// Hold globalMu for the entire Install so Global() readers block
+	// until migration completes. Why the full-lock rather than a
+	// snapshot-then-publish dance: the latter leaves a window where
+	// Global() returns oldMgr but any writes (PUT /network/context,
+	// HandleManualSet) land on the detached oldMgr AFTER inheritFrom
+	// already snapshotted the pre-write state — the write is silently
+	// dropped. Holding globalMu throughout forces concurrent readers to
+	// wait; in-flight writers that had already dereferenced oldMgr take
+	// old.mu, which inheritFrom also acquires, so they serialize cleanly
+	// before migration begins.
+	//
+	// Install is typically sub-millisecond (state copy + per-group
+	// ReleaseBarrier), and the executor-level mux in ApplyConfig
+	// already serializes Install calls, so the additional blocking on
+	// Global() is negligible in practice.
+	globalMu.Lock()
+	defer globalMu.Unlock()
+
+	if globalManager != nil {
+		newMgr.inheritFrom(globalManager)
+	}
+
+	for _, g := range groups {
+		newMgr.ReleaseBarrier(g.Name())
+	}
+
+	globalManager = newMgr
+	return newMgr
+}
+
+// Uninstall clears the global Manager. Intended for shutdown paths and
+// tests; not called by the executor during normal operation. Cancels
+// any running TTL timer so a test's fake manager doesn't leak AfterFunc
+// goroutines into the next test.
+func Uninstall() {
+	globalMu.Lock()
+	old := globalManager
+	globalManager = nil
+	globalMu.Unlock()
+	if old != nil {
+		old.mu.Lock()
+		old.stopTTLTimerLocked()
+		old.mu.Unlock()
+	}
+}
+
+// inheritFrom copies in-memory state from a predecessor Manager during
+// hot reload. §5.8.3 rules:
+//   - per-group: inherit source, last_matched_network (and presence),
+//     startup_eval_pending, missingTargetPending for groups whose name
+//     appears in both the old and new Manager. Groups absent from the
+//     new Manager (dropped by hot reload) are silently discarded. Groups
+//     new to the reload keep their NewManager-initialized state.
+//   - cached ctx: if old had a ctx, re-adopt it in the new Manager,
+//     including expires_at and the TTL timer. The fingerprint is
+//     recomputed so the new Manager's light path can short-circuit on
+//     subsequent identical PUTs. ctxReceivedAt is preserved so
+//     GetStatus().AgeSeconds reflects age-since-last-host-PUT, not
+//     age-since-reload.
+//   - candidate_set_dirty / pending_missing_target atomic flags: a
+//     reload changes group membership, which §5.6.3 treats as a
+//     candidate-set change; we mark dirty so the next TTL heartbeat
+//     forces a full evaluation. pending_missing_target is recomputed
+//     from the migrated per-group bits.
+func (newMgr *Manager) inheritFrom(old *Manager) {
+	old.mu.Lock()
+	defer old.mu.Unlock()
+	newMgr.mu.Lock()
+	defer newMgr.mu.Unlock()
+
+	for name, oldSt := range old.states {
+		newSt, ok := newMgr.states[name]
+		if !ok {
+			// Group dropped in the reload. GC its cachefile bucket
+			// entry so a future reload that brings the same name back
+			// doesn't resurrect state that is no longer authoritative
+			// (§5.6.1: memory state is authoritative, and we've just
+			// decided to forget this group in memory).
+			if newMgr.cache != nil {
+				newMgr.cache.DeleteNetworkPolicyState(name)
+			}
+			continue
+		}
+		// Inherit in-memory state. Overrides anything NewManager loaded
+		// from the cachefile since in-memory state is authoritative for
+		// groups that existed pre-reload (§5.6.1).
+		newSt.source = oldSt.source
+		newSt.lastMatched = oldSt.lastMatched
+		newSt.lastMatchedPresent = oldSt.lastMatchedPresent
+		newSt.startupEvalPending = oldSt.startupEvalPending
+		newSt.missingTargetPending = oldSt.missingTargetPending
+		// barrierReleased is NOT inherited: the new Manager starts with
+		// its own barrier lifecycle so Install's ReleaseBarrier sweep
+		// sees fresh state.
+
+		// Migrate the selector's current proxy. In store-selected=true
+		// mode, patchSelectGroup has already restored it from the
+		// cachefile before updateNetworkPolicy runs, so the new
+		// selector's Now() already matches. In store-selected=false
+		// mode, patchSelectGroup is skipped and the new selector
+		// defaults to COMPATIBLE — without this step, the user's last
+		// manual choice would silently revert to default on hot reload,
+		// leaving source=manual on a proxy that's no longer selected
+		// (a mismatch §5.6.1 specifically forbids by promising in-
+		// memory state survives reload).
+		oldSel := old.groups[name]
+		newSel := newMgr.groups[name]
+		if oldSel != nil && newSel != nil {
+			oldSelected := oldSel.Now()
+			if oldSelected != "" && newSel.Now() != oldSelected && newSel.HasProxy(oldSelected) {
+				if err := newSel.Set(oldSelected); err != nil {
+					log.Warnln("[NetworkPolicy] group %q: could not migrate selected proxy %q across hot reload: %v", name, oldSelected, err)
+				}
+			}
+		}
+	}
+
+	if old.ctx != nil {
+		ctxCopy := deepCopyContext(old.ctx)
+		if err := ctxCopy.NormalizeAndValidate(); err == nil {
+			newMgr.ctx = ctxCopy
+			newMgr.ctxFingerprint = ctxCopy.Fingerprint()
+			newMgr.ctxReceivedAt = old.ctxReceivedAt
+			fpCopy := newMgr.ctxFingerprint
+			newMgr.atomicCtxFingerprint.Store(&fpCopy)
+			newMgr.atomicHasCtx.Store(true)
+
+			if old.ctxExpiresAt != nil {
+				t := *old.ctxExpiresAt
+				newMgr.ctxExpiresAt = &t
+				newMgr.atomicCtxExpiresAtUnix.Store(t.UnixNano())
+				newMgr.startTTLTimerLocked(t)
+			}
+		}
+	}
+
+	// Stop the old Manager's TTL timer. Its AfterFunc closure retains
+	// a reference to the old Manager, which would otherwise keep the
+	// entire state machine (selectors, providers, ctx, etc.) alive
+	// until the original expiry fires — accumulating across consecutive
+	// hot reloads. stopTTLTimerLocked also bumps old.ttlGen so any
+	// callback already scheduled to run finds itself stale.
+	old.stopTTLTimerLocked()
+
+	// Group membership changed → candidate set is effectively dirty
+	// (§5.6.3 "组成员列表变化（热重载）").
+	newMgr.atomicCandidateSetDirtyCounter.Add(1)
+
+	newMgr.recomputePendingMissingTargetLocked()
+}

--- a/component/networkpolicy/install_test.go
+++ b/component/networkpolicy/install_test.go
@@ -1,0 +1,321 @@
+package networkpolicy
+
+import (
+	"testing"
+)
+
+func resetGlobal(t *testing.T) {
+	t.Helper()
+	Uninstall()
+	t.Cleanup(Uninstall)
+}
+
+func TestInstall_FirstTime_PublishesGlobal(t *testing.T) {
+	resetGlobal(t)
+	if Global() != nil {
+		t.Fatal("precondition: Global() should be nil before Install")
+	}
+
+	sel := newMockSelector("auto", "hk", []string{"hk"}, GroupPolicy{})
+	mgr := Install(nil, []SelectorWithPolicy{sel}, nil)
+	if mgr == nil {
+		t.Fatal("Install must return a non-nil Manager")
+	}
+	if Global() != mgr {
+		t.Errorf("Global() must match the Install'd Manager")
+	}
+}
+
+func TestInstall_HotReload_InheritsInMemoryState(t *testing.T) {
+	resetGlobal(t)
+
+	// Cold install: PUT so we have ctx + per-group state to inherit.
+	sel1 := newMockSelector("auto", "hk", []string{"hk", "us"}, GroupPolicy{
+		Mapping: map[string]string{"office": "us"},
+	})
+	mgr1 := Install([]Network{makeNetwork("office", "office-5g")}, []SelectorWithPolicy{sel1}, nil)
+	mgr1.PutContext(makeCtx("office-5g"))
+
+	// User manually switches — now source=manual.
+	sel1.Set("hk")
+	mgr1.HandleManualSet("auto")
+
+	// Hot reload: new Manager for the same group. Expect migration of
+	// source=manual and last_matched=office.
+	sel2 := newMockSelector("auto", "hk", []string{"hk", "us"}, GroupPolicy{
+		Mapping: map[string]string{"office": "us"},
+	})
+	mgr2 := Install([]Network{makeNetwork("office", "office-5g")}, []SelectorWithPolicy{sel2}, nil)
+
+	st := mgr2.states["auto"]
+	if st.source != SourceManual {
+		t.Errorf("hot reload must inherit source=manual; got %q", st.source)
+	}
+	if st.lastMatched != "office" {
+		t.Errorf("hot reload must inherit last_matched=office; got %q", st.lastMatched)
+	}
+}
+
+func TestInstall_HotReload_InheritsCachedCtx(t *testing.T) {
+	resetGlobal(t)
+
+	sel1 := newMockSelector("auto", "us", []string{"hk", "us"}, GroupPolicy{
+		Mapping: map[string]string{"office": "us"},
+	})
+	mgr1 := Install([]Network{makeNetwork("office", "office-5g")}, []SelectorWithPolicy{sel1}, nil)
+	mgr1.PutContext(makeCtxWithTTL("office-5g", 3600))
+
+	sel2 := newMockSelector("auto", "us", []string{"hk", "us"}, GroupPolicy{
+		Mapping: map[string]string{"office": "us"},
+	})
+	mgr2 := Install([]Network{makeNetwork("office", "office-5g")}, []SelectorWithPolicy{sel2}, nil)
+
+	// ForceReEvaluate should see the inherited ctx and run against it
+	// (bypasses unchanged_network because of the hot-reload trigger).
+	res := mgr2.ForceReEvaluate()
+	if res == nil {
+		t.Fatal("hot reload + inherited ctx: ForceReEvaluate must return a result")
+	}
+	if !res.MatchedNetworkPresent || res.MatchedNetwork != "office" {
+		t.Errorf("ForceReEvaluate after inherit should match office; got present=%v value=%q",
+			res.MatchedNetworkPresent, res.MatchedNetwork)
+	}
+}
+
+func TestInstall_HotReload_NewGroupStartsFresh(t *testing.T) {
+	resetGlobal(t)
+
+	sel1 := newMockSelector("a", "hk", []string{"hk"}, GroupPolicy{
+		Mapping: map[string]string{"office": "hk"},
+	})
+	mgr1 := Install([]Network{makeNetwork("office", "office-5g")}, []SelectorWithPolicy{sel1}, nil)
+	mgr1.PutContext(makeCtx("office-5g"))
+	// After Install, sel1's source=auto.
+
+	// Hot reload adds a new group "b".
+	sel2 := newMockSelector("a", "hk", []string{"hk"}, GroupPolicy{
+		Mapping: map[string]string{"office": "hk"},
+	})
+	selNew := newMockSelector("b", "hk", []string{"hk"}, GroupPolicy{
+		Mapping: map[string]string{"office": "hk"},
+	})
+	mgr2 := Install([]Network{makeNetwork("office", "office-5g")}, []SelectorWithPolicy{sel2, selNew}, nil)
+
+	stB := mgr2.states["b"]
+	if stB == nil {
+		t.Fatal("new group b should be initialized")
+	}
+	// New group starts with source=unknown (branch B init, since no cachefile).
+	// Install's ReleaseBarrier sweep then evaluates and advances source.
+	// It should have advanced to auto via matched=none or match.
+	if stB.source == SourceUnknown {
+		t.Errorf("new group's ReleaseBarrier should have advanced source past unknown; got %q", stB.source)
+	}
+}
+
+func TestInstall_HotReload_DroppedGroupIsDiscarded(t *testing.T) {
+	resetGlobal(t)
+
+	sel1 := newMockSelector("a", "hk", []string{"hk"}, GroupPolicy{})
+	selDropped := newMockSelector("b", "hk", []string{"hk"}, GroupPolicy{
+		Mapping: map[string]string{"office": "hk"},
+	})
+	mgr1 := Install([]Network{makeNetwork("office", "office-5g")}, []SelectorWithPolicy{sel1, selDropped}, nil)
+	_ = mgr1
+
+	// Reload without "b". "b" is silently discarded — no panic, no state.
+	sel2 := newMockSelector("a", "hk", []string{"hk"}, GroupPolicy{})
+	mgr2 := Install([]Network{makeNetwork("office", "office-5g")}, []SelectorWithPolicy{sel2}, nil)
+
+	if _, ok := mgr2.states["b"]; ok {
+		t.Errorf("dropped group must not persist in new Manager state map")
+	}
+}
+
+func TestInstall_HotReload_MarksCandidateSetDirty(t *testing.T) {
+	resetGlobal(t)
+
+	sel1 := newMockSelector("auto", "us", []string{"hk", "us"}, GroupPolicy{
+		Mapping: map[string]string{"office": "us"},
+	})
+	Install([]Network{makeNetwork("office", "office-5g")}, []SelectorWithPolicy{sel1}, nil)
+
+	sel2 := newMockSelector("auto", "us", []string{"hk", "us"}, GroupPolicy{
+		Mapping: map[string]string{"office": "us"},
+	})
+	mgr2 := Install([]Network{makeNetwork("office", "office-5g")}, []SelectorWithPolicy{sel2}, nil)
+
+	if mgr2.atomicCandidateSetDirtyCounter.Load() == 0 {
+		t.Errorf("hot reload should mark candidate_set_dirty")
+	}
+}
+
+func TestInstall_ReleasesBarrier(t *testing.T) {
+	resetGlobal(t)
+
+	sel := newMockSelector("auto", "hk", []string{"hk", "DIRECT"}, GroupPolicy{
+		Mapping:      map[string]string{"office": "hk"},
+		HasDefault:   true,
+		DefaultProxy: "DIRECT",
+	})
+	mgr := Install([]Network{makeNetwork("office", "office-5g")}, []SelectorWithPolicy{sel}, nil)
+
+	// Branch B init would have set pending=true; Install's ReleaseBarrier
+	// sweep should have driven the internal matched=<none> eval → default.
+	if sel.Now() != "DIRECT" {
+		t.Errorf("Install should release barrier and apply default; got %q", sel.Now())
+	}
+	if mgr.states["auto"].startupEvalPending {
+		t.Errorf("pending must clear after Install's barrier release")
+	}
+}
+
+// Hot reload across store-selected=false: the new Selector's `selected`
+// defaults to COMPATIBLE (or wherever NewSelector sets it), and
+// patchSelectGroup is skipped. Without migration, source=manual would
+// refer to a proxy the new Selector is no longer showing. inheritFrom
+// must Set() the old Now() on the new Selector.
+func TestInstall_HotReload_MigratesSelectedProxy(t *testing.T) {
+	resetGlobal(t)
+
+	sel1 := newMockSelector("auto", "hk", []string{"hk", "us"}, GroupPolicy{
+		Mapping: map[string]string{"office": "us"},
+	})
+	Install([]Network{makeNetwork("office", "office-5g")}, []SelectorWithPolicy{sel1}, nil)
+	// User manually picks us.
+	sel1.Set("us")
+	Global().HandleManualSet("auto")
+
+	// Hot reload: brand-new Selector instance with the same candidate
+	// set but default `selected` = "hk" (what newMockSelector starts
+	// with). inheritFrom should migrate selected=us from the old one.
+	sel2 := newMockSelector("auto", "hk", []string{"hk", "us"}, GroupPolicy{
+		Mapping: map[string]string{"office": "us"},
+	})
+	Install([]Network{makeNetwork("office", "office-5g")}, []SelectorWithPolicy{sel2}, nil)
+
+	if sel2.Now() != "us" {
+		t.Errorf("hot reload must migrate selected proxy to survive store-selected=false; got %q", sel2.Now())
+	}
+}
+
+// Old Selector's proxy is no longer a candidate on the new Selector
+// (user removed it from proxies:). inheritFrom best-effort leaves the
+// new Selector at its default — no panic, no error surfaced to caller.
+func TestInstall_HotReload_SelectedMigration_MissingCandidateTolerated(t *testing.T) {
+	resetGlobal(t)
+
+	sel1 := newMockSelector("auto", "hk", []string{"hk", "us"}, GroupPolicy{
+		Mapping: map[string]string{"office": "us"},
+	})
+	Install([]Network{makeNetwork("office", "office-5g")}, []SelectorWithPolicy{sel1}, nil)
+	sel1.Set("us")
+	Global().HandleManualSet("auto")
+
+	// New Selector without "us" in candidates.
+	sel2 := newMockSelector("auto", "hk", []string{"hk", "DIRECT"}, GroupPolicy{
+		Mapping: map[string]string{"office": "hk"},
+	})
+	Install([]Network{makeNetwork("office", "office-5g")}, []SelectorWithPolicy{sel2}, nil)
+
+	// Selected stays at default; inheritFrom saw "us" not present and
+	// skipped the Set.
+	if sel2.Now() == "us" {
+		t.Errorf("should not migrate to a proxy not in new candidate set")
+	}
+}
+
+// White-box regression for the stale-TTL-callback generation guard.
+// Calling onTTLExpired with a gen older than mgr.ttlGen must NOT wipe
+// the cached ctx or any of its atomic companions; without the guard, a
+// renewal racing with the old timer's firing would silently clear the
+// freshly-stored context. Asserts multiple invariants so a future
+// regression that partially clears state (e.g., nils ttlTimer but
+// leaves ctx) is still caught.
+func TestOnTTLExpired_StaleGenIgnored(t *testing.T) {
+	resetGlobal(t)
+
+	sel := newMockSelector("auto", "us", []string{"hk", "us"}, GroupPolicy{
+		Mapping: map[string]string{"office": "us"},
+	})
+	mgr := Install([]Network{makeNetwork("office", "office-5g")}, []SelectorWithPolicy{sel}, nil)
+
+	mgr.PutContext(makeCtxWithTTL("office-5g", 3600))
+	mgr.mu.Lock()
+	currentGen := mgr.ttlGen
+	timerBefore := mgr.ttlTimer
+	expiresBefore := mgr.ctxExpiresAt
+	fpBefore := mgr.ctxFingerprint
+	mgr.mu.Unlock()
+	atomicFpBefore := mgr.atomicCtxFingerprint.Load()
+	atomicExpiresBefore := mgr.atomicCtxExpiresAtUnix.Load()
+
+	// Fire a stale callback (gen-1). Must be a no-op on every field.
+	mgr.onTTLExpired(currentGen - 1)
+
+	if !mgr.atomicHasCtx.Load() {
+		t.Errorf("stale onTTLExpired must not clear hasCtx")
+	}
+	mgr.mu.Lock()
+	if mgr.ttlTimer != timerBefore {
+		t.Errorf("stale onTTLExpired must not touch ttlTimer")
+	}
+	if mgr.ctxExpiresAt != expiresBefore {
+		t.Errorf("stale onTTLExpired must not touch ctxExpiresAt")
+	}
+	if mgr.ctxFingerprint != fpBefore {
+		t.Errorf("stale onTTLExpired must not touch ctxFingerprint")
+	}
+	mgr.mu.Unlock()
+	if mgr.atomicCtxFingerprint.Load() != atomicFpBefore {
+		t.Errorf("stale onTTLExpired must not touch atomicCtxFingerprint")
+	}
+	if mgr.atomicCtxExpiresAtUnix.Load() != atomicExpiresBefore {
+		t.Errorf("stale onTTLExpired must not touch atomicCtxExpiresAtUnix")
+	}
+}
+
+func TestUninstall_ClearsGlobal(t *testing.T) {
+	resetGlobal(t)
+
+	sel := newMockSelector("auto", "hk", []string{"hk"}, GroupPolicy{})
+	Install(nil, []SelectorWithPolicy{sel}, nil)
+	Uninstall()
+	if Global() != nil {
+		t.Errorf("Uninstall must clear global")
+	}
+}
+
+// Uninstall stops any scheduled TTL timer on the outgoing Manager so
+// the AfterFunc closure doesn't keep a dead Manager alive until the
+// original expiry. White-box: TTL duration doesn't matter — we just
+// need PutContext to have installed a timer, then verify Uninstall
+// clears the field.
+func TestUninstall_StopsTTLTimer(t *testing.T) {
+	resetGlobal(t)
+
+	sel := newMockSelector("auto", "us", []string{"hk", "us"}, GroupPolicy{
+		Mapping: map[string]string{"office": "us"},
+	})
+	mgr := Install([]Network{makeNetwork("office", "office-5g")}, []SelectorWithPolicy{sel}, nil)
+
+	ttlVal := 3600
+	ctx := makeCtx("office-5g")
+	ctx.TTL = &ttlVal
+	mgr.PutContext(ctx)
+	mgr.mu.Lock()
+	timerBefore := mgr.ttlTimer
+	mgr.mu.Unlock()
+	if timerBefore == nil {
+		t.Fatal("precondition: PutContext with TTL must install a timer")
+	}
+
+	Uninstall()
+
+	mgr.mu.Lock()
+	timerAfter := mgr.ttlTimer
+	mgr.mu.Unlock()
+	if timerAfter != nil {
+		t.Errorf("Uninstall must stop the TTL timer (set to nil)")
+	}
+}

--- a/component/networkpolicy/manager.go
+++ b/component/networkpolicy/manager.go
@@ -1,0 +1,1032 @@
+package networkpolicy
+
+import (
+	"fmt"
+	"net/netip"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/metacubex/mihomo/component/profile/cachefile"
+	"github.com/metacubex/mihomo/log"
+)
+
+// DefaultBarrierTimeout is the per-group provider-ready barrier timeout
+// (architecture §5.6.2 "first-load 超时"). Internal constant for now;
+// promoted to a YAML field if user feedback warrants.
+const DefaultBarrierTimeout = 15 * time.Second
+
+// ApplyResult is one row of applied[] in the PUT /network/context response
+// (architecture §5.4.2).
+type ApplyResult struct {
+	Group           string
+	TargetProxy     string // policy decision; empty when no mapping hit
+	AppliedProxy    string // currently applied proxy; always non-empty
+	Changed         bool   // did this evaluation call selector.Set()?
+	SelectionSource string // auto / manual / unknown
+	Reason          string // one of the seven ReasonXxx constants
+}
+
+// PutResult is the full state-machine response to PutContext. Maps to the
+// §5.4.2 JSON body; REST layer handles wire encoding (nil / MatchedNone →
+// JSON null for matched_network etc.).
+type PutResult struct {
+	// MatchedNetworkPresent + MatchedNetwork mirror the PersistedState
+	// last_matched_network tri-state encoding:
+	//   - MatchedNetworkPresent=false → nil (never evaluated; should only
+	//     appear in intermediate diagnostics, never in a PutResult after
+	//     a completed evaluation)
+	//   - MatchedNetworkPresent=true && MatchedNetwork==MatchedNone →
+	//     evaluated, no match
+	//   - MatchedNetworkPresent=true && MatchedNetwork=="<name>" → matched
+	MatchedNetworkPresent bool
+	MatchedNetwork        string
+
+	Applied   []ApplyResult
+	ExpiresAt *time.Time // nil = sticky (no TTL)
+}
+
+// StatusResult is the GET /network/context response model. Similar to
+// PutResult but without the per-group Changed flag (read-only snapshot).
+type StatusResult struct {
+	HasContext            bool
+	Context               *NetworkContext // deep-copied snapshot
+	MatchedNetworkPresent bool
+	MatchedNetwork        string
+	Groups                []GroupStatus
+	ExpiresAt             *time.Time
+	AgeSeconds            *int64
+}
+
+// GroupStatus is one row of groups[] in GET /network/context.
+type GroupStatus struct {
+	Group                     string
+	CurrentProxy              string
+	SelectionSource           string
+	LastMatchedNetworkPresent bool
+	LastMatchedNetwork        string
+}
+
+// groupState is the per-group state-machine cell the Manager maintains.
+// Access is guarded by Manager.mu (the serial queue).
+type groupState struct {
+	// source is one of SourceAuto / SourceManual / SourceUnknown.
+	source string
+
+	// lastMatched + lastMatchedPresent encode the tri-state described in
+	// §5.6.1: "nil" (Present=false), MatchedNone (Present=true, value =
+	// MatchedNone), or concrete name (Present=true, value = name).
+	lastMatched        string
+	lastMatchedPresent bool
+
+	// missingTargetPending records whether the last evaluation for this
+	// group ended in reason=missing_target. Used to compute the global
+	// atomicHasPendingMissingTarget flag (TTL light path condition d)
+	// from any code path that re-evaluates a single group (not just the
+	// all-groups sweep in PutContext / ForceReEvaluate).
+	missingTargetPending bool
+
+	// startupEvalPending is true until the provider barrier for this
+	// group has released AND (if the group landed in missing_target
+	// during the barrier) the post-barrier re-evaluation has run.
+	// Transitions (§5.6.2 "provider 屏障的实施契约"):
+	//   - initialized true in branch B; false in branch A
+	//   - barrier-period PUT that lands in matched/already_selected/
+	//     default/no_change_no_default → set false
+	//   - barrier-period PUT that lands in missing_target → stays true
+	//     so the post-release recheck covers the retry
+	//   - barrier release with pending=true → re-evaluates with current
+	//     cached ctx (or matched=<none> if no ctx), then clears
+	//   - hot reload: preserved verbatim for groups that survived rename-
+	//     less; new groups start true (treated as branch B for them)
+	startupEvalPending bool
+
+	// barrierReleased flips true when the per-group provider barrier
+	// either detected all referenced providers populated OR the 15s
+	// timeout elapsed. After release, startup-specific paths no longer
+	// apply and the state machine runs in steady state.
+	barrierReleased bool
+}
+
+// selectorWithPolicy interface is defined in policy.go (unexported to the
+// package — outboundgroup.Selector satisfies it via duck-typing, and
+// intra-package tests can supply mocks without needing the interface to
+// be exported).
+
+// Manager is the single state-machine kernel for the network-policy
+// feature. It owns:
+//   - per-group state (source / last_matched / startup_eval_pending)
+//   - cached NetworkContext snapshot + TTL timer
+//   - fingerprint and candidate-set-dirty flags for the TTL light path
+//   - per-group provider barriers
+//
+// The architecture (§5.6.3) requires a single serial queue to prevent
+// interleaved evaluation from corrupting state under concurrent manual
+// PUT / context PUT / TTL expiry / hot reload. Manager uses a plain
+// mutex: all state-mutating APIs acquire mu, complete their work, and
+// release. Non-mutating read paths (TTL light path) use atomic loads on
+// a narrow set of fields published from within mu.
+type Manager struct {
+	mu sync.Mutex
+
+	// Stable for the lifetime of the Manager. groupsOrder preserves YAML
+	// declaration order so applied[] / groups[] output stays deterministic.
+	// Hot reload constructs a fresh Manager in M3c's executor wiring and
+	// migrates in-memory state; this type intentionally does not expose
+	// an in-place Replace to keep the serial-queue invariants simple.
+	groups       map[string]selectorWithPolicy
+	groupsOrder  []string
+	networks     []Network
+	cache        *cachefile.CacheFile
+	barrierTTL   time.Duration
+
+	// Per-group state; key = group name. Written only under mu.
+	states map[string]*groupState
+
+	// ctx is the cached normalized NetworkContext snapshot. Written only
+	// under mu. Deep-copied on every PutContext so callers can't mutate
+	// internal state by retaining references to arguments.
+	ctx             *NetworkContext
+	ctxFingerprint  string
+	ctxExpiresAt    *time.Time
+	ctxReceivedAt   time.Time // when the cached ctx was stored (for GetStatus age_seconds)
+	ttlTimer        *time.Timer // AfterFunc pending TTL expiry; nil when sticky
+	ttlGen          uint64      // monotonic stamp — onTTLExpired ignores stale callbacks
+
+	// Atomic-published flags for the TTL light path (§5.6.3). Readers
+	// outside mu use atomic loads; writers set them under mu. Field
+	// inconsistencies are acceptable — the worst case is one extra full
+	// evaluation that the state machine's own idempotent short-circuit
+	// absorbs.
+	//
+	// atomicCandidateSetDirtyCounter is an incrementing counter, not a
+	// boolean, so we can distinguish "same dirty event we observed pre-
+	// evaluation" from "a new dirty event arrived during the evaluation":
+	// PutContext snapshots the counter before entering evaluation and
+	// uses CompareAndSwap(snapshot, 0) at the end; if a concurrent
+	// OnCandidateSetDirty bumped the counter during the evaluation, the
+	// CAS fails and the signal is preserved for the next cycle.
+	atomicHasCtx                   atomic.Bool
+	atomicCtxFingerprint           atomic.Pointer[string]
+	atomicCtxExpiresAtUnix         atomic.Int64 // 0 = sticky
+	atomicHasPendingMissingTarget  atomic.Bool
+	atomicCandidateSetDirtyCounter atomic.Int64
+}
+
+// NewManager constructs a fresh Manager for the given groups + networks,
+// restoring per-group state from the cachefile bucket per §5.6.2 branch
+// A/B split:
+//   - branch A: bucketNetworkPolicy exists (store-selected can be either
+//     way; NetworkPolicyStateMap returns (map, true)). Every group with
+//     a matching entry restores (source, lastMatched); entries that fail
+//     Validate or reference groups no longer declared are silently
+//     dropped. Groups without an entry start unknown/nil. startupEval
+//     Pending=false for all branch-A groups — no post-barrier internal
+//     evaluation.
+//   - branch B: no bucket (NetworkPolicyStateMap returns (_, false)).
+//     Every group starts unknown/nil with startupEvalPending=true, so
+//     that the subsequent ReleaseBarrier call runs an internal
+//     matched=<none> evaluation (or uses cached ctx if one was PUT
+//     during the barrier).
+//
+// Providers are not polled here; that belongs to M3c (executor wiring).
+// ReleaseBarrier(groupName) is the public entry point executors call
+// when a group's referenced providers are populated or the 15s timeout
+// elapses.
+func NewManager(groups []selectorWithPolicy, networks []Network, cache *cachefile.CacheFile) *Manager {
+	m := &Manager{
+		groups:      make(map[string]selectorWithPolicy, len(groups)),
+		groupsOrder: make([]string, 0, len(groups)),
+		networks:    networks,
+		cache:       cache,
+		barrierTTL:  DefaultBarrierTimeout,
+		states:      make(map[string]*groupState, len(groups)),
+	}
+	for _, g := range groups {
+		name := g.Name()
+		m.groups[name] = g
+		m.groupsOrder = append(m.groupsOrder, name)
+	}
+	m.initStatesFromCache()
+	return m
+}
+
+// initStatesFromCache populates m.states from the cachefile bucket,
+// driving the branch A / B decision. Called from NewManager. On hot
+// reload the executor is responsible for migrating in-memory state
+// from the previous Manager before constructing a new one; see the
+// M3c wiring for the migration protocol (§5.8.3 preservation rules).
+// Assumes no external callers hold mu; skips locking.
+func (m *Manager) initStatesFromCache() {
+	var (
+		stateBytes   map[string][]byte
+		bucketExists bool
+	)
+	if m.cache != nil {
+		stateBytes, bucketExists = m.cache.NetworkPolicyStateMap()
+	}
+	branchA := bucketExists
+	for _, name := range m.groupsOrder {
+		g := m.groups[name]
+		if _, ok := m.states[name]; ok {
+			// Already initialized (e.g., preserved across hot reload).
+			continue
+		}
+		st := &groupState{
+			source:             SourceUnknown,
+			startupEvalPending: !branchA,
+		}
+		if branchA {
+			if raw, ok := stateBytes[name]; ok {
+				if restored, err := decodePersisted(raw); err == nil {
+					st.source = restored.Source
+					if restored.LastMatchedPresent {
+						st.lastMatchedPresent = true
+						st.lastMatched = restored.LastMatched
+					}
+				} else {
+					// Corrupted record: drop it and GC, leaving this
+					// group at unknown/nil within branch A (§5.6.2
+					// "部分组缺 entry").
+					log.Warnln("[NetworkPolicy] discarding corrupt bucket entry for group %q: %v", name, err)
+					if m.cache != nil {
+						m.cache.DeleteNetworkPolicyState(name)
+					}
+				}
+			}
+			// Group has no entry in the bucket → already unknown/nil;
+			// first PUT will force full evaluation per §5.6.2 row 2.
+			// startupEvalPending stays false: branch A doesn't run the
+			// internal matched=<none> evaluation.
+		}
+		// Omit groups that have no GroupPolicy attached (defensive: only
+		// select groups with network-policy should be in the list at
+		// all, but it keeps the state map tight).
+		if g.NetworkPolicy().IsEmpty() {
+			continue
+		}
+		m.states[name] = st
+	}
+}
+
+// decodePersisted unwraps the JSON + Validate chain for load-side
+// record recovery. Uses the M3a PersistedState schema.
+func decodePersisted(raw []byte) (PersistedState, error) {
+	var ps PersistedState
+	if err := ps.UnmarshalJSON(raw); err != nil {
+		return PersistedState{}, err
+	}
+	if err := ps.Validate(); err != nil {
+		return PersistedState{}, err
+	}
+	return ps, nil
+}
+
+// PutContext applies a new NetworkContext from a host PUT and runs the
+// full state machine. Returns a PutResult mirroring §5.4.2 applied[].
+//
+// Concurrency: acquires mu for the full evaluation + cachefile write.
+// The TTL light path (non-evaluating heartbeat refresh) short-circuits
+// before mu is acquired and is handled inline.
+//
+// Ownership: raw is deep-copied before being stored as the new cached
+// ctx; callers may mutate raw after return without corrupting Manager
+// state. raw is also re-normalized via NormalizeAndValidate so that
+// derived fields (subnetsParsed, gatewayIPParsed) are valid for the
+// matcher evaluation.
+func (m *Manager) PutContext(raw *NetworkContext) (*PutResult, error) {
+	if raw == nil {
+		return nil, fmt.Errorf("PutContext: nil context")
+	}
+
+	// Deep-copy BEFORE normalization so we don't re-normalize the
+	// caller's slice/pointer fields (architecture §5.6.3).
+	ctx := deepCopyContext(raw)
+	if err := ctx.NormalizeAndValidate(); err != nil {
+		return nil, err
+	}
+	fp := ctx.Fingerprint()
+
+	// TTL light path (§5.6.3). All five conditions must hold.
+	if resp, ok := m.tryTTLLightPath(ctx, fp); ok {
+		return resp, nil
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	// Snapshot the candidate-set dirty counter BEFORE evaluation so we
+	// can distinguish "dirty event we are consuming" from "dirty event
+	// that arrived while we were evaluating". Cleared at the end via
+	// CAS — if someone bumped the counter during evaluation, the CAS
+	// fails and the new event is preserved for the next PUT.
+	dirtySnapshot := m.atomicCandidateSetDirtyCounter.Load()
+
+	// Expire the previous TTL timer (if any) — we're about to replace
+	// the cached ctx and its expiry window.
+	m.stopTTLTimerLocked()
+
+	matched, matchedPresent := m.matchLocked(ctx)
+	applied := make([]ApplyResult, 0, len(m.groupsOrder))
+	for _, name := range m.groupsOrder {
+		st, ok := m.states[name]
+		if !ok {
+			continue
+		}
+		res := m.evaluateGroupLocked(name, st, matched, matchedPresent, evalTriggerPutContext)
+		applied = append(applied, res)
+	}
+
+	// Store new ctx snapshot + fingerprint atomically with the evaluation.
+	m.ctx = ctx
+	m.ctxFingerprint = fp
+	m.ctxReceivedAt = time.Now()
+	fpCopy := fp
+	m.atomicCtxFingerprint.Store(&fpCopy)
+	m.atomicHasCtx.Store(true)
+
+	var expiresAt *time.Time
+	if ctx.TTL != nil {
+		t := time.Now().Add(time.Duration(*ctx.TTL) * time.Second)
+		expiresAt = &t
+		m.ctxExpiresAt = &t
+		m.atomicCtxExpiresAtUnix.Store(t.UnixNano())
+		m.startTTLTimerLocked(t)
+	} else {
+		m.ctxExpiresAt = nil
+		m.atomicCtxExpiresAtUnix.Store(0)
+	}
+
+	// candidate_set_dirty (§5.6.3) consumed: only clear if the counter is
+	// still at the value we observed pre-evaluation. A bump during the
+	// evaluation (concurrent OnCandidateSetDirty) fails the CAS and keeps
+	// the signal alive for the next PUT — otherwise the race between a
+	// provider refresh and the serial queue would swallow the dirty event.
+	m.atomicCandidateSetDirtyCounter.CompareAndSwap(dirtySnapshot, 0)
+	m.recomputePendingMissingTargetLocked()
+
+	result := &PutResult{
+		MatchedNetworkPresent: matchedPresent,
+		MatchedNetwork:        matched,
+		Applied:               applied,
+		ExpiresAt:             expiresAt,
+	}
+	return result, nil
+}
+
+// tryTTLLightPath checks the five conditions of §5.6.3 and, if all hold,
+// returns the lightweight response without entering the serial queue.
+// Returns (nil, false) for any condition miss — caller falls through to
+// the full evaluation.
+//
+// Condition set:
+//
+//	(a) incoming ctx fingerprint == cached fingerprint
+//	(b) incoming body has ttl (sticky → false)
+//	(c) cached ctx also had ttl (sticky → false)
+//	(d) no pending missing_target retry from the last evaluation
+//	(e) candidate_set_dirty not set since the last evaluation
+//
+// Reads use atomic loads and tolerate brief inconsistencies (the manager
+// queue writes under mu; cross-field tearing between two atomic loads
+// just means we may fall back to the full path once).
+func (m *Manager) tryTTLLightPath(incoming *NetworkContext, incomingFP string) (*PutResult, bool) {
+	if !m.atomicHasCtx.Load() {
+		return nil, false
+	}
+	cached := m.atomicCtxFingerprint.Load()
+	if cached == nil || *cached != incomingFP {
+		return nil, false
+	}
+	if incoming.TTL == nil {
+		return nil, false // (b)
+	}
+	cachedExpiresUnix := m.atomicCtxExpiresAtUnix.Load()
+	if cachedExpiresUnix == 0 {
+		return nil, false // (c) — cached was sticky
+	}
+	if m.atomicHasPendingMissingTarget.Load() {
+		return nil, false // (d)
+	}
+	if m.atomicCandidateSetDirtyCounter.Load() != 0 {
+		return nil, false // (e)
+	}
+
+	// All five conditions hold: just rotate expires_at and emit the
+	// response from the current state without evaluating. We still hold
+	// mu briefly to read per-group states coherently (a light-path read
+	// should not race the serial queue mid-update).
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	// Re-check conditions under mu — atomic reads may have been racing
+	// with the serial queue. If anything changed, fall back to full eval.
+	if m.ctx == nil || m.ctxFingerprint != incomingFP || m.ctxExpiresAt == nil || m.atomicHasPendingMissingTarget.Load() || m.atomicCandidateSetDirtyCounter.Load() != 0 {
+		return nil, false
+	}
+
+	now := time.Now()
+	newExpires := now.Add(time.Duration(*incoming.TTL) * time.Second)
+	m.ctxExpiresAt = &newExpires
+	m.ctxReceivedAt = now // heartbeat also refreshes the "when did we last hear from host" stamp so GetStatus().AgeSeconds reports time-since-latest-PUT, not time-since-first-PUT
+	// Refresh the cached ctx's TTL pointer so GET /network/context
+	// echoes the currently-active TTL. The ctx body itself is
+	// fingerprint-identical and doesn't need re-copying.
+	if m.ctx != nil {
+		ttl := *incoming.TTL
+		m.ctx.TTL = &ttl
+	}
+	m.atomicCtxExpiresAtUnix.Store(newExpires.UnixNano())
+	m.stopTTLTimerLocked()
+	m.startTTLTimerLocked(newExpires)
+
+	// Recompute matched_network from the cached ctx directly. The light
+	// path's fingerprint invariant guarantees Match() returns the same
+	// result as the prior full evaluation, so re-running it is cheap and
+	// produces the same wire value — without depending on any group's
+	// lastMatched as a proxy. Same pattern GetStatus uses, required
+	// because a config with 0 policy groups has no group state to fall
+	// back to and would otherwise report matched_network=null.
+	matched, matchedPresent := m.matchLocked(m.ctx)
+	resolveTarget := matched
+	if matched == MatchedNone {
+		resolveTarget = "" // Resolve treats empty as "no match"
+	}
+
+	applied := make([]ApplyResult, 0, len(m.groupsOrder))
+	for _, name := range m.groupsOrder {
+		st, ok := m.states[name]
+		if !ok {
+			continue
+		}
+		g := m.groups[name]
+		res := ApplyResult{
+			Group:           name,
+			AppliedProxy:    g.Now(),
+			Changed:         false,
+			SelectionSource: st.source,
+		}
+		// Defensive: the light path's condition (d) + branch-B startup
+		// having completed guarantee source != unknown. If we see it
+		// anyway, fall back to full evaluation to avoid emitting a
+		// nonsense reason (§5.6.3 "源=unknown → 不会出现" fallback).
+		if st.source == SourceUnknown {
+			log.Warnln("[NetworkPolicy] TTL light path saw source=unknown on group %q; falling back to full evaluation", name)
+			return nil, false
+		}
+		target, _ := g.NetworkPolicy().Resolve(resolveTarget)
+		res.TargetProxy = target
+		if st.source == SourceManual {
+			res.Reason = ReasonManualLocked
+		} else {
+			res.Reason = ReasonUnchangedNetwork
+		}
+		applied = append(applied, res)
+	}
+
+	return &PutResult{
+		MatchedNetworkPresent: matchedPresent,
+		MatchedNetwork:        matched,
+		Applied:               applied,
+		ExpiresAt:             &newExpires,
+	}, true
+}
+
+// matchLocked evaluates the global Match() against the cached networks
+// and returns the per-ctx matched_network value in the tri-state encoding
+// used by last_matched_network updates (Present=true always after an
+// evaluation; value is either a concrete name or MatchedNone).
+func (m *Manager) matchLocked(ctx *NetworkContext) (value string, present bool) {
+	name, ok := Match(m.networks, ctx)
+	if ok {
+		return name, true
+	}
+	return MatchedNone, true
+}
+
+// evalTrigger distinguishes which §5.6.2 row we're processing, so the
+// state machine can apply the narrow differences correctly.
+type evalTrigger int
+
+const (
+	// evalTriggerPutContext is a normal host PUT /network/context.
+	evalTriggerPutContext evalTrigger = iota
+	// evalTriggerHotReload is a post-reload re-evaluation using the
+	// cached ctx (§5.8.3). Bypasses the unchanged_network / manual_locked
+	// short-circuit so policy-mapping edits take effect even when ctx
+	// fingerprint is stable.
+	evalTriggerHotReload
+	// evalTriggerBarrierRelease is the internal evaluation the barrier
+	// release path runs for groups that still have startupEvalPending=true.
+	// Uses the cached ctx if present; otherwise forces matched=<none>.
+	evalTriggerBarrierRelease
+)
+
+// evaluateGroupLocked runs the §5.6.2 state-machine table for one group.
+// Returns the ApplyResult for the group and, as side effects, updates the
+// per-group state in m.states (and writes cachefile if state changed).
+//
+// The trigger argument governs two narrow details:
+//   - evalTriggerHotReload forces evaluation regardless of matched stability
+//     so YAML policy edits take effect even with stable context.
+//   - evalTriggerBarrierRelease treats the absence of cached ctx as
+//     matched=<none> (§5.6.4 触发源 2).
+func (m *Manager) evaluateGroupLocked(name string, st *groupState, matched string, matchedPresent bool, trigger evalTrigger) (res ApplyResult) {
+	g := m.groups[name]
+	policy := g.NetworkPolicy()
+	res = ApplyResult{
+		Group:        name,
+		AppliedProxy: g.Now(),
+	}
+	// SelectionSource is recorded POST-transition — named return value +
+	// deferred assignment ensures every return site reports the state
+	// machine's post-evaluation source (what the caller will see from
+	// here on), not the pre-transition source.
+	defer func() { res.SelectionSource = st.source }()
+
+	// source=unknown: force full evaluation ignoring stability checks
+	// (§5.6.2 row 2). Covers branch-B first PUT and any group that's
+	// lost its cached state.
+	forceEval := st.source == SourceUnknown || trigger == evalTriggerHotReload
+
+	// matched_result equality uses the tri-state comparison from §5.6.1:
+	// nil (Present=false) compares unequal to anything.
+	sameMatched := !forceEval && st.lastMatchedPresent && matchedPresent && st.lastMatched == matched
+
+	// Row 3 / 4: matched stable + source=auto|manual → short-circuit.
+	// Clearing missingTargetPending here is important: a prior evaluation
+	// that landed in missing_target sets the per-group bit, but if the
+	// user moves through ctx states that come back to the original
+	// matched (A → B misses → A again), the A-evaluation's short-circuit
+	// would otherwise leave pending=true forever, permanently disabling
+	// the TTL light path condition (d).
+	if sameMatched {
+		switch st.source {
+		case SourceAuto:
+			st.missingTargetPending = false
+			res.Reason = ReasonUnchangedNetwork
+			target, _ := policy.Resolve(currentMatchedForResolve(matched, matchedPresent))
+			res.TargetProxy = target
+			return res
+		case SourceManual:
+			st.missingTargetPending = false
+			res.Reason = ReasonManualLocked
+			target, _ := policy.Resolve(currentMatchedForResolve(matched, matchedPresent))
+			res.TargetProxy = target
+			return res
+		}
+	}
+
+	// Full evaluation: resolve target via policy, then classify + apply.
+	target, policyReason := policy.Resolve(currentMatchedForResolve(matched, matchedPresent))
+	res.TargetProxy = target
+
+	// Target reachability check: if policy decided on a concrete proxy
+	// that isn't currently in the group's candidate set (provider not
+	// yet populated, etc.), emit missing_target per §5.8.2. source /
+	// last_matched stay put so the next PUT retries.
+	if target != "" && !g.HasProxy(target) {
+		res.Reason = ReasonMissingTarget
+		st.missingTargetPending = true
+		return res
+	}
+
+	switch policyReason {
+	case ReasonMatched:
+		// target known-reachable. Set if not already, otherwise
+		// already_selected.
+		if g.Now() == target {
+			res.Reason = ReasonAlreadySelected
+		} else {
+			if err := g.Set(target); err != nil {
+				log.Warnln("[NetworkPolicy] group %q Set(%q) failed: %v", name, target, err)
+				// Treat as missing_target — failed Set implies the
+				// target cannot be applied right now. State stays put.
+				res.Reason = ReasonMissingTarget
+				st.missingTargetPending = true
+				return res
+			}
+			res.Changed = true
+			res.AppliedProxy = target
+			res.Reason = ReasonMatched
+		}
+		m.advanceStateLocked(name, st, matched, matchedPresent, SourceAuto)
+
+	case ReasonDefault:
+		// Policy returned the default proxy. Set if different; source=auto;
+		// last_matched advances.
+		if g.Now() == target {
+			res.Reason = ReasonDefault
+		} else {
+			if err := g.Set(target); err != nil {
+				log.Warnln("[NetworkPolicy] group %q default Set(%q) failed: %v", name, target, err)
+				res.Reason = ReasonMissingTarget
+				st.missingTargetPending = true
+				return res
+			}
+			res.Changed = true
+			res.AppliedProxy = target
+			res.Reason = ReasonDefault
+		}
+		m.advanceStateLocked(name, st, matched, matchedPresent, SourceAuto)
+
+	case ReasonNoChangeNoDefault:
+		// Policy has no mapping and no default. Keep current selection;
+		// source=auto; last_matched still advances.
+		res.Reason = ReasonNoChangeNoDefault
+		m.advanceStateLocked(name, st, matched, matchedPresent, SourceAuto)
+
+	default:
+		// Unreachable — Resolve only returns the three reasons above.
+		log.Warnln("[NetworkPolicy] group %q: unexpected policy reason %q", name, policyReason)
+		res.Reason = policyReason
+	}
+
+	return res
+}
+
+// advanceStateLocked updates per-group state after a successful
+// evaluation and writes to cachefile iff state changed. Matches §5.6.3
+// "Cachefile 写盘条件" — only persist on real transitions to keep
+// cachefile churn down.
+func (m *Manager) advanceStateLocked(name string, st *groupState, matched string, matchedPresent bool, newSource string) {
+	oldSource := st.source
+	oldPresent := st.lastMatchedPresent
+	oldMatched := st.lastMatched
+
+	st.source = newSource
+	if matchedPresent {
+		st.lastMatchedPresent = true
+		st.lastMatched = matched
+	}
+	// startup_eval_pending: resolved outcome (non-missing-target) clears
+	// the pending flag — the group has a definite answer for the
+	// post-barrier recheck (§5.6.2 规则).
+	st.startupEvalPending = false
+	// Resolved outcome also means no missing_target pending for this group.
+	st.missingTargetPending = false
+
+	stateChanged := oldSource != st.source || oldPresent != st.lastMatchedPresent || oldMatched != st.lastMatched
+	if !stateChanged {
+		return
+	}
+	m.persistStateLocked(name, st)
+}
+
+// recomputePendingMissingTargetLocked scans all groups and republishes
+// the global atomicHasPendingMissingTarget flag. Called from any path
+// that runs an evaluation — PutContext, ForceReEvaluate, ReleaseBarrier
+// — so condition (d) of the TTL light path stays in sync with the
+// actual state (§5.6.3 contract).
+func (m *Manager) recomputePendingMissingTargetLocked() {
+	any := false
+	for _, st := range m.states {
+		if st.missingTargetPending {
+			any = true
+			break
+		}
+	}
+	m.atomicHasPendingMissingTarget.Store(any)
+}
+
+// persistStateLocked writes the group's current state to the cachefile
+// bucket, gated on StoreSelected. No-op on nil cache.
+func (m *Manager) persistStateLocked(name string, st *groupState) {
+	if m.cache == nil {
+		return
+	}
+	ps := PersistedState{
+		SchemaVersion:      PersistVersion,
+		Source:             st.source,
+		LastMatched:        st.lastMatched,
+		LastMatchedPresent: st.lastMatchedPresent,
+	}
+	if err := WriteNetworkPolicyState(m.cache, name, ps); err != nil {
+		// Write-side Validate failure is a programmer bug: log and
+		// skip. Don't propagate — the runtime already applied the
+		// transition; cachefile is best-effort persistence.
+		log.Warnln("[NetworkPolicy] group %q: persist failed: %v", name, err)
+	}
+}
+
+// currentMatchedForResolve adapts the tri-state matched result to the
+// single-string Resolve API (empty string ↔ "no match" to Resolve).
+func currentMatchedForResolve(matched string, present bool) string {
+	if !present || matched == MatchedNone {
+		return ""
+	}
+	return matched
+}
+
+// DeleteContext implements DELETE /network/context: clears the cached
+// snapshot and cancels the TTL timer, BUT preserves the state machine
+// (source / last_matched / currently-selected proxy stay put per §5.4.3).
+func (m *Manager) DeleteContext() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.stopTTLTimerLocked()
+	m.ctx = nil
+	m.ctxFingerprint = ""
+	m.ctxExpiresAt = nil
+
+	m.atomicHasCtx.Store(false)
+	m.atomicCtxFingerprint.Store(nil)
+	m.atomicCtxExpiresAtUnix.Store(0)
+	// hasPendingMissingTarget and candidateSetDirty are not touched —
+	// they reflect facts about the last completed evaluation's state,
+	// which persists across DELETE.
+}
+
+// HandleManualSet is invoked when the user manually picks a proxy via
+// PUT /proxies/:name for a network-policy-governed group. The state
+// machine updates source=manual; last_matched stays put per §5.6.2
+// row 1. Cachefile is written on change.
+//
+// If the group has no network-policy attached, HandleManualSet is a
+// no-op — the plain selector.Set path already handled it.
+func (m *Manager) HandleManualSet(groupName string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	st, ok := m.states[groupName]
+	if !ok {
+		return
+	}
+	if st.source == SourceManual {
+		return // no transition; cachefile already has this state
+	}
+	st.source = SourceManual
+	// last_matched intentionally unchanged (§5.6.2 row 1); nothing
+	// else is touched — startupEvalPending is left alone so a
+	// subsequent ReleaseBarrier can still run the branch-B recheck if
+	// needed. If that recheck finds a new matched (!= nil), the auto
+	// takeover rule applies (§5.6.2 手动优先) and the user's manual
+	// selection may be overridden — which is consistent with "manual-
+	// wins only on the same network".
+	m.persistStateLocked(groupName, st)
+}
+
+// ReleaseBarrier signals that the per-group provider barrier has
+// resolved (all referenced providers populated, or 15s timeout). Groups
+// whose startupEvalPending is still true at this point run an internal
+// evaluation per §5.6.2:
+//   - if cached ctx present → full evaluation against that ctx
+//     (§5.6.4 触发源 1)
+//   - if no cached ctx → matched=<none> evaluation (§5.6.4 触发源 2)
+//
+// Callers (executor) should invoke this exactly once per group per
+// manager lifetime; additional calls are harmless (no-op if the group
+// has already cleared its pending flag).
+func (m *Manager) ReleaseBarrier(groupName string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	st, ok := m.states[groupName]
+	if !ok {
+		return
+	}
+	if st.barrierReleased {
+		return
+	}
+	st.barrierReleased = true
+
+	if !st.startupEvalPending {
+		return
+	}
+
+	// Recheck: cached ctx or matched=<none>.
+	var matched string
+	var matchedPresent bool
+	if m.ctx != nil {
+		matched, matchedPresent = m.matchLocked(m.ctx)
+	} else {
+		matched = MatchedNone
+		matchedPresent = true // §5.6.4 trigger source 2 treats as evaluated
+	}
+
+	// Evaluate but don't bother returning the result — barrier release is
+	// an internal pathway, not a REST response.
+	_ = m.evaluateGroupLocked(groupName, st, matched, matchedPresent, evalTriggerBarrierRelease)
+	// missing_target on recheck keeps startupEvalPending=true conceptually,
+	// but evaluateGroupLocked clears it on the auto/default paths. For
+	// missing_target, we keep the bit set by NOT calling advanceState
+	// (handled inside evaluateGroupLocked: missing_target returns early
+	// before advanceState, so startupEvalPending remains true — matching
+	// §5.6.2's "missing_target 保持 true" rule).
+	//
+	// Update the global atomicHasPendingMissingTarget to match the
+	// current group states — otherwise a barrier-period missing_target
+	// that resolved on release would keep the light path disabled
+	// indefinitely until the next full evaluation.
+	m.recomputePendingMissingTargetLocked()
+}
+
+// OnCandidateSetDirty marks the candidate-set-dirty flag so subsequent
+// PUT requests go through the full evaluation path (§5.6.3 condition e).
+// Called by the executor on provider subscription refresh / external
+// provider reload / hot-reload group-membership changes.
+//
+// Uses an atomic increment rather than a boolean store so concurrent
+// invocations during a full evaluation are not swallowed by the
+// evaluation's end-of-cycle clear: PutContext snapshots the counter
+// before evaluating and only clears via CompareAndSwap if the counter
+// hasn't moved. A bump during evaluation keeps the signal live for the
+// next PUT.
+func (m *Manager) OnCandidateSetDirty() {
+	m.atomicCandidateSetDirtyCounter.Add(1)
+}
+
+// GetStatus returns a read-only snapshot for GET /network/context.
+func (m *Manager) GetStatus() *StatusResult {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	result := &StatusResult{HasContext: m.ctx != nil}
+	if m.ctx != nil {
+		result.Context = deepCopyContext(m.ctx)
+		if m.ctxExpiresAt != nil {
+			t := *m.ctxExpiresAt
+			result.ExpiresAt = &t
+		}
+		// matched_network is a CTX-level property (§5.4.4 / §5.6.2),
+		// not a per-group aggregate — recompute from the current ctx
+		// directly. Using "first group's last_matched" would return
+		// null in cases where every group sat on missing_target and
+		// never advanced last_matched, even though the ctx clearly
+		// matches a network.
+		matched, present := m.matchLocked(m.ctx)
+		result.MatchedNetworkPresent = present
+		result.MatchedNetwork = matched
+
+		age := int64(time.Since(m.ctxReceivedAt).Seconds())
+		result.AgeSeconds = &age
+	}
+
+	result.Groups = make([]GroupStatus, 0, len(m.groupsOrder))
+	for _, name := range m.groupsOrder {
+		st, ok := m.states[name]
+		if !ok {
+			continue
+		}
+		g := m.groups[name]
+		gs := GroupStatus{
+			Group:                     name,
+			CurrentProxy:              g.Now(),
+			SelectionSource:           st.source,
+			LastMatchedNetworkPresent: st.lastMatchedPresent,
+			LastMatchedNetwork:        st.lastMatched,
+		}
+		result.Groups = append(result.Groups, gs)
+	}
+
+	return result
+}
+
+// ForceReEvaluate is called by the hot-reload path (§5.8.3) to run a
+// single evaluation against the cached ctx, bypassing the stability
+// short-circuit so YAML edits to policy take effect without waiting for
+// a new PUT. No-op when no ctx is cached (§5.8.3 "无 ctx 不评估").
+func (m *Manager) ForceReEvaluate() *PutResult {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if m.ctx == nil {
+		return nil
+	}
+	// ForceReEvaluate is a full evaluation (§5.8.3) — it also consumes
+	// the candidate_set_dirty signal. Snapshot the counter BEFORE the
+	// evaluation so a concurrent OnCandidateSetDirty during eval fails
+	// the end-of-cycle CAS and keeps the signal live for the next PUT.
+	dirtySnapshot := m.atomicCandidateSetDirtyCounter.Load()
+
+	matched, matchedPresent := m.matchLocked(m.ctx)
+	applied := make([]ApplyResult, 0, len(m.groupsOrder))
+	for _, name := range m.groupsOrder {
+		st, ok := m.states[name]
+		if !ok {
+			continue
+		}
+		res := m.evaluateGroupLocked(name, st, matched, matchedPresent, evalTriggerHotReload)
+		applied = append(applied, res)
+	}
+	m.recomputePendingMissingTargetLocked()
+	m.atomicCandidateSetDirtyCounter.CompareAndSwap(dirtySnapshot, 0)
+	return &PutResult{
+		MatchedNetworkPresent: matchedPresent,
+		MatchedNetwork:        matched,
+		Applied:               applied,
+		ExpiresAt:             m.expiresAtSnapshot(),
+	}
+}
+
+// expiresAtSnapshot returns a copy of ctxExpiresAt so callers can't
+// modify internal state via the pointer.
+func (m *Manager) expiresAtSnapshot() *time.Time {
+	if m.ctxExpiresAt == nil {
+		return nil
+	}
+	t := *m.ctxExpiresAt
+	return &t
+}
+
+// stopTTLTimerLocked cancels any running TTL timer. Safe to call with
+// nil m.ttlTimer. Also bumps ttlGen so any already-scheduled callback
+// still in flight finds itself stale and exits on mu acquisition.
+func (m *Manager) stopTTLTimerLocked() {
+	m.ttlGen++
+	if m.ttlTimer != nil {
+		m.ttlTimer.Stop()
+		m.ttlTimer = nil
+	}
+}
+
+// startTTLTimerLocked schedules a callback that fires at expiresAt to
+// clear the cached ctx (state-machine-preserving behavior, §5.4.3).
+//
+// Stale-fire guard: time.Timer.Stop() returns false for callbacks that
+// are already scheduled-to-run or running, and Go has no way to revoke
+// them. Without the generation stamp, a TTL renewal that races with the
+// old timer's expiration would let the old callback wipe the new ctx
+// after we've already replaced it. Each start increments ttlGen and
+// captures it in the closure; onTTLExpired bails out when its captured
+// gen no longer matches the manager's current.
+func (m *Manager) startTTLTimerLocked(expiresAt time.Time) {
+	m.ttlGen++
+	gen := m.ttlGen
+	dur := time.Until(expiresAt)
+	if dur <= 0 {
+		// Already expired; clear synchronously.
+		m.ctx = nil
+		m.ctxFingerprint = ""
+		m.ctxExpiresAt = nil
+		m.atomicHasCtx.Store(false)
+		m.atomicCtxFingerprint.Store(nil)
+		m.atomicCtxExpiresAtUnix.Store(0)
+		return
+	}
+	m.ttlTimer = time.AfterFunc(dur, func() { m.onTTLExpired(gen) })
+}
+
+// onTTLExpired is the TTL timer callback. It reacquires mu, verifies
+// the callback is not stale (generation stamp), drops the cached ctx,
+// and leaves the state machine untouched per §5.4.3.
+func (m *Manager) onTTLExpired(gen uint64) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if gen != m.ttlGen {
+		// A newer TTL renewal has superseded the one this callback was
+		// scheduled for. Doing nothing — the current cached ctx belongs
+		// to the renewal and its own timer will fire at the correct time.
+		return
+	}
+
+	m.ttlTimer = nil
+	m.ctx = nil
+	m.ctxFingerprint = ""
+	m.ctxExpiresAt = nil
+	m.atomicHasCtx.Store(false)
+	m.atomicCtxFingerprint.Store(nil)
+	m.atomicCtxExpiresAtUnix.Store(0)
+}
+
+// deepCopyContext creates a new *NetworkContext whose Interfaces slice,
+// every Subnets slice, Metered pointer, DNSSuffix, and TTL are freshly
+// allocated (§5.6.3 "defensive deep-copy"). Derived fields are cleared
+// and regenerated by NormalizeAndValidate at the call site.
+func deepCopyContext(src *NetworkContext) *NetworkContext {
+	if src == nil {
+		return nil
+	}
+	dst := &NetworkContext{
+		Version: src.Version,
+	}
+	if src.DNSSuffix != nil {
+		dst.DNSSuffix = append([]string(nil), src.DNSSuffix...)
+	}
+	if src.TTL != nil {
+		v := *src.TTL
+		dst.TTL = &v
+	}
+	if src.Interfaces != nil {
+		dst.Interfaces = make([]InterfaceContext, len(src.Interfaces))
+		for i, iface := range src.Interfaces {
+			copied := iface
+			if iface.Subnets != nil {
+				copied.Subnets = append([]string(nil), iface.Subnets...)
+			}
+			if iface.Metered != nil {
+				v := *iface.Metered
+				copied.Metered = &v
+			}
+			// Derived fields (subnetsParsed / gatewayIPParsed) are
+			// repopulated by NormalizeAndValidate; zero them here so we
+			// don't share parsed slices.
+			copied.subnetsParsed = nil
+			copied.gatewayIPParsed = netip.Addr{}
+			dst.Interfaces[i] = copied
+		}
+	}
+	return dst
+}

--- a/component/networkpolicy/manager.go
+++ b/component/networkpolicy/manager.go
@@ -108,7 +108,7 @@ type groupState struct {
 	barrierReleased bool
 }
 
-// selectorWithPolicy interface is defined in policy.go (unexported to the
+// SelectorWithPolicy interface is defined in policy.go (unexported to the
 // package — outboundgroup.Selector satisfies it via duck-typing, and
 // intra-package tests can supply mocks without needing the interface to
 // be exported).
@@ -134,7 +134,7 @@ type Manager struct {
 	// Hot reload constructs a fresh Manager in M3c's executor wiring and
 	// migrates in-memory state; this type intentionally does not expose
 	// an in-place Replace to keep the serial-queue invariants simple.
-	groups       map[string]selectorWithPolicy
+	groups       map[string]SelectorWithPolicy
 	groupsOrder  []string
 	networks     []Network
 	cache        *cachefile.CacheFile
@@ -193,9 +193,9 @@ type Manager struct {
 // ReleaseBarrier(groupName) is the public entry point executors call
 // when a group's referenced providers are populated or the 15s timeout
 // elapses.
-func NewManager(groups []selectorWithPolicy, networks []Network, cache *cachefile.CacheFile) *Manager {
+func NewManager(groups []SelectorWithPolicy, networks []Network, cache *cachefile.CacheFile) *Manager {
 	m := &Manager{
-		groups:      make(map[string]selectorWithPolicy, len(groups)),
+		groups:      make(map[string]SelectorWithPolicy, len(groups)),
 		groupsOrder: make([]string, 0, len(groups)),
 		networks:    networks,
 		cache:       cache,

--- a/component/networkpolicy/manager.go
+++ b/component/networkpolicy/manager.go
@@ -11,10 +11,10 @@ import (
 	"github.com/metacubex/mihomo/log"
 )
 
-// DefaultBarrierTimeout is the per-group provider-ready barrier timeout
+// defaultBarrierTimeout is the per-group provider-ready barrier timeout
 // (architecture §5.6.2 "first-load 超时"). Internal constant for now;
 // promoted to a YAML field if user feedback warrants.
-const DefaultBarrierTimeout = 15 * time.Second
+const defaultBarrierTimeout = 15 * time.Second
 
 // ApplyResult is one row of applied[] in the PUT /network/context response
 // (architecture §5.4.2).
@@ -31,7 +31,7 @@ type ApplyResult struct {
 // §5.4.2 JSON body; REST layer handles wire encoding (nil / MatchedNone →
 // JSON null for matched_network etc.).
 type PutResult struct {
-	// MatchedNetworkPresent + MatchedNetwork mirror the PersistedState
+	// MatchedNetworkPresent + MatchedNetwork mirror the persistedState
 	// last_matched_network tri-state encoding:
 	//   - MatchedNetworkPresent=false → nil (never evaluated; should only
 	//     appear in intermediate diagnostics, never in a PutResult after
@@ -164,7 +164,7 @@ type Manager struct {
 	// evaluation" from "a new dirty event arrived during the evaluation":
 	// PutContext snapshots the counter before entering evaluation and
 	// uses CompareAndSwap(snapshot, 0) at the end; if a concurrent
-	// OnCandidateSetDirty bumped the counter during the evaluation, the
+	// onCandidateSetDirty bumped the counter during the evaluation, the
 	// CAS fails and the signal is preserved for the next cycle.
 	atomicHasCtx                   atomic.Bool
 	atomicCtxFingerprint           atomic.Pointer[string]
@@ -199,7 +199,7 @@ func NewManager(groups []SelectorWithPolicy, networks []Network, cache *cachefil
 		groupsOrder: make([]string, 0, len(groups)),
 		networks:    networks,
 		cache:       cache,
-		barrierTTL:  DefaultBarrierTimeout,
+		barrierTTL:  defaultBarrierTimeout,
 		states:      make(map[string]*groupState, len(groups)),
 	}
 	for _, g := range groups {
@@ -270,14 +270,14 @@ func (m *Manager) initStatesFromCache() {
 }
 
 // decodePersisted unwraps the JSON + Validate chain for load-side
-// record recovery. Uses the M3a PersistedState schema.
-func decodePersisted(raw []byte) (PersistedState, error) {
-	var ps PersistedState
+// record recovery. Uses the M3a persistedState schema.
+func decodePersisted(raw []byte) (persistedState, error) {
+	var ps persistedState
 	if err := ps.UnmarshalJSON(raw); err != nil {
-		return PersistedState{}, err
+		return persistedState{}, err
 	}
 	if err := ps.Validate(); err != nil {
-		return PersistedState{}, err
+		return persistedState{}, err
 	}
 	return ps, nil
 }
@@ -359,7 +359,7 @@ func (m *Manager) PutContext(raw *NetworkContext) (*PutResult, error) {
 
 	// candidate_set_dirty (§5.6.3) consumed: only clear if the counter is
 	// still at the value we observed pre-evaluation. A bump during the
-	// evaluation (concurrent OnCandidateSetDirty) fails the CAS and keeps
+	// evaluation (concurrent onCandidateSetDirty) fails the CAS and keeps
 	// the signal alive for the next PUT — otherwise the race between a
 	// provider refresh and the serial queue would swallow the dirty event.
 	m.atomicCandidateSetDirtyCounter.CompareAndSwap(dirtySnapshot, 0)
@@ -695,13 +695,13 @@ func (m *Manager) persistStateLocked(name string, st *groupState) {
 	if m.cache == nil {
 		return
 	}
-	ps := PersistedState{
-		SchemaVersion:      PersistVersion,
+	ps := persistedState{
+		SchemaVersion:      persistVersion,
 		Source:             st.source,
 		LastMatched:        st.lastMatched,
 		LastMatchedPresent: st.lastMatchedPresent,
 	}
-	if err := WriteNetworkPolicyState(m.cache, name, ps); err != nil {
+	if err := writeNetworkPolicyState(m.cache, name, ps); err != nil {
 		// Write-side Validate failure is a programmer bug: log and
 		// skip. Don't propagate — the runtime already applied the
 		// transition; cachefile is best-effort persistence.
@@ -822,7 +822,7 @@ func (m *Manager) ReleaseBarrier(groupName string) {
 	m.recomputePendingMissingTargetLocked()
 }
 
-// OnCandidateSetDirty marks the candidate-set-dirty flag so subsequent
+// onCandidateSetDirty marks the candidate-set-dirty flag so subsequent
 // PUT requests go through the full evaluation path (§5.6.3 condition e).
 // Called by the executor on provider subscription refresh / external
 // provider reload / hot-reload group-membership changes.
@@ -833,7 +833,7 @@ func (m *Manager) ReleaseBarrier(groupName string) {
 // before evaluating and only clears via CompareAndSwap if the counter
 // hasn't moved. A bump during evaluation keeps the signal live for the
 // next PUT.
-func (m *Manager) OnCandidateSetDirty() {
+func (m *Manager) onCandidateSetDirty() {
 	m.atomicCandidateSetDirtyCounter.Add(1)
 }
 
@@ -896,7 +896,7 @@ func (m *Manager) ForceReEvaluate() *PutResult {
 	}
 	// ForceReEvaluate is a full evaluation (§5.8.3) — it also consumes
 	// the candidate_set_dirty signal. Snapshot the counter BEFORE the
-	// evaluation so a concurrent OnCandidateSetDirty during eval fails
+	// evaluation so a concurrent onCandidateSetDirty during eval fails
 	// the end-of-cycle CAS and keeps the signal live for the next PUT.
 	dirtySnapshot := m.atomicCandidateSetDirtyCounter.Load()
 

--- a/component/networkpolicy/manager_test.go
+++ b/component/networkpolicy/manager_test.go
@@ -5,7 +5,7 @@ import (
 	"time"
 )
 
-// mockSelector is a lightweight selectorWithPolicy implementation for
+// mockSelector is a lightweight SelectorWithPolicy implementation for
 // driving Manager's state machine directly without a real
 // outboundgroup.Selector (which would require wiring up providers, a
 // real proxy map, etc.).
@@ -89,7 +89,7 @@ func TestNewManager_BranchB_NoCache(t *testing.T) {
 	sel := newMockSelector("auto", "hk", []string{"hk", "us"}, GroupPolicy{
 		Mapping: map[string]string{"office": "us"},
 	})
-	mgr := NewManager([]selectorWithPolicy{sel}, []Network{makeNetwork("office", "office-5g")}, nil)
+	mgr := NewManager([]SelectorWithPolicy{sel}, []Network{makeNetwork("office", "office-5g")}, nil)
 	st, ok := mgr.states["auto"]
 	if !ok {
 		t.Fatal("group state not initialized")
@@ -111,7 +111,7 @@ func TestPutContext_Matched_SwitchesTarget(t *testing.T) {
 	sel := newMockSelector("auto", "hk", []string{"hk", "us"}, GroupPolicy{
 		Mapping: map[string]string{"office": "us"},
 	})
-	mgr := NewManager([]selectorWithPolicy{sel}, []Network{makeNetwork("office", "office-5g")}, nil)
+	mgr := NewManager([]SelectorWithPolicy{sel}, []Network{makeNetwork("office", "office-5g")}, nil)
 
 	res, err := mgr.PutContext(makeCtx("office-5g"))
 	if err != nil {
@@ -139,7 +139,7 @@ func TestPutContext_AlreadySelected_NoChange(t *testing.T) {
 	sel := newMockSelector("auto", "us", []string{"hk", "us"}, GroupPolicy{
 		Mapping: map[string]string{"office": "us"},
 	})
-	mgr := NewManager([]selectorWithPolicy{sel}, []Network{makeNetwork("office", "office-5g")}, nil)
+	mgr := NewManager([]SelectorWithPolicy{sel}, []Network{makeNetwork("office", "office-5g")}, nil)
 
 	res, _ := mgr.PutContext(makeCtx("office-5g"))
 	ap := res.Applied[0]
@@ -160,7 +160,7 @@ func TestPutContext_Default_NoMappingForNetwork(t *testing.T) {
 		HasDefault:   true,
 		DefaultProxy: "DIRECT",
 	})
-	mgr := NewManager([]selectorWithPolicy{sel}, []Network{makeNetwork("office", "office-5g")}, nil)
+	mgr := NewManager([]SelectorWithPolicy{sel}, []Network{makeNetwork("office", "office-5g")}, nil)
 
 	// Ctx with a different SSID: matched=<none>, default proxy applies.
 	res, _ := mgr.PutContext(makeCtx("home-wifi"))
@@ -177,7 +177,7 @@ func TestPutContext_NoChangeNoDefault(t *testing.T) {
 	sel := newMockSelector("auto", "hk", []string{"hk"}, GroupPolicy{
 		Mapping: map[string]string{"office": "hk"}, // no default
 	})
-	mgr := NewManager([]selectorWithPolicy{sel}, []Network{makeNetwork("office", "office-5g")}, nil)
+	mgr := NewManager([]SelectorWithPolicy{sel}, []Network{makeNetwork("office", "office-5g")}, nil)
 
 	// matched=<none>, no default → no_change_no_default; keep current.
 	res, _ := mgr.PutContext(makeCtx("home-wifi"))
@@ -200,7 +200,7 @@ func TestPutContext_MissingTarget_NoStateAdvance(t *testing.T) {
 	sel := newMockSelector("auto", "hk", []string{"hk"}, GroupPolicy{
 		Mapping: map[string]string{"office": "subscription-node"},
 	})
-	mgr := NewManager([]selectorWithPolicy{sel}, []Network{makeNetwork("office", "office-5g")}, nil)
+	mgr := NewManager([]SelectorWithPolicy{sel}, []Network{makeNetwork("office", "office-5g")}, nil)
 
 	res, _ := mgr.PutContext(makeCtx("office-5g"))
 	ap := res.Applied[0]
@@ -222,7 +222,7 @@ func TestHandleManualSet_PreservesLastMatched(t *testing.T) {
 	sel := newMockSelector("auto", "hk", []string{"hk", "us"}, GroupPolicy{
 		Mapping: map[string]string{"office": "us"},
 	})
-	mgr := NewManager([]selectorWithPolicy{sel}, []Network{makeNetwork("office", "office-5g")}, nil)
+	mgr := NewManager([]SelectorWithPolicy{sel}, []Network{makeNetwork("office", "office-5g")}, nil)
 
 	// First evaluate to set source=auto + lastMatched=office.
 	mgr.PutContext(makeCtx("office-5g"))
@@ -243,7 +243,7 @@ func TestPutContext_ManualLocked_SameMatched(t *testing.T) {
 	sel := newMockSelector("auto", "hk", []string{"hk", "us"}, GroupPolicy{
 		Mapping: map[string]string{"office": "us"},
 	})
-	mgr := NewManager([]selectorWithPolicy{sel}, []Network{makeNetwork("office", "office-5g")}, nil)
+	mgr := NewManager([]SelectorWithPolicy{sel}, []Network{makeNetwork("office", "office-5g")}, nil)
 
 	mgr.PutContext(makeCtx("office-5g"))
 	sel.Set("hk")
@@ -268,7 +268,7 @@ func TestPutContext_ManualTakenOverOnNetworkChange(t *testing.T) {
 	sel := newMockSelector("auto", "hk", []string{"hk", "us", "DIRECT"}, GroupPolicy{
 		Mapping: map[string]string{"office": "us", "home": "DIRECT"},
 	})
-	mgr := NewManager([]selectorWithPolicy{sel}, []Network{
+	mgr := NewManager([]SelectorWithPolicy{sel}, []Network{
 		makeNetwork("office", "office-5g"),
 		makeNetwork("home", "home-wifi"),
 	}, nil)
@@ -298,7 +298,7 @@ func TestPutContext_UnchangedNetwork_SameMatchedAutoSource(t *testing.T) {
 	sel := newMockSelector("auto", "us", []string{"hk", "us"}, GroupPolicy{
 		Mapping: map[string]string{"office": "us"},
 	})
-	mgr := NewManager([]selectorWithPolicy{sel}, []Network{makeNetwork("office", "office-5g")}, nil)
+	mgr := NewManager([]SelectorWithPolicy{sel}, []Network{makeNetwork("office", "office-5g")}, nil)
 
 	mgr.PutContext(makeCtx("office-5g")) // source→auto, lastMatched=office
 	sel.setHistory = nil
@@ -318,7 +318,7 @@ func TestDeleteContext_PreservesState(t *testing.T) {
 	sel := newMockSelector("auto", "hk", []string{"hk", "us"}, GroupPolicy{
 		Mapping: map[string]string{"office": "us"},
 	})
-	mgr := NewManager([]selectorWithPolicy{sel}, []Network{makeNetwork("office", "office-5g")}, nil)
+	mgr := NewManager([]SelectorWithPolicy{sel}, []Network{makeNetwork("office", "office-5g")}, nil)
 
 	mgr.PutContext(makeCtx("office-5g"))
 	sel.Set("hk")
@@ -347,7 +347,7 @@ func TestTTLLightPath_SameFingerprintBothTTL_ShortCircuits(t *testing.T) {
 	sel := newMockSelector("auto", "hk", []string{"hk", "us"}, GroupPolicy{
 		Mapping: map[string]string{"office": "us"},
 	})
-	mgr := NewManager([]selectorWithPolicy{sel}, []Network{makeNetwork("office", "office-5g")}, nil)
+	mgr := NewManager([]SelectorWithPolicy{sel}, []Network{makeNetwork("office", "office-5g")}, nil)
 
 	// First PUT with TTL: full evaluation, caches expires_at, switches hk→us.
 	first, _ := mgr.PutContext(makeCtxWithTTL("office-5g", 3600))
@@ -377,7 +377,7 @@ func TestTTLLightPath_StickyToSticky_FallsThrough(t *testing.T) {
 	sel := newMockSelector("auto", "us", []string{"hk", "us"}, GroupPolicy{
 		Mapping: map[string]string{"office": "us"},
 	})
-	mgr := NewManager([]selectorWithPolicy{sel}, []Network{makeNetwork("office", "office-5g")}, nil)
+	mgr := NewManager([]SelectorWithPolicy{sel}, []Network{makeNetwork("office", "office-5g")}, nil)
 
 	mgr.PutContext(makeCtx("office-5g"))
 	res, _ := mgr.PutContext(makeCtx("office-5g"))
@@ -398,7 +398,7 @@ func TestTTLLightPath_MissingTargetPendingDisables(t *testing.T) {
 	sel := newMockSelector("auto", "hk", []string{"hk"}, GroupPolicy{
 		Mapping: map[string]string{"office": "sub-node"},
 	})
-	mgr := NewManager([]selectorWithPolicy{sel}, []Network{makeNetwork("office", "office-5g")}, nil)
+	mgr := NewManager([]SelectorWithPolicy{sel}, []Network{makeNetwork("office", "office-5g")}, nil)
 
 	first, _ := mgr.PutContext(makeCtxWithTTL("office-5g", 3600))
 	if first.Applied[0].Reason != ReasonMissingTarget {
@@ -420,7 +420,7 @@ func TestTTLLightPath_CandidateSetDirtyDisables(t *testing.T) {
 	sel := newMockSelector("auto", "us", []string{"hk", "us"}, GroupPolicy{
 		Mapping: map[string]string{"office": "us"},
 	})
-	mgr := NewManager([]selectorWithPolicy{sel}, []Network{makeNetwork("office", "office-5g")}, nil)
+	mgr := NewManager([]SelectorWithPolicy{sel}, []Network{makeNetwork("office", "office-5g")}, nil)
 
 	first, _ := mgr.PutContext(makeCtxWithTTL("office-5g", 3600))
 	_ = first
@@ -452,7 +452,7 @@ func TestReleaseBarrier_NoCtx_EvaluatesAsMatchedNone(t *testing.T) {
 		HasDefault:   true,
 		DefaultProxy: "DIRECT",
 	})
-	mgr := NewManager([]selectorWithPolicy{sel}, []Network{makeNetwork("office", "office-5g")}, nil)
+	mgr := NewManager([]SelectorWithPolicy{sel}, []Network{makeNetwork("office", "office-5g")}, nil)
 
 	mgr.ReleaseBarrier("auto")
 
@@ -478,7 +478,7 @@ func TestReleaseBarrier_WithCtx_UsesCachedCtx(t *testing.T) {
 	sel := newMockSelector("auto", "hk", []string{"hk"}, GroupPolicy{
 		Mapping: map[string]string{"office": "sub-node"},
 	})
-	mgr := NewManager([]selectorWithPolicy{sel}, []Network{makeNetwork("office", "office-5g")}, nil)
+	mgr := NewManager([]SelectorWithPolicy{sel}, []Network{makeNetwork("office", "office-5g")}, nil)
 
 	// PUT during barrier — missing_target.
 	first, _ := mgr.PutContext(makeCtx("office-5g"))
@@ -509,7 +509,7 @@ func TestReleaseBarrier_Idempotent(t *testing.T) {
 		HasDefault:   true,
 		DefaultProxy: "DIRECT",
 	})
-	mgr := NewManager([]selectorWithPolicy{sel}, []Network{makeNetwork("office", "office-5g")}, nil)
+	mgr := NewManager([]SelectorWithPolicy{sel}, []Network{makeNetwork("office", "office-5g")}, nil)
 
 	mgr.ReleaseBarrier("auto")
 	sel.setHistory = nil
@@ -525,7 +525,7 @@ func TestForceReEvaluate_NoCtx_NoOp(t *testing.T) {
 	sel := newMockSelector("auto", "hk", []string{"hk", "us"}, GroupPolicy{
 		Mapping: map[string]string{"office": "us"},
 	})
-	mgr := NewManager([]selectorWithPolicy{sel}, []Network{makeNetwork("office", "office-5g")}, nil)
+	mgr := NewManager([]SelectorWithPolicy{sel}, []Network{makeNetwork("office", "office-5g")}, nil)
 
 	res := mgr.ForceReEvaluate()
 	if res != nil {
@@ -540,7 +540,7 @@ func TestForceReEvaluate_WithCtx_BypassesStability(t *testing.T) {
 	sel := newMockSelector("auto", "us", []string{"hk", "us"}, GroupPolicy{
 		Mapping: map[string]string{"office": "us"},
 	})
-	mgr := NewManager([]selectorWithPolicy{sel}, []Network{makeNetwork("office", "office-5g")}, nil)
+	mgr := NewManager([]SelectorWithPolicy{sel}, []Network{makeNetwork("office", "office-5g")}, nil)
 	mgr.PutContext(makeCtx("office-5g"))
 
 	// Swap the policy so office → hk instead of us.
@@ -563,7 +563,7 @@ func TestPutContext_DeepCopy_CallerMutationIsolated(t *testing.T) {
 	sel := newMockSelector("auto", "hk", []string{"hk", "us"}, GroupPolicy{
 		Mapping: map[string]string{"office": "us"},
 	})
-	mgr := NewManager([]selectorWithPolicy{sel}, []Network{makeNetwork("office", "office-5g")}, nil)
+	mgr := NewManager([]SelectorWithPolicy{sel}, []Network{makeNetwork("office", "office-5g")}, nil)
 
 	ctx := makeCtx("office-5g")
 	ctx.Interfaces[0].Subnets = []string{"10.0.0.0/24"}
@@ -597,7 +597,7 @@ func TestGetStatus_BeforeAnyPut_NoContext(t *testing.T) {
 	sel := newMockSelector("auto", "hk", []string{"hk"}, GroupPolicy{
 		Mapping: map[string]string{"office": "hk"},
 	})
-	mgr := NewManager([]selectorWithPolicy{sel}, []Network{makeNetwork("office", "office-5g")}, nil)
+	mgr := NewManager([]SelectorWithPolicy{sel}, []Network{makeNetwork("office", "office-5g")}, nil)
 
 	st := mgr.GetStatus()
 	if st.HasContext {
@@ -619,7 +619,7 @@ func TestHandleManualSet_PreservesStartupEvalPending(t *testing.T) {
 	sel := newMockSelector("auto", "hk", []string{"hk", "us"}, GroupPolicy{
 		Mapping: map[string]string{"office": "us"},
 	})
-	mgr := NewManager([]selectorWithPolicy{sel}, []Network{makeNetwork("office", "office-5g")}, nil)
+	mgr := NewManager([]SelectorWithPolicy{sel}, []Network{makeNetwork("office", "office-5g")}, nil)
 
 	// Branch B → startupEvalPending starts true.
 	if !mgr.states["auto"].startupEvalPending {
@@ -638,7 +638,7 @@ func TestReleaseBarrier_ClearsGlobalPendingOnResolve(t *testing.T) {
 	sel := newMockSelector("auto", "hk", []string{"hk"}, GroupPolicy{
 		Mapping: map[string]string{"office": "sub-node"},
 	})
-	mgr := NewManager([]selectorWithPolicy{sel}, []Network{makeNetwork("office", "office-5g")}, nil)
+	mgr := NewManager([]SelectorWithPolicy{sel}, []Network{makeNetwork("office", "office-5g")}, nil)
 
 	// PUT during barrier — missing_target.
 	mgr.PutContext(makeCtx("office-5g"))
@@ -662,7 +662,7 @@ func TestForceReEvaluate_ClearsCandidateSetDirty(t *testing.T) {
 	sel := newMockSelector("auto", "us", []string{"hk", "us"}, GroupPolicy{
 		Mapping: map[string]string{"office": "us"},
 	})
-	mgr := NewManager([]selectorWithPolicy{sel}, []Network{makeNetwork("office", "office-5g")}, nil)
+	mgr := NewManager([]SelectorWithPolicy{sel}, []Network{makeNetwork("office", "office-5g")}, nil)
 	mgr.PutContext(makeCtx("office-5g"))
 
 	mgr.OnCandidateSetDirty()
@@ -683,7 +683,7 @@ func TestGetStatus_MatchedFromCtx_NotFromGroupState(t *testing.T) {
 	sel := newMockSelector("auto", "hk", []string{"hk"}, GroupPolicy{
 		Mapping: map[string]string{"office": "sub-node"}, // target unreachable
 	})
-	mgr := NewManager([]selectorWithPolicy{sel}, []Network{makeNetwork("office", "office-5g")}, nil)
+	mgr := NewManager([]SelectorWithPolicy{sel}, []Network{makeNetwork("office", "office-5g")}, nil)
 
 	mgr.PutContext(makeCtx("office-5g")) // → missing_target, last_matched stays nil
 	if mgr.states["auto"].lastMatchedPresent {
@@ -709,7 +709,7 @@ func TestEvaluate_ReturnToOriginalMatched_ClearsPending(t *testing.T) {
 			"home":   "unreachable", // deliberately not in candidates
 		},
 	})
-	mgr := NewManager([]selectorWithPolicy{sel}, []Network{
+	mgr := NewManager([]SelectorWithPolicy{sel}, []Network{
 		makeNetwork("office", "office-5g"),
 		makeNetwork("home", "home-wifi"),
 	}, nil)
@@ -741,7 +741,7 @@ func TestTTLLightPath_RefreshesReceivedAtForAge(t *testing.T) {
 	sel := newMockSelector("auto", "us", []string{"hk", "us"}, GroupPolicy{
 		Mapping: map[string]string{"office": "us"},
 	})
-	mgr := NewManager([]selectorWithPolicy{sel}, []Network{makeNetwork("office", "office-5g")}, nil)
+	mgr := NewManager([]SelectorWithPolicy{sel}, []Network{makeNetwork("office", "office-5g")}, nil)
 
 	mgr.PutContext(makeCtxWithTTL("office-5g", 3600))
 	firstStamp := mgr.ctxReceivedAt
@@ -786,7 +786,7 @@ func TestGetStatus_AgeSecondsPopulated(t *testing.T) {
 	sel := newMockSelector("auto", "hk", []string{"hk", "us"}, GroupPolicy{
 		Mapping: map[string]string{"office": "us"},
 	})
-	mgr := NewManager([]selectorWithPolicy{sel}, []Network{makeNetwork("office", "office-5g")}, nil)
+	mgr := NewManager([]SelectorWithPolicy{sel}, []Network{makeNetwork("office", "office-5g")}, nil)
 
 	mgr.PutContext(makeCtx("office-5g"))
 	time.Sleep(10 * time.Millisecond)
@@ -808,7 +808,7 @@ func TestPutContext_StaleTTLCallbackDoesNotWipeNewCtx(t *testing.T) {
 	sel := newMockSelector("auto", "us", []string{"hk", "us"}, GroupPolicy{
 		Mapping: map[string]string{"office": "us"},
 	})
-	mgr := NewManager([]selectorWithPolicy{sel}, []Network{makeNetwork("office", "office-5g")}, nil)
+	mgr := NewManager([]SelectorWithPolicy{sel}, []Network{makeNetwork("office", "office-5g")}, nil)
 
 	// First PUT with 1-second TTL.
 	mgr.PutContext(makeCtxWithTTL("office-5g", 1))
@@ -828,7 +828,7 @@ func TestGetStatus_AfterPut_ReflectsState(t *testing.T) {
 	sel := newMockSelector("auto", "hk", []string{"hk", "us"}, GroupPolicy{
 		Mapping: map[string]string{"office": "us"},
 	})
-	mgr := NewManager([]selectorWithPolicy{sel}, []Network{makeNetwork("office", "office-5g")}, nil)
+	mgr := NewManager([]SelectorWithPolicy{sel}, []Network{makeNetwork("office", "office-5g")}, nil)
 
 	mgr.PutContext(makeCtx("office-5g"))
 	st := mgr.GetStatus()

--- a/component/networkpolicy/manager_test.go
+++ b/component/networkpolicy/manager_test.go
@@ -426,12 +426,12 @@ func TestTTLLightPath_CandidateSetDirtyDisables(t *testing.T) {
 	_ = first
 
 	// Simulate provider refresh: candidate_set_dirty set.
-	mgr.OnCandidateSetDirty()
+	mgr.onCandidateSetDirty()
 
 	sel.setHistory = nil
 	second, _ := mgr.PutContext(makeCtxWithTTL("office-5g", 3600))
 	// Must have gone through full evaluation — verifiable indirectly by
-	// checking that OnCandidateSetDirty's flag was cleared after the
+	// checking that onCandidateSetDirty's flag was cleared after the
 	// evaluation.
 	if mgr.atomicCandidateSetDirtyCounter.Load() != 0 {
 		t.Errorf("candidate_set_dirty counter must clear after a full evaluation (no concurrent bump)")
@@ -665,9 +665,9 @@ func TestForceReEvaluate_ClearsCandidateSetDirty(t *testing.T) {
 	mgr := NewManager([]SelectorWithPolicy{sel}, []Network{makeNetwork("office", "office-5g")}, nil)
 	mgr.PutContext(makeCtx("office-5g"))
 
-	mgr.OnCandidateSetDirty()
+	mgr.onCandidateSetDirty()
 	if mgr.atomicCandidateSetDirtyCounter.Load() == 0 {
-		t.Fatal("precondition: OnCandidateSetDirty must set counter")
+		t.Fatal("precondition: onCandidateSetDirty must set counter")
 	}
 	mgr.ForceReEvaluate()
 	if mgr.atomicCandidateSetDirtyCounter.Load() != 0 {

--- a/component/networkpolicy/manager_test.go
+++ b/component/networkpolicy/manager_test.go
@@ -1,0 +1,844 @@
+package networkpolicy
+
+import (
+	"testing"
+	"time"
+)
+
+// mockSelector is a lightweight selectorWithPolicy implementation for
+// driving Manager's state machine directly without a real
+// outboundgroup.Selector (which would require wiring up providers, a
+// real proxy map, etc.).
+type mockSelector struct {
+	name       string
+	selected   string
+	candidates map[string]struct{}
+	policy     GroupPolicy
+	source     GroupSource
+	setHistory []string
+}
+
+func newMockSelector(name, initial string, candidates []string, policy GroupPolicy) *mockSelector {
+	m := &mockSelector{
+		name:       name,
+		selected:   initial,
+		candidates: make(map[string]struct{}, len(candidates)),
+		policy:     policy,
+		source: GroupSource{
+			StaticProxies: append([]string(nil), candidates...),
+		},
+	}
+	for _, c := range candidates {
+		m.candidates[c] = struct{}{}
+	}
+	return m
+}
+
+func (m *mockSelector) Name() string { return m.name }
+func (m *mockSelector) Set(name string) error {
+	if _, ok := m.candidates[name]; !ok {
+		return &notFoundErr{name: name}
+	}
+	m.selected = name
+	m.setHistory = append(m.setHistory, name)
+	return nil
+}
+func (m *mockSelector) Now() string { return m.selected }
+func (m *mockSelector) HasProxy(name string) bool {
+	_, ok := m.candidates[name]
+	return ok
+}
+func (m *mockSelector) NetworkPolicy() GroupPolicy { return m.policy }
+func (m *mockSelector) GroupSource() GroupSource   { return m.source }
+
+type notFoundErr struct{ name string }
+
+func (e *notFoundErr) Error() string { return "proxy not found: " + e.name }
+
+// --- small helpers for building contexts and networks --------------------
+
+func makeNetwork(name, ssid string) Network {
+	m, err := ParseMatch(map[string]any{"ssid": ssid})
+	if err != nil {
+		panic(err)
+	}
+	return Network{Name: name, Matcher: m}
+}
+
+func makeCtx(ssid string) *NetworkContext {
+	ctx := &NetworkContext{
+		Version: 1,
+		Interfaces: []InterfaceContext{{
+			Name:      "wlan0",
+			IfaceType: "wifi",
+			SSID:      ssid,
+		}},
+	}
+	return ctx
+}
+
+func makeCtxWithTTL(ssid string, ttl int) *NetworkContext {
+	ctx := makeCtx(ssid)
+	ctx.TTL = &ttl
+	return ctx
+}
+
+// --- Constructor / branch A+B initial state ------------------------------
+
+func TestNewManager_BranchB_NoCache(t *testing.T) {
+	sel := newMockSelector("auto", "hk", []string{"hk", "us"}, GroupPolicy{
+		Mapping: map[string]string{"office": "us"},
+	})
+	mgr := NewManager([]selectorWithPolicy{sel}, []Network{makeNetwork("office", "office-5g")}, nil)
+	st, ok := mgr.states["auto"]
+	if !ok {
+		t.Fatal("group state not initialized")
+	}
+	if st.source != SourceUnknown {
+		t.Errorf("branch B should start source=unknown; got %q", st.source)
+	}
+	if !st.startupEvalPending {
+		t.Errorf("branch B should start startupEvalPending=true")
+	}
+	if st.lastMatchedPresent {
+		t.Errorf("branch B should start lastMatched absent")
+	}
+}
+
+// --- Reason coverage: matched / already_selected / default / etc. --------
+
+func TestPutContext_Matched_SwitchesTarget(t *testing.T) {
+	sel := newMockSelector("auto", "hk", []string{"hk", "us"}, GroupPolicy{
+		Mapping: map[string]string{"office": "us"},
+	})
+	mgr := NewManager([]selectorWithPolicy{sel}, []Network{makeNetwork("office", "office-5g")}, nil)
+
+	res, err := mgr.PutContext(makeCtx("office-5g"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(res.Applied) != 1 {
+		t.Fatalf("want 1 applied, got %d", len(res.Applied))
+	}
+	ap := res.Applied[0]
+	if ap.Reason != ReasonMatched {
+		t.Errorf("want reason=matched, got %q", ap.Reason)
+	}
+	if !ap.Changed {
+		t.Errorf("want changed=true (hk → us)")
+	}
+	if ap.AppliedProxy != "us" {
+		t.Errorf("want applied=us, got %q", ap.AppliedProxy)
+	}
+	if ap.SelectionSource != SourceAuto {
+		t.Errorf("want source=auto after matched; got %q", ap.SelectionSource)
+	}
+}
+
+func TestPutContext_AlreadySelected_NoChange(t *testing.T) {
+	sel := newMockSelector("auto", "us", []string{"hk", "us"}, GroupPolicy{
+		Mapping: map[string]string{"office": "us"},
+	})
+	mgr := NewManager([]selectorWithPolicy{sel}, []Network{makeNetwork("office", "office-5g")}, nil)
+
+	res, _ := mgr.PutContext(makeCtx("office-5g"))
+	ap := res.Applied[0]
+	if ap.Reason != ReasonAlreadySelected {
+		t.Errorf("want already_selected, got %q", ap.Reason)
+	}
+	if ap.Changed {
+		t.Errorf("want changed=false; target equals current selection")
+	}
+	if len(sel.setHistory) != 0 {
+		t.Errorf("want no Set() calls; got %v", sel.setHistory)
+	}
+}
+
+func TestPutContext_Default_NoMappingForNetwork(t *testing.T) {
+	sel := newMockSelector("auto", "us", []string{"hk", "DIRECT"}, GroupPolicy{
+		Mapping:      map[string]string{"office": "hk"},
+		HasDefault:   true,
+		DefaultProxy: "DIRECT",
+	})
+	mgr := NewManager([]selectorWithPolicy{sel}, []Network{makeNetwork("office", "office-5g")}, nil)
+
+	// Ctx with a different SSID: matched=<none>, default proxy applies.
+	res, _ := mgr.PutContext(makeCtx("home-wifi"))
+	ap := res.Applied[0]
+	if ap.Reason != ReasonDefault {
+		t.Errorf("want default, got %q", ap.Reason)
+	}
+	if ap.AppliedProxy != "DIRECT" {
+		t.Errorf("want applied=DIRECT, got %q", ap.AppliedProxy)
+	}
+}
+
+func TestPutContext_NoChangeNoDefault(t *testing.T) {
+	sel := newMockSelector("auto", "hk", []string{"hk"}, GroupPolicy{
+		Mapping: map[string]string{"office": "hk"}, // no default
+	})
+	mgr := NewManager([]selectorWithPolicy{sel}, []Network{makeNetwork("office", "office-5g")}, nil)
+
+	// matched=<none>, no default → no_change_no_default; keep current.
+	res, _ := mgr.PutContext(makeCtx("home-wifi"))
+	ap := res.Applied[0]
+	if ap.Reason != ReasonNoChangeNoDefault {
+		t.Errorf("want no_change_no_default, got %q", ap.Reason)
+	}
+	if ap.AppliedProxy != "hk" {
+		t.Errorf("want unchanged applied=hk, got %q", ap.AppliedProxy)
+	}
+	st := mgr.states["auto"]
+	if st.source != SourceAuto {
+		t.Errorf("want source=auto after no_change_no_default, got %q", st.source)
+	}
+}
+
+func TestPutContext_MissingTarget_NoStateAdvance(t *testing.T) {
+	// Policy target "subscription-node" is not in StaticProxies and
+	// HasProxy returns false → missing_target; state stays.
+	sel := newMockSelector("auto", "hk", []string{"hk"}, GroupPolicy{
+		Mapping: map[string]string{"office": "subscription-node"},
+	})
+	mgr := NewManager([]selectorWithPolicy{sel}, []Network{makeNetwork("office", "office-5g")}, nil)
+
+	res, _ := mgr.PutContext(makeCtx("office-5g"))
+	ap := res.Applied[0]
+	if ap.Reason != ReasonMissingTarget {
+		t.Errorf("want missing_target, got %q", ap.Reason)
+	}
+	st := mgr.states["auto"]
+	if st.source != SourceUnknown {
+		t.Errorf("source must stay unknown after missing_target; got %q", st.source)
+	}
+	if st.lastMatchedPresent {
+		t.Errorf("last_matched must not advance on missing_target")
+	}
+}
+
+// --- Manual-wins semantics ------------------------------------------------
+
+func TestHandleManualSet_PreservesLastMatched(t *testing.T) {
+	sel := newMockSelector("auto", "hk", []string{"hk", "us"}, GroupPolicy{
+		Mapping: map[string]string{"office": "us"},
+	})
+	mgr := NewManager([]selectorWithPolicy{sel}, []Network{makeNetwork("office", "office-5g")}, nil)
+
+	// First evaluate to set source=auto + lastMatched=office.
+	mgr.PutContext(makeCtx("office-5g"))
+	// User manually picks.
+	sel.Set("hk")
+	mgr.HandleManualSet("auto")
+
+	st := mgr.states["auto"]
+	if st.source != SourceManual {
+		t.Errorf("want source=manual, got %q", st.source)
+	}
+	if st.lastMatched != "office" {
+		t.Errorf("last_matched must not move on manual set; got %q", st.lastMatched)
+	}
+}
+
+func TestPutContext_ManualLocked_SameMatched(t *testing.T) {
+	sel := newMockSelector("auto", "hk", []string{"hk", "us"}, GroupPolicy{
+		Mapping: map[string]string{"office": "us"},
+	})
+	mgr := NewManager([]selectorWithPolicy{sel}, []Network{makeNetwork("office", "office-5g")}, nil)
+
+	mgr.PutContext(makeCtx("office-5g"))
+	sel.Set("hk")
+	mgr.HandleManualSet("auto")
+
+	// Same network again → manual_locked; Set not called.
+	sel.setHistory = nil
+	res, _ := mgr.PutContext(makeCtx("office-5g"))
+	ap := res.Applied[0]
+	if ap.Reason != ReasonManualLocked {
+		t.Errorf("want manual_locked, got %q", ap.Reason)
+	}
+	if ap.AppliedProxy != "hk" {
+		t.Errorf("want hk preserved, got %q", ap.AppliedProxy)
+	}
+	if len(sel.setHistory) != 0 {
+		t.Errorf("manual_locked must not call Set(); got %v", sel.setHistory)
+	}
+}
+
+func TestPutContext_ManualTakenOverOnNetworkChange(t *testing.T) {
+	sel := newMockSelector("auto", "hk", []string{"hk", "us", "DIRECT"}, GroupPolicy{
+		Mapping: map[string]string{"office": "us", "home": "DIRECT"},
+	})
+	mgr := NewManager([]selectorWithPolicy{sel}, []Network{
+		makeNetwork("office", "office-5g"),
+		makeNetwork("home", "home-wifi"),
+	}, nil)
+
+	mgr.PutContext(makeCtx("office-5g"))
+	sel.Set("hk")
+	mgr.HandleManualSet("auto")
+
+	// Network changes to home → auto takes over, switches to DIRECT.
+	res, _ := mgr.PutContext(makeCtx("home-wifi"))
+	ap := res.Applied[0]
+	if ap.Reason != ReasonMatched {
+		t.Errorf("want matched (auto takeover), got %q", ap.Reason)
+	}
+	if ap.AppliedProxy != "DIRECT" {
+		t.Errorf("want DIRECT, got %q", ap.AppliedProxy)
+	}
+	st := mgr.states["auto"]
+	if st.source != SourceAuto {
+		t.Errorf("source must flip to auto on network change; got %q", st.source)
+	}
+}
+
+// --- unchanged_network --------------------------------------------------
+
+func TestPutContext_UnchangedNetwork_SameMatchedAutoSource(t *testing.T) {
+	sel := newMockSelector("auto", "us", []string{"hk", "us"}, GroupPolicy{
+		Mapping: map[string]string{"office": "us"},
+	})
+	mgr := NewManager([]selectorWithPolicy{sel}, []Network{makeNetwork("office", "office-5g")}, nil)
+
+	mgr.PutContext(makeCtx("office-5g")) // source→auto, lastMatched=office
+	sel.setHistory = nil
+	res, _ := mgr.PutContext(makeCtx("office-5g"))
+	ap := res.Applied[0]
+	if ap.Reason != ReasonUnchangedNetwork {
+		t.Errorf("want unchanged_network, got %q", ap.Reason)
+	}
+	if len(sel.setHistory) != 0 {
+		t.Errorf("unchanged must not Set()")
+	}
+}
+
+// --- DELETE / TTL preserve state -----------------------------------------
+
+func TestDeleteContext_PreservesState(t *testing.T) {
+	sel := newMockSelector("auto", "hk", []string{"hk", "us"}, GroupPolicy{
+		Mapping: map[string]string{"office": "us"},
+	})
+	mgr := NewManager([]selectorWithPolicy{sel}, []Network{makeNetwork("office", "office-5g")}, nil)
+
+	mgr.PutContext(makeCtx("office-5g"))
+	sel.Set("hk")
+	mgr.HandleManualSet("auto")
+
+	mgr.DeleteContext()
+
+	st := mgr.states["auto"]
+	if st.source != SourceManual {
+		t.Errorf("DELETE must preserve source=manual; got %q", st.source)
+	}
+	if st.lastMatched != "office" {
+		t.Errorf("DELETE must preserve last_matched; got %q", st.lastMatched)
+	}
+	if sel.Now() != "hk" {
+		t.Errorf("DELETE must preserve selected proxy; got %q", sel.Now())
+	}
+	if mgr.ctx != nil {
+		t.Errorf("DELETE must clear cached ctx")
+	}
+}
+
+// --- TTL light path ------------------------------------------------------
+
+func TestTTLLightPath_SameFingerprintBothTTL_ShortCircuits(t *testing.T) {
+	sel := newMockSelector("auto", "hk", []string{"hk", "us"}, GroupPolicy{
+		Mapping: map[string]string{"office": "us"},
+	})
+	mgr := NewManager([]selectorWithPolicy{sel}, []Network{makeNetwork("office", "office-5g")}, nil)
+
+	// First PUT with TTL: full evaluation, caches expires_at, switches hk→us.
+	first, _ := mgr.PutContext(makeCtxWithTTL("office-5g", 3600))
+	if first.Applied[0].Reason != ReasonMatched {
+		t.Fatalf("first PUT should match, got %v", first.Applied[0].Reason)
+	}
+	firstExpires := *first.ExpiresAt
+
+	// Second PUT with same ctx + TTL: should go through light path.
+	time.Sleep(10 * time.Millisecond) // ensure expires_at advances
+	sel.setHistory = nil
+	second, _ := mgr.PutContext(makeCtxWithTTL("office-5g", 3600))
+	if len(sel.setHistory) != 0 {
+		t.Errorf("light path must not Set(); got %v", sel.setHistory)
+	}
+	ap := second.Applied[0]
+	if ap.Reason != ReasonUnchangedNetwork {
+		t.Errorf("light path should report unchanged_network, got %q", ap.Reason)
+	}
+	if !second.ExpiresAt.After(firstExpires) {
+		t.Errorf("expires_at must advance: first=%v second=%v", firstExpires, *second.ExpiresAt)
+	}
+}
+
+func TestTTLLightPath_StickyToSticky_FallsThrough(t *testing.T) {
+	// Both PUTs sticky (no TTL): light path's condition (b) and (c) fail.
+	sel := newMockSelector("auto", "us", []string{"hk", "us"}, GroupPolicy{
+		Mapping: map[string]string{"office": "us"},
+	})
+	mgr := NewManager([]selectorWithPolicy{sel}, []Network{makeNetwork("office", "office-5g")}, nil)
+
+	mgr.PutContext(makeCtx("office-5g"))
+	res, _ := mgr.PutContext(makeCtx("office-5g"))
+	// Must go through full evaluation; reason is unchanged_network via
+	// the STATE MACHINE path (same matched + source=auto), not light path.
+	if res.Applied[0].Reason != ReasonUnchangedNetwork {
+		t.Errorf("want unchanged_network, got %q", res.Applied[0].Reason)
+	}
+	if res.ExpiresAt != nil {
+		t.Errorf("sticky ctx must have nil expires_at; got %v", res.ExpiresAt)
+	}
+}
+
+func TestTTLLightPath_MissingTargetPendingDisables(t *testing.T) {
+	// Target "sub-node" not in candidates → missing_target. Next PUT with
+	// same ctx must NOT take the light path (condition d fails), so the
+	// state machine gets a chance to retry.
+	sel := newMockSelector("auto", "hk", []string{"hk"}, GroupPolicy{
+		Mapping: map[string]string{"office": "sub-node"},
+	})
+	mgr := NewManager([]selectorWithPolicy{sel}, []Network{makeNetwork("office", "office-5g")}, nil)
+
+	first, _ := mgr.PutContext(makeCtxWithTTL("office-5g", 3600))
+	if first.Applied[0].Reason != ReasonMissingTarget {
+		t.Fatalf("first should miss target, got %v", first.Applied[0].Reason)
+	}
+
+	// Second PUT, same ctx + ttl: condition (d) fails → full evaluation.
+	// Add "sub-node" as candidate now so the retry succeeds.
+	sel.candidates["sub-node"] = struct{}{}
+	sel.source.StaticProxies = append(sel.source.StaticProxies, "sub-node")
+
+	second, _ := mgr.PutContext(makeCtxWithTTL("office-5g", 3600))
+	if second.Applied[0].Reason != ReasonMatched {
+		t.Errorf("retry must actually re-evaluate and match, got %q", second.Applied[0].Reason)
+	}
+}
+
+func TestTTLLightPath_CandidateSetDirtyDisables(t *testing.T) {
+	sel := newMockSelector("auto", "us", []string{"hk", "us"}, GroupPolicy{
+		Mapping: map[string]string{"office": "us"},
+	})
+	mgr := NewManager([]selectorWithPolicy{sel}, []Network{makeNetwork("office", "office-5g")}, nil)
+
+	first, _ := mgr.PutContext(makeCtxWithTTL("office-5g", 3600))
+	_ = first
+
+	// Simulate provider refresh: candidate_set_dirty set.
+	mgr.OnCandidateSetDirty()
+
+	sel.setHistory = nil
+	second, _ := mgr.PutContext(makeCtxWithTTL("office-5g", 3600))
+	// Must have gone through full evaluation — verifiable indirectly by
+	// checking that OnCandidateSetDirty's flag was cleared after the
+	// evaluation.
+	if mgr.atomicCandidateSetDirtyCounter.Load() != 0 {
+		t.Errorf("candidate_set_dirty counter must clear after a full evaluation (no concurrent bump)")
+	}
+	// Reason will be unchanged_network (state-machine short-circuit),
+	// but the critical invariant is that the full path ran (dirty flag
+	// cleared), not that Set was called.
+	_ = second
+}
+
+// --- Barrier + startup_eval_pending --------------------------------------
+
+func TestReleaseBarrier_NoCtx_EvaluatesAsMatchedNone(t *testing.T) {
+	// Branch B, no ctx pushed during barrier. Release should trigger
+	// matched=<none> evaluation; policy has default so DIRECT is set.
+	sel := newMockSelector("auto", "hk", []string{"hk", "DIRECT"}, GroupPolicy{
+		Mapping:      map[string]string{"office": "hk"},
+		HasDefault:   true,
+		DefaultProxy: "DIRECT",
+	})
+	mgr := NewManager([]selectorWithPolicy{sel}, []Network{makeNetwork("office", "office-5g")}, nil)
+
+	mgr.ReleaseBarrier("auto")
+
+	if sel.Now() != "DIRECT" {
+		t.Errorf("barrier release must apply default; got %q", sel.Now())
+	}
+	st := mgr.states["auto"]
+	if st.source != SourceAuto {
+		t.Errorf("post-release source must be auto; got %q", st.source)
+	}
+	if st.lastMatched != MatchedNone {
+		t.Errorf("post-release last_matched must be MatchedNone; got %q", st.lastMatched)
+	}
+	if st.startupEvalPending {
+		t.Errorf("startup_eval_pending must clear after successful release")
+	}
+}
+
+func TestReleaseBarrier_WithCtx_UsesCachedCtx(t *testing.T) {
+	// Branch B, barrier period PUT arrived with matched=office but
+	// target missing. Release should re-evaluate with cached ctx now
+	// that providers are ready.
+	sel := newMockSelector("auto", "hk", []string{"hk"}, GroupPolicy{
+		Mapping: map[string]string{"office": "sub-node"},
+	})
+	mgr := NewManager([]selectorWithPolicy{sel}, []Network{makeNetwork("office", "office-5g")}, nil)
+
+	// PUT during barrier — missing_target.
+	first, _ := mgr.PutContext(makeCtx("office-5g"))
+	if first.Applied[0].Reason != ReasonMissingTarget {
+		t.Fatalf("setup: want missing_target, got %v", first.Applied[0].Reason)
+	}
+	st := mgr.states["auto"]
+	if !st.startupEvalPending {
+		t.Errorf("missing_target during barrier must keep pending=true")
+	}
+
+	// Provider populates "sub-node"; release.
+	sel.candidates["sub-node"] = struct{}{}
+	sel.source.StaticProxies = append(sel.source.StaticProxies, "sub-node")
+	mgr.ReleaseBarrier("auto")
+
+	if sel.Now() != "sub-node" {
+		t.Errorf("post-release must retry and set sub-node; got %q", sel.Now())
+	}
+	if mgr.states["auto"].startupEvalPending {
+		t.Errorf("successful retry must clear pending")
+	}
+}
+
+func TestReleaseBarrier_Idempotent(t *testing.T) {
+	sel := newMockSelector("auto", "hk", []string{"hk", "DIRECT"}, GroupPolicy{
+		Mapping:      map[string]string{"office": "hk"},
+		HasDefault:   true,
+		DefaultProxy: "DIRECT",
+	})
+	mgr := NewManager([]selectorWithPolicy{sel}, []Network{makeNetwork("office", "office-5g")}, nil)
+
+	mgr.ReleaseBarrier("auto")
+	sel.setHistory = nil
+	mgr.ReleaseBarrier("auto")
+	if len(sel.setHistory) != 0 {
+		t.Errorf("second release must be no-op; got Set history %v", sel.setHistory)
+	}
+}
+
+// --- ForceReEvaluate (hot reload) ----------------------------------------
+
+func TestForceReEvaluate_NoCtx_NoOp(t *testing.T) {
+	sel := newMockSelector("auto", "hk", []string{"hk", "us"}, GroupPolicy{
+		Mapping: map[string]string{"office": "us"},
+	})
+	mgr := NewManager([]selectorWithPolicy{sel}, []Network{makeNetwork("office", "office-5g")}, nil)
+
+	res := mgr.ForceReEvaluate()
+	if res != nil {
+		t.Errorf("no cached ctx → ForceReEvaluate must return nil")
+	}
+}
+
+func TestForceReEvaluate_WithCtx_BypassesStability(t *testing.T) {
+	// Initially unchanged_network after second PUT; ForceReEvaluate with
+	// same ctx should still run the evaluation (simulating a policy-
+	// mapping YAML edit).
+	sel := newMockSelector("auto", "us", []string{"hk", "us"}, GroupPolicy{
+		Mapping: map[string]string{"office": "us"},
+	})
+	mgr := NewManager([]selectorWithPolicy{sel}, []Network{makeNetwork("office", "office-5g")}, nil)
+	mgr.PutContext(makeCtx("office-5g"))
+
+	// Swap the policy so office → hk instead of us.
+	sel.policy = GroupPolicy{Mapping: map[string]string{"office": "hk"}}
+	res := mgr.ForceReEvaluate()
+	if res == nil {
+		t.Fatal("expected result on force re-evaluate with cached ctx")
+	}
+	if res.Applied[0].Reason != ReasonMatched {
+		t.Errorf("want matched on re-evaluation (policy changed), got %q", res.Applied[0].Reason)
+	}
+	if sel.Now() != "hk" {
+		t.Errorf("force re-eval must apply new policy; got %q", sel.Now())
+	}
+}
+
+// --- Defensive copy -------------------------------------------------------
+
+func TestPutContext_DeepCopy_CallerMutationIsolated(t *testing.T) {
+	sel := newMockSelector("auto", "hk", []string{"hk", "us"}, GroupPolicy{
+		Mapping: map[string]string{"office": "us"},
+	})
+	mgr := NewManager([]selectorWithPolicy{sel}, []Network{makeNetwork("office", "office-5g")}, nil)
+
+	ctx := makeCtx("office-5g")
+	ctx.Interfaces[0].Subnets = []string{"10.0.0.0/24"}
+	_, err := mgr.PutContext(ctx)
+	if err != nil {
+		t.Fatalf("unexpected: %v", err)
+	}
+
+	// Mutate caller's slice; manager's cached ctx must not change.
+	ctx.Interfaces[0].Subnets[0] = "MUTATED"
+	ctx.Interfaces[0].SSID = "MUTATED"
+	if mgr.ctx.Interfaces[0].Subnets[0] == "MUTATED" {
+		t.Errorf("manager shared caller's Subnets slice")
+	}
+	if mgr.ctx.Interfaces[0].SSID == "MUTATED" {
+		t.Errorf("manager shared caller's SSID string (shouldn't — strings are immutable though)")
+	}
+}
+
+// --- Persistence writes ---------------------------------------------------
+
+// Manager writes to cachefile only on state change (§5.6.3). Without a
+// real cachefile we can only test indirectly by checking that
+// persistStateLocked is reachable — covered transitively in the reason
+// tests above via the NewManager(..., nil) path where cache is nil and
+// writes are skipped without error.
+
+// --- Status ---------------------------------------------------------------
+
+func TestGetStatus_BeforeAnyPut_NoContext(t *testing.T) {
+	sel := newMockSelector("auto", "hk", []string{"hk"}, GroupPolicy{
+		Mapping: map[string]string{"office": "hk"},
+	})
+	mgr := NewManager([]selectorWithPolicy{sel}, []Network{makeNetwork("office", "office-5g")}, nil)
+
+	st := mgr.GetStatus()
+	if st.HasContext {
+		t.Errorf("fresh manager should report HasContext=false")
+	}
+	if len(st.Groups) != 1 {
+		t.Errorf("want 1 group in status, got %d", len(st.Groups))
+	}
+	if st.Groups[0].SelectionSource != SourceUnknown {
+		t.Errorf("initial source should be unknown, got %q", st.Groups[0].SelectionSource)
+	}
+}
+
+// Regression: manual set during branch-B barrier must NOT clear
+// startup_eval_pending — the post-barrier recheck is still required
+// so the auto-takeover rule can reassert if matched has advanced
+// (§5.6.2 row 1 only touches selection_source).
+func TestHandleManualSet_PreservesStartupEvalPending(t *testing.T) {
+	sel := newMockSelector("auto", "hk", []string{"hk", "us"}, GroupPolicy{
+		Mapping: map[string]string{"office": "us"},
+	})
+	mgr := NewManager([]selectorWithPolicy{sel}, []Network{makeNetwork("office", "office-5g")}, nil)
+
+	// Branch B → startupEvalPending starts true.
+	if !mgr.states["auto"].startupEvalPending {
+		t.Fatal("precondition: branch B must start pending=true")
+	}
+	mgr.HandleManualSet("auto")
+	if !mgr.states["auto"].startupEvalPending {
+		t.Errorf("HandleManualSet must not clear startup_eval_pending")
+	}
+}
+
+// Regression: ReleaseBarrier post-recheck that resolves missing_target
+// must clear the global atomicHasPendingMissingTarget so TTL light path
+// condition (d) re-enables (§5.6.3).
+func TestReleaseBarrier_ClearsGlobalPendingOnResolve(t *testing.T) {
+	sel := newMockSelector("auto", "hk", []string{"hk"}, GroupPolicy{
+		Mapping: map[string]string{"office": "sub-node"},
+	})
+	mgr := NewManager([]selectorWithPolicy{sel}, []Network{makeNetwork("office", "office-5g")}, nil)
+
+	// PUT during barrier — missing_target.
+	mgr.PutContext(makeCtx("office-5g"))
+	if !mgr.atomicHasPendingMissingTarget.Load() {
+		t.Fatal("precondition: missing_target should set atomic flag")
+	}
+
+	// Provider populates target; release barrier.
+	sel.candidates["sub-node"] = struct{}{}
+	sel.source.StaticProxies = append(sel.source.StaticProxies, "sub-node")
+	mgr.ReleaseBarrier("auto")
+
+	if mgr.atomicHasPendingMissingTarget.Load() {
+		t.Errorf("atomicHasPendingMissingTarget must clear after barrier-release resolves missing_target")
+	}
+}
+
+// Regression: ForceReEvaluate must consume the candidate_set_dirty
+// signal (§5.8.3 hot reload is a full evaluation).
+func TestForceReEvaluate_ClearsCandidateSetDirty(t *testing.T) {
+	sel := newMockSelector("auto", "us", []string{"hk", "us"}, GroupPolicy{
+		Mapping: map[string]string{"office": "us"},
+	})
+	mgr := NewManager([]selectorWithPolicy{sel}, []Network{makeNetwork("office", "office-5g")}, nil)
+	mgr.PutContext(makeCtx("office-5g"))
+
+	mgr.OnCandidateSetDirty()
+	if mgr.atomicCandidateSetDirtyCounter.Load() == 0 {
+		t.Fatal("precondition: OnCandidateSetDirty must set counter")
+	}
+	mgr.ForceReEvaluate()
+	if mgr.atomicCandidateSetDirtyCounter.Load() != 0 {
+		t.Errorf("ForceReEvaluate must clear candidate_set_dirty")
+	}
+}
+
+// Regression: matched_network in GetStatus is a CTX-level property,
+// NOT a per-group aggregate. A group stuck in missing_target never
+// advances last_matched, but the ctx still matches — GetStatus must
+// reflect the ctx match.
+func TestGetStatus_MatchedFromCtx_NotFromGroupState(t *testing.T) {
+	sel := newMockSelector("auto", "hk", []string{"hk"}, GroupPolicy{
+		Mapping: map[string]string{"office": "sub-node"}, // target unreachable
+	})
+	mgr := NewManager([]selectorWithPolicy{sel}, []Network{makeNetwork("office", "office-5g")}, nil)
+
+	mgr.PutContext(makeCtx("office-5g")) // → missing_target, last_matched stays nil
+	if mgr.states["auto"].lastMatchedPresent {
+		t.Fatal("precondition: missing_target must leave lastMatched nil")
+	}
+
+	st := mgr.GetStatus()
+	if !st.MatchedNetworkPresent || st.MatchedNetwork != "office" {
+		t.Errorf("matched_network must come from ctx; got present=%v value=%q", st.MatchedNetworkPresent, st.MatchedNetwork)
+	}
+}
+
+// Regression: missing_target pending bit must be cleared when the ctx
+// returns to the original matched via the sameMatched short-circuit.
+// Without the fix, once any evaluation hit missing_target, the pending
+// bit would stay true even after the user navigated back to a network
+// where the original (reachable) target applied — permanently disabling
+// TTL light-path condition (d) for the entire process lifetime.
+func TestEvaluate_ReturnToOriginalMatched_ClearsPending(t *testing.T) {
+	sel := newMockSelector("auto", "hk", []string{"hk", "us"}, GroupPolicy{
+		Mapping: map[string]string{
+			"office": "us",
+			"home":   "unreachable", // deliberately not in candidates
+		},
+	})
+	mgr := NewManager([]selectorWithPolicy{sel}, []Network{
+		makeNetwork("office", "office-5g"),
+		makeNetwork("home", "home-wifi"),
+	}, nil)
+
+	// PUT(office) → matched, source=auto, pending=false.
+	mgr.PutContext(makeCtx("office-5g"))
+	if mgr.atomicHasPendingMissingTarget.Load() {
+		t.Fatal("precondition: matched path must not set pending")
+	}
+
+	// PUT(home) → missing_target (unreachable), pending=true.
+	mgr.PutContext(makeCtx("home-wifi"))
+	if !mgr.atomicHasPendingMissingTarget.Load() {
+		t.Fatal("precondition: missing_target must set pending")
+	}
+
+	// PUT(office) again → sameMatched short-circuit must clear pending.
+	mgr.PutContext(makeCtx("office-5g"))
+	if mgr.atomicHasPendingMissingTarget.Load() {
+		t.Errorf("sameMatched short-circuit must clear missingTargetPending; TTL light path stays disabled otherwise")
+	}
+}
+
+// Regression: TTL light-path heartbeat must refresh ctxReceivedAt so
+// GetStatus().AgeSeconds reports "time since last host heartbeat" not
+// "time since first PUT". Without the refresh a sticky-heartbeat client
+// would see AgeSeconds climb forever.
+func TestTTLLightPath_RefreshesReceivedAtForAge(t *testing.T) {
+	sel := newMockSelector("auto", "us", []string{"hk", "us"}, GroupPolicy{
+		Mapping: map[string]string{"office": "us"},
+	})
+	mgr := NewManager([]selectorWithPolicy{sel}, []Network{makeNetwork("office", "office-5g")}, nil)
+
+	mgr.PutContext(makeCtxWithTTL("office-5g", 3600))
+	firstStamp := mgr.ctxReceivedAt
+	// Sleep long enough that a non-refreshed stamp is clearly detectable
+	// even with coarse clock resolution on Windows.
+	time.Sleep(30 * time.Millisecond)
+	mgr.PutContext(makeCtxWithTTL("office-5g", 3600)) // light-path heartbeat
+
+	if !mgr.ctxReceivedAt.After(firstStamp) {
+		t.Errorf("ctxReceivedAt must advance on TTL heartbeat; first=%v second=%v", firstStamp, mgr.ctxReceivedAt)
+	}
+}
+
+// Regression: TTL light path must report the real matched_network even
+// when the config has 0 policy groups. Before the fix, the light path
+// reverse-derived matched_network from the first group's lastMatched,
+// which defaulted to MatchedNone when no groups existed — so the first
+// PUT returned "office" (full path) and the second same-ctx TTL PUT
+// returned null (light path).
+func TestTTLLightPath_ZeroGroups_MatchedNetworkStable(t *testing.T) {
+	mgr := NewManager(nil, []Network{makeNetwork("office", "office-5g")}, nil)
+
+	first, _ := mgr.PutContext(makeCtxWithTTL("office-5g", 3600))
+	if !first.MatchedNetworkPresent || first.MatchedNetwork != "office" {
+		t.Fatalf("first PUT matched_network: present=%v value=%q; want present=true value=office",
+			first.MatchedNetworkPresent, first.MatchedNetwork)
+	}
+
+	time.Sleep(10 * time.Millisecond)
+	second, _ := mgr.PutContext(makeCtxWithTTL("office-5g", 3600))
+	if !second.MatchedNetworkPresent || second.MatchedNetwork != "office" {
+		t.Errorf("light-path PUT matched_network regressed: present=%v value=%q; want present=true value=office",
+			second.MatchedNetworkPresent, second.MatchedNetwork)
+	}
+	if len(second.Applied) != 0 {
+		t.Errorf("applied[] must be empty when no policy groups exist; got %v", second.Applied)
+	}
+}
+
+// Regression: GetStatus populates age_seconds from ctxReceivedAt.
+func TestGetStatus_AgeSecondsPopulated(t *testing.T) {
+	sel := newMockSelector("auto", "hk", []string{"hk", "us"}, GroupPolicy{
+		Mapping: map[string]string{"office": "us"},
+	})
+	mgr := NewManager([]selectorWithPolicy{sel}, []Network{makeNetwork("office", "office-5g")}, nil)
+
+	mgr.PutContext(makeCtx("office-5g"))
+	time.Sleep(10 * time.Millisecond)
+	st := mgr.GetStatus()
+	if st.AgeSeconds == nil {
+		t.Fatal("AgeSeconds must be set after PUT")
+	}
+	if *st.AgeSeconds < 0 {
+		t.Errorf("AgeSeconds must be non-negative, got %d", *st.AgeSeconds)
+	}
+}
+
+// Regression: a TTL callback that was scheduled against an old ctx
+// must not wipe a newer ctx that arrived in between. Tested by
+// scheduling a very-short TTL, replacing with a long TTL before the
+// old timer fires, then waiting past when the old timer would have
+// fired to confirm ctx is still cached.
+func TestPutContext_StaleTTLCallbackDoesNotWipeNewCtx(t *testing.T) {
+	sel := newMockSelector("auto", "us", []string{"hk", "us"}, GroupPolicy{
+		Mapping: map[string]string{"office": "us"},
+	})
+	mgr := NewManager([]selectorWithPolicy{sel}, []Network{makeNetwork("office", "office-5g")}, nil)
+
+	// First PUT with 1-second TTL.
+	mgr.PutContext(makeCtxWithTTL("office-5g", 1))
+	// Immediately renew with a longer TTL (simulating heartbeat).
+	mgr.PutContext(makeCtxWithTTL("office-5g", 3600))
+	// Wait past when the first timer would have fired.
+	time.Sleep(1500 * time.Millisecond)
+
+	// The second ctx with the long TTL must still be cached — the
+	// stale-fire guard should have dropped the first timer's callback.
+	if !mgr.atomicHasCtx.Load() {
+		t.Errorf("stale TTL callback wiped fresh ctx (TTL generation guard missing?)")
+	}
+}
+
+func TestGetStatus_AfterPut_ReflectsState(t *testing.T) {
+	sel := newMockSelector("auto", "hk", []string{"hk", "us"}, GroupPolicy{
+		Mapping: map[string]string{"office": "us"},
+	})
+	mgr := NewManager([]selectorWithPolicy{sel}, []Network{makeNetwork("office", "office-5g")}, nil)
+
+	mgr.PutContext(makeCtx("office-5g"))
+	st := mgr.GetStatus()
+	if !st.HasContext {
+		t.Errorf("want HasContext=true after PUT")
+	}
+	if !st.MatchedNetworkPresent || st.MatchedNetwork != "office" {
+		t.Errorf("want matched=office, got present=%v value=%q", st.MatchedNetworkPresent, st.MatchedNetwork)
+	}
+	if st.Groups[0].CurrentProxy != "us" {
+		t.Errorf("want current=us, got %q", st.Groups[0].CurrentProxy)
+	}
+}

--- a/component/networkpolicy/matcher.go
+++ b/component/networkpolicy/matcher.go
@@ -1,0 +1,523 @@
+package networkpolicy
+
+import (
+	"fmt"
+	"net/netip"
+	"strings"
+
+	"golang.org/x/exp/slices"
+)
+
+// Matcher decides whether a NetworkContext hits this rule. The top-level
+// constructor ParseMatch returns a Matcher; concrete implementations are
+// matchBlock and logical combinators (anyMatcher/allMatcher/notMatcher).
+type Matcher interface {
+	Match(ctx *NetworkContext) bool
+}
+
+// matchBlock is the AST node for a single YAML `match:` sub-tree.
+//
+// Compile model (three-tuple):
+//
+//	P = atomic conjunction of per-iface-field predicates (len(ifacePred) > 0)
+//	G = global-field predicate (single Matcher on ctx, currently dns-suffix)
+//	C = list of combinator sub-blocks (any:/all:/not:)
+//
+// Evaluation:
+//
+//	block ≡ (P_empty ? true : ∃iface ∈ interfaces . P(iface)) ∧ G ∧ C_1 ∧ … ∧ C_n
+//
+// The "∃ only wraps when P is non-empty" rule lets blocks with only global
+// fields / combinators still match on interfaces[] = [] — the typical use
+// case being "not: { iface-type: cellular }" holding on an empty inventory.
+//
+// Atomicity: the per-iface fields inside one block are required to hold on
+// the SAME iface — that's what makes ifacePred a conjunction evaluated
+// per-iface instead of "∃iface f1 ∧ ∃iface f2" (which would let two
+// different ifaces satisfy one field each).
+type matchBlock struct {
+	ifacePred   ifacePred // nil/empty → P_empty (no ∃ wrap)
+	globalPred  Matcher   // nil → absent
+	combinators []Matcher
+}
+
+// Match implements Matcher. Returns false for nil ctx (rather than panic) so
+// callers can treat Matcher as a total function; the top-level Match(ctx)
+// also guards against nil, but the public Matcher surface should be safe
+// on its own.
+func (b matchBlock) Match(ctx *NetworkContext) bool {
+	if ctx == nil {
+		return false
+	}
+	if len(b.ifacePred) > 0 {
+		hit := false
+		for i := range ctx.Interfaces {
+			if b.ifacePred.matchIface(&ctx.Interfaces[i]) {
+				hit = true
+				break
+			}
+		}
+		if !hit {
+			return false
+		}
+	}
+	if b.globalPred != nil && !b.globalPred.Match(ctx) {
+		return false
+	}
+	for _, c := range b.combinators {
+		if !c.Match(ctx) {
+			return false
+		}
+	}
+	return true
+}
+
+// ifaceFieldMatcher is the per-iface predicate building block. Each
+// implementation evaluates one field of a single InterfaceContext.
+//
+// Null-field semantics: a field the sampler didn't populate makes matchIface
+// return false for that iface. This excludes null-field ifaces from the ∃
+// domain (rather than treating null as "any value"), which also means a
+// `not:` wrapped over a matcher of a field no iface reports is true — "no
+// iface satisfies the predicate" is the natural reading.
+type ifaceFieldMatcher interface {
+	matchIface(iface *InterfaceContext) bool
+}
+
+// ifacePred is the atomic AND of per-iface field matchers.
+type ifacePred []ifaceFieldMatcher
+
+func (p ifacePred) matchIface(iface *InterfaceContext) bool {
+	for _, m := range p {
+		if !m.matchIface(iface) {
+			return false
+		}
+	}
+	return true
+}
+
+// -------------------- per-iface field matchers --------------------
+
+type nameFieldMatcher struct{ values []string }
+
+func (m nameFieldMatcher) matchIface(iface *InterfaceContext) bool {
+	return iface.Name != "" && slices.Contains(m.values, iface.Name)
+}
+
+type ifaceTypeFieldMatcher struct{ values []string }
+
+func (m ifaceTypeFieldMatcher) matchIface(iface *InterfaceContext) bool {
+	return iface.IfaceType != "" && slices.Contains(m.values, iface.IfaceType)
+}
+
+type ssidFieldMatcher struct{ values []string }
+
+func (m ssidFieldMatcher) matchIface(iface *InterfaceContext) bool {
+	return iface.SSID != "" && slices.Contains(m.values, iface.SSID)
+}
+
+type bssidFieldMatcher struct{ values []string }
+
+func (m bssidFieldMatcher) matchIface(iface *InterfaceContext) bool {
+	return iface.BSSID != "" && slices.Contains(m.values, iface.BSSID)
+}
+
+type gatewayMACFieldMatcher struct{ values []string }
+
+func (m gatewayMACFieldMatcher) matchIface(iface *InterfaceContext) bool {
+	return iface.GatewayMAC != "" && slices.Contains(m.values, iface.GatewayMAC)
+}
+
+type gatewayIPFieldMatcher struct{ matches []ipMatcher }
+
+func (m gatewayIPFieldMatcher) matchIface(iface *InterfaceContext) bool {
+	if !iface.gatewayIPParsed.IsValid() {
+		return false
+	}
+	for _, im := range m.matches {
+		if im.match(iface.gatewayIPParsed) {
+			return true
+		}
+	}
+	return false
+}
+
+type subnetsFieldMatcher struct{ prefixes []netip.Prefix }
+
+func (m subnetsFieldMatcher) matchIface(iface *InterfaceContext) bool {
+	if len(iface.subnetsParsed) == 0 {
+		return false
+	}
+	for _, p := range m.prefixes {
+		for _, q := range iface.subnetsParsed {
+			if p.Overlaps(q) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// ipMatcher represents a single IP or CIDR entry for gateway-ip.
+type ipMatcher struct {
+	addr   netip.Addr
+	prefix netip.Prefix
+	isCIDR bool
+}
+
+func (m ipMatcher) match(got netip.Addr) bool {
+	if m.isCIDR {
+		return m.prefix.Contains(got)
+	}
+	return m.addr == got
+}
+
+// -------------------- global matchers --------------------
+
+// dnsSuffixMatcher evaluates the top-level dns_suffix field. Match semantics:
+// intersection of matcher values (lower-cased at parse time) with ctx.DNSSuffix
+// (lower-cased at normalize time) is non-empty.
+type dnsSuffixMatcher struct{ values []string }
+
+func (m dnsSuffixMatcher) Match(ctx *NetworkContext) bool {
+	if ctx == nil || len(ctx.DNSSuffix) == 0 {
+		return false
+	}
+	for _, v := range m.values {
+		if slices.Contains(ctx.DNSSuffix, v) {
+			return true
+		}
+	}
+	return false
+}
+
+// -------------------- combinators --------------------
+
+type anyMatcher []Matcher
+
+func (m anyMatcher) Match(ctx *NetworkContext) bool {
+	for _, sub := range m {
+		if sub.Match(ctx) {
+			return true
+		}
+	}
+	return false
+}
+
+type allMatcher []Matcher
+
+func (m allMatcher) Match(ctx *NetworkContext) bool {
+	for _, sub := range m {
+		if !sub.Match(ctx) {
+			return false
+		}
+	}
+	return true
+}
+
+type notMatcher struct{ inner Matcher }
+
+func (m notMatcher) Match(ctx *NetworkContext) bool {
+	// Conservative nil guard: nil ctx → no match (rather than double-negate
+	// through to true). Keeps the entire Matcher surface nil-safe with the
+	// unified "no ctx means no match" reading.
+	if ctx == nil {
+		return false
+	}
+	return !m.inner.Match(ctx)
+}
+
+// -------------------- parser --------------------
+
+// ParseMatch parses a YAML match: sub-tree into a Matcher. Empty raw map is
+// rejected — a block with no fields has no meaningful semantic.
+func ParseMatch(raw map[string]any) (Matcher, error) {
+	if len(raw) == 0 {
+		return nil, fmt.Errorf("empty match block: require at least one field")
+	}
+	// Sort keys for deterministic error reporting on malformed blocks.
+	keys := make([]string, 0, len(raw))
+	for k := range raw {
+		keys = append(keys, k)
+	}
+	slices.Sort(keys)
+
+	var fields []ifaceFieldMatcher
+	var combinators []Matcher
+	var globalPred Matcher
+
+	for _, key := range keys {
+		val := raw[key]
+		switch key {
+		case "any":
+			sub, err := parseAny(val)
+			if err != nil {
+				return nil, err
+			}
+			combinators = append(combinators, sub)
+		case "all":
+			sub, err := parseAll(val)
+			if err != nil {
+				return nil, err
+			}
+			combinators = append(combinators, sub)
+		case "not":
+			sub, err := parseNot(val)
+			if err != nil {
+				return nil, err
+			}
+			combinators = append(combinators, sub)
+		case "dns-suffix":
+			m, err := buildDNSSuffixMatcher(val)
+			if err != nil {
+				return nil, err
+			}
+			globalPred = m
+		case "name", "iface-type", "ssid", "bssid", "gateway-ip", "gateway-mac", "subnets":
+			m, err := buildIfaceFieldMatcher(key, val)
+			if err != nil {
+				return nil, err
+			}
+			fields = append(fields, m)
+		case "metered":
+			// The metered matcher is deliberately disabled until host sampler
+			// implementations populate InterfaceContext.Metered reliably.
+			// While all platforms emit Metered=null, `not: {metered: true}`
+			// would silently always-match (∃iface with Metered==true is
+			// false, negation is true), which is surprising. The wire field
+			// is still parsed (forward-compat) but YAML references are
+			// rejected at config-load time with an actionable alternative.
+			return nil, fmt.Errorf("match.metered: not supported (host samplers do not yet populate metered; use iface-type: cellular / wwan instead)")
+		default:
+			return nil, fmt.Errorf("unknown match key: %q", key)
+		}
+	}
+
+	block := matchBlock{
+		globalPred:  globalPred,
+		combinators: combinators,
+	}
+	if len(fields) > 0 {
+		block.ifacePred = ifacePred(fields)
+	}
+	return block, nil
+}
+
+func parseAny(v any) (Matcher, error) {
+	subs, err := parseSubBlocks("any", v)
+	if err != nil {
+		return nil, err
+	}
+	if len(subs) == 1 {
+		return subs[0], nil
+	}
+	return anyMatcher(subs), nil
+}
+
+func parseAll(v any) (Matcher, error) {
+	subs, err := parseSubBlocks("all", v)
+	if err != nil {
+		return nil, err
+	}
+	if len(subs) == 1 {
+		return subs[0], nil
+	}
+	return allMatcher(subs), nil
+}
+
+func parseNot(v any) (Matcher, error) {
+	// `not:` takes exactly one match-block, never a list. This asymmetry
+	// with any:/all: mirrors boolean logic (NOT is unary).
+	sub, ok := v.(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("match.not: expected map (single match-block), got %T", v)
+	}
+	inner, err := ParseMatch(sub)
+	if err != nil {
+		return nil, fmt.Errorf("match.not: %w", err)
+	}
+	return notMatcher{inner: inner}, nil
+}
+
+func parseSubBlocks(opName string, v any) ([]Matcher, error) {
+	list, ok := v.([]any)
+	if !ok {
+		return nil, fmt.Errorf("match.%s: expected list of sub-matches", opName)
+	}
+	if len(list) == 0 {
+		return nil, fmt.Errorf("match.%s: at least one sub-match required", opName)
+	}
+	subs := make([]Matcher, 0, len(list))
+	for i, item := range list {
+		sub, ok := item.(map[string]any)
+		if !ok {
+			return nil, fmt.Errorf("match.%s[%d]: expected map, got %T", opName, i, item)
+		}
+		m, err := ParseMatch(sub)
+		if err != nil {
+			return nil, fmt.Errorf("match.%s[%d]: %w", opName, i, err)
+		}
+		subs = append(subs, m)
+	}
+	return subs, nil
+}
+
+func buildIfaceFieldMatcher(key string, val any) (ifaceFieldMatcher, error) {
+	switch key {
+	case "name":
+		list, err := coerceStringList(key, val)
+		if err != nil {
+			return nil, err
+		}
+		return nameFieldMatcher{values: list}, nil
+
+	case "iface-type":
+		list, err := coerceStringList(key, val)
+		if err != nil {
+			return nil, err
+		}
+		for i := range list {
+			list[i] = strings.ToLower(list[i])
+			if !IsValidIfaceType(list[i]) {
+				return nil, fmt.Errorf("iface-type[%d]: invalid value %q", i, list[i])
+			}
+		}
+		return ifaceTypeFieldMatcher{values: list}, nil
+
+	case "ssid":
+		list, err := coerceStringList(key, val)
+		if err != nil {
+			return nil, err
+		}
+		return ssidFieldMatcher{values: list}, nil
+
+	case "bssid":
+		list, err := coerceStringList(key, val)
+		if err != nil {
+			return nil, err
+		}
+		for i, s := range list {
+			m, err := normalizeMAC(s)
+			if err != nil {
+				return nil, fmt.Errorf("bssid[%d]: %w", i, err)
+			}
+			list[i] = m
+		}
+		return bssidFieldMatcher{values: list}, nil
+
+	case "gateway-mac":
+		list, err := coerceStringList(key, val)
+		if err != nil {
+			return nil, err
+		}
+		for i, s := range list {
+			m, err := normalizeMAC(s)
+			if err != nil {
+				return nil, fmt.Errorf("gateway-mac[%d]: %w", i, err)
+			}
+			list[i] = m
+		}
+		return gatewayMACFieldMatcher{values: list}, nil
+
+	case "gateway-ip":
+		list, err := coerceStringList(key, val)
+		if err != nil {
+			return nil, err
+		}
+		matches := make([]ipMatcher, 0, len(list))
+		for i, s := range list {
+			im, err := parseIPMatcher(s)
+			if err != nil {
+				return nil, fmt.Errorf("gateway-ip[%d]: %q: %w", i, s, err)
+			}
+			matches = append(matches, im)
+		}
+		return gatewayIPFieldMatcher{matches: matches}, nil
+
+	case "subnets":
+		list, err := coerceStringList(key, val)
+		if err != nil {
+			return nil, err
+		}
+		prefixes := make([]netip.Prefix, 0, len(list))
+		for i, s := range list {
+			p, err := netip.ParsePrefix(s)
+			if err != nil {
+				return nil, fmt.Errorf("subnets[%d]: %q: %w", i, s, err)
+			}
+			prefixes = append(prefixes, p.Masked())
+		}
+		return subnetsFieldMatcher{prefixes: prefixes}, nil
+	}
+	return nil, fmt.Errorf("unknown iface field key: %q", key)
+}
+
+func buildDNSSuffixMatcher(val any) (Matcher, error) {
+	list, err := coerceStringList("dns-suffix", val)
+	if err != nil {
+		return nil, err
+	}
+	for i := range list {
+		list[i] = strings.ToLower(list[i])
+	}
+	return dnsSuffixMatcher{values: list}, nil
+}
+
+func parseIPMatcher(s string) (ipMatcher, error) {
+	if strings.ContainsRune(s, '/') {
+		p, err := netip.ParsePrefix(s)
+		if err != nil {
+			return ipMatcher{}, err
+		}
+		return ipMatcher{prefix: p.Masked(), isCIDR: true}, nil
+	}
+	addr, err := netip.ParseAddr(s)
+	if err != nil {
+		return ipMatcher{}, err
+	}
+	// Strip IPv6 zone to align with context-side normalize() behavior.
+	return ipMatcher{addr: addr.WithZone("")}, nil
+}
+
+// coerceStringList turns a YAML-decoded value into []string, rejecting loose
+// type coercions (numbers are not silently stringified). Empty list/string
+// is a hard error so that a match-block is never trivially-satisfiable.
+func coerceStringList(ctx string, v any) ([]string, error) {
+	switch x := v.(type) {
+	case string:
+		if x == "" {
+			return nil, fmt.Errorf("%s: empty string not allowed", ctx)
+		}
+		return []string{x}, nil
+	case []string:
+		if len(x) == 0 {
+			return nil, fmt.Errorf("%s: empty list not allowed", ctx)
+		}
+		out := make([]string, len(x))
+		for i, s := range x {
+			if s == "" {
+				return nil, fmt.Errorf("%s[%d]: empty string not allowed", ctx, i)
+			}
+			out[i] = s
+		}
+		return out, nil
+	case []any:
+		if len(x) == 0 {
+			return nil, fmt.Errorf("%s: empty list not allowed", ctx)
+		}
+		out := make([]string, 0, len(x))
+		for i, item := range x {
+			s, ok := item.(string)
+			if !ok {
+				return nil, fmt.Errorf("%s[%d]: expected string, got %T", ctx, i, item)
+			}
+			if s == "" {
+				return nil, fmt.Errorf("%s[%d]: empty string not allowed", ctx, i)
+			}
+			out = append(out, s)
+		}
+		return out, nil
+	default:
+		return nil, fmt.Errorf("%s: expected string or list, got %T", ctx, v)
+	}
+}

--- a/component/networkpolicy/matcher.go
+++ b/component/networkpolicy/matcher.go
@@ -378,7 +378,7 @@ func buildIfaceFieldMatcher(key string, val any) (ifaceFieldMatcher, error) {
 		}
 		for i := range list {
 			list[i] = strings.ToLower(list[i])
-			if !IsValidIfaceType(list[i]) {
+			if !isValidIfaceType(list[i]) {
 				return nil, fmt.Errorf("iface-type[%d]: invalid value %q", i, list[i])
 			}
 		}

--- a/component/networkpolicy/matcher_test.go
+++ b/component/networkpolicy/matcher_test.go
@@ -1,0 +1,360 @@
+package networkpolicy
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func mustParse(t *testing.T, raw map[string]any) Matcher {
+	t.Helper()
+	m, err := ParseMatch(raw)
+	assert.NoError(t, err)
+	assert.NotNil(t, m)
+	return m
+}
+
+func norm(t *testing.T, c *NetworkContext) *NetworkContext {
+	t.Helper()
+	assert.NoError(t, c.NormalizeAndValidate())
+	return c
+}
+
+func TestParseMatch_Errors(t *testing.T) {
+	cases := []struct {
+		name   string
+		raw    map[string]any
+		errSub string
+	}{
+		{"empty", nil, "empty match block"},
+		{"empty map", map[string]any{}, "empty match block"},
+		{"unknown key", map[string]any{"ssidx": "a"}, "unknown match key"},
+		{"metered disabled", map[string]any{"metered": true}, "not supported"},
+		{"empty any", map[string]any{"any": []any{}}, "at least one sub-match"},
+		{"empty all", map[string]any{"all": []any{}}, "at least one sub-match"},
+		{"any non-map item", map[string]any{"any": []any{"string-not-map"}}, "expected map"},
+		{"all non-list", map[string]any{"all": "not-a-list"}, "expected list"},
+		{"not not a map", map[string]any{"not": []any{}}, "expected map"},
+		{"not empty map", map[string]any{"not": map[string]any{}}, "empty match block"},
+		{"empty field list", map[string]any{"ssid": []any{}}, "empty list"},
+		{"non-string in list", map[string]any{"ssid": []any{"a", 123}}, "expected string"},
+		{"empty string scalar", map[string]any{"ssid": ""}, "empty string"},
+		{"empty string in list", map[string]any{"ssid": []any{"a", ""}}, "empty string"},
+		{"gateway-ip invalid", map[string]any{"gateway-ip": "999.9.9.9"}, "gateway-ip[0]"},
+		{"iface-type invalid enum", map[string]any{"iface-type": "tun"}, "invalid value"},
+		{"iface-type wire invalid", map[string]any{"iface-type": "wire"}, "invalid value"},
+		// Alphabetical key iteration — deterministic error for multi-bad blocks.
+		{"deterministic error order", map[string]any{"zoo": "x", "all": []any{}}, "at least one sub-match"},
+	}
+	for _, tc := range cases {
+		_, err := ParseMatch(tc.raw)
+		assert.ErrorContains(t, err, tc.errSub, "case %q", tc.name)
+	}
+}
+
+func TestParseMatch_Shape(t *testing.T) {
+	// Single per-iface field → matchBlock with one-element ifacePred.
+	m := mustParse(t, map[string]any{"ssid": "a"})
+	b, ok := m.(matchBlock)
+	assert.True(t, ok, "top-level per-iface field should wrap in matchBlock")
+	assert.Len(t, b.ifacePred, 1)
+	assert.Nil(t, b.globalPred)
+	assert.Empty(t, b.combinators)
+
+	// Multi per-iface fields → same matchBlock with multi-element ifacePred.
+	m = mustParse(t, map[string]any{"ssid": "a", "iface-type": "wifi"})
+	b = m.(matchBlock)
+	assert.Len(t, b.ifacePred, 2, "atomic AND of two per-iface fields")
+
+	// Only dns-suffix → matchBlock with only globalPred.
+	m = mustParse(t, map[string]any{"dns-suffix": "corp"})
+	b = m.(matchBlock)
+	assert.Empty(t, b.ifacePred, "dns-suffix is global, not per-iface")
+	assert.NotNil(t, b.globalPred)
+
+	// Only any: with single sub → combinator unwrapped to the sub-matcher.
+	m = mustParse(t, map[string]any{"any": []any{map[string]any{"ssid": "a"}}})
+	b = m.(matchBlock)
+	assert.Empty(t, b.ifacePred)
+	assert.Nil(t, b.globalPred)
+	assert.Len(t, b.combinators, 1)
+	_, wrapped := b.combinators[0].(anyMatcher)
+	assert.False(t, wrapped, "single-sub any: unwrapped to the sub directly")
+
+	// any: with 2+ subs → actually wraps in anyMatcher type.
+	m = mustParse(t, map[string]any{"any": []any{
+		map[string]any{"ssid": "a"},
+		map[string]any{"ssid": "b"},
+	}})
+	b = m.(matchBlock)
+	assert.Len(t, b.combinators, 1)
+	ae, ok := b.combinators[0].(anyMatcher)
+	assert.True(t, ok, "2+ subs should wrap in anyMatcher")
+	assert.Len(t, ae, 2)
+
+	// all: with 2+ subs → allMatcher.
+	m = mustParse(t, map[string]any{"all": []any{
+		map[string]any{"iface-type": "vpn"},
+		map[string]any{"ssid": "office"},
+	}})
+	b = m.(matchBlock)
+	ae2, ok := b.combinators[0].(allMatcher)
+	assert.True(t, ok, "2+ subs should wrap in allMatcher")
+	assert.Len(t, ae2, 2)
+
+	// not: always wraps in notMatcher (single arg, never unwrapped).
+	m = mustParse(t, map[string]any{"not": map[string]any{"ssid": "x"}})
+	b = m.(matchBlock)
+	_, ok = b.combinators[0].(notMatcher)
+	assert.True(t, ok)
+}
+
+// TestMatcher_PerIface covers per-iface field semantics.
+func TestMatcher_PerIface(t *testing.T) {
+	cases := []struct {
+		name  string
+		raw   map[string]any
+		ctx   *NetworkContext
+		want  bool
+	}{
+		// ssid
+		{"ssid list hit", map[string]any{"ssid": []any{"a", "b"}},
+			&NetworkContext{Version: 1, Interfaces: []InterfaceContext{{Name: "wlan0", SSID: "b"}}}, true},
+		{"ssid miss", map[string]any{"ssid": []any{"a", "b"}},
+			&NetworkContext{Version: 1, Interfaces: []InterfaceContext{{Name: "wlan0", SSID: "c"}}}, false},
+		{"ssid empty interfaces", map[string]any{"ssid": "a"},
+			&NetworkContext{Version: 1}, false},
+		{"ssid null field on iface", map[string]any{"ssid": "a"},
+			&NetworkContext{Version: 1, Interfaces: []InterfaceContext{{Name: "wlan0"}}}, false},
+
+		// bssid normalization both sides
+		{"bssid dash hits colon ctx", map[string]any{"bssid": "AA-BB-CC-DD-EE-FF"},
+			&NetworkContext{Version: 1, Interfaces: []InterfaceContext{{Name: "wlan0", BSSID: "aa:bb:cc:dd:ee:ff"}}}, true},
+		{"bssid unseparated hits", map[string]any{"bssid": "AA-BB-CC-DD-EE-FF"},
+			&NetworkContext{Version: 1, Interfaces: []InterfaceContext{{Name: "wlan0", BSSID: "AABBCCDDEEFF"}}}, true},
+
+		// gateway-ip: exact + CIDR + v6 zoned
+		{"gateway-ip exact", map[string]any{"gateway-ip": []any{"192.168.1.1", "10.0.0.0/8"}},
+			&NetworkContext{Version: 1, Interfaces: []InterfaceContext{{Name: "wlan0", GatewayIP: "192.168.1.1"}}}, true},
+		{"gateway-ip cidr", map[string]any{"gateway-ip": []any{"192.168.1.1", "10.0.0.0/8"}},
+			&NetworkContext{Version: 1, Interfaces: []InterfaceContext{{Name: "wlan0", GatewayIP: "10.5.6.7"}}}, true},
+		{"gateway-ip miss", map[string]any{"gateway-ip": []any{"192.168.1.1", "10.0.0.0/8"}},
+			&NetworkContext{Version: 1, Interfaces: []InterfaceContext{{Name: "wlan0", GatewayIP: "172.16.0.1"}}}, false},
+		{"gateway-ip ipv6 zoned hits cidr", map[string]any{"gateway-ip": "fe80::/64"},
+			&NetworkContext{Version: 1, Interfaces: []InterfaceContext{{Name: "wlan0", GatewayIP: "fe80::1%en0"}}}, true},
+
+		// name
+		{"name hit", map[string]any{"name": "wlan0"},
+			&NetworkContext{Version: 1, Interfaces: []InterfaceContext{{Name: "wlan0"}}}, true},
+		{"name miss", map[string]any{"name": "wlan0"},
+			&NetworkContext{Version: 1, Interfaces: []InterfaceContext{{Name: "en0"}}}, false},
+
+		// iface-type
+		{"iface-type hit", map[string]any{"iface-type": "wifi"},
+			&NetworkContext{Version: 1, Interfaces: []InterfaceContext{{Name: "wlan0", IfaceType: "wifi"}}}, true},
+		{"iface-type miss", map[string]any{"iface-type": "wifi"},
+			&NetworkContext{Version: 1, Interfaces: []InterfaceContext{{Name: "wlan0", IfaceType: "ethernet"}}}, false},
+
+		// subnets (overlap)
+		{"subnets overlap", map[string]any{"subnets": "10.0.0.0/8"},
+			&NetworkContext{Version: 1, Interfaces: []InterfaceContext{{Name: "wlan0", Subnets: []string{"10.5.0.0/24"}}}}, true},
+		{"subnets no overlap", map[string]any{"subnets": "10.0.0.0/8"},
+			&NetworkContext{Version: 1, Interfaces: []InterfaceContext{{Name: "wlan0", Subnets: []string{"192.168.0.0/16"}}}}, false},
+		{"subnets v4 no cross v6", map[string]any{"subnets": "10.0.0.0/8"},
+			&NetworkContext{Version: 1, Interfaces: []InterfaceContext{{Name: "wlan0", Subnets: []string{"2001:db8::/32"}}}}, false},
+		{"subnets wildcard v4 matches any v4", map[string]any{"subnets": "0.0.0.0/0"},
+			&NetworkContext{Version: 1, Interfaces: []InterfaceContext{{Name: "wlan0", Subnets: []string{"10.0.0.0/8"}}}}, true},
+		{"subnets wildcard v4 does not match v6", map[string]any{"subnets": "0.0.0.0/0"},
+			&NetworkContext{Version: 1, Interfaces: []InterfaceContext{{Name: "wlan0", Subnets: []string{"2001:db8::/32"}}}}, false},
+
+		// gateway-mac (hit / miss / null / list)
+		{"gateway-mac hit single", map[string]any{"gateway-mac": "aa:bb:cc:dd:ee:ff"},
+			&NetworkContext{Version: 1, Interfaces: []InterfaceContext{{Name: "wlan0", GatewayIP: "10.0.0.1", GatewayMAC: "AA-BB-CC-DD-EE-FF"}}}, true},
+		{"gateway-mac miss", map[string]any{"gateway-mac": "aa:bb:cc:dd:ee:ff"},
+			&NetworkContext{Version: 1, Interfaces: []InterfaceContext{{Name: "wlan0", GatewayIP: "10.0.0.1", GatewayMAC: "11:22:33:44:55:66"}}}, false},
+		{"gateway-mac null on iface", map[string]any{"gateway-mac": "aa:bb:cc:dd:ee:ff"},
+			&NetworkContext{Version: 1, Interfaces: []InterfaceContext{{Name: "wlan0"}}}, false},
+		{"gateway-mac list OR", map[string]any{"gateway-mac": []any{"aa:bb:cc:dd:ee:ff", "11:22:33:44:55:66"}},
+			&NetworkContext{Version: 1, Interfaces: []InterfaceContext{{Name: "wlan0", GatewayIP: "10.0.0.1", GatewayMAC: "11:22:33:44:55:66"}}}, true},
+		{"gateway-mac normalized both sides", map[string]any{"gateway-mac": "AABBCCDDEEFF"},
+			&NetworkContext{Version: 1, Interfaces: []InterfaceContext{{Name: "wlan0", GatewayIP: "10.0.0.1", GatewayMAC: "aa-bb-cc-dd-ee-ff"}}}, true},
+	}
+	for _, tc := range cases {
+		m := mustParse(t, tc.raw)
+		ctx := norm(t, tc.ctx)
+		assert.Equal(t, tc.want, m.Match(ctx), "case %q", tc.name)
+	}
+}
+
+// TestMatcher_Atomicity covers the same-iface AND requirement for per-iface
+// fields inside one match block.
+func TestMatcher_Atomicity(t *testing.T) {
+	raw := map[string]any{"ssid": "a", "iface-type": "wifi"}
+	m := mustParse(t, raw)
+
+	// Same iface satisfies both → true.
+	ctx1 := norm(t, &NetworkContext{Version: 1, Interfaces: []InterfaceContext{
+		{Name: "wlan0", SSID: "a", IfaceType: "wifi"},
+	}})
+	assert.True(t, m.Match(ctx1), "same iface satisfies both")
+
+	// Two ifaces each satisfying one field → false (atomicity).
+	ctx2 := norm(t, &NetworkContext{Version: 1, Interfaces: []InterfaceContext{
+		{Name: "wlan0", SSID: "a", IfaceType: "ethernet"},
+		{Name: "wlan1", SSID: "b", IfaceType: "wifi"},
+	}})
+	assert.False(t, m.Match(ctx2), "split across ifaces must not match")
+
+	// Three ifaces where iface-C has both → true.
+	ctx3 := norm(t, &NetworkContext{Version: 1, Interfaces: []InterfaceContext{
+		{Name: "wlan0", SSID: "a", IfaceType: "ethernet"},
+		{Name: "wlan1", SSID: "b", IfaceType: "wifi"},
+		{Name: "wlan2", SSID: "a", IfaceType: "wifi"},
+	}})
+	assert.True(t, m.Match(ctx3), "third iface satisfies both")
+}
+
+// TestMatcher_Global covers dns-suffix as a global (top-level) predicate.
+func TestMatcher_Global(t *testing.T) {
+	m := mustParse(t, map[string]any{"dns-suffix": "Corp.Example.Com"})
+	// Case-insensitive: parse-time lowercase vs normalize-time lowercase.
+	ctx := norm(t, &NetworkContext{Version: 1, DNSSuffix: []string{"corp.example.com"}})
+	assert.True(t, m.Match(ctx))
+
+	// Empty interfaces + matching dns_suffix → matches (P_empty rule).
+	ctx2 := norm(t, &NetworkContext{Version: 1, DNSSuffix: []string{"corp.example.com"}})
+	assert.True(t, m.Match(ctx2))
+
+	// Empty dns_suffix → no hit.
+	ctx3 := norm(t, &NetworkContext{Version: 1})
+	assert.False(t, m.Match(ctx3))
+
+	// dns-suffix list: OR over matcher values intersecting ctx.
+	m2 := mustParse(t, map[string]any{"dns-suffix": []any{"corp", "home"}})
+	ctx4 := norm(t, &NetworkContext{Version: 1, DNSSuffix: []string{"home", "other"}})
+	assert.True(t, m2.Match(ctx4))
+}
+
+// TestMatcher_Combinators covers any/all/not semantics.
+func TestMatcher_Combinators(t *testing.T) {
+	// any: OR over sub-blocks.
+	mAny := mustParse(t, map[string]any{"any": []any{
+		map[string]any{"ssid": "a"},
+		map[string]any{"iface-type": "vpn"},
+	}})
+	ctx := norm(t, &NetworkContext{Version: 1, Interfaces: []InterfaceContext{
+		{Name: "wg0", IfaceType: "vpn"},
+	}})
+	assert.True(t, mAny.Match(ctx))
+
+	// all: AND over sub-blocks — different ifaces can satisfy each sub-block.
+	mAll := mustParse(t, map[string]any{"all": []any{
+		map[string]any{"iface-type": "vpn"},
+		map[string]any{"iface-type": "wifi", "ssid": "home"},
+	}})
+	ctx2 := norm(t, &NetworkContext{Version: 1, Interfaces: []InterfaceContext{
+		{Name: "wg0", IfaceType: "vpn"},
+		{Name: "wlan0", IfaceType: "wifi", SSID: "home"},
+	}})
+	assert.True(t, mAll.Match(ctx2), "different ifaces each satisfy one sub-block")
+
+	// not: negation.
+	mNot := mustParse(t, map[string]any{"not": map[string]any{"iface-type": "cellular"}})
+	ctx3 := norm(t, &NetworkContext{Version: 1, Interfaces: []InterfaceContext{
+		{Name: "wlan0", IfaceType: "wifi"},
+	}})
+	assert.True(t, mNot.Match(ctx3), "no cellular iface present")
+
+	// not: over empty interfaces[] → true (by design: "no iface satisfies"
+	// reading is natural when no iface exists at all).
+	ctx4 := norm(t, &NetworkContext{Version: 1})
+	assert.True(t, mNot.Match(ctx4))
+
+	// nested: not + any.
+	mExclude := mustParse(t, map[string]any{"not": map[string]any{"any": []any{
+		map[string]any{"iface-type": "cellular"},
+		map[string]any{"iface-type": "wwan"},
+	}}})
+	assert.True(t, mExclude.Match(ctx3))
+	ctxCell := norm(t, &NetworkContext{Version: 1, Interfaces: []InterfaceContext{
+		{Name: "pdp_ip0", IfaceType: "cellular"},
+	}})
+	assert.False(t, mExclude.Match(ctxCell))
+}
+
+// TestMatcher_Mixed covers blocks with per-iface + global + combinator mixed.
+func TestMatcher_Mixed(t *testing.T) {
+	// iface-type: vpn AND dns-suffix: corp.
+	m := mustParse(t, map[string]any{
+		"iface-type": "vpn",
+		"dns-suffix": "corp.example.com",
+	})
+
+	// Both satisfied → true.
+	ctx1 := norm(t, &NetworkContext{
+		Version:    1,
+		Interfaces: []InterfaceContext{{Name: "wg0", IfaceType: "vpn"}},
+		DNSSuffix:  []string{"corp.example.com"},
+	})
+	assert.True(t, m.Match(ctx1))
+
+	// VPN present but no corp DNS → false.
+	ctx2 := norm(t, &NetworkContext{
+		Version:    1,
+		Interfaces: []InterfaceContext{{Name: "wg0", IfaceType: "vpn"}},
+	})
+	assert.False(t, m.Match(ctx2))
+
+	// Corp DNS but no VPN → false.
+	ctx3 := norm(t, &NetworkContext{
+		Version:   1,
+		DNSSuffix: []string{"corp.example.com"},
+	})
+	assert.False(t, m.Match(ctx3))
+}
+
+// TestMatcher_NilCtx ensures the public Matcher surface is nil-safe:
+// calling Match(nil) must return false rather than panic. Relevant for
+// anyone using the Matcher interface outside of the top-level Match().
+func TestMatcher_NilCtx(t *testing.T) {
+	cases := []map[string]any{
+		{"ssid": "a"},                                                        // matchBlock with ifacePred
+		{"dns-suffix": "corp"},                                               // matchBlock with globalPred
+		{"any": []any{map[string]any{"ssid": "a"}, map[string]any{"ssid": "b"}}}, // anyMatcher
+		{"all": []any{map[string]any{"ssid": "a"}, map[string]any{"ssid": "b"}}}, // allMatcher
+		{"not": map[string]any{"ssid": "a"}},                                 // notMatcher wrapping matchBlock
+	}
+	for i, raw := range cases {
+		m := mustParse(t, raw)
+		assert.NotPanics(t, func() {
+			assert.False(t, m.Match(nil), "case %d: Match(nil) should be false", i)
+		}, "case %d: Match(nil) should not panic", i)
+	}
+}
+
+// TestMatcher_NullIfaceField covers: null-field iface is excluded from the
+// ∃ domain, so both positive and `not:`-wrapped matchers behave consistently
+// ("no iface satisfies" reading).
+func TestMatcher_NullIfaceField(t *testing.T) {
+	m := mustParse(t, map[string]any{"ssid": "office"})
+
+	// Iface without ssid set → false (null excluded from ∃ domain).
+	ctx := norm(t, &NetworkContext{Version: 1, Interfaces: []InterfaceContext{
+		{Name: "wlan0"}, // no SSID
+	}})
+	assert.False(t, m.Match(ctx), "iface with null ssid doesn't hit")
+
+	// Multiple ifaces: only the one with set ssid participates.
+	ctx2 := norm(t, &NetworkContext{Version: 1, Interfaces: []InterfaceContext{
+		{Name: "en0"},                 // null ssid
+		{Name: "wlan0", SSID: "office"},
+	}})
+	assert.True(t, m.Match(ctx2))
+
+	// not: over all-null → true (no iface has ssid=office).
+	mNot := mustParse(t, map[string]any{"not": map[string]any{"ssid": "office"}})
+	ctx3 := norm(t, &NetworkContext{Version: 1, Interfaces: []InterfaceContext{
+		{Name: "wlan0"},
+	}})
+	assert.True(t, mNot.Match(ctx3))
+}

--- a/component/networkpolicy/network.go
+++ b/component/networkpolicy/network.go
@@ -1,0 +1,22 @@
+package networkpolicy
+
+// Network is a single entry under the YAML networks: list.
+type Network struct {
+	Name    string
+	Matcher Matcher
+}
+
+// Match scans networks in order and returns the first network whose matcher
+// hits ctx (first-match wins; list order is the priority mechanism).
+// Returns ("", false) when no network matches or ctx is nil.
+func Match(networks []Network, ctx *NetworkContext) (string, bool) {
+	if ctx == nil {
+		return "", false
+	}
+	for i := range networks {
+		if networks[i].Matcher != nil && networks[i].Matcher.Match(ctx) {
+			return networks[i].Name, true
+		}
+	}
+	return "", false
+}

--- a/component/networkpolicy/network_test.go
+++ b/component/networkpolicy/network_test.go
@@ -1,0 +1,47 @@
+package networkpolicy
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMatch(t *testing.T) {
+	m1, _ := ParseMatch(map[string]any{"ssid": "office"})
+	m2, _ := ParseMatch(map[string]any{"ssid": []any{"office", "home"}})
+	networks := []Network{
+		{Name: "office-net", Matcher: m1},
+		{Name: "shared", Matcher: m2},
+	}
+
+	// First hit wins — not "shared" even though it also matches.
+	ctx := &NetworkContext{Version: 1, Interfaces: []InterfaceContext{{Name: "wlan0", SSID: "office"}}}
+	_ = ctx.NormalizeAndValidate()
+	name, ok := Match(networks, ctx)
+	assert.True(t, ok)
+	assert.Equal(t, "office-net", name)
+
+	// No hits → ("", false).
+	ctx = &NetworkContext{Version: 1, Interfaces: []InterfaceContext{{Name: "wlan0", SSID: "unknown"}}}
+	_ = ctx.NormalizeAndValidate()
+	name, ok = Match(networks, ctx)
+	assert.False(t, ok)
+	assert.Equal(t, "", name)
+
+	// nil ctx / empty list / nil matcher entries: never hit, never panic.
+	name, ok = Match(networks, nil)
+	assert.False(t, ok)
+	assert.Equal(t, "", name)
+
+	name, ok = Match(nil, ctx)
+	assert.False(t, ok)
+	assert.Equal(t, "", name)
+
+	// A nil-matcher entry must be skipped rather than treated as a match.
+	entries := []Network{{Name: "broken"}, {Name: "office-net", Matcher: m1}}
+	ctx = &NetworkContext{Version: 1, Interfaces: []InterfaceContext{{Name: "wlan0", SSID: "office"}}}
+	_ = ctx.NormalizeAndValidate()
+	name, ok = Match(entries, ctx)
+	assert.True(t, ok)
+	assert.Equal(t, "office-net", name)
+}

--- a/component/networkpolicy/persist.go
+++ b/component/networkpolicy/persist.go
@@ -1,0 +1,219 @@
+package networkpolicy
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/metacubex/mihomo/component/profile/cachefile"
+)
+
+// PersistedState is the per-group record written to the cachefile's
+// bucketNetworkPolicy. One entry per proxy-group that carries a
+// network-policy (groups without a policy contribute nothing).
+//
+// The wire format is JSON, consistent with the rest of mihomo's bucket
+// payloads. Field names match the in-memory state machine terminology:
+//
+//	{
+//	  "schema_version": 1,
+//	  "source": "auto" | "manual" | "unknown",
+//	  "last_matched_network": null | "<name>" | "<none>"
+//	}
+//
+// schema_version is the bucket-level format version, intentionally NOT
+// reused with the PUT body `version` field (architecture §5.6.1). If a
+// future release needs to evolve the persisted schema, bumping
+// schema_version lets load-side gracefully fall back to "no bucket"
+// (treated as branch B: cold-start, re-evaluate on first PUT) without
+// blocking startup.
+//
+// last_matched_network encodes three internal states:
+//   - JSON `null` → nil sentinel (never evaluated). `LastMatchedPresent
+//     == false` on read. Legitimately reached two ways: branch B initial
+//     state before any evaluation, and source=manual + nil when the
+//     user flipped a group manually before any ctx PUT arrived.
+//   - JSON string "<none>" → MatchedNone sentinel (evaluated, no
+//     network matched). `LastMatchedPresent == true` with the literal
+//     `<none>` value. Note: encoding/json escapes `<` and `>` by
+//     default using the Unicode form `<` / `>` (NOT HTML
+//     entities like `&lt;`), so the actual on-disk byte sequence
+//     between the JSON string quotes is `\u003cnone\u003e` — 16 ASCII
+//     characters. Unmarshal restores the logical 6-char `<none>`.
+//     Raw bbolt inspection tools display the escaped form.
+//   - JSON string "<name>" → matched network name. `LastMatchedPresent
+//     == true`.
+//
+// REST-layer wire encoding (matched_network / last_matched_network in
+// GET /network/context responses) is a separate concern handled by the
+// manager: both the nil and <none> internal sentinels are flattened to
+// JSON null on the wire, with host code using selection_source to
+// disambiguate. Persistence keeps them distinct so the state machine
+// can restart with fidelity.
+type PersistedState struct {
+	// SchemaVersion is the persisted-schema version tag; currently 1.
+	SchemaVersion int `json:"schema_version"`
+
+	// Source is the per-group selection source: "auto" / "manual" /
+	// "unknown".
+	Source string `json:"source"`
+
+	// LastMatched is the saved last_matched_network value. An empty
+	// string is ambiguous without LastMatchedPresent, so this field is
+	// only authoritative when LastMatchedPresent is true.
+	LastMatched string `json:"-"`
+
+	// LastMatchedPresent distinguishes "never evaluated" (nil sentinel,
+	// false) from "evaluated, possibly MatchedNone" (true). In JSON,
+	// absent LastMatched key ↔ LastMatchedPresent=false. The exported
+	// field is not serialized directly; see MarshalJSON / UnmarshalJSON.
+	LastMatchedPresent bool `json:"-"`
+}
+
+// MarshalJSON emits last_matched_network as JSON null when absent, else
+// as a string. Custom to route the LastMatchedPresent tri-state through
+// a single JSON key (not two separate keys — simpler for future bucket
+// consumers that only read this field for diagnostics).
+func (p PersistedState) MarshalJSON() ([]byte, error) {
+	type wire struct {
+		SchemaVersion int     `json:"schema_version"`
+		Source        string  `json:"source"`
+		LastMatched   *string `json:"last_matched_network"`
+	}
+	w := wire{SchemaVersion: p.SchemaVersion, Source: p.Source}
+	if p.LastMatchedPresent {
+		v := p.LastMatched
+		w.LastMatched = &v
+	}
+	return json.Marshal(w)
+}
+
+// UnmarshalJSON decodes the JSON form, populating LastMatchedPresent
+// based on whether last_matched_network is a string (true) or null (false).
+func (p *PersistedState) UnmarshalJSON(data []byte) error {
+	type wire struct {
+		SchemaVersion int     `json:"schema_version"`
+		Source        string  `json:"source"`
+		LastMatched   *string `json:"last_matched_network"`
+	}
+	var w wire
+	if err := json.Unmarshal(data, &w); err != nil {
+		return err
+	}
+	p.SchemaVersion = w.SchemaVersion
+	p.Source = w.Source
+	if w.LastMatched != nil {
+		p.LastMatched = *w.LastMatched
+		p.LastMatchedPresent = true
+	} else {
+		p.LastMatched = ""
+		p.LastMatchedPresent = false
+	}
+	return nil
+}
+
+// Validate checks for shape correctness and state-machine invariants.
+// Returns a non-nil error for any obviously-corrupted or architecturally
+// impossible record.
+//
+// Load-side: callers treat a validation error as "no bucket entry" and
+// drop the state into branch B for that group, rather than feeding the
+// corrupt value into the state machine.
+//
+// Write-side: raw json.Marshal on PersistedState bypasses Validate,
+// and cachefile.SetNetworkPolicyState accepts any byte slice. The
+// idiomatic (and only safe) write path is WriteNetworkPolicyState
+// below, which chains Validate → json.Marshal → bucket Set. Writers
+// that hand-roll the chain must call Validate explicitly; raw marshal
+// + raw Set is a landmine this package deliberately does not booby-trap
+// from the cachefile side (it owns opaque bytes on purpose so the
+// schema stays in networkpolicy).
+//
+// Rejected impossible states (architecture §5.6.1 / §5.6.2 / §5.6.3):
+//   - schema_version != current
+//   - source not in {auto, manual, unknown}
+//   - source == unknown in a persisted record: §5.6.3 only writes on
+//     source/last_matched change, and unknown is the initial in-memory
+//     state the manager transitions OUT of on the first evaluation —
+//     so it is never a legitimate persisted value
+//   - source == auto with LastMatchedPresent=false: auto implies the
+//     state machine has run at least one evaluation (§5.6.2 shows every
+//     transition that SETS source=auto also advances last_matched to
+//     either a concrete name or MatchedNone), so the nil sentinel is
+//     impossible here. source=manual + nil remains legitimate: the
+//     user may flip a group manually before any ctx has been pushed,
+//     leaving last_matched at the nil initial value.
+//   - LastMatchedPresent=true with empty string: MatchedNone is the
+//     correct sentinel for "evaluated, no match"; empty string has no
+//     meaning in this encoding
+//   - LastMatchedPresent=true with DefaultKey ("default"): default is
+//     the policy-layer fallback key, never a network name
+func (p PersistedState) Validate() error {
+	if p.SchemaVersion != PersistVersion {
+		return fmt.Errorf("schema_version %d not supported (current %d)", p.SchemaVersion, PersistVersion)
+	}
+
+	// Structural consistency first: the LastMatchedPresent flag and
+	// LastMatched value must agree. Doing this before the source-specific
+	// rules means programmers who forget to set LastMatchedPresent get a
+	// targeted "inconsistent state" error rather than a downstream
+	// "source=auto requires present" which obscures the real bug.
+	if p.LastMatchedPresent {
+		if p.LastMatched == "" {
+			return fmt.Errorf("last_matched_network is present but empty (use JSON null to encode absence, <none> for evaluated-no-match)")
+		}
+		if p.LastMatched == DefaultKey {
+			return fmt.Errorf("last_matched_network cannot be the reserved key %q", DefaultKey)
+		}
+	} else if p.LastMatched != "" {
+		return fmt.Errorf("last_matched_network has value %q but LastMatchedPresent=false (inconsistent state; MarshalJSON would silently drop the value as null — set LastMatchedPresent=true or clear LastMatched)", p.LastMatched)
+	}
+
+	// State-machine rules: what combinations of source × LastMatchedPresent
+	// are architecturally possible per §5.6.1 / §5.6.2 / §5.6.3.
+	switch p.Source {
+	case SourceAuto:
+		if !p.LastMatchedPresent {
+			return fmt.Errorf("source=%q requires last_matched_network to be present (§5.6.2 advances it on every transition that sets source=auto)", p.Source)
+		}
+	case SourceManual:
+		// ok — manual + nil is legitimate (first manual set before ctx)
+	case SourceUnknown:
+		return fmt.Errorf("source=%q must not be persisted (impossible per §5.6.3; state machine only writes on source/last_matched change)", p.Source)
+	default:
+		return fmt.Errorf("invalid source %q", p.Source)
+	}
+	return nil
+}
+
+// MarshalValidated runs Validate, then json.Marshal. Returns the Validate
+// error on any invariant failure so writers cannot accidentally persist an
+// architecturally impossible state. Prefer this over json.Marshal(p) at
+// write sites — the latter bypasses the invariant guard and will happily
+// serialize source=unknown, auto+nil, present-false+nonempty, etc.
+//
+// For writing to the actual cachefile, WriteNetworkPolicyState combines
+// this helper with the bucket Set call, closing the last hole where a
+// caller could invoke json.Marshal + SetNetworkPolicyState directly and
+// bypass validation.
+func (p PersistedState) MarshalValidated() ([]byte, error) {
+	if err := p.Validate(); err != nil {
+		return nil, err
+	}
+	return json.Marshal(p)
+}
+
+// WriteNetworkPolicyState is the typed write-path entry point: validates
+// the record, serializes it, and persists it through the cachefile bucket
+// in one call. Returns Validate errors so callers can treat write failures
+// uniformly. This is the only write path M3b's manager should use — going
+// directly through cachefile.SetNetworkPolicyState with hand-marshaled
+// bytes bypasses the state-machine invariants and lets corrupt records
+// reach the bucket.
+func WriteNetworkPolicyState(cache *cachefile.CacheFile, group string, state PersistedState) error {
+	buf, err := state.MarshalValidated()
+	if err != nil {
+		return err
+	}
+	cache.SetNetworkPolicyState(group, buf)
+	return nil
+}

--- a/component/networkpolicy/persist.go
+++ b/component/networkpolicy/persist.go
@@ -7,7 +7,7 @@ import (
 	"github.com/metacubex/mihomo/component/profile/cachefile"
 )
 
-// PersistedState is the per-group record written to the cachefile's
+// persistedState is the per-group record written to the cachefile's
 // bucketNetworkPolicy. One entry per proxy-group that carries a
 // network-policy (groups without a policy contribute nothing).
 //
@@ -49,7 +49,7 @@ import (
 // JSON null on the wire, with host code using selection_source to
 // disambiguate. Persistence keeps them distinct so the state machine
 // can restart with fidelity.
-type PersistedState struct {
+type persistedState struct {
 	// SchemaVersion is the persisted-schema version tag; currently 1.
 	SchemaVersion int `json:"schema_version"`
 
@@ -73,7 +73,7 @@ type PersistedState struct {
 // as a string. Custom to route the LastMatchedPresent tri-state through
 // a single JSON key (not two separate keys — simpler for future bucket
 // consumers that only read this field for diagnostics).
-func (p PersistedState) MarshalJSON() ([]byte, error) {
+func (p persistedState) MarshalJSON() ([]byte, error) {
 	type wire struct {
 		SchemaVersion int     `json:"schema_version"`
 		Source        string  `json:"source"`
@@ -89,7 +89,7 @@ func (p PersistedState) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON decodes the JSON form, populating LastMatchedPresent
 // based on whether last_matched_network is a string (true) or null (false).
-func (p *PersistedState) UnmarshalJSON(data []byte) error {
+func (p *persistedState) UnmarshalJSON(data []byte) error {
 	type wire struct {
 		SchemaVersion int     `json:"schema_version"`
 		Source        string  `json:"source"`
@@ -119,9 +119,9 @@ func (p *PersistedState) UnmarshalJSON(data []byte) error {
 // drop the state into branch B for that group, rather than feeding the
 // corrupt value into the state machine.
 //
-// Write-side: raw json.Marshal on PersistedState bypasses Validate,
+// Write-side: raw json.Marshal on persistedState bypasses Validate,
 // and cachefile.SetNetworkPolicyState accepts any byte slice. The
-// idiomatic (and only safe) write path is WriteNetworkPolicyState
+// idiomatic (and only safe) write path is writeNetworkPolicyState
 // below, which chains Validate → json.Marshal → bucket Set. Writers
 // that hand-roll the chain must call Validate explicitly; raw marshal
 // + raw Set is a landmine this package deliberately does not booby-trap
@@ -147,9 +147,9 @@ func (p *PersistedState) UnmarshalJSON(data []byte) error {
 //     meaning in this encoding
 //   - LastMatchedPresent=true with DefaultKey ("default"): default is
 //     the policy-layer fallback key, never a network name
-func (p PersistedState) Validate() error {
-	if p.SchemaVersion != PersistVersion {
-		return fmt.Errorf("schema_version %d not supported (current %d)", p.SchemaVersion, PersistVersion)
+func (p persistedState) Validate() error {
+	if p.SchemaVersion != persistVersion {
+		return fmt.Errorf("schema_version %d not supported (current %d)", p.SchemaVersion, persistVersion)
 	}
 
 	// Structural consistency first: the LastMatchedPresent flag and
@@ -185,32 +185,32 @@ func (p PersistedState) Validate() error {
 	return nil
 }
 
-// MarshalValidated runs Validate, then json.Marshal. Returns the Validate
+// marshalValidated runs Validate, then json.Marshal. Returns the Validate
 // error on any invariant failure so writers cannot accidentally persist an
 // architecturally impossible state. Prefer this over json.Marshal(p) at
 // write sites — the latter bypasses the invariant guard and will happily
 // serialize source=unknown, auto+nil, present-false+nonempty, etc.
 //
-// For writing to the actual cachefile, WriteNetworkPolicyState combines
+// For writing to the actual cachefile, writeNetworkPolicyState combines
 // this helper with the bucket Set call, closing the last hole where a
 // caller could invoke json.Marshal + SetNetworkPolicyState directly and
 // bypass validation.
-func (p PersistedState) MarshalValidated() ([]byte, error) {
+func (p persistedState) marshalValidated() ([]byte, error) {
 	if err := p.Validate(); err != nil {
 		return nil, err
 	}
 	return json.Marshal(p)
 }
 
-// WriteNetworkPolicyState is the typed write-path entry point: validates
+// writeNetworkPolicyState is the typed write-path entry point: validates
 // the record, serializes it, and persists it through the cachefile bucket
 // in one call. Returns Validate errors so callers can treat write failures
 // uniformly. This is the only write path M3b's manager should use — going
 // directly through cachefile.SetNetworkPolicyState with hand-marshaled
 // bytes bypasses the state-machine invariants and lets corrupt records
 // reach the bucket.
-func WriteNetworkPolicyState(cache *cachefile.CacheFile, group string, state PersistedState) error {
-	buf, err := state.MarshalValidated()
+func writeNetworkPolicyState(cache *cachefile.CacheFile, group string, state persistedState) error {
+	buf, err := state.marshalValidated()
 	if err != nil {
 		return err
 	}

--- a/component/networkpolicy/persist_test.go
+++ b/component/networkpolicy/persist_test.go
@@ -1,0 +1,359 @@
+package networkpolicy
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestPersistedState_Roundtrip_ConcreteName(t *testing.T) {
+	orig := PersistedState{
+		SchemaVersion:      PersistVersion,
+		Source:             SourceManual,
+		LastMatched:        "office",
+		LastMatchedPresent: true,
+	}
+	buf, err := json.Marshal(orig)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if !strings.Contains(string(buf), `"last_matched_network":"office"`) {
+		t.Errorf("want string-encoded last_matched_network, got %s", buf)
+	}
+
+	var decoded PersistedState
+	if err := json.Unmarshal(buf, &decoded); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if decoded != orig {
+		t.Errorf("roundtrip mismatch: want %+v got %+v", orig, decoded)
+	}
+}
+
+// MatchedNone is a distinct state from nil (never evaluated), so the
+// persisted form must preserve it as a string literal, not JSON null.
+// Otherwise a restarted kernel would lose the "already evaluated, no
+// network matched" history and re-enter the wrong §5.6.2 branch.
+func TestPersistedState_Roundtrip_MatchedNone(t *testing.T) {
+	orig := PersistedState{
+		SchemaVersion:      PersistVersion,
+		Source:             SourceAuto,
+		LastMatched:        MatchedNone,
+		LastMatchedPresent: true,
+	}
+	buf, err := json.Marshal(orig)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	// encoding/json escapes `<` and `>` to the Unicode form `<`
+	// / `>` (NOT HTML entities), so the raw on-disk bytes between
+	// the JSON string quotes are `<none>` — 16 ASCII chars
+	// rather than the 6-char logical `<none>`. Harmless at rest; Unmarshal
+	// restores the 6-char form. The semantic invariant we care about is
+	// that the payload is a JSON string (not JSON null) and round-trips
+	// to MatchedNone.
+	s := string(buf)
+	if strings.Contains(s, `"last_matched_network":null`) {
+		t.Errorf("MatchedNone must serialize as string, not null; got %s", s)
+	}
+	// Assert the Unicode-escape form actually lands on disk. If a future
+	// change disables HTML escaping via Encoder.SetEscapeHTML(false), this
+	// assertion flips and the commit message / doc must be updated along
+	// with it — the escape sequence IS the on-disk contract, so the test
+	// guards it explicitly. The raw-string literal below contains the
+	// literal backslash-u-003c-n-o-n-e-backslash-u-003e byte sequence.
+	if !strings.Contains(s, `\u003cnone\u003e`) {
+		t.Errorf(`want Unicode-escape form \u003cnone\u003e on disk, got %s`, s)
+	}
+
+	var decoded PersistedState
+	if err := json.Unmarshal(buf, &decoded); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if decoded.LastMatched != MatchedNone {
+		t.Errorf("want decoded LastMatched == %q, got %q", MatchedNone, decoded.LastMatched)
+	}
+	if decoded != orig {
+		t.Errorf("roundtrip mismatch: want %+v got %+v", orig, decoded)
+	}
+}
+
+// Nil sentinel (never evaluated) is emitted as JSON null. Regression
+// guard: the two absence representations (JSON null for nil, JSON
+// "<none>" for MatchedNone) must not collapse at the encoding layer.
+//
+// Note: source=unknown paired with null last_matched is the in-memory
+// initial state that Validate() intentionally rejects (§5.6.3 never
+// persists it), so this test covers the *format layer only* — callers
+// must treat a loaded record with these values as corrupt and fall into
+// branch B. The separate Validate tests enforce that.
+func TestPersistedState_Roundtrip_NilSentinel(t *testing.T) {
+	orig := PersistedState{
+		SchemaVersion:      PersistVersion,
+		Source:             SourceUnknown,
+		LastMatched:        "",
+		LastMatchedPresent: false,
+	}
+	buf, err := json.Marshal(orig)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if !strings.Contains(string(buf), `"last_matched_network":null`) {
+		t.Errorf("want null-encoded last_matched_network, got %s", buf)
+	}
+
+	var decoded PersistedState
+	if err := json.Unmarshal(buf, &decoded); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if decoded.LastMatchedPresent {
+		t.Errorf("null should decode as absent; got present=%v value=%q", decoded.LastMatchedPresent, decoded.LastMatched)
+	}
+	if decoded != orig {
+		t.Errorf("roundtrip mismatch: want %+v got %+v", orig, decoded)
+	}
+}
+
+func TestPersistedState_Validate_Happy(t *testing.T) {
+	// Only auto and manual are valid persisted sources. Unknown is the
+	// initial in-memory state the manager transitions OUT of on first
+	// evaluation — never persisted, never valid on load.
+	//
+	// source=auto requires LastMatchedPresent=true (§5.6.2 advances it
+	// on every transition that sets source=auto); source=manual + nil
+	// is legitimate (first manual set before any ctx PUT).
+	cases := []PersistedState{
+		{SchemaVersion: PersistVersion, Source: SourceAuto, LastMatched: "office", LastMatchedPresent: true},
+		{SchemaVersion: PersistVersion, Source: SourceAuto, LastMatched: MatchedNone, LastMatchedPresent: true},
+		{SchemaVersion: PersistVersion, Source: SourceManual, LastMatched: "office", LastMatchedPresent: true},
+		// manual + MatchedNone: reachable via §5.6.2 "default / no_change_no_default
+		// advanced last_matched to <none>, user then manually switched".
+		{SchemaVersion: PersistVersion, Source: SourceManual, LastMatched: MatchedNone, LastMatchedPresent: true},
+		{SchemaVersion: PersistVersion, Source: SourceManual, LastMatched: "", LastMatchedPresent: false},
+	}
+	for _, p := range cases {
+		if err := p.Validate(); err != nil {
+			t.Errorf("%+v should validate; got %v", p, err)
+		}
+	}
+}
+
+// source=auto paired with nil last_matched is architecturally impossible —
+// §5.6.2's auto-setting transitions (matched / already_selected / default /
+// no_change_no_default) all advance last_matched before leaving. The only
+// legitimate `nil` is on source=manual (first manual set before ctx) or
+// source=unknown (initial in-memory state, never persisted).
+func TestPersistedState_Validate_RejectsAutoWithNil(t *testing.T) {
+	p := PersistedState{
+		SchemaVersion:      PersistVersion,
+		Source:             SourceAuto,
+		LastMatched:        "",
+		LastMatchedPresent: false,
+	}
+	err := p.Validate()
+	if err == nil || !strings.Contains(err.Error(), "requires last_matched_network to be present") {
+		t.Errorf("want auto+nil rejection, got %v", err)
+	}
+}
+
+func TestPersistedState_Validate_RejectsUnknownSchema(t *testing.T) {
+	p := PersistedState{SchemaVersion: 2, Source: SourceAuto}
+	err := p.Validate()
+	if err == nil || !strings.Contains(err.Error(), "schema_version 2") {
+		t.Errorf("want schema_version error, got %v", err)
+	}
+}
+
+func TestPersistedState_Validate_RejectsInvalidSource(t *testing.T) {
+	p := PersistedState{SchemaVersion: PersistVersion, Source: "bogus"}
+	err := p.Validate()
+	if err == nil || !strings.Contains(err.Error(), "invalid source") {
+		t.Errorf("want invalid-source error, got %v", err)
+	}
+}
+
+// source=unknown in a persisted record is architecturally impossible
+// (§5.6.3 only writes on source/last_matched change, and unknown is the
+// initial state, not a destination). Validate must reject it so a
+// corrupted record falls through to branch B rather than propagating a
+// broken state into the manager.
+func TestPersistedState_Validate_RejectsPersistedUnknown(t *testing.T) {
+	p := PersistedState{SchemaVersion: PersistVersion, Source: SourceUnknown}
+	err := p.Validate()
+	if err == nil || !strings.Contains(err.Error(), "must not be persisted") {
+		t.Errorf("want persisted-unknown error, got %v", err)
+	}
+}
+
+// last_matched_network = "" is impossible: absence is encoded via JSON
+// null (LastMatchedPresent=false) and MatchedNone is the correct sentinel
+// for "evaluated, no match". A present-but-empty value means the record
+// was tampered with externally.
+func TestPersistedState_Validate_RejectsEmptyLastMatched(t *testing.T) {
+	p := PersistedState{
+		SchemaVersion:      PersistVersion,
+		Source:             SourceAuto,
+		LastMatched:        "",
+		LastMatchedPresent: true,
+	}
+	err := p.Validate()
+	if err == nil || !strings.Contains(err.Error(), "present but empty") {
+		t.Errorf("want empty-last-matched error, got %v", err)
+	}
+}
+
+// last_matched_network = "default" collides with the reserved policy-layer
+// fallback key; it cannot be a real network name (ParseNetworks rejects
+// it at config parse time). Reject defensively to catch external
+// tampering.
+func TestPersistedState_Validate_RejectsDefaultAsLastMatched(t *testing.T) {
+	p := PersistedState{
+		SchemaVersion:      PersistVersion,
+		Source:             SourceAuto,
+		LastMatched:        DefaultKey,
+		LastMatchedPresent: true,
+	}
+	err := p.Validate()
+	if err == nil || !strings.Contains(err.Error(), "reserved key") {
+		t.Errorf("want reserved-key error, got %v", err)
+	}
+}
+
+// LastMatchedPresent=false paired with a non-empty LastMatched is an
+// internally-inconsistent struct — MarshalJSON would drop the value as
+// JSON null, losing information silently. Validate must catch this on
+// the programmer-construction path.
+func TestPersistedState_Validate_RejectsInconsistentAbsenceWithValue(t *testing.T) {
+	p := PersistedState{
+		SchemaVersion:      PersistVersion,
+		Source:             SourceManual,
+		LastMatched:        "office",
+		LastMatchedPresent: false,
+	}
+	err := p.Validate()
+	if err == nil || !strings.Contains(err.Error(), "LastMatchedPresent=false") {
+		t.Errorf("want inconsistent-absence error, got %v", err)
+	}
+}
+
+// MatchedNone as LastMatched is explicitly valid: "evaluated, no network
+// matched" is a legitimate persisted state.
+func TestPersistedState_Validate_AcceptsMatchedNone(t *testing.T) {
+	p := PersistedState{
+		SchemaVersion:      PersistVersion,
+		Source:             SourceAuto,
+		LastMatched:        MatchedNone,
+		LastMatchedPresent: true,
+	}
+	if err := p.Validate(); err != nil {
+		t.Errorf("MatchedNone should validate; got %v", err)
+	}
+}
+
+// Legacy buckets written by older releases may lack fields we added later;
+// the JSON decoder should handle missing fields without crashing. The
+// resulting struct fails Validate (schema_version=0) so callers still fall
+// through to branch B — the point of this test is that decoding itself is
+// robust, not that the result is usable.
+func TestPersistedState_Unmarshal_MissingFields(t *testing.T) {
+	var p PersistedState
+	if err := json.Unmarshal([]byte(`{}`), &p); err != nil {
+		t.Fatalf("unmarshal empty: %v", err)
+	}
+	if p.LastMatchedPresent {
+		t.Errorf("missing key should decode as absent; got present")
+	}
+	if p.SchemaVersion != 0 || p.Source != "" {
+		t.Errorf("zero-value expected; got %+v", p)
+	}
+}
+
+func TestPersistedState_Unmarshal_Malformed(t *testing.T) {
+	var p PersistedState
+	err := json.Unmarshal([]byte(`not json`), &p)
+	if err == nil {
+		t.Errorf("want error on malformed input; got nil")
+	}
+}
+
+// MarshalValidated returns the Validate error on invariant violations so
+// writers cannot leak impossible states onto disk via raw json.Marshal.
+func TestPersistedState_MarshalValidated_RejectsInvalid(t *testing.T) {
+	invalid := PersistedState{
+		SchemaVersion:      PersistVersion,
+		Source:             SourceAuto,
+		LastMatched:        "",
+		LastMatchedPresent: false,
+	}
+	_, err := invalid.MarshalValidated()
+	if err == nil {
+		t.Errorf("want Validate error on auto+nil, got nil")
+	}
+	// Raw json.Marshal succeeds on the same invalid struct — this is the
+	// loophole MarshalValidated is designed to close. The assertion
+	// documents the contract rather than testing json semantics.
+	if _, rawErr := json.Marshal(invalid); rawErr != nil {
+		t.Errorf("raw json.Marshal should succeed on invalid struct (MarshalValidated is the guard); got %v", rawErr)
+	}
+}
+
+func TestPersistedState_MarshalValidated_PassesThrough(t *testing.T) {
+	valid := PersistedState{
+		SchemaVersion:      PersistVersion,
+		Source:             SourceAuto,
+		LastMatched:        "office",
+		LastMatchedPresent: true,
+	}
+	buf, err := valid.MarshalValidated()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	var decoded PersistedState
+	if err := json.Unmarshal(buf, &decoded); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if decoded != valid {
+		t.Errorf("roundtrip mismatch: want %+v got %+v", valid, decoded)
+	}
+}
+
+// When a caller constructs LastMatchedPresent=false + LastMatched="office"
+// + Source=auto, the most diagnostic error is the inconsistency, not
+// "auto requires present". Structural checks run first so the reported
+// error points at the real bug.
+func TestPersistedState_Validate_InconsistencyTakesPrecedenceOverSource(t *testing.T) {
+	p := PersistedState{
+		SchemaVersion:      PersistVersion,
+		Source:             SourceAuto,
+		LastMatched:        "office",
+		LastMatchedPresent: false,
+	}
+	err := p.Validate()
+	if err == nil {
+		t.Fatalf("want error, got nil")
+	}
+	if !strings.Contains(err.Error(), "LastMatchedPresent=false") {
+		t.Errorf("want inconsistent-state error (structural check first), got %v", err)
+	}
+}
+
+// Same inconsistency on the manual branch — structural check is
+// source-agnostic, so manual + "office" + Present=false must also be
+// caught with the inconsistent-state diagnostic (manual + nil is
+// otherwise legitimate, so source-specific check alone wouldn't catch
+// the bug).
+func TestPersistedState_Validate_InconsistencyOnManual(t *testing.T) {
+	p := PersistedState{
+		SchemaVersion:      PersistVersion,
+		Source:             SourceManual,
+		LastMatched:        "office",
+		LastMatchedPresent: false,
+	}
+	err := p.Validate()
+	if err == nil {
+		t.Fatalf("want error, got nil")
+	}
+	if !strings.Contains(err.Error(), "LastMatchedPresent=false") {
+		t.Errorf("want inconsistent-state error on manual branch, got %v", err)
+	}
+}

--- a/component/networkpolicy/persist_test.go
+++ b/component/networkpolicy/persist_test.go
@@ -7,8 +7,8 @@ import (
 )
 
 func TestPersistedState_Roundtrip_ConcreteName(t *testing.T) {
-	orig := PersistedState{
-		SchemaVersion:      PersistVersion,
+	orig := persistedState{
+		SchemaVersion:      persistVersion,
 		Source:             SourceManual,
 		LastMatched:        "office",
 		LastMatchedPresent: true,
@@ -21,7 +21,7 @@ func TestPersistedState_Roundtrip_ConcreteName(t *testing.T) {
 		t.Errorf("want string-encoded last_matched_network, got %s", buf)
 	}
 
-	var decoded PersistedState
+	var decoded persistedState
 	if err := json.Unmarshal(buf, &decoded); err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}
@@ -35,8 +35,8 @@ func TestPersistedState_Roundtrip_ConcreteName(t *testing.T) {
 // Otherwise a restarted kernel would lose the "already evaluated, no
 // network matched" history and re-enter the wrong §5.6.2 branch.
 func TestPersistedState_Roundtrip_MatchedNone(t *testing.T) {
-	orig := PersistedState{
-		SchemaVersion:      PersistVersion,
+	orig := persistedState{
+		SchemaVersion:      persistVersion,
 		Source:             SourceAuto,
 		LastMatched:        MatchedNone,
 		LastMatchedPresent: true,
@@ -66,7 +66,7 @@ func TestPersistedState_Roundtrip_MatchedNone(t *testing.T) {
 		t.Errorf(`want Unicode-escape form \u003cnone\u003e on disk, got %s`, s)
 	}
 
-	var decoded PersistedState
+	var decoded persistedState
 	if err := json.Unmarshal(buf, &decoded); err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}
@@ -88,8 +88,8 @@ func TestPersistedState_Roundtrip_MatchedNone(t *testing.T) {
 // must treat a loaded record with these values as corrupt and fall into
 // branch B. The separate Validate tests enforce that.
 func TestPersistedState_Roundtrip_NilSentinel(t *testing.T) {
-	orig := PersistedState{
-		SchemaVersion:      PersistVersion,
+	orig := persistedState{
+		SchemaVersion:      persistVersion,
 		Source:             SourceUnknown,
 		LastMatched:        "",
 		LastMatchedPresent: false,
@@ -102,7 +102,7 @@ func TestPersistedState_Roundtrip_NilSentinel(t *testing.T) {
 		t.Errorf("want null-encoded last_matched_network, got %s", buf)
 	}
 
-	var decoded PersistedState
+	var decoded persistedState
 	if err := json.Unmarshal(buf, &decoded); err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}
@@ -122,14 +122,14 @@ func TestPersistedState_Validate_Happy(t *testing.T) {
 	// source=auto requires LastMatchedPresent=true (§5.6.2 advances it
 	// on every transition that sets source=auto); source=manual + nil
 	// is legitimate (first manual set before any ctx PUT).
-	cases := []PersistedState{
-		{SchemaVersion: PersistVersion, Source: SourceAuto, LastMatched: "office", LastMatchedPresent: true},
-		{SchemaVersion: PersistVersion, Source: SourceAuto, LastMatched: MatchedNone, LastMatchedPresent: true},
-		{SchemaVersion: PersistVersion, Source: SourceManual, LastMatched: "office", LastMatchedPresent: true},
+	cases := []persistedState{
+		{SchemaVersion: persistVersion, Source: SourceAuto, LastMatched: "office", LastMatchedPresent: true},
+		{SchemaVersion: persistVersion, Source: SourceAuto, LastMatched: MatchedNone, LastMatchedPresent: true},
+		{SchemaVersion: persistVersion, Source: SourceManual, LastMatched: "office", LastMatchedPresent: true},
 		// manual + MatchedNone: reachable via §5.6.2 "default / no_change_no_default
 		// advanced last_matched to <none>, user then manually switched".
-		{SchemaVersion: PersistVersion, Source: SourceManual, LastMatched: MatchedNone, LastMatchedPresent: true},
-		{SchemaVersion: PersistVersion, Source: SourceManual, LastMatched: "", LastMatchedPresent: false},
+		{SchemaVersion: persistVersion, Source: SourceManual, LastMatched: MatchedNone, LastMatchedPresent: true},
+		{SchemaVersion: persistVersion, Source: SourceManual, LastMatched: "", LastMatchedPresent: false},
 	}
 	for _, p := range cases {
 		if err := p.Validate(); err != nil {
@@ -144,8 +144,8 @@ func TestPersistedState_Validate_Happy(t *testing.T) {
 // legitimate `nil` is on source=manual (first manual set before ctx) or
 // source=unknown (initial in-memory state, never persisted).
 func TestPersistedState_Validate_RejectsAutoWithNil(t *testing.T) {
-	p := PersistedState{
-		SchemaVersion:      PersistVersion,
+	p := persistedState{
+		SchemaVersion:      persistVersion,
 		Source:             SourceAuto,
 		LastMatched:        "",
 		LastMatchedPresent: false,
@@ -157,7 +157,7 @@ func TestPersistedState_Validate_RejectsAutoWithNil(t *testing.T) {
 }
 
 func TestPersistedState_Validate_RejectsUnknownSchema(t *testing.T) {
-	p := PersistedState{SchemaVersion: 2, Source: SourceAuto}
+	p := persistedState{SchemaVersion: 2, Source: SourceAuto}
 	err := p.Validate()
 	if err == nil || !strings.Contains(err.Error(), "schema_version 2") {
 		t.Errorf("want schema_version error, got %v", err)
@@ -165,7 +165,7 @@ func TestPersistedState_Validate_RejectsUnknownSchema(t *testing.T) {
 }
 
 func TestPersistedState_Validate_RejectsInvalidSource(t *testing.T) {
-	p := PersistedState{SchemaVersion: PersistVersion, Source: "bogus"}
+	p := persistedState{SchemaVersion: persistVersion, Source: "bogus"}
 	err := p.Validate()
 	if err == nil || !strings.Contains(err.Error(), "invalid source") {
 		t.Errorf("want invalid-source error, got %v", err)
@@ -178,7 +178,7 @@ func TestPersistedState_Validate_RejectsInvalidSource(t *testing.T) {
 // corrupted record falls through to branch B rather than propagating a
 // broken state into the manager.
 func TestPersistedState_Validate_RejectsPersistedUnknown(t *testing.T) {
-	p := PersistedState{SchemaVersion: PersistVersion, Source: SourceUnknown}
+	p := persistedState{SchemaVersion: persistVersion, Source: SourceUnknown}
 	err := p.Validate()
 	if err == nil || !strings.Contains(err.Error(), "must not be persisted") {
 		t.Errorf("want persisted-unknown error, got %v", err)
@@ -190,8 +190,8 @@ func TestPersistedState_Validate_RejectsPersistedUnknown(t *testing.T) {
 // for "evaluated, no match". A present-but-empty value means the record
 // was tampered with externally.
 func TestPersistedState_Validate_RejectsEmptyLastMatched(t *testing.T) {
-	p := PersistedState{
-		SchemaVersion:      PersistVersion,
+	p := persistedState{
+		SchemaVersion:      persistVersion,
 		Source:             SourceAuto,
 		LastMatched:        "",
 		LastMatchedPresent: true,
@@ -207,8 +207,8 @@ func TestPersistedState_Validate_RejectsEmptyLastMatched(t *testing.T) {
 // it at config parse time). Reject defensively to catch external
 // tampering.
 func TestPersistedState_Validate_RejectsDefaultAsLastMatched(t *testing.T) {
-	p := PersistedState{
-		SchemaVersion:      PersistVersion,
+	p := persistedState{
+		SchemaVersion:      persistVersion,
 		Source:             SourceAuto,
 		LastMatched:        DefaultKey,
 		LastMatchedPresent: true,
@@ -224,8 +224,8 @@ func TestPersistedState_Validate_RejectsDefaultAsLastMatched(t *testing.T) {
 // JSON null, losing information silently. Validate must catch this on
 // the programmer-construction path.
 func TestPersistedState_Validate_RejectsInconsistentAbsenceWithValue(t *testing.T) {
-	p := PersistedState{
-		SchemaVersion:      PersistVersion,
+	p := persistedState{
+		SchemaVersion:      persistVersion,
 		Source:             SourceManual,
 		LastMatched:        "office",
 		LastMatchedPresent: false,
@@ -239,8 +239,8 @@ func TestPersistedState_Validate_RejectsInconsistentAbsenceWithValue(t *testing.
 // MatchedNone as LastMatched is explicitly valid: "evaluated, no network
 // matched" is a legitimate persisted state.
 func TestPersistedState_Validate_AcceptsMatchedNone(t *testing.T) {
-	p := PersistedState{
-		SchemaVersion:      PersistVersion,
+	p := persistedState{
+		SchemaVersion:      persistVersion,
 		Source:             SourceAuto,
 		LastMatched:        MatchedNone,
 		LastMatchedPresent: true,
@@ -256,7 +256,7 @@ func TestPersistedState_Validate_AcceptsMatchedNone(t *testing.T) {
 // through to branch B — the point of this test is that decoding itself is
 // robust, not that the result is usable.
 func TestPersistedState_Unmarshal_MissingFields(t *testing.T) {
-	var p PersistedState
+	var p persistedState
 	if err := json.Unmarshal([]byte(`{}`), &p); err != nil {
 		t.Fatalf("unmarshal empty: %v", err)
 	}
@@ -269,46 +269,46 @@ func TestPersistedState_Unmarshal_MissingFields(t *testing.T) {
 }
 
 func TestPersistedState_Unmarshal_Malformed(t *testing.T) {
-	var p PersistedState
+	var p persistedState
 	err := json.Unmarshal([]byte(`not json`), &p)
 	if err == nil {
 		t.Errorf("want error on malformed input; got nil")
 	}
 }
 
-// MarshalValidated returns the Validate error on invariant violations so
+// marshalValidated returns the Validate error on invariant violations so
 // writers cannot leak impossible states onto disk via raw json.Marshal.
 func TestPersistedState_MarshalValidated_RejectsInvalid(t *testing.T) {
-	invalid := PersistedState{
-		SchemaVersion:      PersistVersion,
+	invalid := persistedState{
+		SchemaVersion:      persistVersion,
 		Source:             SourceAuto,
 		LastMatched:        "",
 		LastMatchedPresent: false,
 	}
-	_, err := invalid.MarshalValidated()
+	_, err := invalid.marshalValidated()
 	if err == nil {
 		t.Errorf("want Validate error on auto+nil, got nil")
 	}
 	// Raw json.Marshal succeeds on the same invalid struct — this is the
-	// loophole MarshalValidated is designed to close. The assertion
+	// loophole marshalValidated is designed to close. The assertion
 	// documents the contract rather than testing json semantics.
 	if _, rawErr := json.Marshal(invalid); rawErr != nil {
-		t.Errorf("raw json.Marshal should succeed on invalid struct (MarshalValidated is the guard); got %v", rawErr)
+		t.Errorf("raw json.Marshal should succeed on invalid struct (marshalValidated is the guard); got %v", rawErr)
 	}
 }
 
 func TestPersistedState_MarshalValidated_PassesThrough(t *testing.T) {
-	valid := PersistedState{
-		SchemaVersion:      PersistVersion,
+	valid := persistedState{
+		SchemaVersion:      persistVersion,
 		Source:             SourceAuto,
 		LastMatched:        "office",
 		LastMatchedPresent: true,
 	}
-	buf, err := valid.MarshalValidated()
+	buf, err := valid.marshalValidated()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	var decoded PersistedState
+	var decoded persistedState
 	if err := json.Unmarshal(buf, &decoded); err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}
@@ -322,8 +322,8 @@ func TestPersistedState_MarshalValidated_PassesThrough(t *testing.T) {
 // "auto requires present". Structural checks run first so the reported
 // error points at the real bug.
 func TestPersistedState_Validate_InconsistencyTakesPrecedenceOverSource(t *testing.T) {
-	p := PersistedState{
-		SchemaVersion:      PersistVersion,
+	p := persistedState{
+		SchemaVersion:      persistVersion,
 		Source:             SourceAuto,
 		LastMatched:        "office",
 		LastMatchedPresent: false,
@@ -343,8 +343,8 @@ func TestPersistedState_Validate_InconsistencyTakesPrecedenceOverSource(t *testi
 // otherwise legitimate, so source-specific check alone wouldn't catch
 // the bug).
 func TestPersistedState_Validate_InconsistencyOnManual(t *testing.T) {
-	p := PersistedState{
-		SchemaVersion:      PersistVersion,
+	p := persistedState{
+		SchemaVersion:      persistVersion,
 		Source:             SourceManual,
 		LastMatched:        "office",
 		LastMatchedPresent: false,

--- a/component/networkpolicy/policy.go
+++ b/component/networkpolicy/policy.go
@@ -1,14 +1,14 @@
 package networkpolicy
 
 const (
-	// PersistVersion is the current schema version persisted alongside the
+	// persistVersion is the current schema version persisted alongside the
 	// per-group last-matched network state in the runtime cache.
-	PersistVersion = 1
+	persistVersion = 1
 
-	// MaxTTLSeconds is the upper bound on PUT /network/context TTL (10 years).
+	// maxTTLSeconds is the upper bound on PUT /network/context TTL (10 years).
 	// Keeps time.Duration well clear of its int64 nanosecond overflow (~292 years)
 	// and prevents AfterFunc from scheduling absurdly far in the future.
-	MaxTTLSeconds = 10 * 365 * 86400
+	maxTTLSeconds = 10 * 365 * 86400
 
 	// DefaultKey is the reserved network-policy key meaning "fallback".
 	DefaultKey = "default"

--- a/component/networkpolicy/policy.go
+++ b/component/networkpolicy/policy.go
@@ -102,18 +102,22 @@ type GroupSource struct {
 
 // selectable is the narrowest interface the network-policy runtime needs to
 // manually switch a proxy-group. Selector, Fallback, and URLTest all satisfy
-// it; the simple ManualSet path uses this when a group has no network-policy
-// attached.
+// it; kept unexported because no caller outside this package needs to
+// reference the name — SelectorWithPolicy embeds it and callers interact
+// with the composed interface.
 type selectable interface {
 	Name() string
 	Set(name string) error
 }
 
-// selectorWithPolicy is the full interface for a select-type group that
+// SelectorWithPolicy is the full interface for a select-type group that
 // carries network-policy metadata. Only *outboundgroup.Selector satisfies it.
 // The runtime state machine and first-init logic depend on Now / HasProxy /
-// NetworkPolicy / GroupSource in addition to the selectable base.
-type selectorWithPolicy interface {
+// NetworkPolicy / GroupSource in addition to the selectable base methods.
+//
+// Exported so the executor can build []SelectorWithPolicy from the parsed
+// proxy map and hand it to NewManager / Install.
+type SelectorWithPolicy interface {
 	selectable
 	Now() string
 	HasProxy(name string) bool

--- a/component/networkpolicy/policy.go
+++ b/component/networkpolicy/policy.go
@@ -1,0 +1,122 @@
+package networkpolicy
+
+const (
+	// PersistVersion is the current schema version persisted alongside the
+	// per-group last-matched network state in the runtime cache.
+	PersistVersion = 1
+
+	// MaxTTLSeconds is the upper bound on PUT /network/context TTL (10 years).
+	// Keeps time.Duration well clear of its int64 nanosecond overflow (~292 years)
+	// and prevents AfterFunc from scheduling absurdly far in the future.
+	MaxTTLSeconds = 10 * 365 * 86400
+
+	// DefaultKey is the reserved network-policy key meaning "fallback".
+	DefaultKey = "default"
+
+	// MatchedNone is the internal sentinel for "no context matched any network".
+	// Used only in persisted per-group state and logs; REST responses serialize
+	// matched_network as JSON null, not this string.
+	MatchedNone = "<none>"
+
+	// Selection source tri-state.
+	SourceAuto    = "auto"
+	SourceManual  = "manual"
+	SourceUnknown = "unknown"
+)
+
+// Reason enumeration for the per-group resolution outcome surfaced via
+// applied[].reason in the REST response.
+const (
+	ReasonMatched           = "matched"
+	ReasonAlreadySelected   = "already_selected"
+	ReasonDefault           = "default"
+	ReasonNoChangeNoDefault = "no_change_no_default"
+	ReasonUnchangedNetwork  = "unchanged_network"
+	ReasonManualLocked      = "manual_locked"
+	ReasonMissingTarget     = "missing_target"
+)
+
+// GroupPolicy is the network-policy: field of a select proxy-group.
+type GroupPolicy struct {
+	// Mapping is network name → proxy name (never contains "default").
+	Mapping map[string]string
+
+	// HasDefault reports whether the YAML explicitly set a default key.
+	HasDefault bool
+
+	// DefaultProxy is the value of the default key (valid iff HasDefault).
+	DefaultProxy string
+}
+
+// IsEmpty reports whether the group declares no policy at all.
+func (p GroupPolicy) IsEmpty() bool {
+	return len(p.Mapping) == 0 && !p.HasDefault
+}
+
+// Resolve maps a matched network name to the target proxy and a reason.
+// matched == "" means "no network matched".
+//
+// Returns:
+//   - (Mapping[matched], ReasonMatched) when matched is non-empty and in Mapping.
+//   - (DefaultProxy, ReasonDefault) when no mapping hits but HasDefault is true.
+//   - ("", ReasonNoChangeNoDefault) otherwise.
+//
+// Resolve does not know the currently-selected proxy, so it never returns
+// ReasonAlreadySelected; the runtime state machine classifies that case.
+func (p GroupPolicy) Resolve(matched string) (target, reason string) {
+	if matched != "" {
+		if t, ok := p.Mapping[matched]; ok {
+			return t, ReasonMatched
+		}
+	}
+	if p.HasDefault {
+		return p.DefaultProxy, ReasonDefault
+	}
+	return "", ReasonNoChangeNoDefault
+}
+
+// GroupSource records parse-time metadata about a proxy-group's candidate
+// set. Populated at YAML parse time; consumed by network-policy validation
+// and by the runtime when deciding whether a target proxy is reachable.
+type GroupSource struct {
+	// StaticProxies is the set of candidate names resolvable at parse time:
+	//   - names listed explicitly under proxies:
+	//   - names from include-all / include-all-proxies expansion, after applying
+	//     Filter / ExcludeFilter / ExcludeType
+	// Must already reflect the final filter result, so that a target present here
+	// is guaranteed reachable by the runtime (subject to provider refresh).
+	StaticProxies []string
+
+	// HasProvider reports whether the group has any provider attached after
+	// include-all-providers / include-all expansion. Used by validation to
+	// decide the tolerant (provider-backed) branch.
+	HasProvider bool
+
+	// Filter / ExcludeFilter / ExcludeType are the group's include-all filtering
+	// rules, recorded for validation and debugging. The runtime does not consult
+	// these directly—runtime filtering is handled by GroupBase.GetProxies.
+	Filter        string
+	ExcludeFilter string
+	ExcludeType   string
+}
+
+// selectable is the narrowest interface the network-policy runtime needs to
+// manually switch a proxy-group. Selector, Fallback, and URLTest all satisfy
+// it; the simple ManualSet path uses this when a group has no network-policy
+// attached.
+type selectable interface {
+	Name() string
+	Set(name string) error
+}
+
+// selectorWithPolicy is the full interface for a select-type group that
+// carries network-policy metadata. Only *outboundgroup.Selector satisfies it.
+// The runtime state machine and first-init logic depend on Now / HasProxy /
+// NetworkPolicy / GroupSource in addition to the selectable base.
+type selectorWithPolicy interface {
+	selectable
+	Now() string
+	HasProxy(name string) bool
+	NetworkPolicy() GroupPolicy
+	GroupSource() GroupSource
+}

--- a/component/networkpolicy/policy_test.go
+++ b/component/networkpolicy/policy_test.go
@@ -1,0 +1,41 @@
+package networkpolicy
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGroupPolicy_IsEmpty(t *testing.T) {
+	assert.True(t, GroupPolicy{}.IsEmpty())
+	assert.False(t, GroupPolicy{Mapping: map[string]string{"office": "hk"}}.IsEmpty())
+	assert.False(t, GroupPolicy{HasDefault: true, DefaultProxy: "direct"}.IsEmpty())
+}
+
+func TestGroupPolicy_Resolve(t *testing.T) {
+	withDefault := GroupPolicy{
+		Mapping:      map[string]string{"office": "hk"},
+		HasDefault:   true,
+		DefaultProxy: "direct",
+	}
+	noDefault := GroupPolicy{Mapping: map[string]string{"office": "hk"}}
+
+	cases := []struct {
+		name       string
+		p          GroupPolicy
+		matched    string
+		wantTarget string
+		wantReason string
+	}{
+		{"matched mapping", withDefault, "office", "hk", ReasonMatched},
+		{"unmapped network falls to default", withDefault, "unknown", "direct", ReasonDefault},
+		{"empty match falls to default", withDefault, "", "direct", ReasonDefault},
+		{"no mapping no default", noDefault, "", "", ReasonNoChangeNoDefault},
+		{"unknown no default", noDefault, "unknown", "", ReasonNoChangeNoDefault},
+	}
+	for _, tc := range cases {
+		target, reason := tc.p.Resolve(tc.matched)
+		assert.Equal(t, tc.wantTarget, target, tc.name)
+		assert.Equal(t, tc.wantReason, reason, tc.name)
+	}
+}

--- a/component/networkpolicy/util.go
+++ b/component/networkpolicy/util.go
@@ -1,0 +1,122 @@
+package networkpolicy
+
+import (
+	"fmt"
+	"strings"
+
+	"golang.org/x/exp/slices"
+)
+
+// normalizeMAC returns s as a lower-case colon-separated MAC address.
+//
+// Accepted input formats (case-insensitive; separator must be uniform):
+//
+//	colon:      "aa:bb:cc:dd:ee:ff"
+//	dash:       "aa-bb-cc-dd-ee-ff"
+//	unseparated "aabbccddeeff"
+//
+// Any other form (mixed separators, wrong group count, non-hex characters)
+// returns an error.
+func normalizeMAC(s string) (string, error) {
+	if s == "" {
+		return "", fmt.Errorf("expected MAC, got empty string")
+	}
+	hasColon := strings.ContainsRune(s, ':')
+	hasDash := strings.ContainsRune(s, '-')
+	var hex string
+	switch {
+	case hasColon && hasDash:
+		return "", fmt.Errorf("expected MAC, got %q (mixed separators)", s)
+	case hasColon:
+		parts := strings.Split(s, ":")
+		if len(parts) != 6 {
+			return "", fmt.Errorf("expected MAC, got %q (need 6 colon-separated groups)", s)
+		}
+		for i, p := range parts {
+			if len(p) != 2 {
+				return "", fmt.Errorf("expected MAC, got %q (group %d is not 2 hex chars)", s, i)
+			}
+		}
+		hex = strings.Join(parts, "")
+	case hasDash:
+		parts := strings.Split(s, "-")
+		if len(parts) != 6 {
+			return "", fmt.Errorf("expected MAC, got %q (need 6 dash-separated groups)", s)
+		}
+		for i, p := range parts {
+			if len(p) != 2 {
+				return "", fmt.Errorf("expected MAC, got %q (group %d is not 2 hex chars)", s, i)
+			}
+		}
+		hex = strings.Join(parts, "")
+	default:
+		if len(s) != 12 {
+			return "", fmt.Errorf("expected MAC, got %q (unseparated form must be 12 hex chars)", s)
+		}
+		hex = s
+	}
+	if !isHex(hex) {
+		return "", fmt.Errorf("expected MAC, got %q (non-hex character)", s)
+	}
+	hex = strings.ToLower(hex)
+	var b strings.Builder
+	b.Grow(17)
+	for i := 0; i < 12; i += 2 {
+		if i > 0 {
+			b.WriteByte(':')
+		}
+		b.WriteString(hex[i : i+2])
+	}
+	return b.String(), nil
+}
+
+func isHex(s string) bool {
+	if s == "" {
+		return false
+	}
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		switch {
+		case c >= '0' && c <= '9':
+		case c >= 'a' && c <= 'f':
+		case c >= 'A' && c <= 'F':
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+// meteredString renders *bool as a stable string for Fingerprint.
+func meteredString(b *bool) string {
+	switch {
+	case b == nil:
+		return "null"
+	case *b:
+		return "true"
+	default:
+		return "false"
+	}
+}
+
+// normalizeDNSSuffix applies the canonical form for the top-level dns_suffix
+// field: lower-case each entry, drop empty strings, sort, dedupe. Returns
+// nil for empty/all-empty input.
+func normalizeDNSSuffix(in []string) []string {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(in))
+	for _, s := range in {
+		if s == "" {
+			continue
+		}
+		out = append(out, strings.ToLower(s))
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	slices.Sort(out)
+	out = slices.Compact(out)
+	return out
+}

--- a/component/networkpolicy/util_test.go
+++ b/component/networkpolicy/util_test.go
@@ -1,0 +1,70 @@
+package networkpolicy
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNormalizeMAC(t *testing.T) {
+	const want = "aa:bb:cc:dd:ee:ff"
+	valid := []string{
+		"aa:bb:cc:dd:ee:ff",
+		"AA:BB:CC:DD:EE:FF",
+		"aa-bb-cc-dd-ee-ff",
+		"AA-BB-CC-DD-EE-FF",
+		"aabbccddeeff",
+		"AABBCCDDEEFF",
+	}
+	for _, in := range valid {
+		got, err := normalizeMAC(in)
+		assert.NoError(t, err, "input=%q", in)
+		assert.Equal(t, want, got, "input=%q", in)
+		// idempotent
+		again, err := normalizeMAC(got)
+		assert.NoError(t, err)
+		assert.Equal(t, got, again)
+	}
+
+	invalid := []string{
+		"",
+		"aa:bb:cc:dd:ee",       // 5 groups
+		"aa:bb:cc:dd:ee:ff:11", // 7 groups
+		"aa:bb:cc:dd:ee:zz",    // non-hex
+		"aa:bb-cc:dd-ee:ff",    // mixed separators
+		"aabb.ccdd.eeff",       // unknown grouping
+		"aabbccddeefg",         // unseparated non-hex
+		"aaabbbcccdddeeefff",   // wrong length
+		"aa:bbb:cc:dd:ee:ff",   // wrong group width
+	}
+	for _, in := range invalid {
+		_, err := normalizeMAC(in)
+		assert.Error(t, err, "input=%q", in)
+	}
+}
+
+func TestMeteredString(t *testing.T) {
+	b := true
+	f := false
+	assert.Equal(t, "null", meteredString(nil))
+	assert.Equal(t, "true", meteredString(&b))
+	assert.Equal(t, "false", meteredString(&f))
+}
+
+func TestNormalizeDNSSuffix(t *testing.T) {
+	cases := []struct {
+		name string
+		in   []string
+		want []string
+	}{
+		{"nil stays nil", nil, nil},
+		{"empty stays nil", []string{}, nil},
+		{"all-empty strings stay nil", []string{"", ""}, nil},
+		{"single entry lowercased", []string{"Corp.Example.COM"}, []string{"corp.example.com"}},
+		{"sort + dedup + lowercase", []string{"CORP", "home", "corp", ""}, []string{"corp", "home"}},
+	}
+	for _, tc := range cases {
+		got := normalizeDNSSuffix(tc.in)
+		assert.Equal(t, tc.want, got, "case %q", tc.name)
+	}
+}

--- a/component/profile/cachefile/cache.go
+++ b/component/profile/cachefile/cache.go
@@ -81,7 +81,8 @@ func (c *CacheFile) SelectedMap() map[string]string {
 // so previously-persisted entries are effectively ignored (bbolt data
 // itself is untouched until the next successful write or explicit delete).
 //
-// value is the caller-encoded JSON payload (see networkpolicy.PersistedState).
+// value is the caller-encoded JSON payload (see the networkpolicy package's
+// internal persistence layer).
 // Storing raw bytes here keeps the cachefile layer untangled from the
 // networkpolicy package's schema.
 func (c *CacheFile) SetNetworkPolicyState(group string, value []byte) {

--- a/component/profile/cachefile/cache.go
+++ b/component/profile/cachefile/cache.go
@@ -23,6 +23,7 @@ var (
 	bucketETag             = []byte("etag")
 	bucketSubscriptionInfo = []byte("subscriptioninfo")
 	bucketStorage          = []byte("storage")
+	bucketNetworkPolicy    = []byte("networkpolicy")
 )
 
 // CacheFile store and update the cache file
@@ -71,6 +72,118 @@ func (c *CacheFile) SelectedMap() map[string]string {
 		return nil
 	})
 	return mapping
+}
+
+// SetNetworkPolicyState persists the per-group network-policy state machine
+// record to bucketNetworkPolicy. Gated on profile.StoreSelected so that the
+// network-policy state follows the same opt-in as the group's selected
+// proxy: toggling StoreSelected off makes subsequent loads skip the bucket,
+// so previously-persisted entries are effectively ignored (bbolt data
+// itself is untouched until the next successful write or explicit delete).
+//
+// value is the caller-encoded JSON payload (see networkpolicy.PersistedState).
+// Storing raw bytes here keeps the cachefile layer untangled from the
+// networkpolicy package's schema.
+func (c *CacheFile) SetNetworkPolicyState(group string, value []byte) {
+	if !profile.StoreSelected.Load() {
+		return
+	} else if c.DB == nil {
+		return
+	}
+
+	err := c.DB.Batch(func(t *bbolt.Tx) error {
+		bucket, err := t.CreateBucketIfNotExists(bucketNetworkPolicy)
+		if err != nil {
+			return err
+		}
+		return bucket.Put([]byte(group), value)
+	})
+	if err != nil {
+		log.Warnln("[CacheFile] write network-policy state to %s failed: %s", c.DB.Path(), err.Error())
+		return
+	}
+}
+
+// DeleteNetworkPolicyState removes the entry for group from the bucket, used
+// when a group's network-policy is removed via hot reload (orphan GC) or
+// when the manager invalidates a corrupted record on load. No-op if the
+// bucket or key does not exist.
+//
+// **Not gated on profile.StoreSelected**: orphan cleanup must work even
+// when the user has toggled StoreSelected off between writes and deletes.
+// Keeping a Delete no-op under the gate would leave stale entries around
+// that resurrect when the user flips StoreSelected back on — the kind of
+// silent regression architecture §5.6 explicitly avoids.
+func (c *CacheFile) DeleteNetworkPolicyState(group string) {
+	if c.DB == nil {
+		return
+	}
+
+	err := c.DB.Batch(func(t *bbolt.Tx) error {
+		bucket := t.Bucket(bucketNetworkPolicy)
+		if bucket == nil {
+			return nil
+		}
+		return bucket.Delete([]byte(group))
+	})
+	if err != nil {
+		log.Warnln("[CacheFile] delete network-policy state from %s failed: %s", c.DB.Path(), err.Error())
+	}
+}
+
+// NetworkPolicyStateMap returns the full group → JSON-bytes map from
+// bucketNetworkPolicy, along with a flag indicating whether the bucket
+// actually exists on disk.
+//
+// Architecture §5.6.2 branch A / B hinges on **bucket existence**, not on
+// whether the bucket has entries: an existing-but-empty bucket (e.g.,
+// after every group's network-policy was removed and orphan-deleted) is
+// still branch A for the groups currently declared. Callers must
+// distinguish the two:
+//
+//	mapping, ok := cache.NetworkPolicyStateMap()
+//	if !ok {
+//	    // branch B: no bucket, cold start — evaluate on first PUT
+//	} else {
+//	    // branch A: bucket exists; groups not in `mapping` start fresh
+//	    // (source=unknown, last_matched=nil) but still within branch A
+//	}
+//
+// Returns (nil, false) when StoreSelected is off, the DB is unavailable,
+// or the bucket has never been created — all three are equivalent to
+// "no persisted state to restore" for the state machine. An empty but
+// existing bucket returns (empty-map, true).
+//
+// Map values are copies of bbolt's tx-scoped slices so callers can retain
+// the bytes past the View closure.
+func (c *CacheFile) NetworkPolicyStateMap() (map[string][]byte, bool) {
+	if !profile.StoreSelected.Load() {
+		return nil, false
+	} else if c.DB == nil {
+		return nil, false
+	}
+
+	var (
+		mapping      map[string][]byte
+		bucketExists bool
+	)
+	c.DB.View(func(t *bbolt.Tx) error {
+		bucket := t.Bucket(bucketNetworkPolicy)
+		if bucket == nil {
+			return nil
+		}
+		bucketExists = true
+		mapping = map[string][]byte{}
+		cur := bucket.Cursor()
+		for k, v := cur.First(); k != nil; k, v = cur.Next() {
+			// Copy v — bbolt reuses the slice once the tx ends.
+			cp := make([]byte, len(v))
+			copy(cp, v)
+			mapping[string(k)] = cp
+		}
+		return nil
+	})
+	return mapping, bucketExists
 }
 
 func (c *CacheFile) Close() error {

--- a/config/config.go
+++ b/config/config.go
@@ -22,6 +22,7 @@ import (
 	"github.com/metacubex/mihomo/component/cidr"
 	"github.com/metacubex/mihomo/component/fakeip"
 	"github.com/metacubex/mihomo/component/geodata"
+	"github.com/metacubex/mihomo/component/networkpolicy"
 	"github.com/metacubex/mihomo/component/process"
 	"github.com/metacubex/mihomo/component/resolver"
 	"github.com/metacubex/mihomo/component/sniffer"
@@ -207,6 +208,7 @@ type Config struct {
 	Tunnels       []LC.Tunnel
 	Sniffer       *sniffer.Config
 	TLS           *TLS
+	Networks      []networkpolicy.Network
 }
 
 type RawCors struct {
@@ -440,6 +442,7 @@ type RawConfig struct {
 	RuleProvider  map[string]map[string]any `yaml:"rule-providers" json:"rule-providers"`
 	Proxy         []map[string]any          `yaml:"proxies" json:"proxies"`
 	ProxyGroup    []map[string]any          `yaml:"proxy-groups" json:"proxy-groups"`
+	Networks      []map[string]any          `yaml:"networks" json:"networks"`
 	Rule          []string                  `yaml:"rules" json:"rule"`
 	SubRules      map[string][]string       `yaml:"sub-rules" json:"sub-rules"`
 	Listeners     []map[string]any          `yaml:"listeners" json:"listeners"`
@@ -655,12 +658,30 @@ func ParseRawConfig(rawCfg *RawConfig) (*Config, error) {
 	}
 	config.TLS = tlsCfg
 
-	proxies, providers, err := parseProxies(rawCfg)
+	networks, err := networkpolicy.ParseNetworks(rawCfg.Networks)
+	if err != nil {
+		return nil, fmt.Errorf("parse networks: %w", err)
+	}
+	config.Networks = networks
+
+	networkNames := make([]string, 0, len(networks))
+	for i := range networks {
+		networkNames = append(networkNames, networks[i].Name)
+	}
+
+	proxies, providers, err := parseProxies(rawCfg, networkNames)
 	if err != nil {
 		return nil, err
 	}
 	config.Proxies = proxies
 	config.Providers = providers
+
+	// Orphan-network diagnostic (architecture §5.8.1): a network defined
+	// under top-level networks: but referenced by no group's
+	// network-policy mapping is a stale config — warn, don't block. The
+	// default key does not participate since it is the fallback, not a
+	// network reference.
+	warnOrphanNetworks(networks, proxies)
 
 	listeners, err := parseListeners(rawCfg)
 	if err != nil {
@@ -737,6 +758,36 @@ func ParseRawConfig(rawCfg *RawConfig) (*Config, error) {
 
 //go:linkname temporaryUpdateGeneral
 func temporaryUpdateGeneral(general *General) func()
+
+// warnOrphanNetworks emits a warning for each top-level network whose name
+// is not referenced by any select group's network-policy mapping
+// (architecture §5.8.1: orphan networks are non-blocking but worth flagging
+// as stale config). The default key in a network-policy map is a fallback,
+// not a network reference, so it does not participate.
+func warnOrphanNetworks(networks []networkpolicy.Network, proxies map[string]C.Proxy) {
+	if len(networks) == 0 {
+		return
+	}
+	referenced := make(map[string]struct{})
+	for _, p := range proxies {
+		adapter, ok := p.(interface{ Adapter() C.ProxyAdapter })
+		if !ok {
+			continue
+		}
+		sel, ok := adapter.Adapter().(*outboundgroup.Selector)
+		if !ok {
+			continue
+		}
+		for name := range sel.NetworkPolicy().Mapping {
+			referenced[name] = struct{}{}
+		}
+	}
+	for _, n := range networks {
+		if _, ok := referenced[n.Name]; !ok {
+			log.Warnln("network-policy: networks[%q] is defined but referenced by no group; remove it or add a mapping", n.Name)
+		}
+	}
+}
 
 func parseGeneral(cfg *RawConfig) (*General, error) {
 	return &General{
@@ -854,7 +905,7 @@ func parseTLS(cfg *RawConfig) (*TLS, error) {
 	}, nil
 }
 
-func parseProxies(cfg *RawConfig) (proxies map[string]C.Proxy, providersMap map[string]P.ProxyProvider, err error) {
+func parseProxies(cfg *RawConfig, allNetworks []string) (proxies map[string]C.Proxy, providersMap map[string]P.ProxyProvider, err error) {
 	proxies = make(map[string]C.Proxy)
 	providersMap = make(map[string]P.ProxyProvider)
 	proxiesConfig := cfg.Proxy
@@ -925,9 +976,24 @@ func parseProxies(cfg *RawConfig) (proxies map[string]C.Proxy, providersMap map[
 	slices.Sort(AllProxies)
 	slices.Sort(AllProviders)
 
+	// Build the stable global proxy-name set for network-policy validation.
+	// Must be computed BEFORE group parsing so every group sees the same
+	// complete set regardless of iteration order; otherwise ParseGroupPolicy's
+	// "globally known vs. truly absent" distinction (architecture §5.8.1)
+	// becomes iteration-order dependent. Includes: DIRECT/REJECT (already in
+	// proxyList), top-level proxies (already in proxyList), every declared
+	// proxy group name (already in proxyList), the remaining built-in
+	// outbounds, and GLOBAL (auto-injected at the end of parseProxies).
+	allProxyNames := make([]string, 0, len(proxyList)+4)
+	allProxyNames = append(allProxyNames, proxyList...)
+	allProxyNames = append(allProxyNames, "REJECT-DROP", "COMPATIBLE", "PASS")
+	if !hasGlobal {
+		allProxyNames = append(allProxyNames, "GLOBAL")
+	}
+
 	// parse proxy group
 	for idx, mapping := range groupsConfig {
-		group, err := outboundgroup.ParseProxyGroup(mapping, proxies, providersMap, AllProxies, AllProviders)
+		group, err := outboundgroup.ParseProxyGroup(mapping, proxies, providersMap, AllProxies, AllProviders, allNetworks, allProxyNames)
 		if err != nil {
 			return nil, nil, fmt.Errorf("proxy group[%d]: %w", idx, err)
 		}

--- a/config/config.go
+++ b/config/config.go
@@ -786,11 +786,7 @@ func warnOrphanNetworks(networks []networkpolicy.Network, proxies map[string]C.P
 	}
 	referenced := make(map[string]struct{})
 	for _, p := range proxies {
-		adapter, ok := p.(interface{ Adapter() C.ProxyAdapter })
-		if !ok {
-			continue
-		}
-		sel, ok := adapter.Adapter().(*outboundgroup.Selector)
+		sel, ok := p.Adapter().(networkpolicy.SelectorWithPolicy)
 		if !ok {
 			continue
 		}

--- a/config/config.go
+++ b/config/config.go
@@ -209,6 +209,13 @@ type Config struct {
 	Sniffer       *sniffer.Config
 	TLS           *TLS
 	Networks      []networkpolicy.Network
+
+	// ProxyGroupOrder is the YAML declaration order of proxy-group
+	// names. Consumed by the executor's network-policy wiring (and
+	// future REST layers) so applied[] / groups[] output can follow
+	// the architecture §5.4.2 "按 proxy-group 在 YAML 中的声明顺序"
+	// contract without re-parsing the raw ProxyGroup slice.
+	ProxyGroupOrder []string
 }
 
 type RawCors struct {
@@ -675,6 +682,15 @@ func ParseRawConfig(rawCfg *RawConfig) (*Config, error) {
 	}
 	config.Proxies = proxies
 	config.Providers = providers
+
+	// Record group declaration order for downstream consumers (executor
+	// network-policy wiring, future REST layers).
+	config.ProxyGroupOrder = make([]string, 0, len(rawCfg.ProxyGroup))
+	for _, mapping := range rawCfg.ProxyGroup {
+		if name, ok := mapping["name"].(string); ok && name != "" {
+			config.ProxyGroupOrder = append(config.ProxyGroupOrder, name)
+		}
+	}
 
 	// Orphan-network diagnostic (architecture §5.8.1): a network defined
 	// under top-level networks: but referenced by no group's

--- a/config/utils_test.go
+++ b/config/utils_test.go
@@ -68,7 +68,7 @@ func TestValidateDialerProxies(t *testing.T) {
 	for _, testCase := range testCases {
 		t.Run(testCase.testName, func(t *testing.T) {
 			config := RawConfig{Proxy: testCase.proxy}
-			_, _, err := parseProxies(&config)
+			_, _, err := parseProxies(&config, nil)
 			if testCase.errContains == "" {
 				assert.NoError(t, err, testCase.testName)
 			} else {

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,1716 @@
+# mihomo REST API 参考
+
+> 以源码为权威，列出 mihomo 内核 RESTful API 的全部路由、参数、响应、状态码与示例。内核：mihomo（MetaCubeX fork of clash-premium）。
+
+---
+
+## 1. 概览
+
+### 1.1 文档覆盖范围
+
+本文档覆盖 `hub/route/` 包注册的全部 HTTP / WebSocket endpoints，包括 network-policy 控制面的 `/network/context` endpoint。每个端点均给出：
+
+- HTTP method 与 path
+- 简介与典型用途
+- path / query / header / body schema
+- 响应 schema（含 WebSocket 帧格式）
+- 涉及的 HTTP 状态码与错误体
+- 一到两个 `curl` / `wscat` 示例
+
+未覆盖：
+
+- `hub/route/external.go` 是给上游嵌入方注册自定义路由的扩展点（`Register(externalRouter)`），mihomo 自身不调用。第三方注册的端点不在本文档范围内。
+- `hub/route/patch_android.go` 仅含 Android 平台特定的运行时 patch，不增加端点。
+- DoH endpoint（`hub/route/doh.go`）只有在 `external-doh-server` 配置了以 `/` 开头的路径时才会挂载，是 RFC 8484 标准接口而非 mihomo 控制面 API。本文档单独列出（见 §12.2）。
+
+### 1.2 端点入口
+
+`hub/route/server.go:router()` 同时把 router 服务到四个 transport：
+
+| Transport | 配置字段 | Secret 鉴权 | CORS | UI | DoH |
+|---|---|---|---|---|---|
+| TCP HTTP | `external-controller` | 是 | 是 | 是 | 是 |
+| TCP TLS | `external-controller-tls` + `external-controller-cert/key/ech-key/client-auth-*` | 是（共用同一 `secret`） | 是 | 是 | 是 |
+| Unix socket | `external-controller-unix` | **否**（始终 secret="" 调用 router）| 是 | 是 | 是 |
+| Windows Named Pipe | `external-controller-pipe`（必须以 `\\.\pipe\` 开头） | **否** | 是 | 是 | 是 |
+
+> 三种 transport 共享 chi router 与 handler；区别只在监听层面与是否走鉴权 middleware。对应实现在 `hub/route/server.go:159` 起的 `start` / `startTLS` / `startUnix` / `startPipe`。
+
+`/debug/*` 路由仅当启动时 `IsDebug=true`（命令行 `-d` 或配置层等价开关）才会挂载，且**不在已认证 group 中**——这是上游历史行为，文档照实记录。
+
+`/restart`、`/configs PUT/PATCH/POST /geo`、`/upgrade`、`/upgrade/geo`、`/rules PATCH /disable` 在 `embedMode=true` 时被屏蔽（用于 SDK 嵌入场景，由调用方 `route.SetEmbedMode(true)` 开启）。
+
+### 1.3 鉴权
+
+`hub/route/server.go:327` 的 `authentication(secret)` middleware 检查每个 HTTP 请求：
+
+- `Authorization: Bearer <secret>`：常规鉴权。`secret` 与配置 `secret` 字段做常量时间比较，失败返回 `401`。
+- `Upgrade: websocket` + `?token=<secret>` query：浏览器 WebSocket 不支持自定义头，所以允许通过 query 参数携带 token；若提供则只校验 token，**忽略 Authorization 头**。
+- 未提供 `Authorization`、且不是带 token 的 WebSocket 请求 → `401 Unauthorized`，body 为 `{"message":"Unauthorized"}`。
+- 配置中 `secret == ""` 时，整个 `r.Group` 直接跳过 middleware，所有 endpoint 公开可访问。
+- 通过 Unix socket / Named Pipe 访问时鉴权也被强制跳过（`startUnix` / `startPipe` 都是用 `secret=""` 调用 `router()`）。
+
+`/debug/*` 端点未走 `authentication` middleware（位于 `r.Group` 之外）；如果开启 `IsDebug` 又同时绑定到非 loopback 地址，等同公开 pprof，请慎用。
+
+### 1.4 跨域 CORS
+
+由顶层 `r.Use(cors.New(...))` 应用到所有路由（`server.go:80`）：
+
+- `Allowed-Methods`：`GET / POST / PUT / PATCH / DELETE`
+- `Allowed-Headers`：`Content-Type / Authorization`
+- `Max-Age`：`300` 秒
+- 由配置 `external-controller-cors.allow-origins` 决定 `Allowed-Origins`；缺省为空列表。
+- 由配置 `external-controller-cors.allow-private-network` 决定是否回写 `Access-Control-Allow-Private-Network: true`（Chrome 私网访问规范）。
+
+CORS 中间件挂在最外层，因此所有 endpoint 都遵循同一规则。
+
+### 1.5 响应与错误约定
+
+所有 JSON 响应由 `github.com/metacubex/chi/render` 渲染，`Content-Type: application/json; charset=utf-8`。
+
+错误响应有三种形态：
+
+1. **`HTTPError`**：`{"message":"<reason>"}`。绝大多数 4xx / 5xx 走这一形态（`hub/route/errors.go`）。
+2. **Network-policy envelope**：`{"code":"<short>","message":"<reason>"}`。仅 `/network/context` 三个 endpoint 使用，供 host sampler 做结构化错误分流——详见 §11.5。
+3. **若干上游兼容的 `render.M`**：例如 `/restart`、`/upgrade*` 的成功响应是 `{"status":"ok"}`，`/version` / `/` 是平铺 map。
+4. **DoH** 响应由 `render.PlainText` 输出 `text/plain; charset=utf-8` 或直接以 `application/dns-message` 写入二进制。
+
+成功响应若不需要 body（如修改资源、关闭连接、删除 context），统一用 `render.NoContent` 返回 `204 No Content`。
+
+mihomo 的状态码用法约定：
+
+| 状态码 | 用途 |
+|---|---|
+| `200` | GET 成功，或 PUT/PATCH/POST 需要返回 body |
+| `204` | PUT/PATCH/DELETE 成功且无 body |
+| `400` | 请求体或参数非法（统一 `{"message":"Body invalid"}` 或携带具体原因） |
+| `401` | 鉴权失败 |
+| `404` | 资源不存在（多用于路径参数定位失败） |
+| `405` | DoH endpoint 在 `wsUpgrade` 与 `dohHandler` 中分别可能产生 |
+| `426` | WebSocket 升级时 `Sec-WebSocket-Version` 不为 `13` |
+| `500` | 内部错误（DNS section 未启用、updater 失败、写盘失败等） |
+| `503` | 服务暂不可用（代理 URLTest 失败、provider Update 失败、network-policy Manager 未就绪等） |
+| `504` | URLTest 超时（`/proxies/{name}/delay`） |
+
+### 1.6 路径中的 `{name}` 编码
+
+代理名 / provider 名可能包含 `%`、`/`、空格等字符。`hub/route/common.go:21 getEscapeParam` 会对 chi 抓到的 path param 做 `url.PathUnescape`；调用方应对名字做 URL 编码（如 `/proxies/auto%20group`）。
+
+### 1.7 WebSocket 升级
+
+部分 endpoint（`/traffic` / `/memory` / `/logs` / `/connections`）支持把同一 GET 请求升级为 WebSocket 流：
+
+- 客户端发 `Upgrade: websocket`、`Connection: Upgrade`、`Sec-WebSocket-Key: <24B base64>`、`Sec-WebSocket-Version: 13`，并通过 `Authorization: Bearer <secret>` **或** `?token=<secret>` 完成鉴权。
+- 服务器响应 `101 Switching Protocols`，自此每个 tick（默认 1s）以 `OpText`（DNS 二进制 endpoint 除外）发送一个 JSON 序列化对象。
+- 当 client 不发 `Upgrade: websocket` 时，相同的 endpoint 退化为 streaming HTTP（`Content-Type: application/json`，每个 tick `Flush` 一段 JSON）。**注意：流式 HTTP 和 WebSocket 共享同一 handler，行为一致，区别仅在帧封装。**
+- 升级失败的 4xx/5xx 见 `wsUpgrade` 实现（`hub/route/common.go:33`）。
+
+### 1.8 字段命名
+
+mihomo 配置 YAML 使用 kebab-case；本文档涉及的 JSON request / response 字段大多为 camelCase（如 `socks-port`、`upTotal`、`startGo`），但部分较新 endpoint（`/network/context`、`/dns/query` 内部字段）使用 snake_case 与 mDNS 风格（`Status`、`Question`）。文档严格按源码字段标注。
+
+---
+
+## 2. 系统级 endpoints
+
+### 2.1 `GET /`
+
+返回静态欢迎信息，可用作健康检查。
+
+| 项目 | 值 |
+|---|---|
+| 鉴权 | 是 |
+| 来源 | `hub/route/server.go:358` |
+
+**响应**：`200 OK`
+
+```json
+{ "hello": "mihomo" }
+```
+
+**示例**：
+
+```bash
+curl -H 'Authorization: Bearer <secret>' http://127.0.0.1:9090/
+```
+
+### 2.2 `GET /version`
+
+返回内核名与版本号。
+
+| 项目 | 值 |
+|---|---|
+| 鉴权 | 是 |
+| 来源 | `hub/route/server.go:563` |
+
+**响应**：`200 OK`
+
+```jsonc
+{
+  "meta": true,            // 始终 true（mihomo fork 标识）
+  "version": "1.10.0"      // constant.Version；编译期常量
+}
+```
+
+**示例**：
+
+```bash
+curl -H 'Authorization: Bearer <secret>' http://127.0.0.1:9090/version
+```
+
+### 2.3 `GET /traffic`
+
+返回**实时**流量与累计字节数。每秒推送一帧。
+
+| 项目 | 值 |
+|---|---|
+| 鉴权 | 是（HTTP 头或 `?token=`） |
+| 推送频率 | 1 秒/帧（`time.NewTicker(time.Second)`） |
+| 协议 | streaming HTTP **或** WebSocket（取决于 `Upgrade` 头） |
+| 来源 | `hub/route/server.go:362` |
+
+**响应每帧 schema**：
+
+```jsonc
+{
+  "up": 12345,         // 当前秒上传速率（bytes/s）
+  "down": 67890,
+  "upTotal": 1234567,  // 自启动以来累计字节
+  "downTotal": 9876543
+}
+```
+
+**HTTP 流式示例**：
+
+```bash
+curl -H 'Authorization: Bearer <secret>' http://127.0.0.1:9090/traffic
+```
+
+**WebSocket 示例**：
+
+```bash
+wscat -c "ws://127.0.0.1:9090/traffic?token=<secret>"
+```
+
+### 2.4 `GET /memory`
+
+返回内核进程 RSS 内存。**第一帧固定为 0**（兼容 chart.js 让曲线从 0 开始）。
+
+| 项目 | 值 |
+|---|---|
+| 鉴权 | 是 |
+| 推送频率 | 1 秒/帧 |
+| 协议 | streaming HTTP 或 WebSocket |
+| 来源 | `hub/route/server.go:408` |
+
+**响应每帧 schema**：
+
+```jsonc
+{
+  "inuse": 12345678,   // 进程 RSS 字节数
+  "oslimit": 0          // 始终 0；保留字段
+}
+```
+
+**示例**：
+
+```bash
+curl -H 'Authorization: Bearer <secret>' http://127.0.0.1:9090/memory
+```
+
+### 2.5 `GET /logs`
+
+订阅日志事件流。
+
+| 项目 | 值 |
+|---|---|
+| 鉴权 | 是 |
+| 协议 | streaming HTTP 或 WebSocket |
+| 来源 | `hub/route/server.go:473` |
+
+**Query**：
+
+| 名称 | 类型 | 说明 |
+|---|---|---|
+| `level` | enum | 默认 `info`。可选 `debug` / `info` / `warning` / `error` / `silent`，由 `log.LogLevelMapping` 决定。`silent` 等同关闭。无效值 → `400`。 |
+| `format` | enum | 可选 `structured`；缺省时为兼容旧客户端的「平铺」格式。 |
+
+**响应每帧 schema**：
+
+- 默认（兼容形态）：
+
+  ```jsonc
+  {
+    "type": "info",         // debug / info / warning / error
+    "payload": "[TCP] connect to 1.2.3.4:443"
+  }
+  ```
+
+- `format=structured`：
+
+  ```jsonc
+  {
+    "time": "15:04:05",
+    "level": "info",        // warning 被改写成 warn
+    "message": "[TCP] ...",
+    "fields": []
+  }
+  ```
+
+**示例**：
+
+```bash
+curl -H 'Authorization: Bearer <secret>' "http://127.0.0.1:9090/logs?level=warning"
+wscat -c "ws://127.0.0.1:9090/logs?level=debug&format=structured&token=<secret>"
+```
+
+---
+
+## 3. Configs
+
+### 3.1 `GET /configs`
+
+返回当前生效的「General + Inbound」配置快照。
+
+| 项目 | 值 |
+|---|---|
+| 鉴权 | 是 |
+| 来源 | `hub/route/configs.go:127` → `hub/executor/executor.go:141 GetGeneral` |
+
+**响应** `200 OK`（字段对应 `config.General` / `config.Inbound`）：
+
+```jsonc
+{
+  // Inbound 子结构（平铺）
+  "port": 7890,
+  "socks-port": 7891,
+  "redir-port": 0,
+  "tproxy-port": 0,
+  "mixed-port": 0,
+  "tun": { /* listener.GetTunConf() 的全部字段，结构见 LC.Tun */ },
+  "tuic-server": { /* listener.GetTuicConf() 的全部字段 */ },
+  "ss-config": "",
+  "vmess-config": "",
+  "authentication": ["user1:pwd1"],
+  "skip-auth-prefixes": ["10.0.0.0/8"],
+  "lan-allowed-ips": [],
+  "lan-disallowed-ips": [],
+  "allow-lan": false,
+  "bind-address": "*",
+  "inbound-tfo": false,
+  "inbound-mptcp": false,
+
+  // General 子结构
+  "mode": "rule",                     // rule / global / direct
+  "unified-delay": false,
+  "log-level": "info",
+  "ipv6": true,
+  "interface-name": "",
+  "routing-mark": 0,
+  "geox-url": {
+    "geo-ip": "https://...",
+    "mmdb": "https://...",
+    "asn": "https://...",
+    "geo-site": "https://..."
+  },
+  "geo-auto-update": false,
+  "geo-update-interval": 24,
+  "geodata-mode": false,
+  "geodata-loader": "memconservative",
+  "geosite-matcher": "succinct",
+  "tcp-concurrent": false,
+  "find-process-mode": "off",         // off / strict / always
+  "sniffing": false,
+  "global-client-fingerprint": "",
+  "global-ua": "mihomo/...",
+  "etag-support": false,
+  "keep-alive-idle": 30,
+  "keep-alive-interval": 30,
+  "disable-keep-alive": false
+}
+```
+
+> `tun` 与 `tuic-server` 子对象字段较多且与平台相关，详细字段定义见 `listener/config/tun.go` 与 `listener/config/tuic.go`，本文档不展开。
+
+**示例**：
+
+```bash
+curl -H 'Authorization: Bearer <secret>' http://127.0.0.1:9090/configs
+```
+
+### 3.2 `PATCH /configs`
+
+**部分**热修改运行时配置（仅在 `embedMode=false` 时挂载）。
+
+| 项目 | 值 |
+|---|---|
+| 鉴权 | 是 |
+| 来源 | `hub/route/configs.go:312` |
+
+**Body**：所有字段均为可选；只发送想要修改的字段：
+
+```jsonc
+{
+  "port": 7890,
+  "socks-port": 7891,
+  "redir-port": 7892,
+  "tproxy-port": 0,
+  "mixed-port": 0,
+  "tun": { /* 同 GET /configs.tun，字段全部可选 */ },
+  "tuic-server": { /* 同 GET /configs.tuic-server */ },
+  "ss-config": "ss://...",
+  "vmess-config": "...",
+  "tcptun-config": "1.1.1.1:443",      // 仅对 PATCH 有效；GET 不返回
+  "udptun-config": "1.1.1.1:443",      // 仅对 PATCH 有效；GET 不返回
+  "allow-lan": true,
+  "skip-auth-prefixes": ["10.0.0.0/8"],
+  "lan-allowed-ips": ["192.168.1.0/24"],
+  "lan-disallowed-ips": [],
+  "bind-address": "*",
+  "mode": "rule",
+  "log-level": "warning",
+  "ipv6": true,
+  "sniffing": true,
+  "tcp-concurrent": true,
+  "find-process-mode": "strict",
+  "interface-name": "en0"
+}
+```
+
+字段说明：
+
+- 监听端口字段会触发对应监听器的 `ReCreateXxx` —— 端口为 0 视作关闭。
+- `mode`、`log-level`、`find-process-mode` 是 enum，传非法值会被对应 setter 接受/拒绝（不在 handler 层校验）。
+- `interface-name` 为空字符串等同 `""`，意味着不绑定具体接口。
+- 未列出字段（如 `tls.*`、`dns.*`）此 endpoint 不支持，需要通过 `PUT /configs` 整体重载。
+
+**响应**：`204 No Content`。
+
+JSON body 解析失败 → `400` + `{"message":"Body invalid"}`。
+
+**示例**：
+
+```bash
+curl -X PATCH \
+     -H 'Authorization: Bearer <secret>' \
+     -H 'Content-Type: application/json' \
+     -d '{"mode":"global","log-level":"debug"}' \
+     http://127.0.0.1:9090/configs
+```
+
+### 3.3 `PUT /configs`
+
+**完整**重载配置（仅在 `embedMode=false` 时挂载）。等同重新解析一份 YAML 并 ApplyConfig。
+
+| 项目 | 值 |
+|---|---|
+| 鉴权 | 是 |
+| 来源 | `hub/route/configs.go:383` |
+
+**Query**：
+
+| 名称 | 类型 | 说明 |
+|---|---|---|
+| `force` | bool | `true` → 即使 listener 配置未变也强制重建监听器；缺省 `false`。 |
+
+**Body**：二选一 ——
+
+```jsonc
+{ "payload": "<完整 YAML 字符串>" }
+// 或
+{ "path": "/abs/path/to/config.yaml" }
+// 都不填则使用默认配置文件路径（C.Path.Config()）
+```
+
+**约束**：
+
+- `path` 必须是绝对路径，否则 `400 invalid`：`{"message":"path is not a absolute path"}`。
+- `path` 必须落在 `C.Path.IsSafePath` 允许的目录内（默认是配置目录），否则 `400`。
+- `payload` 不为空时 `path` 字段被忽略。
+- YAML 解析失败 → `400` + 解析错误原文。
+
+**响应**：
+
+- `204 No Content`：成功。
+- `400`：请求体非法或 YAML 解析失败。
+
+**示例**：
+
+```bash
+# 通过 path
+curl -X PUT \
+     -H 'Authorization: Bearer <secret>' \
+     -H 'Content-Type: application/json' \
+     -d '{"path":"/etc/mihomo/config.yaml"}' \
+     "http://127.0.0.1:9090/configs?force=true"
+
+# 通过 payload
+curl -X PUT \
+     -H 'Authorization: Bearer <secret>' \
+     -H 'Content-Type: application/json' \
+     --data-binary @config.json \
+     http://127.0.0.1:9090/configs
+```
+
+### 3.4 `POST /configs/geo`
+
+主动触发 GeoIP / GeoSite / MMDB / ASN 数据库更新（仅在 `embedMode=false` 时挂载）。
+
+| 项目 | 值 |
+|---|---|
+| 鉴权 | 是 |
+| 来源 | `hub/route/configs.go:434` |
+
+**响应**：
+
+- `204 No Content`：更新成功。
+- `500`：updater 失败 → `{"message":"<reason>"}`。
+
+**示例**：
+
+```bash
+curl -X POST -H 'Authorization: Bearer <secret>' http://127.0.0.1:9090/configs/geo
+```
+
+> 与 `POST /upgrade/geo` 等价（同一 handler，见 §9.3）。
+
+---
+
+## 4. Proxies
+
+代理对象包括：单个 outbound（DIRECT/REJECT/Trojan/Shadowsocks/...）、Selector、Fallback、URLTest、Relay、LoadBalance 等。所有这些都通过 `/proxies` 暴露；只有「proxy group」（具备 `outboundgroup.ProxyGroup` 接口的 Selector / Fallback / URLTest / LoadBalance / Relay 等）也会出现在 `/group` 下。
+
+### 4.1 `GET /proxies`
+
+返回所有 proxy（单 proxy + 组）的合集 map，**包括从所有 ProxyProvider 中展开的 proxy**。
+
+| 项目 | 值 |
+|---|---|
+| 鉴权 | 是 |
+| 来源 | `hub/route/proxies.go` 的 `getProxies` 函数 |
+
+**响应**：`200 OK`
+
+```jsonc
+{
+  "proxies": {
+    "GLOBAL": {
+      "type": "Selector",
+      "now": "auto",
+      "all": ["DIRECT", "REJECT", "auto", "hk-1", "us-1"],
+      "testUrl": "",
+      "hidden": false,
+      "icon": "",
+      "history": [{ "time": "2025-04-19T12:00:00Z", "delay": 50 }],
+      "extra": { /* map[string]map[string]any 形式的额外测速结果 */ },
+      "alive": true,
+      "name": "GLOBAL",
+      "udp": true,
+      "uot": false,
+      "xudp": false,
+      "tfo": false,
+      "mptcp": false,
+      "smux": false,
+      "interface": "",
+      "routing-mark": 0,
+      "provider-name": "",
+      "dialer-proxy": ""
+    },
+    "DIRECT": { "type": "Direct", "id": "...", "history": [], "alive": true, ... },
+    ...
+  }
+}
+```
+
+字段来源：
+
+- `adapter.Proxy.MarshalJSON`（`adapter/adapter.go:135`）注入 `history` / `extra` / `alive` / `name` / `udp` / `uot` / `xudp` / `tfo` / `mptcp` / `smux` / `interface` / `routing-mark` / `provider-name` / `dialer-proxy`。
+- 单 proxy 的 `Base.MarshalJSON`（`adapter/outbound/base.go:99`）只输出 `type` / `id`。
+- 组类型的 MarshalJSON 增加 `now` / `all` / `testUrl` / `hidden` / `icon`，Fallback/URLTest 还增加 `expectedStatus` / `fixed`。
+
+> `proxiesWithProviders` 函数已被标记 deprecated（`hub/route/proxies.go` 的 `proxiesWithProviders`），但保留以维持现有 API 输出兼容性。
+
+**示例**：
+
+```bash
+curl -H 'Authorization: Bearer <secret>' http://127.0.0.1:9090/proxies
+```
+
+### 4.2 `GET /proxies/{name}`
+
+返回单个 proxy 的详情（即上面 `proxies` map 中名为 `name` 的那个值）。
+
+| 项目 | 值 |
+|---|---|
+| 鉴权 | 是 |
+| 来源 | `hub/route/proxies.go` 的 `getProxy` 函数 |
+
+**Path**：`{name}` 经 `url.PathUnescape` 解码。
+
+**响应**：`200 OK` + 同 §4.1 的单个 proxy 对象，或 `404 Not Found`。
+
+**示例**：
+
+```bash
+curl -H 'Authorization: Bearer <secret>' http://127.0.0.1:9090/proxies/GLOBAL
+```
+
+### 4.3 `PUT /proxies/{name}`
+
+切换 Selector / Fallback / URLTest 等可手动选择组的当前选择。
+
+| 项目 | 值 |
+|---|---|
+| 鉴权 | 是 |
+| 来源 | `hub/route/proxies.go` 的 `updateProxy` 函数 |
+
+**Body**：
+
+```jsonc
+{ "name": "hk-1" }
+```
+
+**行为**：
+
+- Handler 委托 `networkpolicy.Default().ManualSet(proxy, req.Name)`，由 Manager 统一处理 selectable/selectorWithPolicy 分派、cachefile 写入与 manual-wins 钩子。带 `network-policy` 的 Selector 额外写 `bucketNetworkPolicy`（source=manual）。
+- 错误通过 `errors.Is` 分级：`ErrManagerNotInitialized` → `503`；`ErrNotSelectable` / `ErrProxyNotExist` → `400`；其他未归类 error → `500` 并 `log.Warnln`。
+- 成功后异步触发 `SwitchProxiesCallback`（若注册），再返回 `204 No Content`。自动切换路径（`PutContext` 等）**不**触发 callback，避免 UI flicker。
+
+**响应**：
+
+| 状态 | body |
+|---|---|
+| `204 No Content` | 切换成功 |
+| `400` | body 不是合法 JSON / group 非 selectable / target 不在候选 |
+| `404` | path 上的 `name` 不存在 |
+| `503` | `{"message":"network-policy manager not initialized"}`（启动窗口） |
+
+**示例**：
+
+```bash
+curl -X PUT \
+     -H 'Authorization: Bearer <secret>' \
+     -H 'Content-Type: application/json' \
+     -d '{"name":"hk-1"}' \
+     http://127.0.0.1:9090/proxies/auto
+```
+
+### 4.4 `DELETE /proxies/{name}`
+
+清除 Selector 之外的可选择组（Fallback / URLTest / LoadBalance）的「fixed」状态——让它回到自动选择。Selector 类型不允许 unfix（`unfixedProxy` 显式过滤）。
+
+| 项目 | 值 |
+|---|---|
+| 鉴权 | 是 |
+| 来源 | `hub/route/proxies.go` 的 `unfixedProxy` 函数 |
+
+**响应**：
+
+| 状态 | body |
+|---|---|
+| `204 No Content` | 清除成功 |
+| `400` | 该 proxy 不是 SelectAble，或者它是 Selector 类型 |
+| `404` | name 不存在 |
+
+**示例**：
+
+```bash
+curl -X DELETE \
+     -H 'Authorization: Bearer <secret>' \
+     http://127.0.0.1:9090/proxies/auto
+```
+
+### 4.5 `GET /proxies/{name}/delay`
+
+对单个 proxy 做一次 URLTest，返回当前延迟。
+
+| 项目 | 值 |
+|---|---|
+| 鉴权 | 是 |
+| 来源 | `hub/route/proxies.go` 的 `getProxyDelay` 函数 |
+
+**Query**：
+
+| 名称 | 类型 | 必填 | 说明 |
+|---|---|---|---|
+| `url` | string | 是 | 测试 URL，例如 `https://www.gstatic.com/generate_204` |
+| `timeout` | int | 是 | 超时毫秒数（int16 范围）；非数字 → `400` |
+| `expected` | string | 否 | HTTP status code 范围，例如 `204` / `200-299` / `200/204/301-302`；非法 → `400`。空表示不限制。 |
+
+**响应**：
+
+| 状态 | body |
+|---|---|
+| `200 OK` | `{"delay": 123}`（毫秒） |
+| `400` | query 缺失或非法 |
+| `503` | 测试失败但未超时（`{"message":"<原因>"}`） |
+| `504` | 超时（`{"message":"Timeout"}`） |
+
+**示例**：
+
+```bash
+curl -H 'Authorization: Bearer <secret>' \
+     "http://127.0.0.1:9090/proxies/hk-1/delay?url=https://www.gstatic.com/generate_204&timeout=3000&expected=204"
+```
+
+---
+
+## 5. Proxy Groups
+
+> 注：`/group` 与 `/proxies` 共享 proxy 实例集合，但 `/group` 只暴露具备 `ProxyGroup` 接口的对象（Selector / URLTest / Fallback / LoadBalance / Relay）。
+
+### 5.1 `GET /group`
+
+| 项目 | 值 |
+|---|---|
+| 鉴权 | 是 |
+| 来源 | `hub/route/groups.go:31` |
+
+**响应**：`200 OK`
+
+```jsonc
+{
+  "proxies": [ /* 数组，元素 schema 同 §4.1 中的组对象 */ ]
+}
+```
+
+> 与 `/proxies` 不同的是，这里只来自 `tunnel.Proxies()`（即顶层声明的组），**不**包含 provider 内的 proxies；同时是数组而非 map。
+
+### 5.2 `GET /group/{name}`
+
+返回单个组对象。若 `name` 不存在或不是组 → `404`。
+
+| 项目 | 值 |
+|---|---|
+| 鉴权 | 是 |
+| 来源 | `hub/route/groups.go:43` |
+
+**示例**：
+
+```bash
+curl -H 'Authorization: Bearer <secret>' http://127.0.0.1:9090/group/auto
+```
+
+### 5.3 `GET /group/{name}/delay`
+
+对一个组内**所有**候选并发跑 URLTest，返回 `map[proxyName]delayMs`。
+
+副作用：调用前会对**非 Selector 类型**的 SelectAble 组执行 `ForceSet("")` + `cachefile.SetSelected(name, "")`，等同于自动模式重置 fixed 状态。Selector 不重置。
+
+| 项目 | 值 |
+|---|---|
+| 鉴权 | 是 |
+| 来源 | `hub/route/groups.go:53` |
+
+**Query**：同 §4.5（`url` / `timeout` / `expected`）。
+
+**响应**：
+
+| 状态 | body |
+|---|---|
+| `200 OK` | `{ "hk-1": 123, "hk-2": 0, ... }`（0 通常表示该 proxy 失败） |
+| `400` | query 非法 |
+| `404` | `name` 不是组 |
+| `504` | URLTest 整体失败（`{"message":"<context deadline exceeded ...>"}`） |
+
+**示例**：
+
+```bash
+curl -H 'Authorization: Bearer <secret>' \
+     "http://127.0.0.1:9090/group/auto/delay?url=https://www.gstatic.com/generate_204&timeout=3000"
+```
+
+---
+
+## 6. Rules
+
+### 6.1 `GET /rules`
+
+| 项目 | 值 |
+|---|---|
+| 鉴权 | 是 |
+| 来源 | `hub/route/rules.go:42` |
+
+**响应**：`200 OK`
+
+```jsonc
+{
+  "rules": [
+    {
+      "index": 0,
+      "type": "DOMAIN",
+      "payload": "google.com",
+      "proxy": "auto",
+      "size": -1,                     // 仅 GEOIP / GEOSITE 给出包含数；其他类型为 -1
+      "extra": {                      // 仅当 rule 已被 RuleWrapper 包装时出现
+        "disabled": false,
+        "hitCount": 12,
+        "hitAt": "2025-04-19T11:59:00Z",
+        "missCount": 3,
+        "missAt": "2025-04-19T11:58:30Z"
+      }
+    }
+  ]
+}
+```
+
+字段来源：
+
+- `Rule.Type` / `Rule.Payload` / `Rule.Adapter` 来自规则解析。
+- `Extra` 与 `RuleWrapper`（`constant/rule.go`）相关，统计 hit / miss。
+
+### 6.2 `PATCH /rules/disable`
+
+按 index 启用/停用一组规则（仅 `embedMode=false` 时挂载，需要 `RuleWrapper`，否则忽略）。
+
+| 项目 | 值 |
+|---|---|
+| 鉴权 | 是 |
+| 来源 | `hub/route/rules.go:76` |
+
+**Body**：`map[int]bool`，key = rule index（同 `GET /rules` 返回的 `index`），value = 是否禁用。
+
+```jsonc
+{ "0": true, "5": false, "12": true }
+```
+
+非法 index 被静默忽略；JSON 解析失败 → `400`。
+
+**响应**：`204 No Content`。
+
+**示例**：
+
+```bash
+curl -X PATCH \
+     -H 'Authorization: Bearer <secret>' \
+     -H 'Content-Type: application/json' \
+     -d '{"3":true,"4":true}' \
+     http://127.0.0.1:9090/rules/disable
+```
+
+---
+
+## 7. Providers
+
+### 7.1 Proxy Providers
+
+#### 7.1.1 `GET /providers/proxies`
+
+| 项目 | 值 |
+|---|---|
+| 鉴权 | 是 |
+| 来源 | `hub/route/provider.go:40` |
+
+**响应**：`200 OK`
+
+```jsonc
+{
+  "providers": {
+    "ProviderA": {
+      "name": "ProviderA",
+      "type": "Proxy",                 // adapter/provider.providerForApi.Type
+      "vehicleType": "HTTP",           // HTTP / File / Compatible / Inline
+      "proxies": [ /* 同 §4.1 中的 proxy 对象 */ ],
+      "testUrl": "https://www.gstatic.com/generate_204",
+      "expectedStatus": "204",
+      "updatedAt": "2025-04-19T11:30:00Z",
+      "subscriptionInfo": {            // 可选；存在时是订阅协议解析出的流量信息
+        "Upload": 0, "Download": 0, "Total": 0, "Expire": 0
+      }
+    }
+  }
+}
+```
+
+字段来源：`adapter/provider/provider.go:34 providerForApi`。
+
+- `compatibleProvider` 不返回 `updatedAt` / `subscriptionInfo` 字段（`omitempty`）。
+- `inlineProvider` 不返回 `subscriptionInfo`。
+
+#### 7.1.2 `GET /providers/proxies/{providerName}`
+
+返回单个 proxy provider 的详情。
+
+| 项目 | 值 |
+|---|---|
+| 鉴权 | 是 |
+| 来源 | `hub/route/provider.go:47` |
+
+**响应**：`200 OK` + 同上 schema 中单个 provider 对象，或 `404`。
+
+#### 7.1.3 `PUT /providers/proxies/{providerName}`
+
+强制刷新一个 proxy provider（重新拉取订阅）。
+
+| 项目 | 值 |
+|---|---|
+| 鉴权 | 是 |
+| 来源 | `hub/route/provider.go:52` |
+
+**响应**：
+
+| 状态 | body |
+|---|---|
+| `204 No Content` | 刷新成功 |
+| `404` | `providerName` 不存在 |
+| `503` | provider 内部 `Update()` 报错（`{"message":"<原因>"}`） |
+
+#### 7.1.4 `GET /providers/proxies/{providerName}/healthcheck`
+
+触发整个 provider 的健康检查（异步并发跑 URLTest），endpoint 立即返回。
+
+| 项目 | 值 |
+|---|---|
+| 鉴权 | 是 |
+| 来源 | `hub/route/provider.go:62` |
+
+**响应**：`204 No Content`。
+
+#### 7.1.5 `GET /providers/proxies/{providerName}/{name}`
+
+返回该 provider 中名为 `name` 的单个 proxy 对象（同 §4.2 schema）。`404` 当 provider 或 proxy 不存在。
+
+| 项目 | 值 |
+|---|---|
+| 鉴权 | 是 |
+| 来源 | `hub/route/provider.go:32` 子路由（`getProxy` handler 复用） |
+
+#### 7.1.6 `GET /providers/proxies/{providerName}/{name}/healthcheck`
+
+对该 provider 中的单个 proxy 做一次 URLTest 并返回延迟。`Query` 与响应同 §4.5（注意：尽管路径叫 `/healthcheck`，handler 复用的是 `getProxyDelay`，所以 `url` / `timeout` / `expected` 仍然是必传 query）。
+
+| 项目 | 值 |
+|---|---|
+| 鉴权 | 是 |
+| 来源 | `hub/route/provider.go:35` |
+
+**示例**：
+
+```bash
+curl -H 'Authorization: Bearer <secret>' \
+     "http://127.0.0.1:9090/providers/proxies/ProviderA/hk-1/healthcheck?url=https://www.gstatic.com/generate_204&timeout=3000"
+```
+
+### 7.2 Rule Providers
+
+#### 7.2.1 `GET /providers/rules`
+
+| 项目 | 值 |
+|---|---|
+| 鉴权 | 是 |
+| 来源 | `hub/route/provider.go:123` |
+
+**响应**：`200 OK`
+
+```jsonc
+{
+  "providers": {
+    "MyRules": {
+      "behavior": "domain",          // domain / ipcidr / classical
+      "format": "yaml",              // yaml / text / mrs；inline 不返回此字段
+      "name": "MyRules",
+      "ruleCount": 1234,
+      "type": "Rule",
+      "vehicleType": "HTTP",         // HTTP / File / Inline
+      "updatedAt": "2025-04-19T10:00:00Z",
+      "payload": ["+.example.com"]   // 仅 inline provider 携带
+    }
+  }
+}
+```
+
+字段来源：`rules/provider/provider.go:35 providerForApi`。
+
+#### 7.2.2 `PUT /providers/rules/{name}`
+
+强制刷新一个 rule provider。
+
+| 项目 | 值 |
+|---|---|
+| 鉴权 | 是 |
+| 来源 | `hub/route/provider.go:130` |
+
+**响应**：
+
+| 状态 | body |
+|---|---|
+| `204 No Content` | 成功 |
+| `404` | `name` 不存在 |
+| `503` | `provider.Update()` 失败（`{"message":"<原因>"}`） |
+
+---
+
+## 8. Connections
+
+### 8.1 `GET /connections`
+
+返回当前活跃连接快照；若以 WebSocket 升级则按 `interval` 周期推送。
+
+| 项目 | 值 |
+|---|---|
+| 鉴权 | 是 |
+| 协议 | 单次 HTTP GET **或** WebSocket |
+| 来源 | `hub/route/connections.go:24` |
+
+**Query**（仅 WebSocket 模式生效）：
+
+| 名称 | 类型 | 默认 | 说明 |
+|---|---|---|---|
+| `interval` | int (ms) | `1000` | 每帧间隔；非数字 → `400` |
+
+**响应 schema**：
+
+```jsonc
+{
+  "downloadTotal": 1234567,   // statistic.Manager 累计字节
+  "uploadTotal":   2345678,
+  "memory": 12345678,         // 进程 RSS（与 /memory 同源）
+  "connections": [
+    {
+      "id": "f3b5...uuid",
+      "metadata": {
+        "network": "tcp",          // tcp / udp
+        "type": "HTTP",            // SOCKS / HTTP / Mixed / Tun / ...
+        "sourceIP": "192.168.1.10",
+        "destinationIP": "1.2.3.4",
+        "sourceGeoIP": ["CN"],     // null = 未查询；[] = 查询无结果
+        "destinationGeoIP": ["US"],
+        "sourceIPASN": "AS123",
+        "destinationIPASN": "AS456",
+        "sourcePort":      "55672",  // 注意是字符串（兼容旧版 JSON）
+        "destinationPort": "443",    // 注意是字符串
+        "inboundIP":       "127.0.0.1",
+        "inboundPort":     "7890",
+        "inboundName":     "DEFAULT-HTTP",
+        "inboundUser":     "",
+        "host": "www.example.com",
+        "dnsMode": "fake-ip",
+        "uid": 501,
+        "process": "curl",
+        "processPath": "/usr/bin/curl",
+        "specialProxy": "",
+        "specialRules": "",
+        "remoteDestination": "1.2.3.4:443",
+        "dscp": 0,
+        "sniffHost": "www.example.com"
+      },
+      "upload": 1234,
+      "download": 5678,
+      "start": "2025-04-19T11:00:00Z",
+      "chains": ["DIRECT"],            // 反向；末尾是最贴近 outbound 的代理
+      "providerChains": [],
+      "rule": "DOMAIN",
+      "rulePayload": "example.com"
+    }
+  ]
+}
+```
+
+> `metadata` 字段对应 `constant/metadata.go:180 Metadata`。注意 `sourcePort` / `destinationPort` / `inboundPort` 出于历史兼容性是字符串。
+
+**HTTP 单次示例**：
+
+```bash
+curl -H 'Authorization: Bearer <secret>' http://127.0.0.1:9090/connections
+```
+
+**WebSocket 周期推送**：
+
+```bash
+wscat -c "ws://127.0.0.1:9090/connections?interval=2000&token=<secret>"
+```
+
+### 8.2 `DELETE /connections`
+
+立即关闭所有活跃连接。
+
+| 项目 | 值 |
+|---|---|
+| 鉴权 | 是 |
+| 来源 | `hub/route/connections.go:81` |
+
+**响应**：`204 No Content`。
+
+### 8.3 `DELETE /connections/{id}`
+
+按 UUID 关闭单个连接；找不到 ID 则**静默成功**。
+
+| 项目 | 值 |
+|---|---|
+| 鉴权 | 是 |
+| 来源 | `hub/route/connections.go:73` |
+
+**响应**：`204 No Content`。
+
+**示例**：
+
+```bash
+curl -X DELETE -H 'Authorization: Bearer <secret>' \
+     http://127.0.0.1:9090/connections/f3b50000-...
+```
+
+---
+
+## 9. Cache / DNS / GEO
+
+### 9.1 `POST /cache/fakeip/flush`
+
+清空 Fake-IP 池。
+
+| 项目 | 值 |
+|---|---|
+| 鉴权 | 是 |
+| 来源 | `hub/route/cache.go:18` |
+
+**响应**：
+
+| 状态 | body |
+|---|---|
+| `204 No Content` | 清空成功 |
+| `400` | `resolver.FlushFakeIP` 失败（如 Fake-IP 未启用），`{"message":"<原因>"}` |
+
+### 9.2 `POST /cache/dns/flush`
+
+清空 DNS 解析缓存。
+
+| 项目 | 值 |
+|---|---|
+| 鉴权 | 是 |
+| 来源 | `hub/route/cache.go:28` |
+
+**响应**：`204 No Content`。
+
+### 9.3 `GET /dns/query`
+
+通过 mihomo 内置 resolver 做 DNS 查询，返回 Google DoH 风格的 JSON。
+
+| 项目 | 值 |
+|---|---|
+| 鉴权 | 是 |
+| 来源 | `hub/route/dns.go:22` |
+
+**Query**：
+
+| 名称 | 类型 | 默认 | 说明 |
+|---|---|---|---|
+| `name` | string | — | 待查询域名（自动追加 `.`） |
+| `type` | string | `A` | DNS RR 类型（`A` / `AAAA` / `CNAME` / `TXT` / `MX` / ...，依据 `dns.StringToType`） |
+
+**响应** `200 OK`：
+
+```jsonc
+{
+  "Status": 0,                // dns.Rcode
+  "Question": [{ "Name": "example.com.", "Qtype": 1, "Qclass": 1 }],
+  "TC": false,
+  "RD": true,
+  "RA": true,
+  "AD": false,
+  "CD": false,
+  "Answer": [
+    { "name": "example.com.", "type": 1, "TTL": 60, "data": "93.184.216.34" }
+  ],
+  "Authority": [...],         // 可选
+  "Additional": [...]         // 可选
+}
+```
+
+**错误**：
+
+| 状态 | body |
+|---|---|
+| `400` | `type` 非法 → `{"message":"invalid query type"}` |
+| `500` | DNS section 未启用 → `{"message":"DNS section is disabled"}` |
+| `500` | 解析失败 → `{"message":"<resolver error>"}` |
+
+**示例**：
+
+```bash
+curl -H 'Authorization: Bearer <secret>' \
+     "http://127.0.0.1:9090/dns/query?name=example.com&type=AAAA"
+```
+
+### 9.4 `POST /upgrade/geo`
+
+等同 `POST /configs/geo`（同一 `updateGeoDatabases` handler；仅 `embedMode=false`）。
+
+| 项目 | 值 |
+|---|---|
+| 鉴权 | 是 |
+| 来源 | `hub/route/upgrade.go:21` → `hub/route/configs.go:434` |
+
+### 9.5 `GET /storage/{key}` / `PUT /storage/{key}` / `DELETE /storage/{key}`
+
+通用 JSON key-value 存储，后端是 `component/profile/cachefile` bucket（与 `selected` / `bucketNetworkPolicy` 共用同一 bbolt 文件但独立 bucket）。供宿主持久化任意 UI 状态、偏好、缓存等——mihomo 不解析 value。
+
+| 项目 | 值 |
+|---|---|
+| 鉴权 | 是 |
+| 来源 | `hub/route/storage.go` |
+
+`GET /storage/{key}`：
+
+- 200 + `application/json`，body 为 `PUT` 时存入的 JSON 原样；不存在则返回 `null`（200）。
+
+`PUT /storage/{key}`：
+
+- body 必须是合法 JSON（任意类型：object / array / string / number / bool / null），非法 → `400 {"message":"Body invalid"}`。
+- 上限 `1 MiB`，超限 → `413 {"message":"payload exceeds 1MB limit"}`。
+- 成功 → `204 No Content`；写盘与否受 `store-selected` 的 cachefile 启用状态影响（写入始终发生；读取由 cachefile 层管理持久化）。
+
+`DELETE /storage/{key}`：
+
+- 幂等；key 不存在也返回 `204`。
+
+`{key}` 支持 URL-encoded 字符（调用方编码，服务端 `url.PathUnescape`），空字符串 key 不推荐但不特殊处理。
+
+**示例**：
+
+```bash
+curl -X PUT -H 'Authorization: Bearer <secret>' \
+     -H 'Content-Type: application/json' \
+     -d '{"ui_theme":"dark","collapsed":["home"]}' \
+     http://127.0.0.1:9090/storage/cvr-ui-state
+
+curl -H 'Authorization: Bearer <secret>' \
+     http://127.0.0.1:9090/storage/cvr-ui-state
+# → {"ui_theme":"dark","collapsed":["home"]}
+
+curl -X DELETE -H 'Authorization: Bearer <secret>' \
+     http://127.0.0.1:9090/storage/cvr-ui-state
+```
+
+---
+
+## 10. Lifecycle / Upgrade
+
+### 10.1 `POST /restart`
+
+冷重启内核进程（仅 `embedMode=false`）。
+
+| 项目 | 值 |
+|---|---|
+| 鉴权 | 是 |
+| 来源 | `hub/route/restart.go:24` |
+
+**行为**：
+
+1. 立即 `render.JSON(w, r, {"status":"ok"})` 并 Flush。
+2. 调用 `executor.Shutdown()` 优雅关闭后，在 Windows 用 `exec.Command(...).Start()` + `os.Exit(0)`，在 Unix 用 `syscall.Exec` 替换映像。
+
+**响应**：
+
+| 状态 | body |
+|---|---|
+| `200 OK` | `{"status":"ok"}`（成功安排重启） |
+| `500` | 拿不到自己的 executable 路径 → `{"message":"getting path: <reason>"}` |
+
+> 注意：成功响应是 `200 + body`，**不是** `204`。
+
+### 10.2 `POST /upgrade`
+
+升级内核到最新发布版（仅 `embedMode=false`）。
+
+| 项目 | 值 |
+|---|---|
+| 鉴权 | 是 |
+| 来源 | `hub/route/upgrade.go:25` |
+
+**Query**：
+
+| 名称 | 类型 | 默认 | 说明 |
+|---|---|---|---|
+| `channel` | string | `""`（即 release） | 传给 `updater.DefaultCoreUpdater.Update`；可选 `Alpha`、`Prerelease` 等，由 updater 实现决定 |
+| `force` | bool | `false` | 跳过版本对比直接覆盖 |
+
+**响应**：
+
+| 状态 | body |
+|---|---|
+| `200 OK` | `{"status":"ok"}`，随后异步触发 `restartExecutable` |
+| `500` | 拿不到 executable 路径 / updater 失败 → `{"message":"<原因>"}` |
+
+**示例**：
+
+```bash
+curl -X POST -H 'Authorization: Bearer <secret>' \
+     "http://127.0.0.1:9090/upgrade?channel=alpha&force=true"
+```
+
+### 10.3 `POST /upgrade/ui`
+
+下载 / 更新外置 UI 包（不受 `embedMode` 限制）。
+
+| 项目 | 值 |
+|---|---|
+| 鉴权 | 是 |
+| 来源 | `hub/route/upgrade.go:55` |
+
+**响应**：
+
+| 状态 | body |
+|---|---|
+| `200 OK` | `{"status":"ok"}` |
+| `500` | UI updater 失败 → `{"message":"<原因>"}` |
+
+> 真正的 UI 静态资源由 `external-ui` 配置项决定的目录服务，挂载点见 §12.1。
+
+---
+
+## 11. Network Policy
+
+> handler 位于 `hub/route/network.go`，状态机位于 `component/networkpolicy/manager.go`，通过 `networkpolicy.Global()` 对外提供 singleton。`select` 代理组根据宿主实时推送的"当前处于哪些网络"自动切换代理，同时允许用户手动选择在同一 network 下粘滞。
+
+### 11.0 通用约定
+
+- 路径全部挂在 `/network/context`（单数；REST 资源单实例多动词）。
+- 鉴权：复用 external-controller `secret`，与 `/proxies` 等同。
+- Manager 未初始化（`ApplyConfig` 启动期毫秒级窗口，或配置未包含 `networks:`）→ `PUT` 返回 `503 Service Unavailable` + `{"code":"internal_error","message":"network-policy manager not yet initialized"}`；`GET` 退化为"无 context"响应（`context`/`matched_network`/`expires_at`/`age_seconds` 均 `null`，`groups: []`）；`DELETE` no-op 仍返回 `204`。
+- JSON 字段命名：PUT / GET body 均用 snake_case；对应 `networks:` / `network-policy:` YAML 使用 kebab-case（两侧由归一化对齐）。
+- `version` 字段必填，固定为 `1`；缺失 → `malformed_body`，其它值 → `invalid_version`。
+- **未知顶层字段**：kernel 宽容忽略（用 Go `json.Unmarshal` 默认行为），便于后续 additive 扩展；host 侧 PUT body schema 对未知字段忽略以利 forward-compat，YAML matcher 对未知 key `fail-fast` 以利配置防呆。
+- 缺失字段 = "未知"，不等于 "false / 空串"；`metered` 是 tri-state（`null` / `true` / `false`）。
+- **错误响应包络**（`/network/context` 专用，与其它 endpoint 的 `{"message":"..."}` 不同）：
+
+  ```jsonc
+  {
+    "code": "<short_identifier>",
+    "message": "<human readable>"
+  }
+  ```
+
+  host 按 `code` 做结构化分流，`invalid_field` 的 `message` 遵循 `field: <path>, reason: <why>` 约定。完整 code 表见 §11.5。
+
+- 归一化规则（`NormalizeAndValidate` 在 PUT 入口执行；GET 回显的 `context` 是归一化后副本）：
+  - `dns_suffix[]`：每项 `strings.ToLower` → 去空字符串 → 字典序排序 → 去重；**不做** trim，每项禁止包含逗号 / 空白 / 控制字符（违反 → `invalid_field`）。
+  - `interfaces[].iface_type`：小写；非枚举值 → `invalid_field`。
+  - `interfaces[].bssid` / `interfaces[].gateway_mac`：归一化为小写冒号分隔；非法 MAC → `invalid_field`。
+  - `interfaces[].gateway_ip`：`netip.ParseAddr`；IPv6 strip zone。
+  - `interfaces[].subnets[]`：`netip.ParsePrefix` + `Masked()` + IPv6 strip zone → 字符串序排序 + 去重。
+  - `interfaces[].ssid`：**不**做归一化（IEEE 802.11 octet string 语义，大小写敏感）。
+- 硬上限：`interfaces.len() ≤ 32`（`MaxInterfaces`），超限 → `too_many_interfaces`。
+- TTL 单位秒，**最大 10 年（`315_360_000`）**，超过或 `<= 0` → `invalid_ttl`；省略 = sticky（不自动过期）；想立即清除请用 DELETE。
+- PUT body 大小上限 10 MiB（`http.MaxBytesReader`）——是 DoS 防护，非 wire 契约；正常 body 离此上限很远。
+
+### 11.1 `PUT /network/context`
+
+把宿主采集到的当前活跃接口集合推给内核，触发状态机评估并切换带 `network-policy` 的 `select` 组。
+
+**Body**（`NetworkContext`，对应 `component/networkpolicy/context.go`）：
+
+```jsonc
+{
+  "version": 1,                              // 必填；固定为 1
+  "interfaces": [                            // 必填；可为空数组（"离线"时走 default 兜底）
+    {
+      "name": "wlan0",                       // 必填；集合内唯一；≤ 255 字节
+      "iface_type": "wifi",                  // wifi | ethernet | cellular | wwan | vpn | loopback | other
+      "ssid": "office-5g",                   // ≤ 32 字节；大小写敏感
+      "bssid": "aa:bb:cc:dd:ee:00",          // 归一化为小写冒号
+      "gateway_ip": "10.0.0.1",              // iff sampler 判定该 iface 为默认路由候选
+      "gateway_mac": "11:22:33:44:55:66",    // 仅在 gateway_ip 填充时才能填
+      "subnets": ["10.0.0.0/24"],            // iface 本地地址前缀
+      "metered": false                       // tri-state null / true / false
+    },
+    {
+      "name": "wg0",
+      "iface_type": "vpn"
+    }
+  ],
+  "dns_suffix": ["corp.example.com"],        // 顶层全局；数组；允许 null / 省略（视作空数组）；scalar 被拒
+  "ttl": 1800                                // 可选；秒；省略 = sticky；≤ 0 或 > 10 年 → invalid_ttl
+}
+```
+
+**关键点**：
+
+- `interfaces[]` 有 32 张上限；`name` 必须集合内唯一；重复 → `duplicate_iface_name`。
+- `gateway_mac` 非空但 `gateway_ip` 空 → `invalid_gateway_combo`（反向允许）。
+- `dns_suffix` **不绑定**任何 iface，始终对应顶层系统 DNS search list；matcher `dns-suffix:` 始终映射到这个全局值。
+- `subnets` 只含接口本地地址前缀（`getifaddrs` 级），**不含**路由表 next-hop（例如 WireGuard `AllowedIPs` 不出现在 `subnets`）。
+- 不含 `primary_iface` / `is_primary`：单接口选择权完全由 `networks:` 列表顺序 first-match 决定。
+
+**响应** `200 OK`：
+
+```jsonc
+{
+  "matched_network": "office",               // 命中 first-match 的 network name；未命中（内部 <none>）或无 ctx → JSON null
+  "applied": [                               // 每个带 network-policy 的 select 组各一项，按 YAML 声明顺序
+    {
+      "group": "auto",
+      "target_proxy": "hk",                  // policy 决策目标；可为 null
+      "applied_proxy": "hk",                 // 本轮应用后的当前代理（始终非 null）
+      "changed": true,                       // 本次是否真的调用了 selector.Set()
+      "selection_source": "auto",            // auto | manual | unknown
+      "reason": "matched"                    // 见下方枚举
+    }
+  ],
+  "expires_at": 1713401800                   // sticky 时为 null
+}
+```
+
+**`reason` 七种枚举**（与 `component/networkpolicy/policy.go` 的 `ReasonXxx` 常量 1:1）：
+
+| reason | 触发条件 | 是否更新 `last_matched_network` |
+|---|---|---|
+| `matched` | Match 命中 N，Mapping[N] 有 target，已成功 Set | 是（设为 N） |
+| `already_selected` | 同 `matched`，但 target 等于当前选择，未调 Set | 是（设为 N） |
+| `default` | Match 未命中 / 命中但 Mapping 无 target；policy 有 `default` 且 target 在候选中 → 切到 default | 是（命中为 N，未命中为 `<none>`） |
+| `no_change_no_default` | 同 `default` 左半触发条件，但 policy **无** `default` → 保持当前选择，source 仍重置为 auto | 是 |
+| `unchanged_network` | matched（含 `<none>`）与本组 `last_matched_network` 相同且 `source == auto` → 跳过评估 | 否 |
+| `manual_locked` | matched（含 `<none>`）与本组 `last_matched_network` 相同且 `source == manual` → 尊重手动选择 | 否 |
+| `missing_target` | policy 求得非空 target 但不在本组当前候选（provider 缺失）→ 跳过切换；source / last_matched 不变 | 否 |
+
+**手动 / 自动状态机（manual-wins）**：
+
+1. 用户手动 `PUT /proxies/:name` → 该组 `selection_source = manual`；`last_matched_network` 不变。
+2. 下次 `PUT /network/context`：
+   - matched 未变 + `source=manual` → `manual_locked`。
+   - matched 变了且评估落入 `matched` / `already_selected` / `default` / `no_change_no_default` → auto 流程接管，`source` 重置为 `auto`，`last_matched` 前进。
+   - matched 变了但评估落入 `missing_target`（target 暂不可达）→ source / last_matched 都保留，等下次 PUT 重试。
+
+**TTL 轻量路径**（§5.6.3）：当以下五个条件全部满足时，PUT 不进 manager 串行队列、不重评估、不写 cachefile，只刷新 `expires_at`：
+(a) 归一化后 ctx fingerprint 与缓存相同；(b) 本次 body 带 `ttl`；(c) 缓存 ctx 已带 `ttl`；(d) 无任何组处于 `missing_target` 待重试；(e) 自上次评估以来候选集未变（provider 未 refresh）。其它所有情况走完整评估路径。
+
+**错误响应**：见 §11.5 code 表。
+
+**示例**：
+
+```bash
+curl -X PUT \
+     -H 'Authorization: Bearer <secret>' \
+     -H 'Content-Type: application/json' \
+     -d '{
+           "version": 1,
+           "interfaces": [
+             {"name":"wlan0","iface_type":"wifi","ssid":"office-5g","gateway_ip":"10.0.0.1"}
+           ],
+           "dns_suffix": ["corp.example.com"],
+           "ttl": 1800
+         }' \
+     http://127.0.0.1:9090/network/context
+```
+
+离线（host 确认没有活跃 iface）推荐：
+
+```bash
+curl -X PUT -H 'Authorization: Bearer <secret>' -H 'Content-Type: application/json' \
+     -d '{"version":1,"interfaces":[]}' http://127.0.0.1:9090/network/context
+```
+
+这会让内核按 `matched_network=<none>` 走 `default` / `no_change_no_default` 分支。**不要**发 DELETE 表达离线——DELETE 保留状态机、不走 default，见 §11.2。
+
+### 11.2 `DELETE /network/context`
+
+清除内核缓存的 ctx 快照（让"当前 ctx"视作 nil）。**不是**"状态机重置"：
+
+- 各组 `selection_source` / `last_matched_network` / 已 selected proxy **全部保留**。
+- **不触发评估、不写 cachefile、不走 `default`**。
+- 若存在 ctx → 清快照 + 取消 TTL timer；若无 ctx → no-op。**两种情况都返回 `204`**。
+
+用途限定三种场景：
+1. host 进程 clean shutdown（放弃当前对话但不抹掉用户 manual 选择）；
+2. host 显式想"kernel 侧无 ctx，保留状态机"；
+3. TTL 自然失效（内核自动触发，等价 DELETE 语义，host 不参与）。
+
+下次 PUT 到来时按保留的 `source` / `last_matched_network` 继续走 §11.1 状态机——特别是"manual 选择在同一 network 下继续尊重"语义继续生效。
+
+**响应**：
+
+| 状态 | body | 场景 |
+|---|---|---|
+| `204 No Content` | 空 | 成功（无论原先有无 ctx） |
+
+**示例**：
+
+```bash
+curl -X DELETE -H 'Authorization: Bearer <secret>' \
+     http://127.0.0.1:9090/network/context
+```
+
+### 11.3 `GET /network/context`
+
+返回当前 ctx 快照 + 各组状态机快照，供 host 做周期性诊断刷新。
+
+**响应** `200 OK`：
+
+```jsonc
+{
+  "context": {                                // 归一化后的 PUT body；无 ctx 时为 null
+    "version": 1,
+    "interfaces": [
+      {"name":"wlan0","iface_type":"wifi","ssid":"office-5g","gateway_ip":"10.0.0.1"}
+    ],
+    "dns_suffix": ["corp.example.com"]
+    // ttl 不回显（用 expires_at + age_seconds 代替）
+  },
+  "matched_network": "office",                // wire null 编码见下方
+  "groups": [                                 // 仅带 `network-policy` 的 select 组，按 YAML 声明顺序
+    {
+      "group": "auto",
+      "current_proxy": "hk",
+      "selection_source": "auto",             // auto | manual | unknown
+      "last_matched_network": "office"        // wire null 编码见下方
+    }
+  ],
+  "expires_at": 1713401800,                   // sticky 或无 ctx 时为 null
+  "age_seconds": 42                           // 自上次 PUT 以来的秒数；无 ctx 时为 null
+}
+```
+
+**无 ctx 时**（冷启动未 PUT / DELETE 后 / TTL 过期后）：`context` / `matched_network` / `expires_at` / `age_seconds` 全为 `null`，`groups[]` 仍按"每组一项"返回（含 `current_proxy` / `selection_source` / `last_matched_network`）。host 轮询逻辑不必做 200-vs-404 分支。
+
+**`matched_network` / `last_matched_network` 的 wire null 编码**：
+
+| 内部状态 | 含义 | wire JSON |
+|---|---|---|
+| 具体 name（如 `"office"`） | 评估命中 | JSON string `"office"` |
+| `<none>`（内部哨兵） | 评估时 Match 未命中任一 network | JSON `null` |
+| `nil`（仅 `last_matched_network` 可能是） | 从未评估过 | JSON `null` |
+
+wire 层不暴露 `"<none>"` 字面量。host 可以配合 `selection_source` 推断内部状态：
+
+- `source=unknown` + `last_matched_network=null` → 从未评估（内部 `nil`）。
+- `source=auto` + `last_matched_network=null` → 已评估但未命中（内部 `<none>`）。
+- `source=manual` + `last_matched_network=null` → **二义**：既可能是"首次 PUT 前先手动切"（内部 `nil`），也可能是"已评估无命中后再手动切"（内部 `<none>`）。host 一般不需要完全反推这两种情形；如需区分应结合自身交互上下文。
+
+**示例**：
+
+```bash
+curl -H 'Authorization: Bearer <secret>' http://127.0.0.1:9090/network/context
+```
+
+### 11.4 与 `PUT /proxies/{name}` 的协作
+
+`PUT /proxies/{name}` 用于切换 select 组的选择。若被切换的组带 `network-policy` 字段，`proxies.go` 在 `selector.Set` 成功返回后调用 `networkpolicy.Global().HandleManualSet(name)`：
+
+- 该组 `selection_source` 被标为 `manual`；`last_matched_network` 不变。
+- 下次 `PUT /network/context` 时状态机按 §11.1 "手动 / 自动状态机"处理（同一 network 下 `manual_locked`；network 变化时 auto 接管）。
+- 锁序：`globalMu → selector.mu → manager.mu`——hook 在 `selector.Set()` 返回**之后**调用（不持有 `selector.mu`），避免与 `manager.PutContext` 的锁序倒置。
+- 不带 `network-policy` 的 select 组不进 hook；传统 `PUT /proxies/{name}` 行为完全不变。
+- `PUT /proxies/{name}` 的外部契约（path / body / status / `SwitchProxiesCallback`）与既有 mihomo 行为等价。
+
+### 11.5 错误响应 code 表
+
+`/network/context` 三个 endpoint 共享下表（遵循 §11.0 的 `{"code","message"}` 包络）；`code` 是稳定标识，`message` 仅人类可读：
+
+| code | HTTP | 场景 |
+|---|---|---|
+| `malformed_body` | 400 | JSON 解析失败 / 顶层非 object / 缺必填（`version` / `interfaces`）/ `dns_suffix` 非数组等字段形态错误（按 Go `encoding/json` 行为，字符串内非法 UTF-8 字节会被替换为 `U+FFFD` 而非拒绝） |
+| `invalid_version` | 400 | `version != 1` |
+| `invalid_ttl` | 400 | `ttl <= 0` 或 `> 10 年` |
+| `too_many_interfaces` | 400 | `interfaces.len() > 32` |
+| `duplicate_iface_name` | 400 | `interfaces[]` 中 `name` 重复 |
+| `invalid_field` | 400 | 字段级校验失败（MAC / IP / CIDR / enum 格式错误；`name` 为空或 > 255 字节；`ssid` > 32 字节；`dns_suffix[]` 含逗号 / 空白 / 控制字符等）。`message` 采用 `field: <path>, reason: <why>` 约定 |
+| `invalid_gateway_combo` | 400 | `gateway_mac` 填充但 `gateway_ip` 为空 |
+| `internal_error` | 5xx | 未归类错误，包含 Manager 未初始化（配置未挂接 / 启动未完成） |
+
+**host 处理建议**：
+- `4xx` + 已知 code → log error 字段级内容，**不自动 retry**（配置 bug，retry 会放大日志）。
+- `4xx` + `internal_error` / 未知 code → log 原样 payload。
+- `5xx` → 按现有 retry 策略退避重试。
+
+### 11.6 Listener 契约对应
+
+`GET /configs` 的 `tun.device` 字段返回 listener 实际 bound 的 iface 名（`tunLister.Config().Device`），所有 Device 解析路径（auto-detect / invalid name / fd-override）在进入 `sing_tun.New` 成功后都把解析结果写回 `options.Device`。这让 host sampler 能用 `/configs.tun.device` 过滤"mihomo 自己的 TUN"，避免把它当成用户装的 VPN 上报给 `PUT /network/context`。
+
+**caveats**：
+- macOS utun 上的名字仍是 `CalculateInterfaceName()` 的 pre-bind 估计（"扫描空闲 utunN"），不是严格的 post-bind ground truth——极端竞争下可能与实际 bind 名不一致。
+- fd-override 路径在 `getTunnelName(fd)` 失败时 `options.Device` 退回调用方原值（可能为空串）。
+
+---
+
+## 12. UI / DoH
+
+### 12.1 `GET /ui` / `GET /ui/*`
+
+仅当 `external-ui` 配置非空时挂载。
+
+| 项目 | 值 |
+|---|---|
+| 鉴权 | 否（不在 `r.Group` 之内） |
+| 来源 | `hub/route/server.go:144` |
+
+**行为**：
+
+- `GET /ui` → `307 Temporary Redirect` → `/ui/`
+- `GET /ui/*` → 从 `external-ui` 指定的目录里 `http.FileServer` 服务静态资源（前缀剥离 `/ui`）。
+
+资源更新见 `POST /upgrade/ui`（§10.3）。
+
+### 12.2 DoH `external-doh-server`
+
+仅当配置 `external-doh-server` 以 `/` 开头时把 `dohRouter()` 挂到该路径下，作为 RFC 8484 的 DoH 端点。
+
+| 项目 | 值 |
+|---|---|
+| 鉴权 | 否（在 `r.Group` 之外） |
+| 来源 | `hub/route/server.go:152`、`hub/route/doh.go:14` |
+
+**支持方法**：`GET` 与 `POST`。
+
+- **GET**：`?dns=<base64url(dns wire format)>`。请求示例：
+  ```bash
+  curl -H 'Accept: application/dns-message' \
+       "https://controller.example.com/dns-query?dns=..."
+  ```
+- **POST**：必须 `Content-Type: application/dns-message`，body 是 ≤ 65535 B 的 DNS wire format。
+  ```bash
+  curl -X POST \
+       -H 'Content-Type: application/dns-message' \
+       --data-binary @query.bin \
+       https://controller.example.com/dns-query
+  ```
+
+**响应**：
+
+| 状态 | Content-Type | body |
+|---|---|---|
+| `200 OK` | `application/dns-message` | DNS wire format（resolver 返回值） |
+| `405` | `text/plain` | `method not allowed` |
+| `500` | `text/plain` | `DNS section is disabled` / `invalid content-type` / `<error>` |
+
+> 与 `/dns/query` 不同：`/dns/query` 是 mihomo 自定义的 JSON GET，`dohRouter` 是标准 DoH。
+
+---
+
+## 13. Debug
+
+> 仅当 `Config.IsDebug=true`（命令行 `-d`）时挂载，且 **不在已认证 group 之内** —— 不要把 debug + 非 loopback 暴露在外网。
+
+挂载点：`/debug/*`。
+
+| 子路径 | 方法 | 来源 | 说明 |
+|---|---|---|---|
+| `PUT /debug/gc` | PUT | `hub/route/server.go:109` | 触发 `runtime/debug.FreeOSMemory()`；无响应体（200 + 空 body） |
+| `/debug/pprof/*` | GET | `chi/middleware.Profiler` | 标准 `net/http/pprof` 路径：`/debug/pprof/`、`/debug/pprof/heap`、`/debug/pprof/profile?seconds=30`、`/debug/pprof/goroutine?debug=2` 等 |
+
+**示例**：
+
+```bash
+# 触发 GC
+curl -X PUT http://127.0.0.1:9090/debug/gc
+
+# 抓取 30 秒 CPU profile
+curl -o cpu.pprof "http://127.0.0.1:9090/debug/pprof/profile?seconds=30"
+
+# 查看 goroutine 堆栈
+curl "http://127.0.0.1:9090/debug/pprof/goroutine?debug=2"
+```
+
+---
+
+## 14. 错误体与状态码索引
+
+### 14.1 错误体
+
+```jsonc
+// HTTPError（绝大多数 4xx/5xx）
+{ "message": "Body invalid" }
+
+// Network-policy envelope（仅 /network/context 三个 endpoint；详见 §11.5）
+{ "code": "invalid_field", "message": "field: interfaces[0].gateway_ip, reason: parse error" }
+
+// 上游兼容形态（仅以下 endpoint）
+{ "status": "ok" }              // POST /restart, POST /upgrade, POST /upgrade/ui
+
+// DoH（text/plain，非 JSON）
+"DNS section is disabled"
+```
+
+预定义 sentinel（`hub/route/errors.go`）：
+
+| 变量 | message |
+|---|---|
+| `ErrUnauthorized` | `Unauthorized` |
+| `ErrBadRequest` | `Body invalid` |
+| `ErrForbidden` | `Forbidden` |
+| `ErrNotFound` | `Resource not found` |
+| `ErrRequestTimeout` | `Timeout` |
+
+### 14.2 状态码用例汇总
+
+| 状态码 | 出现位置 |
+|---|---|
+| `200` | 所有 GET 成功；`PUT /proxies/.../delay`；`POST /restart` / `POST /upgrade` 的成功回执；`PUT /network/context` 成功 |
+| `204` | `PUT /proxies/{name}`、`DELETE /proxies/{name}`、`PATCH /configs`、`PUT /configs`、`POST /configs/geo`、`PATCH /rules/disable`、`DELETE /connections*`、`POST /cache/*`、`PUT /providers/{name}`、`GET /providers/{name}/healthcheck`、`DELETE /network/context` |
+| `307` | `GET /ui` → `/ui/` |
+| `400` | body 解析失败、参数非法、`Selector` 操作不合法、`ManualSet` 触发的 `ErrNotSelectable` / `ErrProxyNotExist`、`NormalizeAndValidate` 报错 |
+| `401` | 鉴权失败（`Authorization` 头或 `?token=` 不匹配） |
+| `404` | `findProxyByName` / `findProviderByName` / `findRuleProviderByName` / `findProviderProxyByName` 找不到资源 |
+| `405` | `wsUpgrade` 非 GET 方法、DoH 非 GET/POST |
+| `426` | WebSocket 升级时 `Sec-WebSocket-Version` 不为 `13` |
+| `500` | DNS 未启用、updater 失败、写盘失败、获取自身路径失败、防御性兜底 |
+| `503` | `provider.Update()` 失败、`/proxies/.../delay` 失败但未超时、`networkpolicy` Manager 未就绪 |
+| `504` | `/proxies/.../delay`、`/group/.../delay` 超时 |
+
+---
+
+## 15. 路由总表
+
+| Method | Path | 鉴权 | 来源 | embedMode 屏蔽 |
+|---|---|---|---|---|
+| GET | `/` | 是 | `server.go:121` | 否 |
+| GET | `/version` | 是 | `server.go:125` | 否 |
+| GET | `/traffic` | 是（HTTP/WS） | `server.go:123` | 否 |
+| GET | `/memory` | 是（HTTP/WS） | `server.go:124` | 否 |
+| GET | `/logs` | 是（HTTP/WS） | `server.go:122` | 否 |
+| GET | `/configs` | 是 | `configs.go:27` | 否 |
+| PUT | `/configs` | 是 | `configs.go:29` | 是 |
+| PATCH | `/configs` | 是 | `configs.go:31` | 是 |
+| POST | `/configs/geo` | 是 | `configs.go:30` | 是 |
+| GET | `/proxies` | 是 | `proxies.go:28` | 否 |
+| GET | `/proxies/{name}` | 是 | `proxies.go:32` | 否 |
+| GET | `/proxies/{name}/delay` | 是 | `proxies.go:33` | 否 |
+| PUT | `/proxies/{name}` | 是 | `proxies.go:34` | 否 |
+| DELETE | `/proxies/{name}` | 是 | `proxies.go:35` | 否 |
+| GET | `/group` | 是 | `groups.go:21` | 否 |
+| GET | `/group/{name}` | 是 | `groups.go:25` | 否 |
+| GET | `/group/{name}/delay` | 是 | `groups.go:26` | 否 |
+| GET | `/rules` | 是 | `rules.go:16` | 否 |
+| PATCH | `/rules/disable` | 是 | `rules.go:18` | 是 |
+| GET | `/connections` | 是（HTTP/WS） | `connections.go:18` | 否 |
+| DELETE | `/connections` | 是 | `connections.go:19` | 否 |
+| DELETE | `/connections/{id}` | 是 | `connections.go:20` | 否 |
+| GET | `/providers/proxies` | 是 | `provider.go:18` | 否 |
+| GET | `/providers/proxies/{providerName}` | 是 | `provider.go:22` | 否 |
+| PUT | `/providers/proxies/{providerName}` | 是 | `provider.go:23` | 否 |
+| GET | `/providers/proxies/{providerName}/healthcheck` | 是 | `provider.go:24` | 否 |
+| GET | `/providers/proxies/{providerName}/{name}` | 是 | `provider.go:34` | 否 |
+| GET | `/providers/proxies/{providerName}/{name}/healthcheck` | 是 | `provider.go:35` | 否 |
+| GET | `/providers/rules` | 是 | `provider.go:115` | 否 |
+| PUT | `/providers/rules/{name}` | 是 | `provider.go:118` | 否 |
+| POST | `/cache/fakeip/flush` | 是 | `cache.go:13` | 否 |
+| POST | `/cache/dns/flush` | 是 | `cache.go:14` | 否 |
+| GET | `/dns/query` | 是 | `dns.go:18` | 否 |
+| POST | `/restart` | 是 | `restart.go:20` | 是（整段不挂载） |
+| POST | `/upgrade` | 是 | `upgrade.go:19` | 是 |
+| POST | `/upgrade/geo` | 是 | `upgrade.go:20` | 是 |
+| POST | `/upgrade/ui` | 是 | `upgrade.go:17` | 否 |
+| GET | `/storage/{key}` | 是 | `storage.go:16` | 否 |
+| PUT | `/storage/{key}` | 是 | `storage.go:17` | 否 |
+| DELETE | `/storage/{key}` | 是 | `storage.go:18` | 否 |
+| PUT | `/network/context` | 是 | `network.go:putNetworkContext` | 否 |
+| DELETE | `/network/context` | 是 | `network.go:deleteNetworkContext` | 否 |
+| GET | `/network/context` | 是 | `network.go:getNetworkContext` | 否 |
+| GET | `/ui`、`/ui/*` | 否 | `server.go:144`（条件挂载） | 否 |
+| GET/POST | `<external-doh-server path>` | 否 | `server.go:152`（条件挂载） | 否 |
+| PUT | `/debug/gc` | 否 | `server.go:109`（仅 IsDebug） | 否 |
+| ANY | `/debug/pprof/*` | 否 | `chi/middleware.Profiler`（仅 IsDebug） | 否 |
+
+---
+
+## 16. 与 Clash Premium / Clash Meta API 的差异提示
+
+mihomo 在 Clash Premium 基础上扩展了若干字段与 endpoint，本节仅列出与"原版 Clash"显著差异的点：
+
+- `/proxies/{name}` 输出的字段集更广（`alive` / `extra` / `xudp` / `tfo` / `mptcp` / `smux` / `provider-name` / `dialer-proxy` 等）。
+- `/group/{name}/delay` 的副作用：对 Selector 之外的组会重置 fixed 状态。
+- `/rules` 输出新增 `extra`（hit/miss 计数），`size`（GEOIP/GEOSITE 包含数）。
+- `PATCH /rules/disable`、`POST /upgrade`、`POST /upgrade/ui`、`/dns/query`、`/cache/fakeip/flush` 等 endpoint 是 mihomo 新增。
+- `/version` 返回 `meta: true`。
+- `/network/context`（见 §11）是 mihomo 的 network-policy 控制面。
+
+---
+
+> 文档末尾。如需对接 mihomo API，建议优先以本文档与 `hub/route/` 源码为准；上游 OpenAPI 工作（如 [clash-meta-api-doc](https://github.com/MetaCubeX/Clash.Meta.Doc)）可作辅助参考但与本仓库行为可能略有差异。

--- a/docs/config.yaml
+++ b/docs/config.yaml
@@ -2169,7 +2169,8 @@ listeners:
 # 让 `select` 代理组按当前网络环境自动切换。宿主（如 clash-verge-rev）
 # 通过 `PUT /network/context` 推送活跃接口集合，内核按 `networks:` 规则
 # 顺序 first-match 定名；之后每个带 `network-policy:` 的 select 组按命中
-# 的 network name 查表切到对应代理。详见 docs/network-policy.md。
+# 的 network name 查表切到对应代理。完整字段 / 组合子语义 / REST 契约详见
+# docs/api.md §11。
 
 # networks:
 #   # 规则按列表顺序 first-match；顶层多个 per-iface 字段要求同一张

--- a/docs/config.yaml
+++ b/docs/config.yaml
@@ -2164,3 +2164,63 @@ listeners:
 #  alpn:
 #    - h3
 #  max-udp-relay-packet-size: 1500
+
+# 网络策略（network-policy）
+# 让 `select` 代理组按当前网络环境自动切换。宿主（如 clash-verge-rev）
+# 通过 `PUT /network/context` 推送活跃接口集合，内核按 `networks:` 规则
+# 顺序 first-match 定名；之后每个带 `network-policy:` 的 select 组按命中
+# 的 network name 查表切到对应代理。详见 docs/network-policy.md。
+
+# networks:
+#   # 规则按列表顺序 first-match；顶层多个 per-iface 字段要求同一张
+#   # iface 同时满足（原子 AND），跨 iface 的 AND 用 `all:` 显式拆开。
+#   - name: home
+#     match:
+#       ssid: home-network
+#       iface-type: wifi
+#   - name: office
+#     match:
+#       any:                         # OR：任一子表达式命中即可
+#         - ssid: [office-5g, office-2.4g]
+#         - gateway-mac: "aa:bb:cc:dd:ee:00"
+#   - name: corp-vpn
+#     match:
+#       all:                         # AND 跨 iface：Wi-Fi + VPN 共存
+#         - iface-type: wifi
+#         - iface-type: vpn
+#           dns-suffix: corp.example.com
+#   - name: mobile
+#     match:
+#       any:
+#         - iface-type: cellular     # 内置 modem / 手机热点
+#         - iface-type: wwan         # USB / PCIe 蜂窝模块
+#
+# network-policy 写在 `select` 类型的代理组里。Mapping 的 key 是
+# `networks[].name`（或特殊键 `default`），value 必须是该组当前可见的候
+# 选代理名：
+#   - `proxies:` 里显式列出的代理（含 DIRECT / REJECT 等内置 outbound）：
+#     parse-time fail-fast
+#   - `use:` / `include-all-providers` / `include-all` 展开的 provider 节
+#     点：parse-time 宽容，首次 PUT 时再判 missing_target
+#
+# proxy-groups:
+#   - name: "auto-region"
+#     type: select
+#     proxies: [hk, us, jp, DIRECT]
+#     network-policy:
+#       home: hk                     # 在家走香港
+#       office: us                   # 公司走美国
+#       corp-vpn: DIRECT             # 进 VPN 直连（公司内网）
+#       mobile: jp                   # 4G 场景走日本
+#       default: hk                  # 未命中任何 network（或命中但本组无对应 mapping）时的兜底
+#
+# 关键语义（摘要）：
+# - 用户手动 PUT /proxies/:name 切换后该组进入 manual 状态，同一 network
+#   下后续 PUT 不覆盖；切换到新 network 时自动恢复为 auto（但若新 network
+#   求得的目标代理当前不在候选中，本轮按 missing_target 保留原状态，等
+#   下次 PUT 重试）
+# - `default` 是 Mapping 的一个保留 key，语义是"未命中任何 network（含
+#   matched=<none>）**或命中但本组 Mapping 无对应 target** 时的兜底目标"；
+#   若省略则保持当前选择不变
+# - YAML matcher 对未知 key 严格 fail-fast（例如误写 `metered:` 会报配
+#   置错误）——wire 层对未知字段宽容忽略，两边策略有意非对称

--- a/hub/executor/executor.go
+++ b/hub/executor/executor.go
@@ -491,7 +491,7 @@ func collectNetworkPolicySelectors(groupOrder []string, proxies map[string]C.Pro
 		if !ok {
 			continue
 		}
-		sel, ok := p.Adapter().(*outboundgroup.Selector)
+		sel, ok := p.Adapter().(networkpolicy.SelectorWithPolicy)
 		if !ok {
 			continue
 		}

--- a/hub/executor/executor.go
+++ b/hub/executor/executor.go
@@ -21,6 +21,7 @@ import (
 	mihomoHttp "github.com/metacubex/mihomo/component/http"
 	"github.com/metacubex/mihomo/component/iface"
 	"github.com/metacubex/mihomo/component/keepalive"
+	"github.com/metacubex/mihomo/component/networkpolicy"
 	"github.com/metacubex/mihomo/component/profile"
 	"github.com/metacubex/mihomo/component/profile/cachefile"
 	"github.com/metacubex/mihomo/component/resolver"
@@ -115,6 +116,13 @@ func ApplyConfig(cfg *config.Config, force bool) {
 	initInnerTcp()
 	loadProvider(cfg.Providers)
 	updateProfile(cfg)
+	// network-policy depends only on proxy providers (for candidate-set
+	// visibility) and on patchSelectGroup having restored each
+	// Selector's `selected` value. Rule providers are irrelevant to
+	// its barrier — per architecture §5.6.2 "按组独立屏障 / 不采用全局
+	// 屏障", the barrier release must not wait on the slowest rule
+	// provider. So it runs BEFORE loadProvider(cfg.RuleProviders).
+	updateNetworkPolicy(cfg)
 	loadProvider(cfg.RuleProviders)
 	runtime.GC()
 	tunnel.OnRunning()
@@ -447,6 +455,51 @@ func updateProfile(cfg *config.Config) {
 	if profileCfg.StoreSelected {
 		patchSelectGroup(cfg.Proxies)
 	}
+}
+
+// updateNetworkPolicy installs or migrates the network-policy Manager.
+//
+// Ordering within ApplyConfig matters and is enforced by the call site:
+//   - updateProxies builds the proxy map (so Selectors exist).
+//   - loadProvider(cfg.Providers) blocks until all providers finish
+//     Initial() — by the time this function runs, provider-backed
+//     candidate sets are populated (or gave up), so the Manager's
+//     per-group barrier can be released immediately.
+//   - updateProfile / patchSelectGroup restores each Selector's
+//     `selected` from bucketSelected BEFORE the Manager inspects Now().
+//
+// After Install, ForceReEvaluate runs unconditionally: on a first-time
+// cold start it's a no-op (no cached ctx), and on hot reload it
+// re-runs evaluation against the inherited ctx so YAML policy edits
+// take effect (§5.8.3).
+func updateNetworkPolicy(cfg *config.Config) {
+	selectors := collectNetworkPolicySelectors(cfg.ProxyGroupOrder, cfg.Proxies)
+	mgr := networkpolicy.Install(cfg.Networks, selectors, cachefile.Cache())
+	mgr.ForceReEvaluate()
+}
+
+// collectNetworkPolicySelectors walks proxy groups in YAML declaration
+// order and returns the Selectors that carry a non-empty network-policy.
+// Architecture §5.4.2 requires applied[] / groups[] in REST responses to
+// reflect the user-authored ordering, so the iteration order here
+// propagates straight into Manager.groupsOrder.
+func collectNetworkPolicySelectors(groupOrder []string, proxies map[string]C.Proxy) []networkpolicy.SelectorWithPolicy {
+	out := make([]networkpolicy.SelectorWithPolicy, 0, len(groupOrder))
+	for _, name := range groupOrder {
+		p, ok := proxies[name]
+		if !ok {
+			continue
+		}
+		sel, ok := p.Adapter().(*outboundgroup.Selector)
+		if !ok {
+			continue
+		}
+		if sel.NetworkPolicy().IsEmpty() {
+			continue
+		}
+		out = append(out, sel)
+	}
+	return out
 }
 
 func patchSelectGroup(proxies map[string]C.Proxy) {

--- a/hub/executor/executor.go
+++ b/hub/executor/executor.go
@@ -476,6 +476,7 @@ func updateNetworkPolicy(cfg *config.Config) {
 	selectors := collectNetworkPolicySelectors(cfg.ProxyGroupOrder, cfg.Proxies)
 	mgr := networkpolicy.Install(cfg.Networks, selectors, cachefile.Cache())
 	mgr.ForceReEvaluate()
+	warnNetworkPolicyExternalController(cfg)
 }
 
 // collectNetworkPolicySelectors walks proxy groups in YAML declaration

--- a/hub/executor/network_policy_warn.go
+++ b/hub/executor/network_policy_warn.go
@@ -1,0 +1,136 @@
+package executor
+
+import (
+	"net"
+	"strings"
+
+	"github.com/metacubex/mihomo/component/networkpolicy"
+	"github.com/metacubex/mihomo/config"
+	C "github.com/metacubex/mihomo/constant"
+	"github.com/metacubex/mihomo/log"
+)
+
+// warnNetworkPolicyExternalController emits a WARN log when the
+// external-controller endpoint is exposed in a way that lets anyone on
+// the network manipulate proxy selection via PUT /network/context (and
+// therefore override the user's manual choices via the network-policy
+// state machine).
+//
+// Conditions for the warning (architecture §5.2.1):
+//   - network-policy is configured (at least one select group has a
+//     non-empty GroupPolicy)
+//   - external-controller is enabled AND not bound to loopback
+//   - no Secret is set
+//   - AND the endpoint is not protected by strong mutual-TLS
+//     (external-controller-tls with client-auth-cert AND ClientAuthType
+//     == "require-and-verify" exempts the warning; weaker auth modes
+//     like "request" / "verify-if-given" / empty do not)
+//
+// Scope: only the TCP and TLS endpoints are considered. Unix-socket
+// (`external-controller-unix`) and named-pipe
+// (`external-controller-pipe`) bindings rely on filesystem-level
+// permissions (POSIX modes / Windows ACLs) for access control and are
+// outside the scope of this warning per architecture §5.2.1.
+//
+// The warning is informational — the network-policy feature still
+// works; mihomo does not block or reconfigure anything. Users who
+// understand the implication (e.g., LAN-only deployments behind a
+// trusted firewall) can ignore it.
+func warnNetworkPolicyExternalController(cfg *config.Config) {
+	if cfg == nil || cfg.Controller == nil {
+		return
+	}
+	if !hasAnyNetworkPolicyGroup(cfg.Proxies) {
+		return
+	}
+
+	ctrl := cfg.Controller
+	plainExposed := isNonLoopbackBind(ctrl.ExternalController)
+	tlsExposed := isNonLoopbackBind(ctrl.ExternalControllerTLS)
+
+	if !plainExposed && !tlsExposed {
+		return
+	}
+
+	// A non-empty secret guards both plain and TLS endpoints.
+	if ctrl.Secret != "" {
+		return
+	}
+
+	// TLS endpoint with strong mutual-TLS (cert + require-and-verify)
+	// is considered protected; in that case the warning only applies
+	// if the plain endpoint is also exposed.
+	if tlsExposed && !plainExposed && cfg.TLS != nil && hasStrongClientAuth(cfg.TLS) {
+		return
+	}
+
+	log.Warnln("[NetworkPolicy] external-controller is bound to a non-loopback address without a secret while network-policy is configured; any client that can reach the controller can manipulate proxy selection. Set `secret:` (or bind to loopback, or configure external-controller-tls with `tls.client-auth-type: require-and-verify` + `tls.client-auth-cert`) to restrict access.")
+}
+
+// isNonLoopbackBind reports whether the external-controller bind string
+// resolves to a non-loopback host. Empty / unparseable values return
+// false (endpoint effectively not exposed as far as this check is
+// concerned). A bare ":9090" binds to all interfaces → non-loopback.
+//
+// Hostname handling is intentionally a static allowlist of well-known
+// loopback aliases ("localhost", "ip6-localhost", "ip6-loopback")
+// rather than a DNS lookup: doing net.LookupHost at startup would block
+// on a flaky resolver, and the warning is informational anyway.
+// Custom /etc/hosts aliases that map to loopback may produce a false-
+// positive warning; the user can either use the canonical name or
+// ignore the warning.
+func isNonLoopbackBind(addr string) bool {
+	if addr == "" {
+		return false
+	}
+	host, _, err := net.SplitHostPort(addr)
+	if err != nil {
+		// No host:port separator; treat as unparseable → conservative
+		// false (don't warn on a malformed spec; the controller will
+		// fail to bind anyway and produce its own error).
+		return false
+	}
+	if host == "" {
+		// e.g. ":9090" — binds to all interfaces.
+		return true
+	}
+	ip := net.ParseIP(host)
+	if ip == nil {
+		// Static allowlist of well-known loopback hostname aliases.
+		// Anything else → conservatively assume the operator meant
+		// "exposed" and emit the warning.
+		switch strings.ToLower(host) {
+		case "localhost", "ip6-localhost", "ip6-loopback":
+			return false
+		}
+		return true
+	}
+	return !ip.IsLoopback()
+}
+
+// hasStrongClientAuth reports whether the TLS config enforces
+// certificate-based mutual authentication strong enough to exempt the
+// warning. Requires both a client-auth certificate and the strictest
+// auth type Go's crypto/tls accepts — any weaker mode (request,
+// verify-if-given, require-any) doesn't actually reject unauthorized
+// clients.
+func hasStrongClientAuth(tls *config.TLS) bool {
+	if tls == nil || tls.ClientAuthCert == "" {
+		return false
+	}
+	return strings.EqualFold(tls.ClientAuthType, "require-and-verify")
+}
+
+// hasAnyNetworkPolicyGroup returns true if any proxy group carries a
+// non-empty network-policy subfield, i.e., the network-policy feature
+// is in use for this configuration.
+func hasAnyNetworkPolicyGroup(proxies map[string]C.Proxy) bool {
+	for _, p := range proxies {
+		if np, ok := p.Adapter().(networkpolicy.SelectorWithPolicy); ok {
+			if !np.NetworkPolicy().IsEmpty() {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/hub/executor/network_policy_warn_test.go
+++ b/hub/executor/network_policy_warn_test.go
@@ -1,0 +1,55 @@
+package executor
+
+import (
+	"testing"
+
+	"github.com/metacubex/mihomo/config"
+)
+
+func TestIsNonLoopbackBind(t *testing.T) {
+	cases := []struct {
+		addr string
+		want bool
+	}{
+		{"", false},                    // empty → not exposed
+		{"127.0.0.1:9090", false},      // IPv4 loopback
+		{"[::1]:9090", false},          // IPv6 loopback
+		{"localhost:9090", false},      // hostname
+		{"LocalHost:9090", false},      // case-insensitive hostname
+		{"ip6-localhost:9090", false},  // IPv6 alias
+		{"ip6-loopback:9090", false},   // alternate IPv6 alias
+		{":9090", true},                // bind-all
+		{"0.0.0.0:9090", true},         // IPv4 wildcard
+		{"[::]:9090", true},             // IPv6 wildcard
+		{"192.168.1.1:9090", true},      // LAN IP
+		{"myhost:9090", true},            // unknown hostname → assume exposed
+		{"bogus", false},                 // unparseable → conservative no
+	}
+	for _, c := range cases {
+		if got := isNonLoopbackBind(c.addr); got != c.want {
+			t.Errorf("isNonLoopbackBind(%q) = %v, want %v", c.addr, got, c.want)
+		}
+	}
+}
+
+func TestHasStrongClientAuth(t *testing.T) {
+	cases := []struct {
+		name string
+		tls  *config.TLS
+		want bool
+	}{
+		{"nil tls", nil, false},
+		{"empty cert", &config.TLS{ClientAuthType: "require-and-verify"}, false},
+		{"cert + empty type", &config.TLS{ClientAuthCert: "/etc/ca.pem"}, false},
+		{"cert + request", &config.TLS{ClientAuthCert: "/etc/ca.pem", ClientAuthType: "request"}, false},
+		{"cert + verify-if-given", &config.TLS{ClientAuthCert: "/etc/ca.pem", ClientAuthType: "verify-if-given"}, false},
+		{"cert + require-any", &config.TLS{ClientAuthCert: "/etc/ca.pem", ClientAuthType: "require-any"}, false},
+		{"cert + require-and-verify", &config.TLS{ClientAuthCert: "/etc/ca.pem", ClientAuthType: "require-and-verify"}, true},
+		{"cert + Require-And-Verify (case)", &config.TLS{ClientAuthCert: "/etc/ca.pem", ClientAuthType: "Require-And-Verify"}, true},
+	}
+	for _, c := range cases {
+		if got := hasStrongClientAuth(c.tls); got != c.want {
+			t.Errorf("%s: hasStrongClientAuth = %v, want %v", c.name, got, c.want)
+		}
+	}
+}

--- a/hub/route/network.go
+++ b/hub/route/network.go
@@ -1,0 +1,367 @@
+package route
+
+import (
+	"encoding/json"
+	"errors"
+	"io"
+
+	"github.com/metacubex/mihomo/component/networkpolicy"
+
+	"github.com/metacubex/chi"
+	"github.com/metacubex/chi/render"
+	"github.com/metacubex/http"
+)
+
+// maxPutBodyBytes caps the PUT /network/context body to 10 MiB. The
+// architecture (§5.4.5) intentionally leaves dns_suffix / subnets
+// element counts unbounded, so any cap is implementation pragma rather
+// than a wire contract. 10 MiB is generous enough to cover any
+// plausible legitimate body (32 ifaces × thousands of subnets ≪ 10 MiB
+// even with verbose JSON formatting) while bounding the linear
+// allocate / sort / dedupe cost of a pathological multi-GB request.
+//
+// Defense-in-depth scope: this cap also protects against loopback-
+// local hostile processes and authenticated-but-misbehaving clients,
+// which the external-controller secret + non-loopback warning don't
+// cover.
+const maxPutBodyBytes = 10 << 20
+
+// networkContextRouter mounts PUT / DELETE / GET at /network/context per
+// architecture §5.4.
+func networkContextRouter() http.Handler {
+	r := chi.NewRouter()
+	r.Put("/", putNetworkContext)
+	r.Delete("/", deleteNetworkContext)
+	r.Get("/", getNetworkContext)
+	return r
+}
+
+// npErrorResponse is the standard error payload (architecture §5.4.8 /
+// §2.5). Short code + human-readable message; host uses code for
+// structured error handling.
+type npErrorResponse struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
+}
+
+func writeNPError(w http.ResponseWriter, r *http.Request, httpStatus int, code, msg string) {
+	render.Status(r, httpStatus)
+	render.JSON(w, r, npErrorResponse{Code: code, Message: msg})
+}
+
+// putNetworkContext handles PUT /network/context per architecture §5.4.1.
+// Decodes the body, classifies validation errors into the error-code
+// vocabulary §5.4.8 requires, calls manager.PutContext, and serializes
+// the applied[] response with the wire encoding rules from §5.6.4
+// (internal <none> / nil both → JSON null for matched_network).
+func putNetworkContext(w http.ResponseWriter, r *http.Request) {
+	mgr := networkpolicy.Global()
+	if mgr == nil {
+		writeNPError(w, r, http.StatusServiceUnavailable, "internal_error", "network-policy manager not yet initialized")
+		return
+	}
+
+	// Body decoding contract:
+	//   - http.MaxBytesReader caps the body at maxPutBodyBytes; any
+	//     overflow produces a MaxBytesError that surfaces through the
+	//     decoder's first Decode call as malformed_body (with a clear
+	//     "request body too large" message).
+	//   - Strict JSON: no trailing content after the root object;
+	//     "{...}garbage" is malformed_body, not silently truncated as
+	//     bare json.Decoder.Decode would allow.
+	//
+	// Implementation: a follow-up Decode of a sink that doesn't return
+	// io.EOF proves there's a second top-level token (i.e. trailing
+	// junk). This is the standard library's idiom for strict JSON
+	// streams.
+	r.Body = http.MaxBytesReader(w, r.Body, maxPutBodyBytes)
+
+	var ctx networkpolicy.NetworkContext
+	dec := json.NewDecoder(r.Body)
+	if err := dec.Decode(&ctx); err != nil {
+		code := "malformed_body"
+		msg := stripSentinelPrefix(err)
+		writeNPError(w, r, http.StatusBadRequest, code, msg)
+		return
+	}
+	var sink json.RawMessage
+	if err := dec.Decode(&sink); err != io.EOF {
+		writeNPError(w, r, http.StatusBadRequest, "malformed_body", "trailing content after JSON root")
+		return
+	}
+
+	result, err := mgr.PutContext(&ctx)
+	if err != nil {
+		code, msg := classifyPutError(err)
+		// Only known validation sentinels map to 400. Anything else
+		// (including future internal errors from Manager.PutContext)
+		// surfaces as 5xx internal_error so host doesn't mistake a
+		// transient kernel failure for a permanent config bug and
+		// suppress retries (architecture §5.4.8 host handling rule).
+		if code == "internal_error" {
+			writeNPError(w, r, http.StatusInternalServerError, code, msg)
+			return
+		}
+		writeNPError(w, r, http.StatusBadRequest, code, msg)
+		return
+	}
+
+	render.JSON(w, r, putResultToWire(result))
+}
+
+// deleteNetworkContext handles DELETE /network/context per §5.4.3.
+// Always returns 204 (even when no ctx was cached). Preserves the
+// per-group state machine; the TTL timer is cancelled; the state
+// machine rolls forward only on the next PUT per §5.6.2.
+func deleteNetworkContext(w http.ResponseWriter, r *http.Request) {
+	mgr := networkpolicy.Global()
+	if mgr != nil {
+		mgr.DeleteContext()
+	}
+	render.NoContent(w, r)
+}
+
+// getNetworkContext handles GET /network/context per §5.4.4.
+//
+// No-context case returns 200 with context / matched_network / expires_at
+// / age_seconds all set to JSON null and groups[] still populated so
+// polling clients don't have to branch on 200-vs-404.
+func getNetworkContext(w http.ResponseWriter, r *http.Request) {
+	mgr := networkpolicy.Global()
+	if mgr == nil {
+		// Renders the same shape as "no context" so host polling stays
+		// uniform before and after Install completes.
+		render.JSON(w, r, noContextStatus(nil))
+		return
+	}
+	status := mgr.GetStatus()
+	render.JSON(w, r, statusToWire(status))
+}
+
+// classifyPutError maps a NetworkContext validation error to the §2.5
+// error-code vocabulary via the sentinel chain the networkpolicy
+// package wraps into each error. errors.Is preserves ordering — the
+// first sentinel NormalizeAndValidate actually emitted is the one we
+// route on, so composite-failure bodies always see the correct
+// (code, message) pair.
+//
+// The returned message is the error's full String() form, which for
+// invalid_field errors matches the §5.4.8 "field: <path>, reason:
+// <why>" contract because the networkpolicy package emits them that
+// way at their source sites.
+//
+// Unknown errors (no recognized sentinel) map to internal_error rather
+// than invalid_field. This matters for forward-compat: if a future
+// Manager.PutContext returns a transient internal error, the REST
+// layer surfaces 5xx so host's retry policy kicks in (architecture
+// §5.4.8 "5xx → 按现有 retry 策略退避重试"); misclassifying as
+// invalid_field would suppress retries and silently strand the host.
+func classifyPutError(err error) (code, msg string) {
+	if err == nil {
+		return "", ""
+	}
+	msg = stripSentinelPrefix(err)
+	switch {
+	case errors.Is(err, networkpolicy.ErrMalformedBody):
+		// Defense-in-depth: putNetworkContext catches ErrMalformedBody
+		// at the DecodeJSON stage already, so this branch is unreachable
+		// from the live PUT path. Kept so a future code path that flows
+		// ErrMalformedBody through Manager.PutContext still routes
+		// correctly.
+		return "malformed_body", msg
+	case errors.Is(err, networkpolicy.ErrInvalidVersion):
+		return "invalid_version", msg
+	case errors.Is(err, networkpolicy.ErrInvalidTTL):
+		return "invalid_ttl", msg
+	case errors.Is(err, networkpolicy.ErrTooManyInterfaces):
+		return "too_many_interfaces", msg
+	case errors.Is(err, networkpolicy.ErrDuplicateIfaceName):
+		return "duplicate_iface_name", msg
+	case errors.Is(err, networkpolicy.ErrInvalidGatewayCombo):
+		return "invalid_gateway_combo", msg
+	case errors.Is(err, networkpolicy.ErrInvalidField):
+		return "invalid_field", msg
+	}
+	// Unrecognized error: surface as internal_error 5xx so host treats
+	// it as transient and applies its retry/backoff policy. The full
+	// error.Error() goes into the message for diagnostics.
+	return "internal_error", err.Error()
+}
+
+// classifySentinels is the ordered list of sentinel errors recognized
+// by classifyPutError + stripSentinelPrefix. Derived from the
+// networkpolicy package's exported errors so adding a new sentinel
+// there + a switch case in classifyPutError is sufficient — the prefix
+// stripper picks it up automatically without a manual hardcoded
+// duplicate list (which round-3 review flagged as a drift risk).
+var classifySentinels = []error{
+	networkpolicy.ErrMalformedBody,
+	networkpolicy.ErrInvalidVersion,
+	networkpolicy.ErrInvalidTTL,
+	networkpolicy.ErrTooManyInterfaces,
+	networkpolicy.ErrDuplicateIfaceName,
+	networkpolicy.ErrInvalidGatewayCombo,
+	networkpolicy.ErrInvalidField,
+}
+
+// stripSentinelPrefix removes the leading "<code>: " inserted by the
+// fmt.Errorf("%w: ...", ErrXxx) wrap pattern so the outgoing REST
+// message reads cleanly ("field: interfaces[0].bssid, reason: ...")
+// rather than duplicating the code ("invalid_field: field: ..., reason:
+// ..."). If no sentinel matches, return the full string so nothing is
+// lost.
+func stripSentinelPrefix(err error) string {
+	msg := err.Error()
+	for _, s := range classifySentinels {
+		prefix := s.Error() + ": "
+		if len(msg) >= len(prefix) && msg[:len(prefix)] == prefix {
+			return msg[len(prefix):]
+		}
+	}
+	return msg
+}
+
+// Wire types (package-level so PUT / GET / no-ctx code paths share a
+// single source of truth — adding a field happens in one place rather
+// than risking tag drift across three duplicates).
+
+type appliedRowWire struct {
+	Group           string  `json:"group"`
+	TargetProxy     *string `json:"target_proxy"`
+	AppliedProxy    string  `json:"applied_proxy"`
+	Changed         bool    `json:"changed"`
+	SelectionSource string  `json:"selection_source"`
+	Reason          string  `json:"reason"`
+}
+
+type putWire struct {
+	MatchedNetwork *string          `json:"matched_network"`
+	Applied        []appliedRowWire `json:"applied"`
+	ExpiresAt      *int64           `json:"expires_at"`
+}
+
+type statusGroupWire struct {
+	Group              string  `json:"group"`
+	CurrentProxy       string  `json:"current_proxy"`
+	SelectionSource    string  `json:"selection_source"`
+	LastMatchedNetwork *string `json:"last_matched_network"`
+}
+
+type statusWire struct {
+	Context        any               `json:"context"`
+	MatchedNetwork *string           `json:"matched_network"`
+	Groups         []statusGroupWire `json:"groups"`
+	ExpiresAt      *int64            `json:"expires_at"`
+	AgeSeconds     *int64            `json:"age_seconds"`
+}
+
+// putResultToWire converts the internal PutResult to the JSON body
+// per §5.4.2. matched_network uses the wire encoding from §5.6.4:
+// both the MatchedNone sentinel and the nil (never-evaluated) state
+// serialize to JSON null; host disambiguates via selection_source in
+// applied[] entries.
+func putResultToWire(r *networkpolicy.PutResult) any {
+	out := putWire{
+		MatchedNetwork: wireMatchedNetwork(r.MatchedNetworkPresent, r.MatchedNetwork),
+		Applied:        make([]appliedRowWire, 0, len(r.Applied)),
+	}
+	for _, a := range r.Applied {
+		row := appliedRowWire{
+			Group:           a.Group,
+			AppliedProxy:    a.AppliedProxy,
+			Changed:         a.Changed,
+			SelectionSource: a.SelectionSource,
+			Reason:          a.Reason,
+		}
+		if a.TargetProxy != "" {
+			target := a.TargetProxy
+			row.TargetProxy = &target
+		}
+		out.Applied = append(out.Applied, row)
+	}
+	if r.ExpiresAt != nil {
+		unix := r.ExpiresAt.Unix()
+		out.ExpiresAt = &unix
+	}
+	return out
+}
+
+// statusToWire converts the internal StatusResult to the §5.4.4 JSON.
+func statusToWire(s *networkpolicy.StatusResult) any {
+	if s == nil || !s.HasContext {
+		return noContextStatus(s)
+	}
+	out := statusWire{
+		Context:        contextForStatusWire(s.Context),
+		MatchedNetwork: wireMatchedNetwork(s.MatchedNetworkPresent, s.MatchedNetwork),
+		Groups:         buildStatusGroups(s.Groups),
+	}
+	if s.ExpiresAt != nil {
+		unix := s.ExpiresAt.Unix()
+		out.ExpiresAt = &unix
+	}
+	if s.AgeSeconds != nil {
+		age := *s.AgeSeconds
+		out.AgeSeconds = &age
+	}
+	return out
+}
+
+// noContextStatus renders the GET body when no ctx is cached — matches
+// §5.4.4's "context: null + matched_network: null + expires_at: null +
+// age_seconds: null" shape so host clients don't need to branch.
+// groups[] is still populated if the caller passed a StatusResult so
+// current per-group source / selected stay visible.
+func noContextStatus(s *networkpolicy.StatusResult) any {
+	out := statusWire{Groups: []statusGroupWire{}}
+	if s != nil {
+		out.Groups = buildStatusGroups(s.Groups)
+	}
+	return out
+}
+
+// buildStatusGroups converts the internal []GroupStatus to the wire
+// shape, applying the §5.6.4 last_matched_network null-encoding rule.
+func buildStatusGroups(in []networkpolicy.GroupStatus) []statusGroupWire {
+	out := make([]statusGroupWire, 0, len(in))
+	for _, g := range in {
+		out = append(out, statusGroupWire{
+			Group:              g.Group,
+			CurrentProxy:       g.CurrentProxy,
+			SelectionSource:    g.SelectionSource,
+			LastMatchedNetwork: wireMatchedNetwork(g.LastMatchedNetworkPresent, g.LastMatchedNetwork),
+		})
+	}
+	return out
+}
+
+// wireMatchedNetwork maps the internal tri-state (present bool + value)
+// to the wire representation per §5.6.4:
+//   - present == false  →  JSON null (never evaluated)
+//   - value == MatchedNone  →  JSON null (evaluated, no match)
+//   - concrete name  →  JSON string
+//
+// Host disambiguates the two null cases via selection_source.
+func wireMatchedNetwork(present bool, value string) *string {
+	if !present || value == networkpolicy.MatchedNone {
+		return nil
+	}
+	v := value
+	return &v
+}
+
+// contextForStatusWire serializes the cached NetworkContext for the GET
+// response in the same wire shape as PUT input, minus ttl (§5.4.4
+// "不回显 ttl"). NetworkContext's default JSON marshaling already
+// omits the unexported derived fields and honors the snake_case struct
+// tags; we just need to suppress the TTL field by shallow-cloning and
+// nil'ing it. The Interfaces slice is shared with the cached ctx but
+// only for read — no mutation.
+func contextForStatusWire(ctx *networkpolicy.NetworkContext) any {
+	if ctx == nil {
+		return nil
+	}
+	clone := *ctx
+	clone.TTL = nil
+	return &clone
+}

--- a/hub/route/network_test.go
+++ b/hub/route/network_test.go
@@ -1,0 +1,560 @@
+package route
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/metacubex/mihomo/component/networkpolicy"
+
+	"github.com/metacubex/chi"
+	"github.com/metacubex/http"
+	"github.com/metacubex/http/httptest"
+)
+
+// mockSelector is a SelectorWithPolicy implementation wide enough to
+// drive the Manager + REST handlers. Kept in this package so test
+// fixtures don't need to reach into the networkpolicy package's
+// unexported mockSelector.
+type mockSelector struct {
+	name       string
+	selected   string
+	candidates map[string]struct{}
+	policy     networkpolicy.GroupPolicy
+	source     networkpolicy.GroupSource
+}
+
+func newMockSel(name, initial string, candidates []string, policy networkpolicy.GroupPolicy) *mockSelector {
+	m := &mockSelector{
+		name:       name,
+		selected:   initial,
+		candidates: make(map[string]struct{}, len(candidates)),
+		policy:     policy,
+		source: networkpolicy.GroupSource{
+			StaticProxies: append([]string(nil), candidates...),
+		},
+	}
+	for _, c := range candidates {
+		m.candidates[c] = struct{}{}
+	}
+	return m
+}
+
+func (m *mockSelector) Name() string { return m.name }
+func (m *mockSelector) Set(name string) error {
+	if _, ok := m.candidates[name]; !ok {
+		return &selectorErr{msg: "not in candidates: " + name}
+	}
+	m.selected = name
+	return nil
+}
+func (m *mockSelector) Now() string                             { return m.selected }
+func (m *mockSelector) HasProxy(n string) bool                  { _, ok := m.candidates[n]; return ok }
+func (m *mockSelector) NetworkPolicy() networkpolicy.GroupPolicy { return m.policy }
+func (m *mockSelector) GroupSource() networkpolicy.GroupSource   { return m.source }
+
+type selectorErr struct{ msg string }
+
+func (e *selectorErr) Error() string { return e.msg }
+
+// setupManager installs a Manager with one select group governed by a
+// single `office → us` network-policy mapping. Returns a cleanup fn.
+func setupManager(t *testing.T) func() {
+	t.Helper()
+	networkpolicy.Uninstall()
+
+	sel := newMockSel("auto", "hk", []string{"hk", "us", "DIRECT"}, networkpolicy.GroupPolicy{
+		Mapping:      map[string]string{"office": "us"},
+		HasDefault:   true,
+		DefaultProxy: "DIRECT",
+	})
+	matcher, err := networkpolicy.ParseMatch(map[string]any{"ssid": "office-5g"})
+	if err != nil {
+		t.Fatalf("parse matcher: %v", err)
+	}
+	nets := []networkpolicy.Network{{Name: "office", Matcher: matcher}}
+	networkpolicy.Install(nets, []networkpolicy.SelectorWithPolicy{sel}, nil)
+
+	return func() { networkpolicy.Uninstall() }
+}
+
+// serve executes a request against the /network/context router and
+// returns the recorded response.
+func serve(method, body string) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(method, "/", strings.NewReader(body))
+	if body != "" {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	w := httptest.NewRecorder()
+	// Chi router carries the route path; mount at root since we test
+	// a single subrouter in isolation.
+	r := chi.NewRouter()
+	r.Mount("/", networkContextRouter())
+	r.ServeHTTP(w, req)
+	return w
+}
+
+// --- PUT /network/context ----------------------------------------------
+
+func TestPutNetworkContext_Happy(t *testing.T) {
+	defer setupManager(t)()
+
+	body := `{"version":1,"interfaces":[{"name":"wlan0","iface_type":"wifi","ssid":"office-5g"}]}`
+	w := serve(http.MethodPut, body)
+	if w.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d; body=%s", w.Code, w.Body.String())
+	}
+
+	var resp struct {
+		MatchedNetwork *string `json:"matched_network"`
+		Applied        []struct {
+			Group           string  `json:"group"`
+			TargetProxy     *string `json:"target_proxy"`
+			AppliedProxy    string  `json:"applied_proxy"`
+			Changed         bool    `json:"changed"`
+			SelectionSource string  `json:"selection_source"`
+			Reason          string  `json:"reason"`
+		} `json:"applied"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v; body=%s", err, w.Body.String())
+	}
+	if resp.MatchedNetwork == nil || *resp.MatchedNetwork != "office" {
+		t.Errorf("want matched_network=office, got %+v", resp.MatchedNetwork)
+	}
+	if len(resp.Applied) != 1 {
+		t.Fatalf("want 1 applied row, got %d", len(resp.Applied))
+	}
+	if resp.Applied[0].Reason != networkpolicy.ReasonMatched {
+		t.Errorf("want matched, got %q", resp.Applied[0].Reason)
+	}
+	if resp.Applied[0].AppliedProxy != "us" {
+		t.Errorf("want applied=us, got %q", resp.Applied[0].AppliedProxy)
+	}
+}
+
+func TestPutNetworkContext_MalformedBody(t *testing.T) {
+	defer setupManager(t)()
+
+	w := serve(http.MethodPut, `not json`)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("want 400, got %d", w.Code)
+	}
+	code := decodeErrCode(t, w.Body.Bytes())
+	if code != "malformed_body" {
+		t.Errorf("want code=malformed_body, got %q", code)
+	}
+}
+
+// Strict JSON contract: trailing non-whitespace after the root value
+// is malformed_body. Bare json.Decoder.Decode would silently accept
+// "{...}garbage" — the strict-end check in the handler rejects it.
+func TestPutNetworkContext_TrailingJunkRejected(t *testing.T) {
+	defer setupManager(t)()
+
+	w := serve(http.MethodPut, `{"version":1,"interfaces":[]}garbage`)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("trailing junk must be 400; got %d body=%s", w.Code, w.Body.String())
+	}
+	if got := decodeErrCode(t, w.Body.Bytes()); got != "malformed_body" {
+		t.Errorf("want malformed_body for trailing junk, got %q", got)
+	}
+}
+
+// Body-size cap: pathological bodies above maxPutBodyBytes are rejected
+// as malformed_body via http.MaxBytesReader. The 10 MiB cap is generous
+// enough that no realistic body hits it, but it bounds DoS exposure
+// from local hostile processes / authenticated-but-misbehaving clients
+// that the secret + loopback warning don't cover.
+func TestPutNetworkContext_OversizeBodyRejected(t *testing.T) {
+	defer setupManager(t)()
+
+	// Build a body larger than maxPutBodyBytes. Use a JSON-valid string
+	// padded with a long dns_suffix entry so the cap is what fails,
+	// not the parser hitting EOF mid-token.
+	var buf bytes.Buffer
+	buf.WriteString(`{"version":1,"interfaces":[],"dns_suffix":["`)
+	const targetSize = 12 << 20 // 12 MiB > 10 MiB cap
+	for buf.Len() < targetSize {
+		buf.WriteString("padpadpadpadpadpadpadpadpadpadpadpadpadpadpadpad")
+	}
+	buf.WriteString(`"]}`)
+
+	w := serve(http.MethodPut, buf.String())
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("oversize body must be 400; got %d", w.Code)
+	}
+	if got := decodeErrCode(t, w.Body.Bytes()); got != "malformed_body" {
+		t.Errorf("want malformed_body for oversize, got %q", got)
+	}
+}
+
+func TestPutNetworkContext_MissingVersion(t *testing.T) {
+	defer setupManager(t)()
+
+	// UnmarshalJSON enforces version presence → malformed_body.
+	w := serve(http.MethodPut, `{"interfaces":[]}`)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("want 400, got %d", w.Code)
+	}
+	if got := decodeErrCode(t, w.Body.Bytes()); got != "malformed_body" {
+		t.Errorf("want malformed_body, got %q", got)
+	}
+}
+
+func TestPutNetworkContext_InvalidVersion(t *testing.T) {
+	defer setupManager(t)()
+
+	w := serve(http.MethodPut, `{"version":2,"interfaces":[]}`)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("want 400, got %d", w.Code)
+	}
+	if got := decodeErrCode(t, w.Body.Bytes()); got != "invalid_version" {
+		t.Errorf("want invalid_version, got %q", got)
+	}
+}
+
+func TestPutNetworkContext_InvalidTTL(t *testing.T) {
+	defer setupManager(t)()
+
+	w := serve(http.MethodPut, `{"version":1,"interfaces":[],"ttl":0}`)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("want 400, got %d; body=%s", w.Code, w.Body.String())
+	}
+	if got := decodeErrCode(t, w.Body.Bytes()); got != "invalid_ttl" {
+		t.Errorf("want invalid_ttl, got %q", got)
+	}
+}
+
+func TestPutNetworkContext_InvalidTTL_AboveUpperBound(t *testing.T) {
+	defer setupManager(t)()
+
+	// maxTTLSeconds is an unexported package constant; 10 years + 1 second
+	// hard-coded here mirrors component/networkpolicy/context.go and pins
+	// the REST layer's end-to-end upper-bound rejection to invalid_ttl
+	// (rather than internal_error / invalid_field).
+	const aboveMaxTTL = 10*365*86400 + 1
+	body := fmt.Sprintf(`{"version":1,"interfaces":[],"ttl":%d}`, aboveMaxTTL)
+	w := serve(http.MethodPut, body)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("want 400, got %d; body=%s", w.Code, w.Body.String())
+	}
+	if got := decodeErrCode(t, w.Body.Bytes()); got != "invalid_ttl" {
+		t.Errorf("want invalid_ttl, got %q", got)
+	}
+}
+
+func TestPutNetworkContext_TooManyInterfaces(t *testing.T) {
+	defer setupManager(t)()
+
+	var buf bytes.Buffer
+	buf.WriteString(`{"version":1,"interfaces":[`)
+	for i := 0; i < networkpolicy.MaxInterfaces+1; i++ {
+		if i > 0 {
+			buf.WriteByte(',')
+		}
+		buf.WriteString(`{"name":"eth`)
+		buf.WriteString(strconv.Itoa(i))
+		buf.WriteString(`"}`)
+	}
+	buf.WriteString(`]}`)
+
+	w := serve(http.MethodPut, buf.String())
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("want 400, got %d; body=%s", w.Code, w.Body.String())
+	}
+	if got := decodeErrCode(t, w.Body.Bytes()); got != "too_many_interfaces" {
+		t.Errorf("want too_many_interfaces, got %q", got)
+	}
+}
+
+func TestPutNetworkContext_DuplicateIfaceName(t *testing.T) {
+	defer setupManager(t)()
+
+	w := serve(http.MethodPut, `{"version":1,"interfaces":[{"name":"en0"},{"name":"en0"}]}`)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("want 400, got %d; body=%s", w.Code, w.Body.String())
+	}
+	if got := decodeErrCode(t, w.Body.Bytes()); got != "duplicate_iface_name" {
+		t.Errorf("want duplicate_iface_name, got %q", got)
+	}
+}
+
+func TestPutNetworkContext_InvalidGatewayCombo(t *testing.T) {
+	defer setupManager(t)()
+
+	w := serve(http.MethodPut, `{"version":1,"interfaces":[{"name":"en0","gateway_mac":"aa:bb:cc:dd:ee:ff"}]}`)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("want 400, got %d; body=%s", w.Code, w.Body.String())
+	}
+	if got := decodeErrCode(t, w.Body.Bytes()); got != "invalid_gateway_combo" {
+		t.Errorf("want invalid_gateway_combo, got %q", got)
+	}
+}
+
+func TestPutNetworkContext_InvalidField_BadMAC(t *testing.T) {
+	defer setupManager(t)()
+
+	w := serve(http.MethodPut, `{"version":1,"interfaces":[{"name":"en0","gateway_ip":"1.2.3.4","gateway_mac":"not-a-mac"}]}`)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("want 400, got %d; body=%s", w.Code, w.Body.String())
+	}
+	if got := decodeErrCode(t, w.Body.Bytes()); got != "invalid_field" {
+		t.Errorf("want invalid_field (bad MAC), got %q", got)
+	}
+}
+
+// Composite: gateway_mac is invalid AND gateway_ip is empty. With the
+// sentinel-based classifier, normalize() emits ErrInvalidField for the
+// MAC parse failure FIRST (before validate() reaches the gateway_combo
+// check), so the REST code must be invalid_field — not the misleading
+// invalid_gateway_combo a struct-only classifier would have produced.
+func TestPutNetworkContext_BadMAC_EmptyGatewayIP_RoutesToInvalidField(t *testing.T) {
+	defer setupManager(t)()
+
+	w := serve(http.MethodPut, `{"version":1,"interfaces":[{"name":"en0","gateway_mac":"not-a-mac"}]}`)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("want 400, got %d; body=%s", w.Code, w.Body.String())
+	}
+	if got := decodeErrCode(t, w.Body.Bytes()); got != "invalid_field" {
+		t.Errorf("composite (bad MAC + empty IP) should route to invalid_field, got %q", got)
+	}
+}
+
+// Composite: version=2 AND too many interfaces. The classifier must
+// route on the FIRST emitted error per NormalizeAndValidate's order
+// (too_many_interfaces is checked before version).
+func TestPutNetworkContext_BadVersion_TooManyInterfaces_RoutesToTooMany(t *testing.T) {
+	defer setupManager(t)()
+
+	var buf bytes.Buffer
+	buf.WriteString(`{"version":2,"interfaces":[`)
+	for i := 0; i < networkpolicy.MaxInterfaces+1; i++ {
+		if i > 0 {
+			buf.WriteByte(',')
+		}
+		buf.WriteString(`{"name":"eth`)
+		buf.WriteString(strconv.Itoa(i))
+		buf.WriteString(`"}`)
+	}
+	buf.WriteString(`]}`)
+
+	w := serve(http.MethodPut, buf.String())
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("want 400, got %d; body=%s", w.Code, w.Body.String())
+	}
+	if got := decodeErrCode(t, w.Body.Bytes()); got != "too_many_interfaces" {
+		t.Errorf("composite (bad version + too many) should route to too_many_interfaces (emitted first); got %q", got)
+	}
+}
+
+func TestPutNetworkContext_InvalidField_BadIfaceType(t *testing.T) {
+	defer setupManager(t)()
+
+	w := serve(http.MethodPut, `{"version":1,"interfaces":[{"name":"en0","iface_type":"satellite"}]}`)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("want 400, got %d; body=%s", w.Code, w.Body.String())
+	}
+	if got := decodeErrCode(t, w.Body.Bytes()); got != "invalid_field" {
+		t.Errorf("want invalid_field (bad iface_type), got %q", got)
+	}
+}
+
+// Regression: schema-legal large body must not be rejected by an
+// arbitrary REST-layer size cap. Architecture §5.4.5 leaves
+// dns_suffix / subnets element counts unbounded; any cap above the
+// manager's actual memory limits is contract-violating.
+func TestPutNetworkContext_LargeBody_NotRejected(t *testing.T) {
+	defer setupManager(t)()
+
+	var buf bytes.Buffer
+	buf.WriteString(`{"version":1,"interfaces":[],"dns_suffix":[`)
+	const n = 80000 // ~1.5 MiB after JSON-encoding
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			buf.WriteByte(',')
+		}
+		buf.WriteByte('"')
+		buf.WriteString("entry")
+		buf.WriteString(strconv.Itoa(i))
+		buf.WriteString(".example.com")
+		buf.WriteByte('"')
+	}
+	buf.WriteString(`]}`)
+
+	w := serve(http.MethodPut, buf.String())
+	if w.Code != http.StatusOK {
+		// Truncate body in error message to avoid a multi-MB dump.
+		bodyPreview := w.Body.String()
+		if len(bodyPreview) > 200 {
+			bodyPreview = bodyPreview[:200]
+		}
+		t.Errorf("schema-legal large body must be accepted; got %d body=%s", w.Code, bodyPreview)
+	}
+}
+
+// invalid_field message must follow §5.4.8's "field: <path>, reason:
+// <why>" format so host log parsers can extract the field path.
+func TestPutNetworkContext_InvalidField_MessageFormat(t *testing.T) {
+	defer setupManager(t)()
+
+	w := serve(http.MethodPut, `{"version":1,"interfaces":[{"name":"en0","iface_type":"satellite"}]}`)
+	var resp struct {
+		Code    string `json:"code"`
+		Message string `json:"message"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !strings.HasPrefix(resp.Message, "field: interfaces[0].iface_type, reason:") {
+		t.Errorf("want 'field: <path>, reason: <why>' format, got %q", resp.Message)
+	}
+}
+
+func TestPutNetworkContext_WireEncodingMatchedNone(t *testing.T) {
+	defer setupManager(t)()
+
+	// SSID doesn't match any network → MatchedNone → wire JSON null.
+	body := `{"version":1,"interfaces":[{"name":"wlan0","iface_type":"wifi","ssid":"random-wifi"}]}`
+	w := serve(http.MethodPut, body)
+	if w.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), `"matched_network":null`) {
+		t.Errorf("MatchedNone must serialize matched_network as JSON null; got %s", w.Body.String())
+	}
+	// The default branch should kick in → AppliedProxy=DIRECT.
+	if !strings.Contains(w.Body.String(), `"applied_proxy":"DIRECT"`) {
+		t.Errorf("want default branch to apply DIRECT; got %s", w.Body.String())
+	}
+}
+
+func TestPutNetworkContext_NoManager(t *testing.T) {
+	networkpolicy.Uninstall()
+	w := serve(http.MethodPut, `{"version":1,"interfaces":[]}`)
+	if w.Code != http.StatusServiceUnavailable {
+		t.Errorf("want 503 when no manager, got %d", w.Code)
+	}
+	if got := decodeErrCode(t, w.Body.Bytes()); got != "internal_error" {
+		t.Errorf("want internal_error, got %q", got)
+	}
+}
+
+// --- DELETE /network/context -------------------------------------------
+
+func TestDeleteNetworkContext_NoManager(t *testing.T) {
+	networkpolicy.Uninstall()
+	w := serve(http.MethodDelete, "")
+	if w.Code != http.StatusNoContent {
+		t.Errorf("DELETE must return 204 even without manager (idempotent per §5.4.3); got %d", w.Code)
+	}
+}
+
+func TestDeleteNetworkContext_PreservesState(t *testing.T) {
+	defer setupManager(t)()
+
+	// Establish state via PUT.
+	serve(http.MethodPut, `{"version":1,"interfaces":[{"name":"wlan0","iface_type":"wifi","ssid":"office-5g"}]}`)
+
+	// DELETE → 204.
+	w := serve(http.MethodDelete, "")
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("want 204, got %d", w.Code)
+	}
+
+	// GET should now report no context but keep the group row with its
+	// (preserved) source / current_proxy. §5.4.3 contract: DELETE clears
+	// the ctx snapshot only; per-group state machine is untouched.
+	w = serve(http.MethodGet, "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("GET want 200, got %d", w.Code)
+	}
+	var st struct {
+		Context *any `json:"context"`
+		Groups  []struct {
+			Group           string `json:"group"`
+			CurrentProxy    string `json:"current_proxy"`
+			SelectionSource string `json:"selection_source"`
+		} `json:"groups"`
+	}
+	json.Unmarshal(w.Body.Bytes(), &st)
+	if st.Context != nil && *st.Context != nil {
+		t.Errorf("DELETE should have nil'd context; got %+v", st.Context)
+	}
+	if len(st.Groups) != 1 {
+		t.Fatalf("DELETE must preserve groups[]; got %d rows", len(st.Groups))
+	}
+	if st.Groups[0].Group != "auto" {
+		t.Errorf("preserved group row should be 'auto', got %q", st.Groups[0].Group)
+	}
+	if st.Groups[0].CurrentProxy != "us" {
+		t.Errorf("DELETE must preserve current_proxy=us (state machine untouched); got %q", st.Groups[0].CurrentProxy)
+	}
+	if st.Groups[0].SelectionSource == "" {
+		t.Errorf("DELETE must preserve selection_source; got empty")
+	}
+}
+
+// --- GET /network/context ----------------------------------------------
+
+func TestGetNetworkContext_NoManager(t *testing.T) {
+	networkpolicy.Uninstall()
+	w := serve(http.MethodGet, "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("GET must return 200 with null body even without manager; got %d", w.Code)
+	}
+	body := w.Body.String()
+	if !strings.Contains(body, `"context":null`) {
+		t.Errorf("want context:null, got %s", body)
+	}
+}
+
+func TestGetNetworkContext_HappyAfterPut(t *testing.T) {
+	defer setupManager(t)()
+	serve(http.MethodPut, `{"version":1,"interfaces":[{"name":"wlan0","iface_type":"wifi","ssid":"office-5g"}]}`)
+
+	w := serve(http.MethodGet, "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d", w.Code)
+	}
+	var st struct {
+		MatchedNetwork *string `json:"matched_network"`
+		Groups         []struct {
+			Group              string  `json:"group"`
+			CurrentProxy       string  `json:"current_proxy"`
+			SelectionSource    string  `json:"selection_source"`
+			LastMatchedNetwork *string `json:"last_matched_network"`
+		} `json:"groups"`
+		AgeSeconds *int64 `json:"age_seconds"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &st); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if st.MatchedNetwork == nil || *st.MatchedNetwork != "office" {
+		t.Errorf("want matched=office, got %+v", st.MatchedNetwork)
+	}
+	if len(st.Groups) != 1 || st.Groups[0].CurrentProxy != "us" {
+		t.Errorf("want groups[0].current_proxy=us, got %+v", st.Groups)
+	}
+	if st.AgeSeconds == nil {
+		t.Errorf("want age_seconds populated")
+	}
+}
+
+// --- helpers -----------------------------------------------------------
+
+func decodeErrCode(t *testing.T, body []byte) string {
+	t.Helper()
+	var resp struct {
+		Code    string `json:"code"`
+		Message string `json:"message"`
+	}
+	if err := json.Unmarshal(body, &resp); err != nil {
+		t.Fatalf("decode error response: %v; body=%s", err, body)
+	}
+	return resp.Code
+}
+

--- a/hub/route/proxies.go
+++ b/hub/route/proxies.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/metacubex/mihomo/adapter/outboundgroup"
 	"github.com/metacubex/mihomo/common/utils"
+	"github.com/metacubex/mihomo/component/networkpolicy"
 	"github.com/metacubex/mihomo/component/profile/cachefile"
 	C "github.com/metacubex/mihomo/constant"
 	"github.com/metacubex/mihomo/tunnel"
@@ -96,6 +97,19 @@ func updateProxy(w http.ResponseWriter, r *http.Request) {
 	}
 
 	cachefile.Cache().SetSelected(proxy.Name(), req.Name)
+
+	// network-policy hook (architecture §5.6.2 row 1): if the group
+	// carries a network-policy, record the user's manual choice so the
+	// state machine flips source=manual and the manual-wins invariant
+	// kicks in at the next PUT /network/context. Called AFTER Set()
+	// has returned (no Selector lock held by this handler) to honor
+	// the networkpolicy/install.go lock order (globalMu → sel.mu).
+	if np, ok := proxy.Adapter().(networkpolicy.SelectorWithPolicy); ok && !np.NetworkPolicy().IsEmpty() {
+		if mgr := networkpolicy.Global(); mgr != nil {
+			mgr.HandleManualSet(np.Name())
+		}
+	}
+
 	if SwitchProxiesCallback != nil {
 		// refresh tray menu
 		go SwitchProxiesCallback(proxy.Name(), req.Name)

--- a/hub/route/server.go
+++ b/hub/route/server.go
@@ -132,6 +132,7 @@ func router(isDebug bool, secret string, dohServer string, cors Cors) *chi.Mux {
 		r.Mount("/providers/rules", ruleProviderRouter())
 		r.Mount("/cache", cacheRouter())
 		r.Mount("/dns", dnsRouter())
+		r.Mount("/network/context", networkContextRouter())
 		r.Mount("/storage", storageRouter())
 		if !embedMode { // disallow restart in embed mode
 			r.Mount("/restart", restartRouter())

--- a/listener/sing_tun/server.go
+++ b/listener/sing_tun/server.go
@@ -157,6 +157,7 @@ func New(options LC.Tun, tunnel C.Tunnel, additions ...inbound.Addition) (l *Lis
 	if options.FileDescriptor > 0 {
 		if tunnelName, err := getTunnelName(int32(options.FileDescriptor)); err == nil {
 			tunName = tunnelName // sing-tun must have the truth tun interface name even it from a fd
+			options.Device = tunName // mirror into options.Device so Config()/GET /configs report the real bound name, not the user's (possibly empty) original value
 			//forwarderBindInterface = true
 			log.Debugln("[TUN] use tun name %s for fd %d", tunnelName, options.FileDescriptor)
 		} else {


### PR DESCRIPTION
> **Update (Apr 22, 2026)**: This PR has been force-pushed to replace the original single-primary-iface design with a clean-slate multi-interface rewrite. The original design failed to express common desktop scenarios (wired + Wi-Fi with different gateways; Wi-Fi + VPN coexistence; "in the office" when both Ethernet and Wi-Fi are up). Design discussion is at [#2722][rfc]. No reviewer time had been consumed on the old revision (0 formal review comments), so the in-place rewrite is the least disruptive path. If you'd prefer a fresh PR number for a clean review history, just say so and I'll close + reopen.

## TL;DR

**English**: Introduces a top-level `networks:` YAML block and a per-`select`-group `network-policy:` mapping, exposed through `PUT / DELETE / GET /network/context`. A GUI host pushes a `NetworkContext` containing the full active-interface set; the kernel evaluates the rule list in order, applies the first-match's policy target on each affected group, and preserves user manual picks within the same network. Zero behavioral change when `networks:` is absent.

**中文**：新增 YAML `networks:` 顶层字段与 `select` 组的 `network-policy:` 子字段，通过 `PUT / DELETE / GET /network/context` 三个 REST 端点暴露。宿主推送包含全部活跃接口集合的 `NetworkContext`，内核按 `networks:` 列表顺序 first-match 求值，对每个带 policy 的 `select` 组应用对应目标；同一 network 下用户手动选择被尊重，network 变化时自动流程接管。不配置 `networks:` 时行为与旧版字节级等价。

Closes [MetaCubeX/mihomo#1330]. Design RFC: [#2722][rfc]. Pairs with [clash-verge-rev#1231] on the GUI side.

[rfc]: https://github.com/MetaCubeX/mihomo/discussions/2722
[MetaCubeX/mihomo#1330]: https://github.com/MetaCubeX/mihomo/issues/1330
[clash-verge-rev#1231]: https://github.com/clash-verge-rev/clash-verge-rev/issues/1231

## Why the force-push (what changed from the previous revision)

The earlier five-commit revision modeled `NetworkContext` as a single "primary interface" snapshot with fields like `primary_iface` / `iface_type` / `ssid` / `gateway_mac` at the top level. On desktop that proves too narrow:

- **Multi-NIC is the common case** (wired + Wi-Fi together), and the host has no principled way to pick "the" primary. Whichever one it picks throws away the other's identity.
- `{iface-type: vpn, ...}` rules could never match a user-installed WireGuard that runs *alongside* Wi-Fi, because the host's "physical-iface-fallback" would hide the VPN when the VPN wasn't the primary.
- Combined conditions like "home Wi-Fi + company VPN" are inexpressible in a single-iface schema.

The v2 design in this PR:

- Host reports **all active interfaces** (`interfaces[]`, hard-capped at 32), plus a top-level `dns_suffix` list.
- Matchers evaluate with `∃iface ∈ interfaces` semantics; multiple per-iface fields in the same block must be satisfied by the **same** iface (atomic AND). `any:` / `all:` / `not:` combinators are grammar primitives.
- Per-network precedence is expressed by **rule order** in `networks:` (first-match wins). The "primary interface" concept is gone.

The architecture is intentionally conservative: no CGO, no new platform dependencies, no subscription-pushed policy (signed YAML stays the source of truth).

## High-level design

The functionality splits naturally into two halves:

| Concern | Owner | Why |
|---|---|---|
| Platform-specific network detection (WlanAPI, NWPathMonitor, netlink, `NetworkCallback`) | GUI host | Rust / Kotlin ecosystems already have first-class APIs; deep OS event subscriptions; desktop-app territory |
| Rule semantics, `select` group state, persistence, REST | mihomo kernel (this PR) | Same concepts as `store-selected`; needs to live with proxy groups; YAML rules should travel with the subscription |

Rules live in YAML so they ride subscriptions, backups, and are visible to any GUI that implements the detector. Host and kernel communicate through a single versioned REST contract (`/network/context`). No new platform APIs, CGO, or third-party deps in the kernel.

## What's in this PR

Twelve commits, layered so each one compiles, passes `go vet`, and keeps existing tests green:

1. **`feat(network-policy): add package skeleton with multi-interface schema`** — new `component/networkpolicy/` package: `NetworkContext` (`interfaces[]` + global `dns_suffix` + optional `ttl`), `NormalizeAndValidate`, stable FNV-64a `Fingerprint`, the block-level matcher AST with `any:` / `all:` / `not:` combinators and `∃iface` semantics, `GroupPolicy`, shared constants. Pure logic.
2. **`feat(network-policy): parse networks and network-policy in config`** — wires the schema into `config.Parse`: `ParseNetworks` builds the list, `ParseGroupPolicy` validates each `select` group's Mapping (static proxies fail-fast, provider-expanded targets tolerant-until-first-PUT, `default` as reserved key). `Selector` gains `NetworkPolicy()` / `GroupSource()` getters. No runtime behaviour yet.
3. **`feat(network-policy): persist bucketNetworkPolicy`** — new `bucketNetworkPolicy` bucket in `component/profile/cachefile` stores `{source, last_matched_network}` per group (proxy name stays in the existing `bucketSelected`). Decode path tolerates schema drift (unknown `schema_version` → treated as branch B, cold start).
4. **`feat(network-policy): add manager with state machine and TTL`** — the `Manager` singleton: per-group state (source + last_matched), global ctx snapshot + TTL timer with generation-stamped stale-callback protection, single-serial-queue evaluation pipeline (`evaluate → selector.Set → cachefile → publish`). TTL-light-path handles heartbeat renewals under five guard conditions so steady state doesn't hit the full pipeline. Provider barrier on startup prevents races with subscription-driven candidate sets.
5. **`feat(network-policy): wire manager into executor lifecycle`** — `hub/executor/executor.go` owns `Install` / `Uninstall` via `ApplyConfig` (the package exports only these two; a single `Install` handles both first-time install and hot-reload state migration via the internal `inheritFrom`). Hot-reload migrates per-group state + ctx + TTL timer + selected proxy from old to new Manager. `collectNetworkPolicySelectors` uses the `SelectorWithPolicy` interface (no concrete type assertions).
6. **`feat(network-policy): expose /network/context REST endpoints`** — `hub/route/network.go` registers `PUT / DELETE / GET` under `/network/context`, with a 10 MiB body cap, strict-end JSON parsing (no trailing junk), and sentinel-error classification that maps validation errors to the `{code, message}` envelope (see §REST API).
7. **`feat(network-policy): hook manual PUT /proxies/:name into state machine`** — `updateProxy` calls `Manager.HandleManualSet(name)` after `selector.Set` returns; respects lock order `globalMu → selector.mu → manager.mu` (hook runs outside `selector.mu`). Select groups without `network-policy` keep byte-for-byte compatible behavior.
8. **`feat(network-policy): warn on exposed external-controller without secret`** — startup warning when `networks:` is configured, `external-controller` is bound to a non-loopback address, and no `secret` is set (TLS with strong mutual-auth exempts the warning).
9. **`refactor(network-policy): narrow exported API surface`** — package-private where possible; only `SelectorWithPolicy` / the sentinel error values / `NetworkContext` / `Install` / a few lifecycle exports remain.
10. **`docs: document network-policy config and REST API`** — `docs/config.yaml` gains the `networks:` + `network-policy:` comment-only example; `docs/api.md` is a new comprehensive REST reference (covers every endpoint in `hub/route/`, including the `/network/context` contract in full: the wire schema, the `applied[]` shape, the seven-reason enumeration, the manual-wins state machine including the `missing_target` branch, the tri-state wire-null encoding for `matched_network` / `last_matched_network`, and the complete `{code, message}` error code matrix).
11. **`feat(tun): expose actual bound device name in /configs response`** — tiny fd-override fix in `listener/sing_tun/server.go`: when `FileDescriptor > 0`, after `getTunnelName(fd)` succeeds, mirror the resolved name into `options.Device` so `tunLister.Config().Device` and therefore `GET /configs.tun.device` reflect the real bound interface. Host samplers rely on this to filter mihomo's own TUN from the `NetworkContext` they push.
12. **`docs(network-policy): fix dangling reference in config.yaml`** — post-review follow-up: the comment block added in commit #10 pointed at `docs/network-policy.md` which was never committed; redirected to `docs/api.md §11` where the full field list / combinator semantics / REST contract already live.

## Configuration

Minimal — one network, one group:

```yaml
networks:
  - name: office
    match:
      ssid: corp-5g
      iface-type: wifi

proxy-groups:
  - name: Smart
    type: select
    proxies: [hk, us, DIRECT]
    network-policy:
      office: hk
      default: DIRECT     # matched-nothing or matched-but-no-mapping fallback
```

Richer grammar (per-iface atomic AND, field-level OR, sub-block combinators):

```yaml
networks:
  # Ethernet with a specific gateway MAC (office wired)
  - name: office-wired
    match:
      iface-type: ethernet
      gateway-mac: "aa:bb:cc:dd:ee:00"

  # Wi-Fi to any AP in the office set (field-level OR)
  - name: office-wifi
    match:
      ssid: [corp-5g, corp-2.4g, corp-guest]
      iface-type: wifi

  # Home Wi-Fi + company VPN simultaneously (cross-iface AND)
  - name: home-with-corp-vpn
    match:
      all:
        - iface-type: wifi
          ssid: home-network
        - iface-type: vpn
          dns-suffix: corp.example.com   # dns-suffix is global, not bound to this sub-block

  # Any cellular / wwan interface (`not:` for the complement)
  - name: no-cellular
    match:
      not:
        any:
          - iface-type: cellular
          - iface-type: wwan
```

Full field list, combinator semantics (including the "same iface satisfies all top-level per-iface fields" atomic rule), normalization, and the `dns-suffix` global-scope caveat are in `docs/api.md` §11 and `docs/config.yaml` (the committed example block).

## REST API

| Method | Path | Purpose |
|---|---|---|
| `PUT` | `/network/context` | Host pushes the current active-interface snapshot; returns `matched_network` + per-group `applied[]` |
| `DELETE` | `/network/context` | Clear the cached context (204); per-group state is **preserved** (does not trigger `default`) |
| `GET` | `/network/context` | Normalized snapshot of the context, current `matched_network`, per-group `current_proxy` / `selection_source` / `last_matched_network` |

```bash
curl -X PUT \
  -H "Authorization: Bearer $SECRET" \
  -H "Content-Type: application/json" \
  -d '{
        "version": 1,
        "interfaces": [
          {"name":"wlan0","iface_type":"wifi","ssid":"corp-5g","gateway_ip":"10.0.0.1"}
        ],
        "dns_suffix": ["corp.example.com"],
        "ttl": 1800
      }' \
  http://127.0.0.1:9090/network/context
```

Error responses on `/network/context` use a structured envelope (distinct from other mihomo endpoints' `{"message":"..."}`):

```jsonc
{ "code": "invalid_field", "message": "field: interfaces[0].gateway_ip, reason: parse error" }
```

Stable `code` values: `malformed_body` / `invalid_version` / `invalid_ttl` / `too_many_interfaces` / `duplicate_iface_name` / `invalid_field` / `invalid_gateway_combo` / `internal_error`. Full schema, normalization rules, and per-code semantics are in `docs/api.md` §11.

## Runtime semantics

**Manual-wins is hard-coded.** When the user hand-picks a proxy on a policy-bearing group, the group's `selection_source` flips to `manual`. Subsequent `PUT /network/context` behavior:

- `matched_network` unchanged + `source=manual` → `reason=manual_locked`, user's pick preserved.
- `matched_network` changed + evaluation lands in `matched` / `already_selected` / `default` / `no_change_no_default` → auto flow takes over, `source` resets to `auto`, `last_matched_network` advances.
- `matched_network` changed but evaluation lands in `missing_target` (policy-resolved target not currently in the group's candidates, e.g., a subscription-provided node not yet loaded) → skip the switch, `source` and `last_matched_network` **preserved**, retried on the next PUT.

Seven `reason` values surface on `applied[i].reason`: `matched` / `already_selected` / `default` / `no_change_no_default` / `unchanged_network` (fingerprint-stable skip for the auto path) / `manual_locked` / `missing_target`.

`DELETE /network/context` intentionally **preserves** per-group state (`selection_source`, `last_matched_network`, currently-selected proxy). It only clears the kernel's cached `NetworkContext` snapshot so the TTL timer can be cancelled. Use cases: host clean shutdown; deliberate "no context, but keep state machine" mode; natural TTL expiry (equivalent). **Do not** use `DELETE` to express "host is offline" — instead `PUT {version:1, interfaces:[]}`, which runs the `default` / `no_change_no_default` branch for every group.

State persists across restarts via two buckets: `bucketSelected` (unchanged semantics — "which proxy was selected") + new `bucketNetworkPolicy` (`{schema_version, source, last_matched_network}` — "how that selection was made"). Both gated by `profile.store-selected: true`, consistent with existing behaviour.

A TTL "light path" skips the full evaluation pipeline when five conditions all hold: fingerprint unchanged, both current and previous bodies carried a TTL, no group has a pending `missing_target` retry, and the candidate set hasn't drifted since the last full evaluation. Hosts doing periodic keep-alive PUTs pay essentially zero kernel-side cost.

## Compatibility

- **Zero behaviour change without `networks:`**. Configs that omit the new keys hit exactly the pre-PR code paths: no Manager is installed, `applyOnce` never runs, `updateProxy`'s pre-existing code path is unchanged, `bucketNetworkPolicy` is never written.
- **No new platform dependencies, no CGO, no third-party imports** — standard library + `golang.org/x/exp/slices` / `netip` (already in use).
- **Cachefile forward/backward compatible**: old kernels reading a new DB ignore `bucketNetworkPolicy`; new kernels reading an old DB (no bucket) start on branch B (cold-start, run initial evaluation after the provider barrier releases).
- **REST-layer forward-compat**: the wire schema permits unknown fields (`json.Unmarshal` default) so new host versions can coexist with older kernels. YAML matchers are the opposite — unknown keys fail-fast, so config bugs surface early.

## Security

The startup warning in `warnNetworkPolicyExternalController` fires when all three conditions hold simultaneously, per endpoint:

1. At least one proxy group declares `network-policy:` in the config.
2. `external-controller` / `external-controller-tls` binds a non-loopback address.
3. No REST `secret` is set (TLS endpoint with `client-auth-type: require-and-verify` + a client-auth cert is treated as equivalent to a secret for this check).

Non-blocking — it's a nudge for the operator, never an abort. Unix sockets and Windows named pipes are intentionally skipped (filesystem / pipe ACLs already gate access).

The underlying rationale: on a policy-bearing select group, `PUT /network/context` indirectly picks proxies for the user. An unauthenticated LAN attacker could otherwise push a crafted context to force traffic through a specific node.

## Testing

- `go test ./component/networkpolicy/... ./config/... ./adapter/outboundgroup/... ./hub/route/... ./hub/executor/... ./component/profile/cachefile/... ./listener/...` all green.
- ~4,000 LoC of tests across the new `_test.go` files. Coverage includes: normalisation idempotency, FNV fingerprint stability, matcher atomic-AND semantics and combinators against the full architecture test matrix, state machine branches (including cold-start branch A vs B, provider barrier, startup eval pending flag), TTL timer stale-callback protection, persistence downgrade scenarios, manual-wins golden paths, concurrent `HandleManualSet` + `PutContext`, REST handler error-code mapping end-to-end (including the `ttl > 10 years` upper-bound case), and the hot-reload `Install` → `inheritFrom` state-migration path.
- Manual smoke: start with `networks:` + `network-policy:`; `curl -X PUT /network/context` with a multi-interface body and observe `applied[*].reason`; re-`PUT` with same body → `unchanged_network`; `PUT /proxies/Smart -d '{"name":"us"}'` then re-`PUT` same context → `manual_locked`; change the `interfaces[]` to a different network → auto takeover; `DELETE` → state preserved, groups keep their current proxies; next PUT resumes state machine with retained `source`.

## Out of scope / Follow-ups

- **Host-side detection is not in this PR** — mihomo alone only switches when an external actor (clash-verge-rev, FlClash, a cron script, `systemd-networkd` dispatcher) `PUT`s a context. The kernel contract is stable; GUI implementations ([clash-verge-rev#1231]) can land whenever.
- **No automatic Linux netlink collector in-tree**. The architecture allows adding one later as an opt-in component for headless deployments.
- **Matcher `metered:` is currently fail-fast** (reserved field on the wire but disabled in the matcher). Three-platform samplers don't collect it yet; opening the matcher now would let users write `not: {metered: true}` rules that silently always match.
- **macOS utun real bound name** is still best-effort (pre-bind estimate from `CalculateInterfaceName()`). Tightening that to a true post-bind read-back is deferred.

---

# 中文版本

> **更新（2026-04-22）**：本 PR 已经 force-push，用 clean-slate 重新设计取代了原先的"单 primary 接口"版本。原设计在桌面场景下表达力不足（有线+Wi-Fi 同时在线、Wi-Fi+VPN 共存、"在公司"同时包含有线和 Wi-Fi 等），RFC 讨论见 [#2722][rfc]。旧版本没有消耗 reviewer 时间（0 条 formal review comment），in-place 重写是最小扰动的方案。如维护者偏好新开 PR 号获得干净的 review 历史，告知即可，我关闭这个并重新开一个。

## 概要

新增 YAML `networks:` 顶层字段与 `select` 组的 `network-policy:` 子字段，通过 `PUT / DELETE / GET /network/context` 三个 REST 端点暴露。宿主检测到网络变化后把包含全部活跃接口集合的 `NetworkContext` 推给内核；内核按 `networks:` 列表顺序 first-match 求值，对每个带 policy 的 `select` 组应用对应目标代理；同一 network 下用户手动选择被尊重，network 切换时自动流程接管。未配置 `networks:` 时行为与旧版字节级等价。

Closes [MetaCubeX/mihomo#1330]。设计讨论：[#2722][rfc]。与 [clash-verge-rev#1231] 的 GUI 侧工作配套。

## 与之前版本的区别（为什么要 force-push）

之前的 5 commit 版本把 `NetworkContext` 建模为一张 "primary interface" 快照，顶层直接挂 `primary_iface` / `iface_type` / `ssid` / `gateway_mac` 等字段。桌面端这种抽象太窄：

- **多网卡共存是常态**（有线 + Wi-Fi 同时在线），宿主没有放之四海皆准的 "主接口" 判定法则；选了其中一个就丢失另一个的身份信息。
- `{iface-type: vpn, ...}` 规则永远匹不到用户自装的 WireGuard（当 VPN 不是 primary 时会被宿主的 "物理接口优先 fallback" 隐藏掉）。
- "家里 Wi-Fi + 公司 VPN" 这类组合条件在单接口 schema 下完全表达不出来。

本 PR 的 v2 设计：

- 宿主上报**所有活跃接口**（`interfaces[]`，硬上限 32），外加顶层 `dns_suffix` 列表。
- Matcher 按 `∃iface ∈ interfaces` 求值；同一 block 里多个 per-iface 字段必须由**同一张** iface 同时满足（原子 AND）。`any:` / `all:` / `not:` 是语法一级组合子。
- network 间优先级由 `networks:` 列表**顺序**表达（first-match），彻底放弃 "primary iface" 概念。

设计整体克制：无 CGO、无新平台依赖、不走订阅推送（保留 YAML 作为 source of truth）。

## 本 PR 包含什么

12 个 commit，每个都能单独 `go build` / `go vet` / `go test` 通过：

1. `feat(network-policy): add package skeleton with multi-interface schema` — `component/networkpolicy/` 新包，含 `NetworkContext` / 归一化 / FNV-64a fingerprint / 块级 matcher AST（`any:` / `all:` / `not:` + `∃iface` 语义）。
2. `feat(network-policy): parse networks and network-policy in config` — 接入 `config.Parse`，`ParseNetworks` + `ParseGroupPolicy`（静态代理 fail-fast、provider 节点容忍到首次 PUT、`default` 为保留 key）。
3. `feat(network-policy): persist bucketNetworkPolicy` — cachefile 新 bucket 存 `{source, last_matched_network}`；解码路径容忍 schema 漂移。
4. `feat(network-policy): add manager with state machine and TTL` — `Manager` 单例：每组状态机 + 全局 ctx 快照 + generation 防 stale 的 TTL timer + 五条件 TTL 轻量路径 + provider 首载屏障。
5. `feat(network-policy): wire manager into executor lifecycle` — `executor.go` 的 `Install` / `Uninstall`（包里只导出这两个；`Install` 内部通过私有的 `inheritFrom` 完成热重载状态迁移），热重载继承每组状态 / ctx / TTL / 已选代理。
6. `feat(network-policy): expose /network/context REST endpoints` — `hub/route/network.go` 注册三个 endpoint，带 10 MiB body cap、严格 JSON 结尾检查、`{code, message}` 错误码分类。
7. `feat(network-policy): hook manual PUT /proxies/:name into state machine` — `updateProxy` 在 `selector.Set` 成功后调 `Manager.HandleManualSet`，不带 `network-policy` 的组行为不变。
8. `feat(network-policy): warn on exposed external-controller without secret` — 启动期三条件全部成立时输出 warning（有 policy + non-loopback + 无 secret）。
9. `refactor(network-policy): narrow exported API surface` — 尽可能包内私有，仅保留必要导出面。
10. `docs: document network-policy config and REST API` — `docs/config.yaml` 加注释例子块；新增 `docs/api.md` 完整 REST 参考（覆盖所有 `hub/route/` endpoint 以及 `/network/context` 契约的全部细节）。
11. `feat(tun): expose actual bound device name in /configs response` — `sing_tun.New` 的 fd-override 分支补 `options.Device = tunName` 写回，让 `GET /configs.tun.device` 返回 listener 实际 bound 名，供 host sampler 过滤 mihomo 自己的 TUN。
12. `docs(network-policy): fix dangling reference in config.yaml` — review 后修补：commit #10 的注释块指向了未提交的 `docs/network-policy.md`，改为指向实际存在的 `docs/api.md §11`（完整字段 / 组合子语义 / REST 契约都在那里）。

## 运行时语义要点

**Manual-wins 状态机**：用户手动切换后该组 `source=manual`；下次 PUT 时：

- matched 未变 + `source=manual` → `manual_locked`，保留用户选择。
- matched 变了且落入 `matched` / `already_selected` / `default` / `no_change_no_default` → auto 接管，`source` 重置为 `auto`，`last_matched` 前进。
- matched 变了但落入 `missing_target`（policy 求得的目标代理当前不在本组候选）→ 跳过切换，state **保留**，等下次 PUT 重试。

**DELETE 仅清 ctx 快照，保留状态机**（不触发评估、不走 `default`）。要表达"宿主离线"请发 `PUT {version:1, interfaces:[]}` 让各组走 `default` 兜底。

**持久化**：`bucketSelected`（既有，proxy 名）+ 新增 `bucketNetworkPolicy`（`{schema_version, source, last_matched}`）；均受 `profile.store-selected: true` 门控。

**TTL 轻量路径**：五条件全部成立时 PUT 跳过完整评估管线（fingerprint 未变 / 本次与上次都带 ttl / 无 pending missing_target / 候选集未漂移）。

## 兼容性

未配置 `networks:` 时行为零变化；不引入 CGO 或新依赖；cachefile 前后双向兼容；wire schema 对未知字段宽容，matcher YAML 对未知 key fail-fast。

## 测试

`go test ./component/networkpolicy/... ./config/... ./adapter/outboundgroup/... ./hub/route/... ./hub/executor/... ./component/profile/cachefile/... ./listener/...` 全绿。约 4000 LoC 测试覆盖归一化、fingerprint、matcher 原子 AND、状态机分支（含分支 A/B、provider barrier、startupEvalPending）、TTL 防 stale callback、持久化降级、manual-wins 黄金路径、`HandleManualSet` + `PutContext` 并发、REST 错误码端到端、热重载继承。

## 范围之外

- **宿主侧检测不在本 PR 内**。内核契约已稳定，GUI 实现可独立推进。
- **内核不含自动 Linux netlink 采集器**。
- **`metered:` matcher 当前 fail-fast**（wire 字段保留，三平台 sampler 尚未采集）。
- **macOS utun 实际 bound 名仍是 best-effort**（pre-bind 估计值），真正的 post-bind 读回延后处理。

