### PR TITLE
fix: panic in vless xhttp h3 mode when quic dial fails

### DIFF
--- a/adapter/outbound/vless.go
+++ b/adapter/outbound/vless.go
@@ -636,6 +636,9 @@ func NewVless(option VlessOption) (*Vless, error) {
 						return nil, err
 					}
 					_, quicConn, err := common.DialQuic(ctx, v.addr, v.DialOptions(), v.dialer, tlsConfig, cfg, true)
+					if err != nil {
+						return nil, err
+					}
 					return quicConn, nil
 				},
 				v.option.ALPN,
@@ -790,6 +793,9 @@ func NewVless(option VlessOption) (*Vless, error) {
 							return nil, err
 						}
 						_, quicConn, err := common.DialQuic(ctx, downloadAddr, v.DialOptions(), v.dialer, tlsConfig, cfg, true)
+						if err != nil {
+							return nil, err
+						}
 						return quicConn, nil
 					},
 					downloadALPN,


### PR DESCRIPTION
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal 0xc0000005 code=0x0 addr=0x438 pc=0x7ff749853181]

goroutine 94060 [running]:
github.com/metacubex/quic-go.(*Conn).QlogTrace(...)
        C:/Users/admin/go/pkg/mod/github.com/metacubex/quic-go@v0.59.1-0.20260413153657-53bb22f2c306/connection.go:3132
github.com/metacubex/quic-go/http3.newClientConn(0x0, 0x0, 0x0, 0x0, 0x0, 0x0)
        C:/Users/admin/go/pkg/mod/github.com/metacubex/quic-go@v0.59.1-0.20260413153657-53bb22f2c306/http3/client.go:93 +0x41
github.com/metacubex/quic-go/http3.(*Transport).init.func1(0x7ff74aa56f00?)
        C:/Users/admin/go/pkg/mod/github.com/metacubex/quic-go@v0.59.1-0.20260413153657-53bb22f2c306/http3/transport.go:131 +0x2b
github.com/metacubex/quic-go/http3.(*Transport).dial(0xc001b91560, {0x7ff74aa56f00, 0xc00ea68190}, {0xc002defe78, 0x12})
        C:/Users/admin/go/pkg/mod/github.com/metacubex/quic-go@v0.59.1-0.20260413153657-53bb22f2c306/http3/transport.go:386 +0x17c
github.com/metacubex/quic-go/http3.(*Transport).getClient.func1()
        C:/Users/admin/go/pkg/mod/github.com/metacubex/quic-go@v0.59.1-0.20260413153657-53bb22f2c306/http3/transport.go:318 +0x71
created by github.com/metacubex/quic-go/http3.(*Transport).getClient in goroutine 94059
        C:/Users/admin/go/pkg/mod/github.com/metacubex/quic-go@v0.59.1-0.20260413153657-53bb22f2c306/http3/transport.go:315 +0x297
```