### PR TITLE
fix: validate Linux process netlink matches

### DIFF
--- a/component/process/process_linux.go
+++ b/component/process/process_linux.go
@@ -133,17 +133,79 @@ func resolveSocketByNetlink(network string, ip netip.Addr, srcPort int) (uint32,
 		return 0, 0, err
 	}
 
+	var fallbackUID, fallbackInode uint32
+	fallbackFound := false
 	for _, msg := range messages {
 		if len(msg.Data) < inetDiagResponseSize {
 			continue
 		}
 
 		response := (*inetDiagResponse)(unsafe.Pointer(&msg.Data[0]))
+		if response.INode == 0 {
+			continue
+		}
 
-		return response.UID, response.INode, nil
+		switch responseSourceMatch(response, request.Protocol, ip, srcPort) {
+		case sourceExactMatch:
+			return response.UID, response.INode, nil
+		case sourceWildcardMatch:
+			if !fallbackFound {
+				fallbackUID = response.UID
+				fallbackInode = response.INode
+				fallbackFound = true
+			}
+		}
+	}
+
+	if fallbackFound {
+		return fallbackUID, fallbackInode, nil
 	}
 
 	return 0, 0, ErrNotFound
+}
+
+type sourceMatch int
+
+const (
+	sourceNoMatch sourceMatch = iota
+	sourceWildcardMatch
+	sourceExactMatch
+)
+
+func responseSourceMatch(response *inetDiagResponse, protocol byte, ip netip.Addr, srcPort int) sourceMatch {
+	if binary.BigEndian.Uint16(response.SrcPort[:]) != uint16(srcPort) {
+		return sourceNoMatch
+	}
+
+	responseIP, ok := responseSourceAddr(response)
+	if !ok {
+		return sourceNoMatch
+	}
+
+	if responseIP == ip.Unmap() {
+		return sourceExactMatch
+	}
+
+	if protocol == unix.IPPROTO_UDP && responseIP.IsUnspecified() {
+		return sourceWildcardMatch
+	}
+
+	return sourceNoMatch
+}
+
+func responseSourceAddr(response *inetDiagResponse) (netip.Addr, bool) {
+	switch response.Family {
+	case unix.AF_INET:
+		var ip [4]byte
+		copy(ip[:], response.Src[:4])
+		return netip.AddrFrom4(ip), true
+	case unix.AF_INET6:
+		var ip [16]byte
+		copy(ip[:], response.Src[:])
+		return netip.AddrFrom16(ip).Unmap(), true
+	default:
+		return netip.Addr{}, false
+	}
 }
 
 func resolveProcessNameByProcSearch(inode, uid uint32) (string, error) {

--- a/component/process/process_linux_test.go
+++ b/component/process/process_linux_test.go
@@ -1,0 +1,101 @@
+//go:build linux
+
+package process
+
+import (
+	"errors"
+	"net"
+	"net/netip"
+	"os"
+	"testing"
+)
+
+func TestResolveSocketByNetlinkRejectsWrongSourceIP(t *testing.T) {
+	listener, err := net.Listen("tcp4", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer listener.Close()
+
+	accepted := make(chan net.Conn, 1)
+	go func() {
+		conn, err := listener.Accept()
+		if err == nil {
+			accepted <- conn
+		}
+	}()
+
+	conn, err := net.Dial("tcp4", listener.Addr().String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+
+	serverConn := <-accepted
+	defer serverConn.Close()
+
+	localAddr := conn.LocalAddr().(*net.TCPAddr).AddrPort()
+	wrongIP := netip.MustParseAddr("28.0.0.1")
+
+	uid, inode, err := resolveSocketByNetlink(TCP, wrongIP, int(localAddr.Port()))
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("resolveSocketByNetlink(%s:%d) = uid %d inode %d err %v, want ErrNotFound", wrongIP, localAddr.Port(), uid, inode, err)
+	}
+}
+
+func TestResolveSocketByNetlinkMatchesSourceSocket(t *testing.T) {
+	listener, err := net.Listen("tcp4", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer listener.Close()
+
+	accepted := make(chan net.Conn, 1)
+	go func() {
+		conn, err := listener.Accept()
+		if err == nil {
+			accepted <- conn
+		}
+	}()
+
+	conn, err := net.Dial("tcp4", listener.Addr().String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+
+	serverConn := <-accepted
+	defer serverConn.Close()
+
+	localAddr := conn.LocalAddr().(*net.TCPAddr).AddrPort()
+	uid, inode, err := resolveSocketByNetlink(TCP, localAddr.Addr(), int(localAddr.Port()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if uid != uint32(os.Getuid()) {
+		t.Fatalf("uid = %d, want current uid %d", uid, os.Getuid())
+	}
+	if inode == 0 {
+		t.Fatal("inode = 0, want non-zero")
+	}
+}
+
+func TestResolveSocketByNetlinkMatchesUDPWildcardSocket(t *testing.T) {
+	conn, err := net.ListenUDP("udp4", &net.UDPAddr{IP: net.IPv4zero, Port: 0})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+
+	localAddr := conn.LocalAddr().(*net.UDPAddr).AddrPort()
+	uid, inode, err := resolveSocketByNetlink(UDP, netip.MustParseAddr("127.0.0.1"), int(localAddr.Port()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if uid != uint32(os.Getuid()) {
+		t.Fatalf("uid = %d, want current uid %d", uid, os.Getuid())
+	}
+	if inode == 0 {
+		t.Fatal("inode = 0, want non-zero")
+	}
+}


### PR DESCRIPTION
## Summary

Linux process lookup now rejects unrelated netlink dump responses before resolving process metadata. This prevents TUN/fake-ip connections from being attributed to another process that happens to own the same source port, while preserving UDP wildcard socket lookup as a fallback when no exact UDP bind exists.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT--5](https://img.shields.io/badge/GPT--5-000000)
