### PR TITLE
feat: add essential rules before tunnel mode routing

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -189,24 +189,25 @@ type TLS struct {
 
 // Config is mihomo config manager
 type Config struct {
-	General       *General
-	Controller    *Controller
-	Experimental  *Experimental
-	IPTables      *IPTables
-	NTP           *NTP
-	DNS           *DNS
-	Hosts         *trie.DomainTrie[resolver.HostValue]
-	Profile       *Profile
-	Rules         []C.Rule
-	SubRules      map[string][]C.Rule
-	Users         []auth.AuthUser
-	Proxies       map[string]C.Proxy
-	Listeners     map[string]C.InboundListener
-	Providers     map[string]P.ProxyProvider
-	RuleProviders map[string]P.RuleProvider
-	Tunnels       []LC.Tunnel
-	Sniffer       *sniffer.Config
-	TLS           *TLS
+	General        *General
+	Controller     *Controller
+	Experimental   *Experimental
+	IPTables       *IPTables
+	NTP            *NTP
+	DNS            *DNS
+	Hosts          *trie.DomainTrie[resolver.HostValue]
+	Profile        *Profile
+	EssentialRules []C.Rule
+	Rules          []C.Rule
+	SubRules       map[string][]C.Rule
+	Users          []auth.AuthUser
+	Proxies        map[string]C.Proxy
+	Listeners      map[string]C.InboundListener
+	Providers      map[string]P.ProxyProvider
+	RuleProviders  map[string]P.RuleProvider
+	Tunnels        []LC.Tunnel
+	Sniffer        *sniffer.Config
+	TLS            *TLS
 }
 
 type RawCors struct {
@@ -436,24 +437,25 @@ type RawConfig struct {
 	KeepAliveInterval       int                     `yaml:"keep-alive-interval" json:"keep-alive-interval"`
 	DisableKeepAlive        bool                    `yaml:"disable-keep-alive" json:"disable-keep-alive"`
 
-	ProxyProvider map[string]map[string]any `yaml:"proxy-providers" json:"proxy-providers"`
-	RuleProvider  map[string]map[string]any `yaml:"rule-providers" json:"rule-providers"`
-	Proxy         []map[string]any          `yaml:"proxies" json:"proxies"`
-	ProxyGroup    []map[string]any          `yaml:"proxy-groups" json:"proxy-groups"`
-	Rule          []string                  `yaml:"rules" json:"rule"`
-	SubRules      map[string][]string       `yaml:"sub-rules" json:"sub-rules"`
-	Listeners     []map[string]any          `yaml:"listeners" json:"listeners"`
-	Hosts         map[string]any            `yaml:"hosts" json:"hosts"`
-	DNS           RawDNS                    `yaml:"dns" json:"dns"`
-	NTP           RawNTP                    `yaml:"ntp" json:"ntp"`
-	Tun           RawTun                    `yaml:"tun" json:"tun"`
-	TuicServer    RawTuicServer             `yaml:"tuic-server" json:"tuic-server"`
-	IPTables      RawIPTables               `yaml:"iptables" json:"iptables"`
-	Experimental  RawExperimental           `yaml:"experimental" json:"experimental"`
-	Profile       RawProfile                `yaml:"profile" json:"profile"`
-	GeoXUrl       RawGeoXUrl                `yaml:"geox-url" json:"geox-url"`
-	Sniffer       RawSniffer                `yaml:"sniffer" json:"sniffer"`
-	TLS           RawTLS                    `yaml:"tls" json:"tls"`
+	ProxyProvider  map[string]map[string]any `yaml:"proxy-providers" json:"proxy-providers"`
+	RuleProvider   map[string]map[string]any `yaml:"rule-providers" json:"rule-providers"`
+	Proxy          []map[string]any          `yaml:"proxies" json:"proxies"`
+	ProxyGroup     []map[string]any          `yaml:"proxy-groups" json:"proxy-groups"`
+	EssentialRules []string                  `yaml:"essential-rules" json:"essential-rules"`
+	Rule           []string                  `yaml:"rules" json:"rule"`
+	SubRules       map[string][]string       `yaml:"sub-rules" json:"sub-rules"`
+	Listeners      []map[string]any          `yaml:"listeners" json:"listeners"`
+	Hosts          map[string]any            `yaml:"hosts" json:"hosts"`
+	DNS            RawDNS                    `yaml:"dns" json:"dns"`
+	NTP            RawNTP                    `yaml:"ntp" json:"ntp"`
+	Tun            RawTun                    `yaml:"tun" json:"tun"`
+	TuicServer     RawTuicServer             `yaml:"tuic-server" json:"tuic-server"`
+	IPTables       RawIPTables               `yaml:"iptables" json:"iptables"`
+	Experimental   RawExperimental           `yaml:"experimental" json:"experimental"`
+	Profile        RawProfile                `yaml:"profile" json:"profile"`
+	GeoXUrl        RawGeoXUrl                `yaml:"geox-url" json:"geox-url"`
+	Sniffer        RawSniffer                `yaml:"sniffer" json:"sniffer"`
+	TLS            RawTLS                    `yaml:"tls" json:"tls"`
 
 	ClashForAndroid RawClashForAndroid `yaml:"clash-for-android" json:"clash-for-android"`
 }
@@ -483,6 +485,7 @@ func DefaultRawConfig() *RawConfig {
 		Authentication:    []string{},
 		LogLevel:          log.INFO,
 		Hosts:             map[string]any{},
+		EssentialRules:    []string{},
 		Rule:              []string{},
 		Proxy:             []map[string]any{},
 		ProxyGroup:        []map[string]any{},
@@ -681,6 +684,12 @@ func ParseRawConfig(rawCfg *RawConfig) (*Config, error) {
 		return nil, err
 	}
 	config.SubRules = subRules
+
+	essentialRules, err := parseRules(rawCfg.EssentialRules, proxies, ruleProviders, subRules, "essential-rules")
+	if err != nil {
+		return nil, err
+	}
+	config.EssentialRules = essentialRules
 
 	rules, err := parseRules(rawCfg.Rule, proxies, ruleProviders, subRules, "rules")
 	if err != nil {
@@ -1095,7 +1104,7 @@ func parseRules(rulesConfig []string, proxies map[string]C.Proxy, ruleProviders 
 			}
 		}
 
-		if format == "rules" { // only wrap top level rules
+		if format == "rules" || format == "essential-rules" { // only wrap top level rules
 			parsed = RW.NewRuleWrapper(parsed)
 		}
 

--- a/docs/config.yaml
+++ b/docs/config.yaml
@@ -1426,6 +1426,10 @@ rule-providers:
       - '*.*.microsoft.com'
       - 'books.itunes.apple.com'
 
+# 必要规则会先于 mode 匹配；命中后不再受 direct / global / rule 模式影响。
+# essential-rules:
+#   - DOMAIN-SUFFIX,example.com,REJECT
+
 rules:
   - RULE-SET,rule1,REJECT
   - IP-ASN,1,PROXY

--- a/hub/executor/executor.go
+++ b/hub/executor/executor.go
@@ -99,7 +99,7 @@ func ApplyConfig(cfg *config.Config, force bool) {
 	updateExperimental(cfg.Experimental)
 	updateUsers(cfg.Users)
 	updateProxies(cfg.Proxies, cfg.Providers)
-	updateRules(cfg.Rules, cfg.SubRules, cfg.RuleProviders)
+	updateRules(cfg.EssentialRules, cfg.Rules, cfg.SubRules, cfg.RuleProviders)
 	updateSniffer(cfg.Sniffer)
 	updateHosts(cfg.Hosts)
 	updateGeneral(cfg.General, true)
@@ -309,8 +309,8 @@ func updateProxies(proxies map[string]C.Proxy, providers map[string]P.ProxyProvi
 	tunnel.UpdateProxies(proxies, providers)
 }
 
-func updateRules(rules []C.Rule, subRules map[string][]C.Rule, ruleProviders map[string]P.RuleProvider) {
-	tunnel.UpdateRules(rules, subRules, ruleProviders)
+func updateRules(essentialRules []C.Rule, rules []C.Rule, subRules map[string][]C.Rule, ruleProviders map[string]P.RuleProvider) {
+	tunnel.UpdateRules(essentialRules, rules, subRules, ruleProviders)
 }
 
 func loadProvider[T P.Provider](providers map[string]T) {

--- a/hub/route/rules.go
+++ b/hub/route/rules.go
@@ -40,7 +40,16 @@ type RuleExtra struct {
 }
 
 func getRules(w http.ResponseWriter, r *http.Request) {
-	rawRules := tunnel.Rules()
+	rules := formatRules(tunnel.Rules())
+	essentialRules := formatRules(tunnel.EssentialRules())
+
+	render.JSON(w, r, render.M{
+		"rules":           rules,
+		"essential-rules": essentialRules,
+	})
+}
+
+func formatRules(rawRules []constant.Rule) []Rule {
 	rules := make([]Rule, 0, len(rawRules))
 	for index, rule := range rawRules {
 		r := Rule{
@@ -67,9 +76,7 @@ func getRules(w http.ResponseWriter, r *http.Request) {
 
 	}
 
-	render.JSON(w, r, render.M{
-		"rules": rules,
-	})
+	return rules
 }
 
 // disableRules disable or enable rules by their indexes.

--- a/tunnel/tunnel.go
+++ b/tunnel/tunnel.go
@@ -54,7 +54,8 @@ var (
 	udpInOnce sync.Once
 
 	// Outbound Rule
-	mode = Rule
+	mode           = Rule
+	essentialRules []C.Rule
 
 	// default timeout for UDP session
 	udpTimeout = 60 * time.Second
@@ -190,13 +191,19 @@ func Rules() []C.Rule {
 	return rules
 }
 
+// EssentialRules returns rules matched before tunnel mode routing.
+func EssentialRules() []C.Rule {
+	return essentialRules
+}
+
 func Listeners() map[string]C.InboundListener {
 	return listeners
 }
 
 // UpdateRules handle update rules
-func UpdateRules(newRules []C.Rule, newSubRule map[string][]C.Rule, rp map[string]P.RuleProvider) {
+func UpdateRules(newEssentialRules []C.Rule, newRules []C.Rule, newSubRule map[string][]C.Rule, rp map[string]P.RuleProvider) {
 	configMux.Lock()
+	essentialRules = newEssentialRules
 	rules = newRules
 	ruleProviders = rp
 	subRules = newSubRule
@@ -376,6 +383,10 @@ func resolveMetadata(metadata *C.Metadata) (proxy C.Proxy, rule C.Rule, err erro
 		helper.FindProcess = nil
 	case process.FindProcessOff:
 		helper.FindProcess = nil
+	}
+
+	if proxy, rule, matched := matchEssentialRules(metadata, helper); matched {
+		return proxy, rule, nil
 	}
 
 	switch mode {
@@ -630,11 +641,30 @@ func logMetadata(metadata *C.Metadata, rule C.Rule, remoteConn C.Connection) {
 	}
 }
 
+func matchEssentialRules(metadata *C.Metadata, helper C.RuleMatchHelper) (C.Proxy, C.Rule, bool) {
+	configMux.RLock()
+	defer configMux.RUnlock()
+
+	if len(essentialRules) == 0 {
+		return nil, nil, false
+	}
+	log.Debugln("[Rule] use essential rules")
+	return matchRules(metadata, helper, essentialRules)
+}
+
 func match(metadata *C.Metadata, helper C.RuleMatchHelper) (C.Proxy, C.Rule, error) {
 	configMux.RLock()
 	defer configMux.RUnlock()
 
-	for _, rule := range getRules(metadata) {
+	if adapter, rule, matched := matchRules(metadata, helper, getRules(metadata)); matched {
+		return adapter, rule, nil
+	}
+
+	return proxies["DIRECT"], nil, nil
+}
+
+func matchRules(metadata *C.Metadata, helper C.RuleMatchHelper, rules []C.Rule) (C.Proxy, C.Rule, bool) {
+	for _, rule := range rules {
 		if matched, ada := rule.Match(metadata, helper); matched {
 			adapter, ok := proxies[ada]
 			if !ok {
@@ -659,11 +689,11 @@ func match(metadata *C.Metadata, helper C.RuleMatchHelper) (C.Proxy, C.Rule, err
 				continue
 			}
 
-			return adapter, rule, nil
+			return adapter, rule, true
 		}
 	}
 
-	return proxies["DIRECT"], nil, nil
+	return nil, nil, false
 }
 
 func getRules(metadata *C.Metadata) []C.Rule {


### PR DESCRIPTION
Add essential-rules support so critical routing rules are evaluated before direct, global, or rule mode routing

---

无论何种模式都会绝对生效的优先规则，主要用于reject去广告