### PR TITLE
feat: support configurable health check requests

### DIFF
--- a/adapter/adapter.go
+++ b/adapter/adapter.go
@@ -1,13 +1,19 @@
 package adapter
 
 import (
+	"compress/gzip"
+	"compress/zlib"
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net"
 	"net/url"
 	"strings"
 	"time"
+
+	"github.com/andybalholm/brotli"
+	"github.com/dlclark/regexp2"
 
 	"github.com/metacubex/mihomo/common/atomic"
 	"github.com/metacubex/mihomo/common/queue"
@@ -163,7 +169,7 @@ func (p *Proxy) MarshalJSON() ([]byte, error) {
 
 // URLTest get the delay for the specified URL
 // implements C.Proxy
-func (p *Proxy) URLTest(ctx context.Context, url string, expectedStatus utils.IntRanges[uint16]) (t uint16, err error) {
+func (p *Proxy) URLTest(ctx context.Context, url string, expectedStatus utils.IntRanges[uint16], options ...C.HealthCheckOption) (t uint16, err error) {
 	var satisfied bool
 
 	defer func() {
@@ -215,11 +221,29 @@ func (p *Proxy) URLTest(ctx context.Context, url string, expectedStatus utils.In
 		_ = instance.Close()
 	}()
 
-	req, err := http.NewRequest(http.MethodHead, url, nil)
+	option := C.HealthCheckOption{ExpectedStatus: expectedStatus}.WithDefault()
+	if len(options) != 0 {
+		option = options[0].WithDefault()
+	}
+
+	method := http.MethodHead
+	if option.Method == C.HealthCheckMethodGet {
+		method = http.MethodGet
+	}
+
+	req, err := http.NewRequest(method, url, nil)
 	if err != nil {
 		return
 	}
 	req = req.WithContext(ctx)
+	for key, values := range option.Headers {
+		for _, value := range values {
+			req.Header.Add(key, value)
+		}
+	}
+	if method == http.MethodGet && req.Header.Get("Accept-Encoding") == "" {
+		req.Header.Set("Accept-Encoding", "gzip, br")
+	}
 
 	tlsConfig, err := ca.GetTLSConfig(ca.Option{})
 	if err != nil {
@@ -230,6 +254,7 @@ func (p *Proxy) URLTest(ctx context.Context, url string, expectedStatus utils.In
 		DialContext: func(context.Context, string, string) (net.Conn, error) {
 			return instance, nil
 		},
+		DisableCompression: true,
 		// from http.DefaultTransport
 		MaxIdleConns:          100,
 		IdleConnTimeout:       90 * time.Second,
@@ -254,7 +279,11 @@ func (p *Proxy) URLTest(ctx context.Context, url string, expectedStatus utils.In
 		return
 	}
 
+	satisfied, err = healthCheckResponseSatisfied(resp, option)
 	_ = resp.Body.Close()
+	if err != nil {
+		return
+	}
 
 	if unifiedDelay {
 		second := time.Now()
@@ -263,7 +292,11 @@ func (p *Proxy) URLTest(ctx context.Context, url string, expectedStatus utils.In
 		secondResp, ignoredErr = client.Do(req)
 		if ignoredErr == nil {
 			resp = secondResp
+			satisfied, err = healthCheckResponseSatisfied(resp, option)
 			_ = resp.Body.Close()
+			if err != nil {
+				return
+			}
 			start = second
 		} else {
 			if strings.HasPrefix(url, "http://") {
@@ -273,9 +306,75 @@ func (p *Proxy) URLTest(ctx context.Context, url string, expectedStatus utils.In
 		}
 	}
 
-	satisfied = resp != nil && (expectedStatus == nil || expectedStatus.Check(uint16(resp.StatusCode)))
 	t = uint16(time.Since(start) / time.Millisecond)
 	return
+}
+
+func healthCheckResponseSatisfied(resp *http.Response, option C.HealthCheckOption) (bool, error) {
+	if resp == nil {
+		return false, nil
+	}
+	if option.ExpectedStatus != nil && !option.ExpectedStatus.Check(uint16(resp.StatusCode)) {
+		return false, nil
+	}
+	if option.Method != C.HealthCheckMethodGet || option.ExpectedBodyMatch == "" {
+		return true, nil
+	}
+
+	body, err := readHealthCheckBody(resp)
+	if err != nil {
+		return false, err
+	}
+	matcher, err := regexp2.Compile(option.ExpectedBodyMatch, regexp2.None)
+	if err != nil {
+		return false, err
+	}
+	// A user-provided pattern must not be able to block the health-check
+	// worker indefinitely through catastrophic backtracking.
+	matcher.MatchTimeout = 5 * time.Second
+	matched, err := matcher.MatchString(string(body))
+	if err != nil {
+		return false, err
+	}
+	return matched, nil
+}
+
+func readHealthCheckBody(resp *http.Response) (body []byte, err error) {
+	var reader io.Reader = resp.Body
+	encodings := strings.Split(resp.Header.Get("Content-Encoding"), ",")
+	closers := make([]io.Closer, 0, len(encodings))
+	defer func() {
+		for i := len(closers) - 1; i >= 0; i-- {
+			if closeErr := closers[i].Close(); err == nil {
+				err = closeErr
+			}
+		}
+	}()
+	for i := len(encodings) - 1; i >= 0; i-- {
+		switch encoding := strings.ToLower(strings.TrimSpace(encodings[i])); encoding {
+		case "", "identity":
+			continue
+		case "gzip":
+			gzipReader, err := gzip.NewReader(reader)
+			if err != nil {
+				return nil, err
+			}
+			reader = gzipReader
+			closers = append(closers, gzipReader)
+		case "deflate":
+			zlibReader, err := zlib.NewReader(reader)
+			if err != nil {
+				return nil, err
+			}
+			reader = zlibReader
+			closers = append(closers, zlibReader)
+		case "br":
+			reader = brotli.NewReader(reader)
+		default:
+			return nil, fmt.Errorf("unsupported health check content encoding: %s", encoding)
+		}
+	}
+	return io.ReadAll(reader)
 }
 
 func NewProxy(adapter C.ProxyAdapter) *Proxy {

--- a/adapter/healthcheck_test.go
+++ b/adapter/healthcheck_test.go
@@ -1,0 +1,103 @@
+package adapter
+
+import (
+	"bytes"
+	"compress/gzip"
+	"io"
+	"testing"
+
+	"github.com/andybalholm/brotli"
+	http "github.com/metacubex/http"
+	"github.com/stretchr/testify/require"
+
+	C "github.com/metacubex/mihomo/constant"
+)
+
+func TestHealthCheckResponseSatisfiedMatchesDecodedBody(t *testing.T) {
+	body := []byte("region=HK; service=available")
+
+	tests := []struct {
+		name     string
+		encoding string
+		payload  []byte
+	}{
+		{name: "plain", payload: body},
+		{name: "gzip", encoding: "gzip", payload: gzipHealthCheckBody(t, body)},
+		{name: "brotli", encoding: "br", payload: brotliHealthCheckBody(t, body)},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resp := &http.Response{
+				StatusCode: 200,
+				Header:     http.Header{},
+				Body:       io.NopCloser(bytes.NewReader(tt.payload)),
+			}
+			if tt.encoding != "" {
+				resp.Header.Set("Content-Encoding", tt.encoding)
+			}
+
+			matched, err := healthCheckResponseSatisfied(resp, C.HealthCheckOption{
+				ExpectedStatus:    nil,
+				Method:            C.HealthCheckMethodGet,
+				ExpectedBodyMatch: `(?i)region=hk`,
+			})
+			require.NoError(t, err)
+			require.True(t, matched)
+		})
+	}
+}
+
+func TestHealthCheckResponseSatisfiedDecodesChainedContentEncoding(t *testing.T) {
+	// The response is encoded as br first and gzip second, represented by the
+	// Content-Encoding list in the order in which the encodings were applied.
+	encoded := brotliHealthCheckBody(t, []byte("available"))
+	encoded = gzipHealthCheckBody(t, encoded)
+	resp := &http.Response{
+		StatusCode: 200,
+		Header:     http.Header{"Content-Encoding": []string{"br, gzip"}},
+		Body:       io.NopCloser(bytes.NewReader(encoded)),
+	}
+
+	matched, err := healthCheckResponseSatisfied(resp, C.HealthCheckOption{
+		Method:            C.HealthCheckMethodGet,
+		ExpectedBodyMatch: "available",
+	})
+	require.NoError(t, err)
+	require.True(t, matched)
+}
+
+func TestHealthCheckResponseSatisfiedRejectsUnsupportedEncoding(t *testing.T) {
+	resp := &http.Response{
+		StatusCode: 200,
+		Header:     http.Header{"Content-Encoding": []string{"zstd"}},
+		Body:       io.NopCloser(bytes.NewReader([]byte("available"))),
+	}
+
+	matched, err := healthCheckResponseSatisfied(resp, C.HealthCheckOption{
+		Method:            C.HealthCheckMethodGet,
+		ExpectedBodyMatch: "available",
+	})
+	require.Error(t, err)
+	require.False(t, matched)
+}
+
+func gzipHealthCheckBody(t *testing.T, body []byte) []byte {
+	t.Helper()
+	var buffer bytes.Buffer
+	writer := gzip.NewWriter(&buffer)
+	_, err := writer.Write(body)
+	require.NoError(t, err)
+	require.NoError(t, writer.Close())
+	return buffer.Bytes()
+}
+
+func brotliHealthCheckBody(t *testing.T, body []byte) []byte {
+	t.Helper()
+	var buffer bytes.Buffer
+	writer := brotli.NewWriter(&buffer)
+	_, err := writer.Write(body)
+	require.NoError(t, err)
+	require.NoError(t, writer.Close())
+	return buffer.Bytes()
+}

--- a/adapter/outboundgroup/fallback.go
+++ b/adapter/outboundgroup/fallback.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/metacubex/mihomo/common/callback"
 	N "github.com/metacubex/mihomo/common/net"
-	"github.com/metacubex/mihomo/common/utils"
 	C "github.com/metacubex/mihomo/constant"
 	P "github.com/metacubex/mihomo/constant/provider"
 )
@@ -17,10 +16,11 @@ type FallbackOption struct{}
 
 type Fallback struct {
 	*GroupBase
-	disableUDP     bool
-	testUrl        string
-	selected       string
-	expectedStatus string
+	disableUDP        bool
+	testUrl           string
+	selected          string
+	expectedStatus    string
+	healthCheckOption C.HealthCheckOption
 }
 
 func (f *Fallback) Now() string {
@@ -140,8 +140,7 @@ func (f *Fallback) Set(name string) error {
 	if !p.AliveForTestUrl(f.testUrl) {
 		ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond*time.Duration(5000))
 		defer cancel()
-		expectedStatus, _ := utils.NewUnsignedRanges[uint16](f.expectedStatus)
-		_, _ = p.URLTest(ctx, f.testUrl, expectedStatus)
+		_, _ = p.URLTest(ctx, f.testUrl, f.healthCheckOption.ExpectedStatus, f.healthCheckOption)
 	}
 
 	return nil
@@ -174,8 +173,9 @@ func NewFallback(option GroupCommonOption, fallbackOption FallbackOption, emptyF
 			EmptyFallback:  emptyFallback,
 			Providers:      providers,
 		}),
-		disableUDP:     option.DisableUDP,
-		testUrl:        option.URL,
-		expectedStatus: option.ExpectedStatus,
+		disableUDP:        option.DisableUDP,
+		testUrl:           option.URL,
+		expectedStatus:    option.ExpectedStatus,
+		healthCheckOption: option.HealthCheckOption(),
 	}, nil
 }

--- a/adapter/outboundgroup/groupbase.go
+++ b/adapter/outboundgroup/groupbase.go
@@ -234,16 +234,20 @@ func (gb *GroupBase) GetProxies(touch bool) []C.Proxy {
 	return proxies
 }
 
-func (gb *GroupBase) URLTest(ctx context.Context, url string, expectedStatus utils.IntRanges[uint16]) (map[string]uint16, error) {
+func (gb *GroupBase) URLTest(ctx context.Context, url string, expectedStatus utils.IntRanges[uint16], options ...C.HealthCheckOption) (map[string]uint16, error) {
 	var wg sync.WaitGroup
 	var lock sync.Mutex
 	mp := map[string]uint16{}
+	healthCheckOption := C.HealthCheckOption{ExpectedStatus: expectedStatus}.WithDefault()
+	if len(options) != 0 {
+		healthCheckOption = options[0].WithDefault()
+	}
 	proxies := gb.GetProxies(false)
 	for _, proxy := range proxies {
 		proxy := proxy
 		wg.Add(1)
 		go func() {
-			delay, err := proxy.URLTest(ctx, url, expectedStatus)
+			delay, err := proxy.URLTest(ctx, url, healthCheckOption.ExpectedStatus, healthCheckOption)
 			if err == nil {
 				lock.Lock()
 				mp[proxy.Name()] = delay

--- a/adapter/outboundgroup/parser.go
+++ b/adapter/outboundgroup/parser.go
@@ -23,26 +23,34 @@ var (
 )
 
 type GroupCommonOption struct {
-	Name                string   `group:"name"`
-	Type                string   `group:"type"`
-	Proxies             []string `group:"proxies,omitempty"`
-	Use                 []string `group:"use,omitempty"`
-	URL                 string   `group:"url,omitempty"`
-	Interval            int      `group:"interval,omitempty"`
-	TestTimeout         int      `group:"timeout,omitempty"`
-	MaxFailedTimes      int      `group:"max-failed-times,omitempty"`
-	EmptyFallback       string   `group:"empty-fallback,omitempty"`
-	Lazy                bool     `group:"lazy,omitempty"`
-	DisableUDP          bool     `group:"disable-udp,omitempty"`
-	Filter              string   `group:"filter,omitempty"`
-	ExcludeFilter       string   `group:"exclude-filter,omitempty"`
-	ExcludeType         string   `group:"exclude-type,omitempty"`
-	ExpectedStatus      string   `group:"expected-status,omitempty"`
-	IncludeAll          bool     `group:"include-all,omitempty"`
-	IncludeAllProxies   bool     `group:"include-all-proxies,omitempty"`
-	IncludeAllProviders bool     `group:"include-all-providers,omitempty"`
-	Hidden              bool     `group:"hidden,omitempty"`
-	Icon                string   `group:"icon,omitempty"`
+	Name                string              `group:"name"`
+	Type                string              `group:"type"`
+	Proxies             []string            `group:"proxies,omitempty"`
+	Use                 []string            `group:"use,omitempty"`
+	URL                 string              `group:"url,omitempty"`
+	Interval            int                 `group:"interval,omitempty"`
+	TestTimeout         int                 `group:"timeout,omitempty"`
+	MaxFailedTimes      int                 `group:"max-failed-times,omitempty"`
+	EmptyFallback       string              `group:"empty-fallback,omitempty"`
+	Lazy                bool                `group:"lazy,omitempty"`
+	DisableUDP          bool                `group:"disable-udp,omitempty"`
+	Filter              string              `group:"filter,omitempty"`
+	ExcludeFilter       string              `group:"exclude-filter,omitempty"`
+	ExcludeType         string              `group:"exclude-type,omitempty"`
+	ExpectedStatus      string              `group:"expected-status,omitempty"`
+	CheckMethod         string              `group:"check-method,omitempty"`
+	HTTPHeaders         any                 `group:"http-headers,omitempty"`
+	ExpectedBodyMatch   string              `group:"expected-body-match,omitempty"`
+	HealthCheck         C.HealthCheckOption `group:"-"`
+	IncludeAll          bool                `group:"include-all,omitempty"`
+	IncludeAllProxies   bool                `group:"include-all-proxies,omitempty"`
+	IncludeAllProviders bool                `group:"include-all-providers,omitempty"`
+	Hidden              bool                `group:"hidden,omitempty"`
+	Icon                string              `group:"icon,omitempty"`
+}
+
+func (o *GroupCommonOption) HealthCheckOption() C.HealthCheckOption {
+	return o.HealthCheck.WithDefault()
 }
 
 func ParseProxyGroup(config map[string]any, proxyMap map[string]C.Proxy, providersMap map[string]P.ProxyProvider, AllProxies []string, AllProviders []string) (ProxyGroup, error) {
@@ -122,12 +130,18 @@ func ParseProxyGroup(config map[string]any, proxyMap map[string]C.Proxy, provide
 	if err != nil {
 		return nil, fmt.Errorf("%s: %w", groupName, err)
 	}
+	healthCheckOption, err := C.NewHealthCheckOption(expectedStatus, groupOption.CheckMethod, groupOption.HTTPHeaders, groupOption.ExpectedBodyMatch)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", groupName, err)
+	}
 
 	status := strings.TrimSpace(groupOption.ExpectedStatus)
 	if status == "" {
 		status = "*"
 	}
 	groupOption.ExpectedStatus = status
+	groupOption.CheckMethod = healthCheckOption.Method
+	groupOption.HealthCheck = healthCheckOption
 
 	if len(groupOption.Use) != 0 {
 		PDs, err := getProviders(providersMap, groupOption.Use)
@@ -147,7 +161,7 @@ func ParseProxyGroup(config map[string]any, proxyMap map[string]C.Proxy, provide
 				groupOption.URL = C.DefaultTestURL
 			}
 		} else {
-			addTestUrlToProviders(PDs, groupOption.URL, expectedStatus, groupOption.Filter, uint(groupOption.Interval))
+			addTestUrlToProviders(PDs, groupOption.URL, healthCheckOption, groupOption.Filter, uint(groupOption.Interval))
 		}
 		providers = append(providers, PDs...)
 	}
@@ -173,7 +187,7 @@ func ParseProxyGroup(config map[string]any, proxyMap map[string]C.Proxy, provide
 			}
 		}
 
-		hc := provider.NewHealthCheck(ps, groupOption.URL, uint(groupOption.TestTimeout), uint(groupOption.Interval), groupOption.Lazy, expectedStatus)
+		hc := provider.NewHealthCheckWithOption(ps, groupOption.URL, uint(groupOption.TestTimeout), uint(groupOption.Interval), groupOption.Lazy, healthCheckOption)
 
 		pd, err := provider.NewCompatibleProvider(groupName, ps, hc)
 		if err != nil {
@@ -248,12 +262,12 @@ func getProviders(mapping map[string]P.ProxyProvider, list []string) ([]P.ProxyP
 	return ps, nil
 }
 
-func addTestUrlToProviders(providers []P.ProxyProvider, url string, expectedStatus utils.IntRanges[uint16], filter string, interval uint) {
+func addTestUrlToProviders(providers []P.ProxyProvider, url string, option C.HealthCheckOption, filter string, interval uint) {
 	if len(providers) == 0 || len(url) == 0 {
 		return
 	}
 
 	for _, pd := range providers {
-		pd.RegisterHealthCheckTask(url, expectedStatus, filter, interval)
+		pd.RegisterHealthCheckTask(url, option, filter, interval)
 	}
 }

--- a/adapter/outboundgroup/urltest.go
+++ b/adapter/outboundgroup/urltest.go
@@ -188,8 +188,8 @@ func (u *URLTest) Proxies() []C.Proxy {
 	return u.GetProxies(false)
 }
 
-func (u *URLTest) URLTest(ctx context.Context, url string, expectedStatus utils.IntRanges[uint16]) (map[string]uint16, error) {
-	return u.GroupBase.URLTest(ctx, u.testUrl, expectedStatus)
+func (u *URLTest) URLTest(ctx context.Context, url string, expectedStatus utils.IntRanges[uint16], options ...C.HealthCheckOption) (map[string]uint16, error) {
+	return u.GroupBase.URLTest(ctx, u.testUrl, expectedStatus, options...)
 }
 
 func NewURLTest(option GroupCommonOption, urlTestOption URLTestOption, emptyFallback C.Proxy, providers []P.ProxyProvider) (*URLTest, error) {

--- a/adapter/outboundgroup/util.go
+++ b/adapter/outboundgroup/util.go
@@ -19,7 +19,7 @@ type ProxyGroup interface {
 	Hidden() bool
 	Icon() string
 
-	URLTest(ctx context.Context, url string, expectedStatus utils.IntRanges[uint16]) (mp map[string]uint16, err error)
+	URLTest(ctx context.Context, url string, expectedStatus utils.IntRanges[uint16], options ...C.HealthCheckOption) (mp map[string]uint16, err error)
 }
 
 var _ ProxyGroup = (*Fallback)(nil)

--- a/adapter/provider/healthcheck.go
+++ b/adapter/provider/healthcheck.go
@@ -22,23 +22,23 @@ type HealthCheckOption struct {
 }
 
 type extraOption struct {
-	expectedStatus utils.IntRanges[uint16]
-	filters        map[string]struct{}
+	option  C.HealthCheckOption
+	filters map[string]struct{}
 }
 
 type HealthCheck struct {
-	ctx            context.Context
-	ctxCancel      context.CancelFunc
-	url            string
-	extra          map[string]*extraOption
-	mu             sync.Mutex
-	proxies        []C.Proxy
-	interval       time.Duration
-	lazy           bool
-	expectedStatus utils.IntRanges[uint16]
-	lastTouch      atomic.TypedValue[time.Time]
-	singleDo       *singledo.Single[struct{}]
-	timeout        time.Duration
+	ctx       context.Context
+	ctxCancel context.CancelFunc
+	url       string
+	extra     map[string]*extraOption
+	mu        sync.Mutex
+	proxies   []C.Proxy
+	interval  time.Duration
+	lazy      bool
+	option    C.HealthCheckOption
+	lastTouch atomic.TypedValue[time.Time]
+	singleDo  *singledo.Single[struct{}]
+	timeout   time.Duration
 }
 
 func (hc *HealthCheck) process() {
@@ -65,7 +65,7 @@ func (hc *HealthCheck) setProxies(proxies []C.Proxy) {
 	hc.proxies = proxies
 }
 
-func (hc *HealthCheck) registerHealthCheckTask(url string, expectedStatus utils.IntRanges[uint16], filter string, interval uint) {
+func (hc *HealthCheck) registerHealthCheckTask(url string, option C.HealthCheckOption, filter string, interval uint) {
 	url = strings.TrimSpace(url)
 	if len(url) == 0 || url == hc.url {
 		log.Debugln("ignore invalid health check url: %s", url)
@@ -95,9 +95,9 @@ func (hc *HealthCheck) registerHealthCheckTask(url string, expectedStatus utils.
 		return
 	}
 
-	option := &extraOption{filters: map[string]struct{}{}, expectedStatus: expectedStatus}
-	splitAndAddFiltersToExtra(filter, option)
-	hc.extra[url] = option
+	extra := &extraOption{filters: map[string]struct{}{}, option: option.WithDefault()}
+	splitAndAddFiltersToExtra(filter, extra)
+	hc.extra[url] = extra
 }
 
 func splitAndAddFiltersToExtra(filter string, option *extraOption) {
@@ -132,7 +132,7 @@ func (hc *HealthCheck) check() {
 		b.SetLimit(10)
 
 		// execute default health check
-		option := &extraOption{filters: nil, expectedStatus: hc.expectedStatus}
+		option := &extraOption{filters: nil, option: hc.option}
 		hc.execute(b, hc.url, id, option)
 
 		// execute extra health check
@@ -155,9 +155,9 @@ func (hc *HealthCheck) execute(b *errgroup.Group, url, uid string, option *extra
 	}
 
 	var filterReg *regexp2.Regexp
-	var expectedStatus utils.IntRanges[uint16]
+	healthCheckOption := C.HealthCheckOption{}.WithDefault()
 	if option != nil {
-		expectedStatus = option.expectedStatus
+		healthCheckOption = option.option.WithDefault()
 		if len(option.filters) != 0 {
 			filters := make([]string, 0, len(option.filters))
 			for filter := range option.filters {
@@ -181,7 +181,7 @@ func (hc *HealthCheck) execute(b *errgroup.Group, url, uid string, option *extra
 			ctx, cancel := context.WithTimeout(hc.ctx, hc.timeout)
 			defer cancel()
 			log.Debugln("Health Checking, proxy: %s, url: %s, id: {%s}", p.Name(), url, uid)
-			_, _ = p.URLTest(ctx, url, expectedStatus)
+			_, _ = p.URLTest(ctx, url, healthCheckOption.ExpectedStatus, healthCheckOption)
 			log.Debugln("Health Checked, proxy: %s, url: %s, alive: %t, delay: %d ms uid: {%s}", p.Name(), url, p.AliveForTestUrl(url), p.LastDelayForTestUrl(url), uid)
 			return nil
 		})
@@ -193,25 +193,30 @@ func (hc *HealthCheck) close() {
 }
 
 func NewHealthCheck(proxies []C.Proxy, url string, timeout uint, interval uint, lazy bool, expectedStatus utils.IntRanges[uint16]) *HealthCheck {
+	return NewHealthCheckWithOption(proxies, url, timeout, interval, lazy, C.HealthCheckOption{ExpectedStatus: expectedStatus})
+}
+
+func NewHealthCheckWithOption(proxies []C.Proxy, url string, timeout uint, interval uint, lazy bool, option C.HealthCheckOption) *HealthCheck {
 	if url == "" {
-		expectedStatus = nil
+		option.ExpectedStatus = nil
 		interval = 0
 	}
 	if timeout == 0 {
 		timeout = 5000
 	}
+	option = option.WithDefault()
 	ctx, cancel := context.WithCancel(context.Background())
 
 	return &HealthCheck{
-		ctx:            ctx,
-		ctxCancel:      cancel,
-		proxies:        proxies,
-		url:            url,
-		timeout:        time.Duration(timeout) * time.Millisecond,
-		extra:          map[string]*extraOption{},
-		interval:       time.Duration(interval) * time.Second,
-		lazy:           lazy,
-		expectedStatus: expectedStatus,
-		singleDo:       singledo.NewSingle[struct{}](time.Second),
+		ctx:       ctx,
+		ctxCancel: cancel,
+		proxies:   proxies,
+		url:       url,
+		timeout:   time.Duration(timeout) * time.Millisecond,
+		extra:     map[string]*extraOption{},
+		interval:  time.Duration(interval) * time.Second,
+		lazy:      lazy,
+		option:    option,
+		singleDo:  singledo.NewSingle[struct{}](time.Second),
 	}
 }

--- a/adapter/provider/parser.go
+++ b/adapter/provider/parser.go
@@ -17,12 +17,15 @@ var (
 )
 
 type healthCheckSchema struct {
-	Enable         bool   `provider:"enable"`
-	URL            string `provider:"url,omitempty"`
-	Interval       int    `provider:"interval,omitempty"`
-	TestTimeout    int    `provider:"timeout,omitempty"`
-	Lazy           bool   `provider:"lazy,omitempty"`
-	ExpectedStatus string `provider:"expected-status,omitempty"`
+	Enable            bool   `provider:"enable"`
+	URL               string `provider:"url,omitempty"`
+	Interval          int    `provider:"interval,omitempty"`
+	TestTimeout       int    `provider:"timeout,omitempty"`
+	Lazy              bool   `provider:"lazy,omitempty"`
+	ExpectedStatus    string `provider:"expected-status,omitempty"`
+	CheckMethod       string `provider:"check-method,omitempty"`
+	HTTPHeaders       any    `provider:"http-headers,omitempty"`
+	ExpectedBodyMatch string `provider:"expected-body-match,omitempty"`
 }
 
 type proxyProviderSchema struct {
@@ -60,6 +63,10 @@ func ParseProxyProvider(name string, mapping map[string]any, tunnel C.Tunnel) (P
 	if err != nil {
 		return nil, err
 	}
+	healthCheckOption, err := C.NewHealthCheckOption(expectedStatus, schema.HealthCheck.CheckMethod, schema.HealthCheck.HTTPHeaders, schema.HealthCheck.ExpectedBodyMatch)
+	if err != nil {
+		return nil, err
+	}
 
 	var hcInterval uint
 	if schema.HealthCheck.Enable {
@@ -68,7 +75,7 @@ func ParseProxyProvider(name string, mapping map[string]any, tunnel C.Tunnel) (P
 		}
 		hcInterval = uint(schema.HealthCheck.Interval)
 	}
-	hc := NewHealthCheck([]C.Proxy{}, schema.HealthCheck.URL, uint(schema.HealthCheck.TestTimeout), hcInterval, schema.HealthCheck.Lazy, expectedStatus)
+	hc := NewHealthCheckWithOption([]C.Proxy{}, schema.HealthCheck.URL, uint(schema.HealthCheck.TestTimeout), hcInterval, schema.HealthCheck.Lazy, healthCheckOption)
 
 	parser, err := NewProxiesParser(name, tunnel, schema.Filter, schema.ExcludeFilter, schema.ExcludeType, schema.DialerProxy, schema.Override, schema.AgeSecretKey)
 	if err != nil {

--- a/adapter/provider/provider.go
+++ b/adapter/provider/provider.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/metacubex/mihomo/adapter"
 	"github.com/metacubex/mihomo/common/convert"
-	"github.com/metacubex/mihomo/common/utils"
 	"github.com/metacubex/mihomo/common/yaml"
 	"github.com/metacubex/mihomo/component/age"
 	"github.com/metacubex/mihomo/component/profile/cachefile"
@@ -96,8 +95,8 @@ func (bp *baseProvider) HealthCheckURL() string {
 	return bp.healthCheck.url
 }
 
-func (bp *baseProvider) RegisterHealthCheckTask(url string, expectedStatus utils.IntRanges[uint16], filter string, interval uint) {
-	bp.healthCheck.registerHealthCheckTask(url, expectedStatus, filter, interval)
+func (bp *baseProvider) RegisterHealthCheckTask(url string, option C.HealthCheckOption, filter string, interval uint) {
+	bp.healthCheck.registerHealthCheckTask(url, option, filter, interval)
 }
 
 func (bp *baseProvider) setProxies(proxies []C.Proxy) {
@@ -134,7 +133,7 @@ func (pp *proxySetProvider) MarshalJSON() ([]byte, error) {
 		VehicleType:      pp.VehicleType().String(),
 		Proxies:          pp.Proxies(),
 		TestUrl:          pp.healthCheck.url,
-		ExpectedStatus:   pp.healthCheck.expectedStatus.String(),
+		ExpectedStatus:   pp.healthCheck.option.ExpectedStatus.String(),
 		UpdatedAt:        pp.UpdatedAt(),
 		SubscriptionInfo: pp.subscriptionInfo,
 	})
@@ -243,7 +242,7 @@ func (ip *inlineProvider) MarshalJSON() ([]byte, error) {
 		VehicleType:    ip.VehicleType().String(),
 		Proxies:        ip.Proxies(),
 		TestUrl:        ip.healthCheck.url,
-		ExpectedStatus: ip.healthCheck.expectedStatus.String(),
+		ExpectedStatus: ip.healthCheck.option.ExpectedStatus.String(),
 		UpdatedAt:      ip.updateAt,
 	})
 }
@@ -305,7 +304,7 @@ func (cp *compatibleProvider) MarshalJSON() ([]byte, error) {
 		VehicleType:    cp.VehicleType().String(),
 		Proxies:        cp.Proxies(),
 		TestUrl:        cp.healthCheck.url,
-		ExpectedStatus: cp.healthCheck.expectedStatus.String(),
+		ExpectedStatus: cp.healthCheck.option.ExpectedStatus.String(),
 	})
 }
 

--- a/constant/adapters.go
+++ b/constant/adapters.go
@@ -169,7 +169,7 @@ type Proxy interface {
 	DelayHistory() []DelayHistory
 	ExtraDelayHistories() map[string]ProxyState
 	LastDelayForTestUrl(url string) uint16
-	URLTest(ctx context.Context, url string, expectedStatus utils.IntRanges[uint16]) (uint16, error)
+	URLTest(ctx context.Context, url string, expectedStatus utils.IntRanges[uint16], options ...HealthCheckOption) (uint16, error)
 }
 
 // AdapterType is enum of adapter type

--- a/constant/healthcheck.go
+++ b/constant/healthcheck.go
@@ -1,0 +1,216 @@
+package constant
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+
+	"github.com/dlclark/regexp2"
+
+	"github.com/metacubex/mihomo/common/utils"
+)
+
+const (
+	HealthCheckMethodHead = "http_head"
+	HealthCheckMethodGet  = "http_get"
+)
+
+type HealthCheckOption struct {
+	ExpectedStatus    utils.IntRanges[uint16]
+	Method            string
+	Headers           map[string][]string
+	ExpectedBodyMatch string
+}
+
+func NewHealthCheckOption(expectedStatus utils.IntRanges[uint16], method string, rawHeaders any, expectedBodyMatch string) (HealthCheckOption, error) {
+	method, err := NormalizeHealthCheckMethod(method)
+	if err != nil {
+		return HealthCheckOption{}, err
+	}
+	if expectedBodyMatch != "" && method != HealthCheckMethodGet {
+		return HealthCheckOption{}, fmt.Errorf("expected-body-match requires check-method %s", HealthCheckMethodGet)
+	}
+	if expectedBodyMatch != "" {
+		if _, err := regexp2.Compile(expectedBodyMatch, regexp2.None); err != nil {
+			return HealthCheckOption{}, fmt.Errorf("expected-body-match regex error: %w", err)
+		}
+	}
+
+	headers, err := ParseHealthCheckHeaders(rawHeaders)
+	if err != nil {
+		return HealthCheckOption{}, err
+	}
+
+	return HealthCheckOption{
+		ExpectedStatus:    expectedStatus,
+		Method:            method,
+		Headers:           headers,
+		ExpectedBodyMatch: expectedBodyMatch,
+	}, nil
+}
+
+func (o HealthCheckOption) WithDefault() HealthCheckOption {
+	if o.Method == "" {
+		o.Method = HealthCheckMethodHead
+	}
+	return o
+}
+
+func NormalizeHealthCheckMethod(method string) (string, error) {
+	switch strings.ToLower(strings.TrimSpace(method)) {
+	case "", HealthCheckMethodHead, "head", "http-head":
+		return HealthCheckMethodHead, nil
+	case HealthCheckMethodGet, "get", "http-get":
+		return HealthCheckMethodGet, nil
+	default:
+		return "", fmt.Errorf("unsupported health check method: %s", method)
+	}
+}
+
+func ParseHealthCheckHeaders(raw any) (map[string][]string, error) {
+	if raw == nil {
+		return nil, nil
+	}
+
+	headers := map[string][]string{}
+	if err := appendHealthCheckHeaders(headers, raw); err != nil {
+		return nil, err
+	}
+	if len(headers) == 0 {
+		return nil, nil
+	}
+	return headers, nil
+}
+
+func appendHealthCheckHeaders(headers map[string][]string, raw any) error {
+	if raw == nil {
+		return nil
+	}
+
+	rv := reflect.ValueOf(raw)
+	if !rv.IsValid() {
+		return nil
+	}
+
+	switch rv.Kind() {
+	case reflect.Map:
+		return appendHealthCheckHeadersFromMap(headers, rv)
+	case reflect.Slice, reflect.Array:
+		for i := 0; i < rv.Len(); i++ {
+			if err := appendHealthCheckHeaderItem(headers, rv.Index(i).Interface()); err != nil {
+				return fmt.Errorf("http-headers[%d]: %w", i, err)
+			}
+		}
+		return nil
+	default:
+		return fmt.Errorf("http-headers expected map or array, got %T", raw)
+	}
+}
+
+func appendHealthCheckHeaderItem(headers map[string][]string, raw any) error {
+	switch item := raw.(type) {
+	case string:
+		name, value, ok := strings.Cut(item, ":")
+		if !ok {
+			return fmt.Errorf("header string must be in 'Name: value' format")
+		}
+		appendHealthCheckHeaderValue(headers, name, value)
+		return nil
+	default:
+		rv := reflect.ValueOf(raw)
+		if rv.IsValid() && rv.Kind() == reflect.Map {
+			return appendHealthCheckHeadersFromMap(headers, rv)
+		}
+		return fmt.Errorf("unsupported header item %T", raw)
+	}
+}
+
+func appendHealthCheckHeadersFromMap(headers map[string][]string, data reflect.Value) error {
+	if data.Len() == 0 {
+		return nil
+	}
+
+	nameValue, hasName := mapStringLookup(data, "name")
+	if hasName {
+		name, ok := asString(nameValue.Interface())
+		if !ok {
+			return fmt.Errorf("header name must be string")
+		}
+
+		if value, ok := mapStringLookup(data, "value"); ok {
+			return appendHealthCheckHeaderValues(headers, name, value.Interface())
+		}
+		if value, ok := mapStringLookup(data, "values"); ok {
+			return appendHealthCheckHeaderValues(headers, name, value.Interface())
+		}
+		return fmt.Errorf("header with name must contain value or values")
+	}
+
+	for _, key := range data.MapKeys() {
+		name, ok := asString(key.Interface())
+		if !ok {
+			return fmt.Errorf("header name must be string")
+		}
+		if err := appendHealthCheckHeaderValues(headers, name, data.MapIndex(key).Interface()); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func appendHealthCheckHeaderValues(headers map[string][]string, name string, raw any) error {
+	switch value := raw.(type) {
+	case string:
+		appendHealthCheckHeaderValue(headers, name, value)
+		return nil
+	}
+
+	rv := reflect.ValueOf(raw)
+	if !rv.IsValid() {
+		return nil
+	}
+
+	switch rv.Kind() {
+	case reflect.Slice, reflect.Array:
+		for i := 0; i < rv.Len(); i++ {
+			value, ok := asString(rv.Index(i).Interface())
+			if !ok {
+				return fmt.Errorf("header %s value must be string", name)
+			}
+			appendHealthCheckHeaderValue(headers, name, value)
+		}
+		return nil
+	default:
+		value, ok := asString(raw)
+		if !ok {
+			return fmt.Errorf("header %s value must be string", name)
+		}
+		appendHealthCheckHeaderValue(headers, name, value)
+		return nil
+	}
+}
+
+func appendHealthCheckHeaderValue(headers map[string][]string, name string, value string) {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return
+	}
+	headers[name] = append(headers[name], strings.TrimSpace(value))
+}
+
+func mapStringLookup(data reflect.Value, key string) (reflect.Value, bool) {
+	for _, mapKey := range data.MapKeys() {
+		if name, ok := asString(mapKey.Interface()); ok && strings.EqualFold(name, key) {
+			return data.MapIndex(mapKey), true
+		}
+	}
+	return reflect.Value{}, false
+}
+
+func asString(raw any) (string, bool) {
+	if raw == nil {
+		return "", false
+	}
+	value, ok := raw.(string)
+	return value, ok
+}

--- a/constant/healthcheck_test.go
+++ b/constant/healthcheck_test.go
@@ -1,0 +1,33 @@
+package constant
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewHealthCheckOption(t *testing.T) {
+	option, err := NewHealthCheckOption(nil, "", nil, "")
+	require.NoError(t, err)
+	require.Equal(t, HealthCheckMethodHead, option.Method)
+
+	option, err = NewHealthCheckOption(nil, "GET", []any{
+		map[string]any{"name": "User-Agent", "value": "mihomo"},
+		map[string]any{"Accept": []any{"text/plain", "application/json"}},
+	}, "(?i)success")
+	require.NoError(t, err)
+	require.Equal(t, HealthCheckMethodGet, option.Method)
+	require.Equal(t, []string{"mihomo"}, option.Headers["User-Agent"])
+	require.Equal(t, []string{"text/plain", "application/json"}, option.Headers["Accept"])
+	require.Equal(t, "(?i)success", option.ExpectedBodyMatch)
+}
+
+func TestNewHealthCheckOptionRejectsBodyMatchWithoutGet(t *testing.T) {
+	_, err := NewHealthCheckOption(nil, HealthCheckMethodHead, nil, "success")
+	require.Error(t, err)
+}
+
+func TestNewHealthCheckOptionRejectsInvalidMethod(t *testing.T) {
+	_, err := NewHealthCheckOption(nil, "post", nil, "")
+	require.Error(t, err)
+}

--- a/constant/provider/interface.go
+++ b/constant/provider/interface.go
@@ -82,7 +82,7 @@ type ProxyProvider interface {
 	Touch()
 	HealthCheck()
 	Version() uint32
-	RegisterHealthCheckTask(url string, expectedStatus utils.IntRanges[uint16], filter string, interval uint)
+	RegisterHealthCheckTask(url string, option constant.HealthCheckOption, filter string, interval uint)
 	HealthCheckURL() string
 }
 

--- a/docs/config.yaml
+++ b/docs/config.yaml
@@ -1722,6 +1722,13 @@ proxy-groups:
       - vmess1
     # tolerance: 150
     # lazy: true
+    # check-method: http_head # 健康检查请求方法，可选 http_head / http_get，默认 http_head
+    # http-headers: # 健康检查请求头，可用于 http_head / http_get
+    #   - name: User-Agent
+    #     value: mihomo
+    #   - name: Accept
+    #     value: text/plain
+    # expected-body-match: "(?i)success" # 仅 check-method 为 http_get 时生效，使用正则表达式匹配响应体，匹配成功才认为节点可用；http_get 默认支持 gzip/br 解压缩
     # expected-status: 204 # 当健康检查返回状态码与期望值不符时，认为节点不可用
     url: "https://cp.cloudflare.com/generate_204"
     interval: 300
@@ -1807,6 +1814,13 @@ proxy-providers:
       enable: true
       interval: 600
       # lazy: true
+      # check-method: http_head # 健康检查请求方法，可选 http_head / http_get，默认 http_head
+      # http-headers: # 健康检查请求头，可用于 http_head / http_get
+      #   - name: User-Agent
+      #     value: mihomo
+      #   - name: Accept
+      #     value: text/plain
+      # expected-body-match: "(?i)success" # 仅 check-method 为 http_get 时生效，使用正则表达式匹配响应体，匹配成功才认为节点可用；http_get 默认支持 gzip/br 解压缩
       url: https://cp.cloudflare.com/generate_204
       # expected-status: 204 # 当健康检查返回状态码与期望值不符时，认为节点不可用
     override: # 覆写节点加载时的一些配置项


### PR DESCRIPTION
## 背景

健康检查原先固定发送 HTTP HEAD，只能根据连接是否成功和 HTTP 状态码判断节点存活，无法验证节点是否真正满足特定业务可用性（例如地区、流媒体或需要请求头鉴权的检测地址）。

## 实现内容

### 请求配置

- 新增 `check-method`，支持 `http_head`（默认）和 `http_get`，同时兼容 `head`/`get` 别名。
- 新增 `http-headers`，支持文档示例中的 `[{name, value}]` 数组，也支持常见的 `Name: value` 字符串和 map 形式；同名请求头可配置多个值。
- 新增 `expected-body-match`，使用 regexp2 正则匹配 GET 响应体；只有 HTTP 状态码和响应体都满足时，节点才会被标记为该检测地址可用。该字段仅允许与 `http_get` 一起使用，配置阶段会提前校验正则。

### 响应处理

- GET 请求显式声明 `Accept-Encoding: gzip, br`（用户自定义请求头优先）。
- 在关闭 Transport 自动压缩后，显式处理 `gzip`、`br`、`deflate`、`identity`，并支持按 RFC 顺序解码组合 `Content-Encoding`。
- 解码失败、未知编码或正则匹配超时都会使本次健康检查失败，避免把压缩/异常内容误判为可用。
- 正则匹配设置 5 秒上限，避免恶意或高复杂度表达式阻塞健康检查 worker。

### 配置链路和兼容性

- proxy group 与 proxy provider 共用 `constant.HealthCheckOption`，配置解析、provider 额外检测任务、fallback 手动检测和所有现有 URLTest 调用均保持兼容。
- 未配置新字段时仍使用原有 HEAD + expected-status 行为；旧的 `NewHealthCheck` 和三参数 `URLTest` 调用无需修改。
- 保留 `empty-fallback` 等当前 Alpha 基线新增字段，已将实现重放到最新 `Alpha`，解决 PR #2771 与基线的冲突。

## 配置示例

```yaml
proxy-groups:
  - name: HK地区
    type: url-test
    proxies: [ss1, ss2]
    url: https://1.1.1.1/cdn-cgi/trace
    check-method: http_get
    http-headers:
      - name: User-Agent
        value: mihomo
    expected-body-match: "(?i)loc=HK"
```

## 验证

- `go test ./...` 通过（全仓库测试）。
- 新增 adapter 回归测试，覆盖明文、gzip、brotli、组合编码、未知编码失败和响应体正则匹配。
- `git diff --check` 通过。