### PR TITLE
chore: use mihomo name & ver to tailscale reported ver to avoid update prompts

### DIFF
--- a/adapter/outbound/tailscale.go
+++ b/adapter/outbound/tailscale.go
@@ -21,8 +21,10 @@ import (
 	"github.com/metacubex/mihomo/log"
 
 	"github.com/metacubex/tailscale/envknob"
+	"github.com/metacubex/tailscale/hostinfo"
 	"github.com/metacubex/tailscale/ipn"
 	"github.com/metacubex/tailscale/net/netmon"
+	"github.com/metacubex/tailscale/tailcfg"
 	"github.com/metacubex/tailscale/tsnet"
 	D "github.com/miekg/dns"
 )
@@ -62,6 +64,9 @@ type TailscaleOption struct {
 }
 
 func init() {
+	hostinfo.RegisterHostinfoNewHook(func(hi *tailcfg.Hostinfo) {
+		hi.IPNVersion = C.MihomoName + " " + C.Version
+	})
 	envknob.SetNoLogsNoSupport()
 	if runtime.GOOS == "android" { // Android SDK 30 no longer permits Go's net.Interfaces to work (Issue 2293)
 		netmon.RegisterInterfaceGetter(func() (nif []netmon.Interface, err error) {


### PR DESCRIPTION
当前的行为，会在tailscale控制台上提示版本可更新
<img width="891" height="446" alt="image" src="https://github.com/user-attachments/assets/77fd1d38-03a7-4c5f-b10f-6c7fc8f54c52" />

参考sing-box的做法，修改后，加入了自己的名字和版本号，就不会提示了
<img width="216" height="64" alt="image" src="https://github.com/user-attachments/assets/bf419998-d5a4-42e8-a3d5-e12416dc6c7c" />

