### PR TITLE
feat: Add TSUNAMI protocol outbound support

### DIFF
--- a/adapter/outbound/tsunami.go
+++ b/adapter/outbound/tsunami.go
@@ -1,0 +1,138 @@
+package outbound
+
+import (
+	"context"
+	"net"
+	"strconv"
+
+	N "github.com/metacubex/mihomo/common/net"
+	"github.com/metacubex/mihomo/component/proxydialer"
+	C "github.com/metacubex/mihomo/constant"
+	"github.com/metacubex/mihomo/transport/tsunami"
+	"github.com/metacubex/mihomo/transport/vmess"
+
+	M "github.com/metacubex/sing/common/metadata"
+	"github.com/metacubex/sing/common/uot"
+)
+
+type Tsunami struct {
+	*Base
+	client *tsunami.Client
+	option *TsunamiOption
+}
+
+type TsunamiOption struct {
+	BasicOption
+	Name              string     `proxy:"name"`
+	Server            string     `proxy:"server"`
+	Port              int        `proxy:"port"`
+	Password          string     `proxy:"password"`
+	ALPN              []string   `proxy:"alpn,omitempty"`
+	SNI               string     `proxy:"sni,omitempty"`
+	ECHOpts           ECHOptions `proxy:"ech-opts,omitempty"`
+	ClientFingerprint string     `proxy:"client-fingerprint,omitempty"`
+	SkipCertVerify    bool       `proxy:"skip-cert-verify,omitempty"`
+	Fingerprint       string     `proxy:"fingerprint,omitempty"`
+	Certificate       string     `proxy:"certificate,omitempty"`
+	PrivateKey        string     `proxy:"private-key,omitempty"`
+	UDP               bool       `proxy:"udp,omitempty"`
+}
+
+func (t *Tsunami) DialContext(ctx context.Context, metadata *C.Metadata) (_ C.Conn, err error) {
+	c, err := t.client.CreateProxy(ctx, M.ParseSocksaddrHostPort(metadata.String(), metadata.DstPort))
+	if err != nil {
+		return nil, err
+	}
+	return NewConn(c, t), nil
+}
+
+func (t *Tsunami) ListenPacketContext(ctx context.Context, metadata *C.Metadata) (_ C.PacketConn, err error) {
+	if err = t.ResolveUDP(ctx, metadata); err != nil {
+		return nil, err
+	}
+
+	// create tcp connection for UoT
+	c, err := t.client.CreateProxy(ctx, uot.RequestDestination(2))
+	if err != nil {
+		return nil, err
+	}
+
+	// create uot on tcp
+	destination := M.SocksaddrFromNet(metadata.UDPAddr())
+	return newPacketConn(N.NewThreadSafePacketConn(uot.NewLazyConn(c, uot.Request{Destination: destination})), t), nil
+}
+
+// SupportUOT implements C.ProxyAdapter
+func (t *Tsunami) SupportUOT() bool {
+	return true
+}
+
+// ProxyInfo implements C.ProxyAdapter
+func (t *Tsunami) ProxyInfo() C.ProxyInfo {
+	info := t.Base.ProxyInfo()
+	info.DialerProxy = t.option.DialerProxy
+	return info
+}
+
+// Close implements C.ProxyAdapter
+func (t *Tsunami) Close() error {
+	return t.client.Close()
+}
+
+func NewTsunami(option TsunamiOption) (*Tsunami, error) {
+	addr := net.JoinHostPort(option.Server, strconv.Itoa(option.Port))
+	outbound := &Tsunami{
+		Base: NewBase(BaseOption{
+			Name:         option.Name,
+			Addr:         addr,
+			Type:         C.Tsunami,
+			ProviderName: option.ProviderName,
+			UDP:          option.UDP,
+			TFO:          option.TFO,
+			MPTCP:        option.MPTCP,
+			Interface:    option.Interface,
+			RoutingMark:  option.RoutingMark,
+			Prefer:       option.IPVersion,
+		}),
+		option: &option,
+	}
+	outbound.dialer = option.NewDialer(outbound.DialOptions())
+	singDialer := proxydialer.NewSingDialer(outbound.dialer)
+
+	echConfig, err := option.ECHOpts.Parse()
+	if err != nil {
+		return nil, err
+	}
+
+	// TSUNAMI requires TLS 1.3 with ALPN h2
+	alpn := option.ALPN
+	if len(alpn) == 0 {
+		alpn = []string{"h2"}
+	}
+
+	tlsConfig := &vmess.TLSConfig{
+		Host:              option.SNI,
+		SkipCertVerify:    option.SkipCertVerify,
+		NextProtos:        alpn,
+		FingerPrint:       option.Fingerprint,
+		Certificate:       option.Certificate,
+		PrivateKey:        option.PrivateKey,
+		ClientFingerprint: option.ClientFingerprint,
+		ECH:               echConfig,
+	}
+	if tlsConfig.Host == "" {
+		tlsConfig.Host = option.Server
+	}
+
+	tOption := tsunami.ClientConfig{
+		Password:  option.Password,
+		Server:    M.ParseSocksaddrHostPort(option.Server, uint16(option.Port)),
+		Dialer:    singDialer,
+		TLSConfig: tlsConfig,
+	}
+
+	client := tsunami.NewClient(context.TODO(), tOption)
+	outbound.client = client
+
+	return outbound, nil
+}

--- a/adapter/parser.go
+++ b/adapter/parser.go
@@ -152,6 +152,13 @@ func ParseProxy(mapping map[string]any, options ...ProxyOption) (C.Proxy, error)
 			break
 		}
 		proxy, err = outbound.NewAnyTLS(*anytlsOption)
+	case "tsunami":
+		tsunamiOption := &outbound.TsunamiOption{BasicOption: basicOption}
+		err = decoder.Decode(mapping, tsunamiOption)
+		if err != nil {
+			break
+		}
+		proxy, err = outbound.NewTsunami(*tsunamiOption)
 	case "sudoku":
 		sudokuOption := &outbound.SudokuOption{BasicOption: basicOption}
 		err = decoder.Decode(mapping, sudokuOption)

--- a/constant/adapters.go
+++ b/constant/adapters.go
@@ -47,6 +47,7 @@ const (
 	Sudoku
 	Masque
 	TrustTunnel
+	Tsunami
 )
 
 const (
@@ -218,6 +219,8 @@ func (at AdapterType) String() string {
 		return "Masque"
 	case TrustTunnel:
 		return "TrustTunnel"
+	case Tsunami:
+		return "Tsunami"
 	case Relay:
 		return "Relay"
 	case Selector:

--- a/constant/metadata.go
+++ b/constant/metadata.go
@@ -41,6 +41,7 @@ const (
 	MIERU
 	SUDOKU
 	TRUSTTUNNEL
+	TSUNAMI
 	INNER
 )
 
@@ -118,6 +119,8 @@ func (t Type) String() string {
 		return "Sudoku"
 	case TRUSTTUNNEL:
 		return "TrustTunnel"
+	case TSUNAMI:
+		return "Tsunami"
 	case INNER:
 		return "Inner"
 	default:
@@ -164,6 +167,8 @@ func ParseType(t string) (*Type, error) {
 		res = SUDOKU
 	case "TRUSTTUNNEL":
 		res = TRUSTTUNNEL
+	case "TSUNAMI":
+		res = TSUNAMI
 	case "INNER":
 		res = INNER
 	default:

--- a/transport/tsunami/client.go
+++ b/transport/tsunami/client.go
@@ -1,0 +1,90 @@
+package tsunami
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/binary"
+	"net"
+
+	"github.com/metacubex/mihomo/transport/vmess"
+
+	M "github.com/metacubex/sing/common/metadata"
+	N "github.com/metacubex/sing/common/network"
+)
+
+// ClientConfig holds the configuration for the TSUNAMI transport client.
+type ClientConfig struct {
+	Password  string
+	Server    M.Socksaddr
+	Dialer    N.Dialer
+	TLSConfig *vmess.TLSConfig
+}
+
+// Client manages TSUNAMI connections to the remote server.
+type Client struct {
+	passwordHash [32]byte
+	tlsConfig    *vmess.TLSConfig
+	dialer       N.Dialer
+	server       M.Socksaddr
+}
+
+// NewClient creates a new TSUNAMI transport client.
+func NewClient(ctx context.Context, config ClientConfig) *Client {
+	hash := sha256.Sum256([]byte(config.Password))
+	c := &Client{
+		passwordHash: hash,
+		tlsConfig:    config.TLSConfig,
+		dialer:       config.Dialer,
+		server:       config.Server,
+	}
+	return c
+}
+
+// CreateProxy creates a proxied connection through TSUNAMI to the given destination.
+func (c *Client) CreateProxy(ctx context.Context, destination M.Socksaddr) (net.Conn, error) {
+	conn, err := c.createOutboundConnection(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	// Write destination address for the proxy
+	err = M.SocksaddrSerializer.WriteAddrPort(conn, destination)
+	if err != nil {
+		conn.Close()
+		return nil, err
+	}
+	return conn, nil
+}
+
+// createOutboundConnection establishes a new TLS connection and authenticates.
+func (c *Client) createOutboundConnection(ctx context.Context) (net.Conn, error) {
+	// Dial raw TCP
+	conn, err := c.dialer.DialContext(ctx, N.NetworkTCP, c.server)
+	if err != nil {
+		return nil, err
+	}
+
+	// Wrap with TLS
+	tlsConn, err := vmess.StreamTLSConn(ctx, conn, c.tlsConfig)
+	if err != nil {
+		conn.Close()
+		return nil, err
+	}
+
+	// Send authentication: SHA-256(password) + padding_length(0) + no padding
+	authBuf := make([]byte, 32+2)
+	copy(authBuf[:32], c.passwordHash[:])
+	binary.BigEndian.PutUint16(authBuf[32:34], 0) // no padding
+	_, err = tlsConn.Write(authBuf)
+	if err != nil {
+		tlsConn.Close()
+		return nil, err
+	}
+
+	return tlsConn, nil
+}
+
+// Close closes the client.
+func (c *Client) Close() error {
+	return nil
+}


### PR DESCRIPTION
## Summary
Add TSUNAMI protocol as a first-class outbound proxy type in mihomo.

## Changes

### Modified Files
- **constant/adapters.go**: Add `Tsunami` AdapterType constant
- **constant/metadata.go**: Add `TSUNAMI` metadata Type, String(), and ParseType()
- **adapter/parser.go**: Add `tsunami` case to proxy config parser

### New Files
- **transport/tsunami/client.go**: TSUNAMI transport client
  - SHA-256(password) authentication
  - TLS 1.3 via `vmess.StreamTLSConn` (supports uTLS fingerprinting)
  - ALPN `h2` default
- **adapter/outbound/tsunami.go**: Outbound adapter
  - `DialContext`: TCP proxy connections
  - `ListenPacketContext`: UDP via UoT v2
  - `SupportUOT()`: true
  - Config: password, sni, alpn, client-fingerprint, skip-cert-verify, ech-opts

## Config Example
```yaml
proxies:
  - name: tsunami-node
    type: tsunami
    server: example.com
    port: 443
    password: your-uuid
    sni: example.com
    udp: true
    client-fingerprint: chrome
```