### PR TITLE
feat(rules): extend slash-separated OR payload support to GEOSITE, GEOIP, and IP-ASN

### DIFF
--- a/docs/config.yaml
+++ b/docs/config.yaml
@@ -274,6 +274,7 @@ dns:
     - rule-set:fakeip-filter
     # fakeip-filter 为 geosite 中名为 fakeip-filter 的分类（需要自行保证该分类存在）
     - geosite:fakeip-filter
+    # geosite:fakeip-filter/private # geosite: 前缀也支持正斜杠(/)分割
 
     # 当 fake-ip-filter-mode: rule 时开启规则模式
     # fake-ip 与路由 rules 匹配逻辑一致(自上而下)，语法也一致，支持GEOSITE、RuleSet、DOMAIN*、MATCH
@@ -360,6 +361,7 @@ dns:
     "geosite:cn,private,apple":
       - https://doh.pub/dns-query
       - https://dns.alidns.com/dns-query
+    # "geosite:google/youtube": https://dns.google/dns-query # geosite: 前缀也支持正斜杠(/)分割
     "geosite:category-ads-all": rcode://success
     "www.baidu.com,+.google.cn": [223.5.5.5, https://dns.alidns.com/dns-query]
     ## global，dns 为 rule-providers 中的名为 global 和 dns 规则订阅，
@@ -917,7 +919,6 @@ proxies: # socks5
       # max-connections: 1 # Maximum connections. Conflict with max-streams.
       # min-streams: 0 # Minimum multiplexed streams in a connection before opening a new connection. Conflict with max-streams.
       # max-streams: 0 # Maximum multiplexed streams in a connection before opening a new connection. Conflict with max-connections and min-streams.
-      
     reality-opts:
       public-key: CrrQSjAG_YkHLwvM2M-7XkKJilgL5upBKCp0od0tLhE
       short-id: 10f897e26c4b9478
@@ -1440,7 +1441,7 @@ proxies: # socks5
   - name: sudoku
     type: sudoku
     server: server_ip/domain # 1.2.3.4 or domain
-    port: 443 
+    port: 443
     key: "<client_key>" # 如果你使用sudoku生成的ED25519密钥对，请填写密钥对中的私钥，否则填入和服务端相同的uuid
     aead-method: chacha20-poly1305 # 可选：chacha20-poly1305、aes-128-gcm、none（不建议；none 不提供 AEAD 保护）
     padding-min: 2 # 最小填充率（0-100）
@@ -1688,11 +1689,17 @@ rule-providers:
 
 rules:
   - RULE-SET,rule1,REJECT
-  - IP-ASN,1,PROXY
+  - IP-ASN,13335,PROXY # 匹配 cloudflare ASN13335 IP 段
+  - IP-ASN,13335/396982,PROXY # 支持正斜杠(/)分割, 效果等同于 OR
   - DOMAIN-REGEX,^abc,DIRECT
   - DOMAIN-SUFFIX,baidu.com,DIRECT
   - DOMAIN-KEYWORD,google,ss1
   - DOMAIN-WILDCARD,test.*.mihomo.com,ss1
+  - GEOSITE,baidu,DIRECT # 匹配所有百度网站域名
+  - GEOSITE,google/youtube,PROXY # 支持正斜杠(/)分割, 效果等同于 OR
+  - GEOIP,cn,DIRECT # 匹配所有 CN IP 段
+  - GEOIP,cn/us,PROXY # 支持正斜杠(/)分割, 效果等同于 OR
+  - SRC-GEOIP,cn/us,DIRECT # SRC-GEOIP 和 SRC-IP-ASN 同样支持正斜杠(/)分割
   - IP-CIDR,1.1.1.1/32,ss1
   - IP-CIDR6,2409::/64,DIRECT
   # 当满足条件是 TCP 或 UDP 流量时，使用名为 sub-rule-name1 的规则集

--- a/rules/common/geoip.go
+++ b/rules/common/geoip.go
@@ -17,10 +17,45 @@ import (
 
 type GEOIP struct {
 	Base
-	country     string
+	countries   []string
+	payload     string
 	adapter     string
 	noResolveIP bool
 	isSourceIP  bool
+}
+
+type namedGeoIPMatcher struct {
+	country string
+	matcher router.IPMatcher
+}
+
+type multiGeoIPMatcher []router.IPMatcher
+
+type lanIPMatcher struct{}
+
+func (m multiGeoIPMatcher) Match(ip netip.Addr) bool {
+	for _, matcher := range m {
+		if matcher.Match(ip) {
+			return true
+		}
+	}
+	return false
+}
+
+func (m multiGeoIPMatcher) Count() int {
+	count := 0
+	for _, matcher := range m {
+		count += matcher.Count()
+	}
+	return count
+}
+
+func (lanIPMatcher) Match(ip netip.Addr) bool {
+	return isLanIP(ip)
+}
+
+func (lanIPMatcher) Count() int {
+	return 0
 }
 
 var _ C.Rule = (*GEOIP)(nil)
@@ -45,42 +80,49 @@ func (g *GEOIP) Match(metadata *C.Metadata, helper C.RuleMatchHelper) (bool, str
 		return false, ""
 	}
 
-	if g.country == "lan" {
-		return g.isLan(ip), g.adapter
+	if g.matchLan(ip) {
+		return true, g.adapter
+	}
+	if !g.hasNonLanCountry() {
+		return false, g.adapter
 	}
 
 	if geodata.GeodataMode() {
 		if g.isSourceIP {
-			if slices.Contains(metadata.SrcGeoIP, g.country) {
+			if g.matchCountries(metadata.SrcGeoIP) {
 				return true, g.adapter
 			}
 		} else {
-			if slices.Contains(metadata.DstGeoIP, g.country) {
+			if g.matchCountries(metadata.DstGeoIP) {
 				return true, g.adapter
 			}
 		}
-		matcher, err := g.getIPMatcher()
+
+		matchers, err := g.getNamedIPMatchers()
 		if err != nil {
-			return false, ""
+			return false, g.adapter
 		}
-		match := matcher.Match(ip)
-		if match {
-			if g.isSourceIP {
-				metadata.SrcGeoIP = append(metadata.SrcGeoIP, g.country)
-			} else {
-				metadata.DstGeoIP = append(metadata.DstGeoIP, g.country)
+		for _, matcher := range matchers {
+			if matcher.matcher.Match(ip) {
+				if g.isSourceIP {
+					metadata.SrcGeoIP = append(metadata.SrcGeoIP, matcher.country)
+				} else {
+					metadata.DstGeoIP = append(metadata.DstGeoIP, matcher.country)
+				}
+				return true, g.adapter
 			}
 		}
-		return match, g.adapter
+
+		return false, g.adapter
 	}
 
 	if g.isSourceIP {
 		if metadata.SrcGeoIP != nil {
-			return slices.Contains(metadata.SrcGeoIP, g.country), g.adapter
+			return g.matchCountries(metadata.SrcGeoIP), g.adapter
 		}
 	} else {
 		if metadata.DstGeoIP != nil {
-			return slices.Contains(metadata.DstGeoIP, g.country), g.adapter
+			return g.matchCountries(metadata.DstGeoIP), g.adapter
 		}
 	}
 	codes := mmdb.IPInstance().LookupCode(ip.AsSlice())
@@ -89,32 +131,45 @@ func (g *GEOIP) Match(metadata *C.Metadata, helper C.RuleMatchHelper) (bool, str
 	} else {
 		metadata.DstGeoIP = codes
 	}
-	if slices.Contains(codes, g.country) {
+	if g.matchCountries(codes) {
 		return true, g.adapter
 	}
-	return false, ""
+	return false, g.adapter
 }
 
 // MatchIp implements C.IpMatcher
 func (g *GEOIP) MatchIp(ip netip.Addr) bool {
+	match, ok := g.matchIp(ip)
+	return ok && match
+}
+
+func (g *GEOIP) matchIp(ip netip.Addr) (match bool, ok bool) {
 	if !ip.IsValid() {
-		return false
+		return false, true
 	}
 
-	if g.country == "lan" {
-		return g.isLan(ip)
+	if g.matchLan(ip) {
+		return true, true
+	}
+	if !g.hasNonLanCountry() {
+		return false, true
 	}
 
 	if geodata.GeodataMode() {
-		matcher, err := g.getIPMatcher()
+		matchers, err := g.getNamedIPMatchers()
 		if err != nil {
-			return false
+			return false, false
 		}
-		return matcher.Match(ip)
+		for _, matcher := range matchers {
+			if matcher.matcher.Match(ip) {
+				return true, true
+			}
+		}
+		return false, true
 	}
 
 	codes := mmdb.IPInstance().LookupCode(ip.AsSlice())
-	return slices.Contains(codes, g.country)
+	return g.matchCountries(codes), true
 }
 
 // MatchIp implements C.IpMatcher
@@ -127,20 +182,8 @@ func (g dnsFallbackFilter) MatchIp(ip netip.Addr) bool {
 		return false
 	}
 
-	if g.country == "lan" {
-		return !g.isLan(ip)
-	}
-
-	if geodata.GeodataMode() {
-		matcher, err := g.getIPMatcher()
-		if err != nil {
-			return false
-		}
-		return !matcher.Match(ip)
-	}
-
-	codes := mmdb.IPInstance().LookupCode(ip.AsSlice())
-	return !slices.Contains(codes, g.country)
+	match, ok := g.GEOIP.matchIp(ip)
+	return ok && !match
 }
 
 type dnsFallbackFilter struct {
@@ -152,11 +195,7 @@ func (g *GEOIP) DnsFallbackFilter() C.IpMatcher { // for dns.fallback-filter.geo
 }
 
 func (g *GEOIP) isLan(ip netip.Addr) bool {
-	return ip.IsPrivate() ||
-		ip.IsUnspecified() ||
-		ip.IsLoopback() ||
-		ip.IsMulticast() ||
-		ip.IsLinkLocalUnicast()
+	return isLanIP(ip)
 }
 
 func (g *GEOIP) Adapter() string {
@@ -164,22 +203,83 @@ func (g *GEOIP) Adapter() string {
 }
 
 func (g *GEOIP) Payload() string {
-	return g.country
+	return g.payload
 }
 
 func (g *GEOIP) GetCountry() string {
-	return g.country
+	if len(g.countries) == 0 {
+		return ""
+	}
+	return g.countries[0]
+}
+
+func (g *GEOIP) GetCountries() []string {
+	return append([]string(nil), g.countries...)
 }
 
 func (g *GEOIP) GetIPMatcher() (router.IPMatcher, error) {
 	if geodata.GeodataMode() {
-		return g.getIPMatcher()
+		return g.getCombinedIPMatcher()
+	}
+	if g.hasLanCountry() && !g.hasNonLanCountry() {
+		return lanIPMatcher{}, nil
 	}
 	return nil, errors.New("not geodata mode")
 }
 
-func (g *GEOIP) getIPMatcher() (router.IPMatcher, error) {
-	geoIPMatcher, err := geodata.LoadGeoIPMatcher(g.country)
+func (g *GEOIP) getNamedIPMatchers() ([]namedGeoIPMatcher, error) {
+	return g.loadNamedIPMatchers()
+}
+
+func (g *GEOIP) loadNamedIPMatchers() ([]namedGeoIPMatcher, error) {
+	matchers := make([]namedGeoIPMatcher, 0, len(g.countries))
+	for _, country := range g.countries {
+		if country == "lan" {
+			continue
+		}
+		matcher, err := g.getIPMatcher(country)
+		if err != nil {
+			return nil, err
+		}
+		matchers = append(matchers, namedGeoIPMatcher{country: country, matcher: matcher})
+	}
+
+	if len(matchers) == 0 {
+		return nil, errors.New("geoip matcher has no data")
+	}
+	return matchers, nil
+}
+
+func (g *GEOIP) getCombinedIPMatcher() (router.IPMatcher, error) {
+	matchers := make(multiGeoIPMatcher, 0, len(g.countries))
+	if g.hasLanCountry() {
+		matchers = append(matchers, lanIPMatcher{})
+	}
+	if g.hasNonLanCountry() {
+		namedMatchers, err := g.getNamedIPMatchers()
+		if err != nil {
+			return nil, err
+		}
+		for _, matcher := range namedMatchers {
+			matchers = append(matchers, matcher.matcher)
+		}
+	}
+
+	return newMultiGeoIPMatcher(matchers)
+}
+
+func newMultiGeoIPMatcher(matchers []router.IPMatcher) (router.IPMatcher, error) {
+	if len(matchers) == 0 {
+		return nil, errors.New("geoip matcher has no data")
+	}
+	if len(matchers) == 1 {
+		return matchers[0], nil
+	}
+	return multiGeoIPMatcher(matchers), nil
+}
+
+func (g *GEOIP) getIPMatcher(country string) (router.IPMatcher, error) {
+	geoIPMatcher, err := geodata.LoadGeoIPMatcher(country)
 	if err != nil {
 		return nil, fmt.Errorf("[GeoIP] %w", err)
 	}
@@ -188,8 +288,7 @@ func (g *GEOIP) getIPMatcher() (router.IPMatcher, error) {
 }
 
 func (g *GEOIP) GetRecodeSize() int {
-	// skip pseudorule lan
-	if g.country == "lan" {
+	if !g.hasNonLanCountry() {
 		return 0
 	}
 
@@ -200,17 +299,29 @@ func (g *GEOIP) GetRecodeSize() int {
 }
 
 func NewGEOIP(country string, adapter string, isSrc, noResolveIP bool) (*GEOIP, error) {
-	country = strings.ToLower(country)
+	countries, err := parseSlashSeparatedPayload(country, "geoip country", strings.ToLower)
+	if err != nil {
+		return nil, err
+	}
 
 	geoip := &GEOIP{
 		Base:        Base{},
-		country:     country,
+		countries:   countries,
+		payload:     strings.Join(countries, "/"),
 		adapter:     adapter,
 		noResolveIP: noResolveIP,
 		isSourceIP:  isSrc,
 	}
 
-	if country == "lan" {
+	allLan := true
+	for _, country := range countries {
+		if country != "lan" {
+			allLan = false
+			break
+		}
+	}
+
+	if allLan {
 		return geoip, nil
 	}
 
@@ -220,14 +331,61 @@ func NewGEOIP(country string, adapter string, isSrc, noResolveIP bool) (*GEOIP, 
 	}
 
 	if geodata.GeodataMode() {
-		geoIPMatcher, err := geoip.getIPMatcher() // test load
+		matcher, err := geoip.getCombinedIPMatcher() // test load
 		if err != nil {
 			return nil, err
 		}
-		log.Infoln("Finished initial GeoIP rule %s => %s, records: %d", country, adapter, geoIPMatcher.Count())
+		log.Infoln("Finished initial GeoIP rule %s => %s, records: %d", geoip.payload, adapter, matcher.Count())
 	}
 
 	return geoip, nil
+}
+
+func (g *GEOIP) matchLan(ip netip.Addr) bool {
+	for _, country := range g.countries {
+		if country == "lan" {
+			return isLanIP(ip)
+		}
+	}
+	return false
+}
+
+func (g *GEOIP) matchCountries(codes []string) bool {
+	for _, country := range g.countries {
+		if country == "lan" {
+			continue
+		}
+		if slices.Contains(codes, country) {
+			return true
+		}
+	}
+	return false
+}
+
+func (g *GEOIP) hasNonLanCountry() bool {
+	for _, country := range g.countries {
+		if country != "lan" {
+			return true
+		}
+	}
+	return false
+}
+
+func (g *GEOIP) hasLanCountry() bool {
+	for _, country := range g.countries {
+		if country == "lan" {
+			return true
+		}
+	}
+	return false
+}
+
+func isLanIP(ip netip.Addr) bool {
+	return ip.IsPrivate() ||
+		ip.IsUnspecified() ||
+		ip.IsLoopback() ||
+		ip.IsMulticast() ||
+		ip.IsLinkLocalUnicast()
 }
 
 var _ C.Rule = (*GEOIP)(nil)

--- a/rules/common/geosite.go
+++ b/rules/common/geosite.go
@@ -2,6 +2,7 @@ package common
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/metacubex/mihomo/component/geodata"
 	_ "github.com/metacubex/mihomo/component/geodata/memconservative"
@@ -13,9 +14,29 @@ import (
 
 type GEOSITE struct {
 	Base
-	country    string
+	countries  []string
+	payload    string
 	adapter    string
 	recodeSize int
+}
+
+type multiGeoSiteMatcher []router.DomainMatcher
+
+func (m multiGeoSiteMatcher) ApplyDomain(domain string) bool {
+	for _, matcher := range m {
+		if matcher.ApplyDomain(domain) {
+			return true
+		}
+	}
+	return false
+}
+
+func (m multiGeoSiteMatcher) Count() int {
+	count := 0
+	for _, matcher := range m {
+		count += matcher.Count()
+	}
+	return count
 }
 
 func (gs *GEOSITE) RuleType() C.RuleType {
@@ -43,15 +64,31 @@ func (gs *GEOSITE) Adapter() string {
 }
 
 func (gs *GEOSITE) Payload() string {
-	return gs.country
+	return gs.payload
 }
 
 func (gs *GEOSITE) GetDomainMatcher() (router.DomainMatcher, error) {
-	matcher, err := geodata.LoadGeoSiteMatcher(gs.country)
-	if err != nil {
-		return nil, fmt.Errorf("load GeoSite data error, %w", err)
+	return gs.loadDomainMatcher()
+}
+
+func (gs *GEOSITE) loadDomainMatcher() (router.DomainMatcher, error) {
+	matchers := make(multiGeoSiteMatcher, 0, len(gs.countries))
+	for _, country := range gs.countries {
+		matcher, err := geodata.LoadGeoSiteMatcher(country)
+		if err != nil {
+			return nil, fmt.Errorf("load GeoSite data error, %w", err)
+		}
+		matchers = append(matchers, matcher)
 	}
-	return matcher, nil
+
+	switch len(matchers) {
+	case 0:
+		return nil, fmt.Errorf("load GeoSite data error, empty matcher list")
+	case 1:
+		return matchers[0], nil
+	default:
+		return matchers, nil
+	}
 }
 
 func (gs *GEOSITE) GetRecodeSize() int {
@@ -62,23 +99,29 @@ func (gs *GEOSITE) GetRecodeSize() int {
 }
 
 func NewGEOSITE(country string, adapter string) (*GEOSITE, error) {
+	countries, err := parseSlashSeparatedPayload(country, "geosite country", strings.ToLower)
+	if err != nil {
+		return nil, err
+	}
+
 	if err := geodata.InitGeoSite(); err != nil {
 		log.Errorln("can't initial GeoSite: %s", err)
 		return nil, err
 	}
 
 	geoSite := &GEOSITE{
-		Base:    Base{},
-		country: country,
-		adapter: adapter,
+		Base:      Base{},
+		countries: countries,
+		payload:   strings.Join(countries, "/"),
+		adapter:   adapter,
 	}
 
-	matcher, err := geoSite.GetDomainMatcher() // test load
+	matcher, err := geoSite.loadDomainMatcher() // test load
 	if err != nil {
 		return nil, err
 	}
 
-	log.Infoln("Finished initial GeoSite rule %s => %s, records: %d", country, adapter, matcher.Count())
+	log.Infoln("Finished initial GeoSite rule %s => %s, records: %d", geoSite.payload, adapter, matcher.Count())
 
 	return geoSite, nil
 }

--- a/rules/common/ipasn.go
+++ b/rules/common/ipasn.go
@@ -1,6 +1,8 @@
 package common
 
 import (
+	"strings"
+
 	"github.com/metacubex/mihomo/component/geodata"
 	"github.com/metacubex/mihomo/component/mmdb"
 	C "github.com/metacubex/mihomo/constant"
@@ -9,7 +11,8 @@ import (
 
 type ASN struct {
 	Base
-	asn         string
+	asns        []string
+	payload     string
 	adapter     string
 	noResolveIP bool
 	isSourceIP  bool
@@ -35,7 +38,13 @@ func (a *ASN) Match(metadata *C.Metadata, helper C.RuleMatchHelper) (bool, strin
 		metadata.DstIPASN = asn + " " + aso
 	}
 
-	return a.asn == asn, a.adapter
+	for _, ruleASN := range a.asns {
+		if ruleASN == asn {
+			return true, a.adapter
+		}
+	}
+
+	return false, a.adapter
 }
 
 func (a *ASN) RuleType() C.RuleType {
@@ -50,14 +59,26 @@ func (a *ASN) Adapter() string {
 }
 
 func (a *ASN) Payload() string {
-	return a.asn
+	return a.payload
 }
 
 func (a *ASN) GetASN() string {
-	return a.asn
+	if len(a.asns) == 0 {
+		return ""
+	}
+	return a.asns[0]
+}
+
+func (a *ASN) GetASNs() []string {
+	return append([]string(nil), a.asns...)
 }
 
 func NewIPASN(asn string, adapter string, isSrc, noResolveIP bool) (*ASN, error) {
+	asns, err := parseSlashSeparatedPayload(asn, "asn", nil)
+	if err != nil {
+		return nil, err
+	}
+
 	if err := geodata.InitASN(); err != nil {
 		log.Errorln("can't initial ASN: %s", err)
 		return nil, err
@@ -65,7 +86,8 @@ func NewIPASN(asn string, adapter string, isSrc, noResolveIP bool) (*ASN, error)
 
 	return &ASN{
 		Base:        Base{},
-		asn:         asn,
+		asns:        asns,
+		payload:     strings.Join(asns, "/"),
 		adapter:     adapter,
 		noResolveIP: noResolveIP,
 		isSourceIP:  isSrc,

--- a/rules/common/payload.go
+++ b/rules/common/payload.go
@@ -1,0 +1,28 @@
+package common
+
+import (
+	"fmt"
+	"strings"
+
+	"golang.org/x/exp/slices"
+)
+
+func parseSlashSeparatedPayload(payload, valueName string, normalize func(string) string) ([]string, error) {
+	parts := strings.Split(payload, "/")
+	parsed := make([]string, 0, len(parts))
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			return nil, fmt.Errorf("%s couldn't be empty", valueName)
+		}
+		if normalize != nil {
+			part = normalize(part)
+		}
+		if slices.Contains(parsed, part) {
+			continue
+		}
+		parsed = append(parsed, part)
+	}
+
+	return parsed, nil
+}

--- a/rules/common/payload_test.go
+++ b/rules/common/payload_test.go
@@ -1,0 +1,356 @@
+package common
+
+import (
+	"net/netip"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/metacubex/mihomo/component/geodata"
+	"github.com/metacubex/mihomo/component/geodata/router"
+	C "github.com/metacubex/mihomo/constant"
+)
+
+func TestParseSlashSeparatedPayload(t *testing.T) {
+	t.Parallel()
+
+	values, err := parseSlashSeparatedPayload(" CN / us ", "country", strings.ToLower)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	expected := []string{"cn", "us"}
+	if !reflect.DeepEqual(values, expected) {
+		t.Fatalf("unexpected parsed values: got %v, want %v", values, expected)
+	}
+}
+
+func TestParseSlashSeparatedPayloadDeduplicatesPreservingOrder(t *testing.T) {
+	t.Parallel()
+
+	values, err := parseSlashSeparatedPayload(" CN / us / cn / jp / us ", "country", strings.ToLower)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	expected := []string{"cn", "us", "jp"}
+	if !reflect.DeepEqual(values, expected) {
+		t.Fatalf("unexpected parsed values: got %v, want %v", values, expected)
+	}
+}
+
+func TestParseSlashSeparatedPayloadRejectsEmptyPart(t *testing.T) {
+	t.Parallel()
+
+	testCases := []string{"cn//us", " / cn", "cn / "}
+	for _, input := range testCases {
+		if _, err := parseSlashSeparatedPayload(input, "country", nil); err == nil {
+			t.Fatalf("expected error for empty slash-separated part in %q", input)
+		}
+	}
+}
+
+func TestNewGEOIPRejectsEmptySlashPayloadBeforeGeodata(t *testing.T) {
+	t.Parallel()
+
+	if _, err := NewGEOIP("lan/", "DIRECT", false, true); err == nil {
+		t.Fatalf("expected error for empty slash-separated geoip payload")
+	}
+}
+
+func TestNewGEOIPLanPayloadCanonicalizesWithoutGeodata(t *testing.T) {
+	t.Parallel()
+
+	rule, err := NewGEOIP(" LAN / lan ", "DIRECT", false, true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if got, want := rule.Payload(), "lan"; got != want {
+		t.Fatalf("unexpected payload: got %q, want %q", got, want)
+	}
+}
+
+func TestGEOSITEPayloadCanonicalization(t *testing.T) {
+	t.Parallel()
+
+	countries, err := parseSlashSeparatedPayload("CN / gfw / cn", "geosite country", strings.ToLower)
+	if err != nil {
+		t.Fatalf("unexpected parse error: %v", err)
+	}
+
+	rule := &GEOSITE{countries: countries, payload: strings.Join(countries, "/")}
+	if got, want := rule.Payload(), "cn/gfw"; got != want {
+		t.Fatalf("unexpected payload: got %q, want %q", got, want)
+	}
+}
+
+func TestIPASNPayloadCanonicalization(t *testing.T) {
+	t.Parallel()
+
+	asns, err := parseSlashSeparatedPayload("123 / 456 / 123", "asn", nil)
+	if err != nil {
+		t.Fatalf("unexpected parse error: %v", err)
+	}
+
+	rule := &ASN{asns: asns, payload: strings.Join(asns, "/")}
+	if got, want := rule.Payload(), "123/456"; got != want {
+		t.Fatalf("unexpected payload: got %q, want %q", got, want)
+	}
+}
+
+func TestGEOIPMixedPayloadCanonicalizes(t *testing.T) {
+	t.Parallel()
+
+	countries, err := parseSlashSeparatedPayload(" LAN / cn / lan ", "geoip country", strings.ToLower)
+	if err != nil {
+		t.Fatalf("unexpected parse error: %v", err)
+	}
+
+	rule := &GEOIP{countries: countries, payload: strings.Join(countries, "/")}
+	if got, want := rule.Payload(), "lan/cn"; got != want {
+		t.Fatalf("unexpected payload: got %q, want %q", got, want)
+	}
+}
+
+func TestGEOIPGetCountryReturnsFirstCountry(t *testing.T) {
+	t.Parallel()
+
+	rule := &GEOIP{countries: []string{"cn", "us"}, payload: "cn/us"}
+	if got, want := rule.GetCountry(), "cn"; got != want {
+		t.Fatalf("unexpected country: got %q, want %q", got, want)
+	}
+}
+
+func TestGEOIPGetCountriesReturnsCopy(t *testing.T) {
+	t.Parallel()
+
+	rule := &GEOIP{countries: []string{"cn", "us"}, payload: "cn/us"}
+	countries := rule.GetCountries()
+	countries[0] = "jp"
+	if got, want := rule.GetCountries()[0], "cn"; got != want {
+		t.Fatalf("unexpected country mutation: got %q, want %q", got, want)
+	}
+}
+
+func TestASNGetASNReturnsFirstASN(t *testing.T) {
+	t.Parallel()
+
+	rule := &ASN{asns: []string{"13335", "396982"}, payload: "13335/396982"}
+	if got, want := rule.GetASN(), "13335"; got != want {
+		t.Fatalf("unexpected asn: got %q, want %q", got, want)
+	}
+}
+
+func TestASNGetASNsReturnsCopy(t *testing.T) {
+	t.Parallel()
+
+	rule := &ASN{asns: []string{"13335", "396982"}, payload: "13335/396982"}
+	asns := rule.GetASNs()
+	asns[0] = "1"
+	if got, want := rule.GetASNs()[0], "13335"; got != want {
+		t.Fatalf("unexpected asn mutation: got %q, want %q", got, want)
+	}
+}
+
+func TestNewGEOIPPureLanHasZeroRecordSize(t *testing.T) {
+	t.Parallel()
+
+	rule, err := NewGEOIP("lan", "DIRECT", false, true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if got := rule.GetRecodeSize(); got != 0 {
+		t.Fatalf("unexpected record size: got %d, want 0", got)
+	}
+}
+
+func TestGeoIPPureLanDoesNotMatchPublicIP(t *testing.T) {
+	t.Parallel()
+
+	rule := &GEOIP{countries: []string{"lan"}}
+	if rule.MatchIp(netip.MustParseAddr("8.8.8.8")) {
+		t.Fatalf("unexpected match for public address with pure lan geoip rule")
+	}
+}
+
+func TestGeoIPReturnsAdapterOnLanMiss(t *testing.T) {
+	t.Parallel()
+
+	rule := &GEOIP{countries: []string{"lan"}, adapter: "DIRECT"}
+	matched, adapter := rule.Match(&C.Metadata{DstIP: netip.MustParseAddr("8.8.8.8")}, C.RuleMatchHelper{})
+	if matched {
+		t.Fatalf("unexpected match for public address with pure lan geoip rule")
+	}
+	if adapter != "DIRECT" {
+		t.Fatalf("unexpected adapter: got %q, want %q", adapter, "DIRECT")
+	}
+}
+
+func TestGeoIPMatchLanMixedPayload(t *testing.T) {
+	t.Parallel()
+
+	rule := &GEOIP{countries: []string{"lan", "cn"}}
+	if !rule.MatchIp(netip.MustParseAddr("192.168.1.1")) {
+		t.Fatalf("expected lan address to match mixed geoip rule")
+	}
+}
+
+func TestGeoIPGetCombinedIPMatcherIncludesLan(t *testing.T) {
+	oldGeodataMode := geodata.GeodataMode()
+	geodata.SetGeodataMode(true)
+	t.Cleanup(func() {
+		geodata.SetGeodataMode(oldGeodataMode)
+	})
+
+	rule := &GEOIP{countries: []string{"lan"}}
+	matcher, err := rule.GetIPMatcher()
+	if err != nil {
+		t.Fatalf("unexpected matcher error: %v", err)
+	}
+	if !matcher.Match(netip.MustParseAddr("192.168.1.1")) {
+		t.Fatalf("expected exported geoip matcher to include lan addresses")
+	}
+	if matcher.Match(netip.MustParseAddr("8.8.8.8")) {
+		t.Fatalf("unexpected public address match with lan-only matcher")
+	}
+	if got := matcher.Count(); got != 0 {
+		t.Fatalf("unexpected lan matcher count: got %d, want 0", got)
+	}
+}
+
+func TestMultiGeoIPMatcherMatchesAnyAndCountsAllRecords(t *testing.T) {
+	t.Parallel()
+
+	matchers := []router.IPMatcher{
+		staticIPMatcher{
+			ips:   map[netip.Addr]bool{netip.MustParseAddr("8.8.8.8"): true},
+			count: 1,
+		},
+		staticIPMatcher{
+			ips:   map[netip.Addr]bool{netip.MustParseAddr("223.5.5.5"): true},
+			count: 1,
+		},
+	}
+	matcher, err := newMultiGeoIPMatcher(matchers)
+	if err != nil {
+		t.Fatalf("unexpected matcher error: %v", err)
+	}
+	if !matcher.Match(netip.MustParseAddr("223.5.5.5")) {
+		t.Fatalf("expected combined geoip matcher to match")
+	}
+	if !matcher.Match(netip.MustParseAddr("8.8.8.8")) {
+		t.Fatalf("expected combined geoip matcher to match")
+	}
+	if got, want := matcher.Count(), 2; got != want {
+		t.Fatalf("unexpected matcher count: got %d, want %d", got, want)
+	}
+}
+
+func TestGeoIPLoadNamedIPMatchersFailsOnAnyInvalidPayload(t *testing.T) {
+	oldGeodataMode := geodata.GeodataMode()
+	geodata.SetGeodataMode(true)
+	t.Cleanup(func() {
+		geodata.SetGeodataMode(oldGeodataMode)
+	})
+
+	rule := &GEOIP{countries: []string{"lan", ""}}
+	if _, err := rule.loadNamedIPMatchers(); err == nil {
+		t.Fatalf("expected error when any non-lan matcher cannot load")
+	}
+}
+
+func TestGEOIPMatchUsesCachedMetadataOnMiss(t *testing.T) {
+	t.Parallel()
+
+	rule := &GEOIP{countries: []string{"us"}, adapter: "DIRECT"}
+	metadata := &C.Metadata{
+		DstIP:    netip.MustParseAddr("8.8.8.8"),
+		DstGeoIP: []string{"cn"},
+	}
+
+	matched, adapter := rule.Match(metadata, C.RuleMatchHelper{})
+	if matched {
+		t.Fatalf("expected cached geoip metadata miss")
+	}
+	if adapter != "DIRECT" {
+		t.Fatalf("unexpected adapter: got %q, want %q", adapter, "DIRECT")
+	}
+}
+
+func TestGeoIPDnsFallbackFilterPreservesLanBypass(t *testing.T) {
+	t.Parallel()
+
+	filter := dnsFallbackFilter{GEOIP: &GEOIP{countries: []string{"lan", "cn"}}}
+	if filter.MatchIp(netip.MustParseAddr("10.0.0.1")) {
+		t.Fatalf("expected lan address to bypass fallback filter")
+	}
+}
+
+func TestGeoIPDnsFallbackFilterDoesNotFallbackOnMatcherError(t *testing.T) {
+	oldGeodataMode := geodata.GeodataMode()
+	geodata.SetGeodataMode(true)
+	t.Cleanup(func() {
+		geodata.SetGeodataMode(oldGeodataMode)
+	})
+
+	filter := dnsFallbackFilter{GEOIP: &GEOIP{countries: []string{""}}}
+	if filter.MatchIp(netip.MustParseAddr("8.8.8.8")) {
+		t.Fatalf("expected matcher error to bypass fallback filter")
+	}
+}
+
+func TestMultiGeoSiteMatcherMatchesAnyAndCountsAllRecords(t *testing.T) {
+	t.Parallel()
+
+	matcher := multiGeoSiteMatcher{
+		staticDomainMatcher{domains: map[string]bool{"google.com": true}, count: 1},
+		staticDomainMatcher{domains: map[string]bool{"youtube.com": true}, count: 1},
+	}
+
+	if !matcher.ApplyDomain("youtube.com") {
+		t.Fatalf("expected combined geosite matcher to match")
+	}
+	if got, want := matcher.Count(), 2; got != want {
+		t.Fatalf("unexpected matcher count: got %d, want %d", got, want)
+	}
+}
+
+func TestGeoSiteLoadDomainMatcherFailsOnAnyInvalidPayload(t *testing.T) {
+	t.Parallel()
+
+	rule := &GEOSITE{
+		countries: []string{"", "still-missing"},
+		payload:   "/still-missing",
+	}
+	if _, err := rule.loadDomainMatcher(); err == nil {
+		t.Fatalf("expected error when any geosite matcher cannot load")
+	}
+}
+
+type staticIPMatcher struct {
+	ips   map[netip.Addr]bool
+	count int
+}
+
+func (m staticIPMatcher) Match(ip netip.Addr) bool {
+	return m.ips[ip]
+}
+
+func (m staticIPMatcher) Count() int {
+	return m.count
+}
+
+type staticDomainMatcher struct {
+	domains map[string]bool
+	count   int
+}
+
+func (m staticDomainMatcher) ApplyDomain(domain string) bool {
+	return m.domains[domain]
+}
+
+func (m staticDomainMatcher) Count() int {
+	return m.count
+}

--- a/rules/parser_test.go
+++ b/rules/parser_test.go
@@ -1,0 +1,28 @@
+package rules
+
+import (
+	"net/netip"
+	"testing"
+
+	C "github.com/metacubex/mihomo/constant"
+)
+
+func TestParseRuleGEOIPSlashLan(t *testing.T) {
+	t.Parallel()
+
+	rule, err := ParseRule("GEOIP", " LAN / lan ", "DIRECT", nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected parse error: %v", err)
+	}
+	if got, want := rule.Payload(), "lan"; got != want {
+		t.Fatalf("unexpected payload: got %q, want %q", got, want)
+	}
+
+	matched, adapter := rule.Match(&C.Metadata{DstIP: netip.MustParseAddr("192.168.1.1")}, C.RuleMatchHelper{})
+	if !matched {
+		t.Fatalf("expected parsed slash geoip rule to match lan address")
+	}
+	if adapter != "DIRECT" {
+		t.Fatalf("unexpected adapter: got %q, want %q", adapter, "DIRECT")
+	}
+}


### PR DESCRIPTION
## Summary

Extend slash-separated payload support to more rule types so one rule can OR-match multiple values without a long `OR` rule.

This supports:

- `GEOSITE,cn/gfw,PROXY`
- `GEOIP,lan/cn,DIRECT`
- `SRC-GEOIP,cn/us,DIRECT`
- `IP-ASN,1/13335,PROXY`
- `SRC-IP-ASN,13335/396982,DIRECT`

The behavior matches existing slash-separated list patterns in rules such as `IN-TYPE`, `IN-USER`, `IN-NAME`, `REMATCH-NAME`, and numeric range rules.

## Support Table

Rule type | Syntax | Slash support
-- | -- | --
GEOSITE | GEOSITE,google/youtube,PROXY | ★ yes
GEOIP | GEOIP,cn/us,PROXY[,no-resolve\|src] | ★ yes
SRC-GEOIP | SRC-GEOIP,cn/us,PROXY | ★ yes
IP-ASN | IP-ASN,13335/396982,PROXY[,no-resolve\|src] | ★ yes
SRC-IP-ASN | SRC-IP-ASN,13335/396982,PROXY | ★ yes
UID | UID,1000/1001/2000-3000,PROXY | ◐ yes, numeric ranges; Linux/Android only
IN-TYPE | IN-TYPE,HTTP/SOCKS/MIXED,PROXY | ◐ yes, manual split
IN-USER | IN-USER,user1/user2,PROXY | ◐ yes, manual split
IN-NAME | IN-NAME,in1/in2,PROXY | ◐ yes, manual split
DOMAIN | DOMAIN,example.com,PROXY | No
DOMAIN-SUFFIX | DOMAIN-SUFFIX,example.com,PROXY | No
DOMAIN-KEYWORD | DOMAIN-KEYWORD,google,PROXY | No
DOMAIN-REGEX | DOMAIN-REGEX,^abc,PROXY | No
DOMAIN-WILDCARD | DOMAIN-WILDCARD,*.example.com,PROXY | No
IP-CIDR | IP-CIDR,1.1.1.0/24,PROXY[,no-resolve\|src] | No, slash is CIDR
IP-CIDR6 | IP-CIDR6,2409::/64,PROXY[,no-resolve\|src] | No, slash is CIDR
SRC-IP-CIDR | SRC-IP-CIDR,192.168.1.0/24,PROXY | No, slash is CIDR
IP-SUFFIX | IP-SUFFIX,1.2.3.4/32,PROXY[,no-resolve\|src] | No, slash is prefix length
SRC-IP-SUFFIX | SRC-IP-SUFFIX,1.2.3.4/32,PROXY | No, slash is prefix length
SRC-PORT | SRC-PORT,80/443/1000-2000,PROXY | ◐ yes, numeric ranges
DST-PORT | DST-PORT,80/443/1000-2000,PROXY | ◐ yes, numeric ranges
IN-PORT | IN-PORT,7890/7891,PROXY | ◐ yes, numeric ranges
DSCP | DSCP,0/8/16-32,PROXY | ◐ yes, numeric ranges
PROCESS-NAME | PROCESS-NAME,curl,PROXY | No
PROCESS-PATH | PROCESS-PATH,/usr/bin/curl,PROXY | No
PROCESS-NAME-REGEX | PROCESS-NAME-REGEX,^curl$,PROXY | No
PROCESS-PATH-REGEX | PROCESS-PATH-REGEX,/bin/.*,PROXY | No
PROCESS-NAME-WILDCARD | PROCESS-NAME-WILDCARD,curl*,PROXY | No
PROCESS-PATH-WILDCARD | PROCESS-PATH-WILDCARD,*/curl,PROXY | No
NETWORK | NETWORK,TCP,PROXY or NETWORK,UDP,PROXY | No
REMATCH-NAME | REMATCH-NAME,name1/name2,PROXY | ◐ yes, manual split
RULE-SET | RULE-SET,provider-name,PROXY[,no-resolve\|src] | No
MATCH | MATCH,PROXY | N/A

## What Changed

### Rule behavior

- `GEOSITE` accepts slash-separated categories and matches if any category matches.
- `GEOIP` accepts slash-separated countries and pseudo-values and matches if any value matches.
  - Mixed payloads such as `lan/cn` are supported.
  - Pure `lan` behavior is preserved.
  - `SRC-GEOIP` inherits the same support.
- `IP-ASN` accepts slash-separated ASNs and matches if any ASN matches.
  - `SRC-IP-ASN` inherits the same support.

### Parsing

Added a shared slash-separated payload parser that:

- trims whitespace around each segment
- rejects empty segments such as `cn//us`, `/cn`, and `cn/`
- deduplicates values while preserving order
- supports optional normalization, such as lowercasing GeoSite and GeoIP payloads

### Internal behavior

- Canonicalized stored payload strings for logging and UI display.
- Added combined matcher support for multi-value `GEOSITE` and `GEOIP` payloads.
- Added exported copy accessors for multi-value payloads:
  - `GEOIP.GetCountries()`
  - `ASN.GetASNs()`
- Preserved `GetCountry()` and `GetASN()` compatibility by returning the first parsed value.
- Kept matcher loading aligned with current geodata cache behavior instead of caching matchers directly on rule instances.

### Documentation

Added examples for:

- routing rules using slash-separated `GEOSITE`, `GEOIP`, `SRC-GEOIP`, and `IP-ASN`
- `geosite:` prefix usage in DNS-related config examples

## Examples

```yaml
rules:
  - IP-ASN,1/13335,PROXY
  - SRC-IP-ASN,13335/396982,DIRECT
  - GEOSITE,cn/gfw,PROXY
  - GEOIP,lan/cn,DIRECT
  - SRC-GEOIP,cn/us,DIRECT
```

```yaml
dns:
  nameserver-policy:
    "geosite:google/youtube": https://dns.google/dns-query
```

## Tests

Added/updated tests covering:

- shared slash-separated payload parsing
- trimming, deduplication, and canonicalization
- empty segment rejection
- GEOIP `lan` and mixed payload behavior
- combined GeoIP and GeoSite matcher behavior
- DNS fallback behavior when GeoIP matcher loading fails
- copied accessor behavior for multi-value GEOIP and ASN payloads
- parser-level coverage for slash GEOIP payloads

Tested with:

```text
go test ./rules/...
go test ./...
```