### PR TITLE
feat: add exec proxy provider

### DIFF
--- a/adapter/provider/parser.go
+++ b/adapter/provider/parser.go
@@ -3,6 +3,8 @@ package provider
 import (
 	"errors"
 	"fmt"
+	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/metacubex/mihomo/common/structure"
@@ -30,6 +32,8 @@ type proxyProviderSchema struct {
 	Path          string           `provider:"path,omitempty"`
 	URL           string           `provider:"url,omitempty"`
 	Proxy         string           `provider:"proxy,omitempty"`
+	Command       []string         `provider:"command,omitempty"`
+	Timeout       int              `provider:"timeout,omitempty"`
 	Interval      int              `provider:"interval,omitempty"`
 	Filter        string           `provider:"filter,omitempty"`
 	ExcludeFilter string           `provider:"exclude-filter,omitempty"`
@@ -45,6 +49,12 @@ type proxyProviderSchema struct {
 
 func ParseProxyProvider(name string, mapping map[string]any, tunnel C.Tunnel) (P.ProxyProvider, error) {
 	decoder := structure.NewDecoder(structure.Option{TagName: "provider", WeaklyTypedInput: true})
+
+	if schemaType, ok := mapping["type"].(string); ok && schemaType == "exec" {
+		if err := validateExecCommandRaw(mapping); err != nil {
+			return nil, err
+		}
+	}
 
 	schema := &proxyProviderSchema{
 		HealthCheck: healthCheckSchema{
@@ -91,6 +101,22 @@ func ParseProxyProvider(name string, mapping map[string]any, tunnel C.Tunnel) (P
 			}
 		}
 		vehicle = resource.NewHTTPVehicle(schema.URL, path, schema.Proxy, schema.Header, resource.DefaultHttpTimeout, schema.SizeLimit)
+	case "exec":
+		if err := validateExecCommand(schema.Command); err != nil {
+			return nil, err
+		}
+		path := C.Path.GetPathByHash("proxies", "exec:"+strings.Join(schema.Command, "\x00"))
+		if schema.Path != "" {
+			path = C.Path.Resolve(schema.Path)
+			if !C.Path.IsSafePath(path) {
+				return nil, C.Path.ErrNotSafePath(path)
+			}
+		}
+		timeout := resource.DefaultHttpTimeout
+		if schema.Timeout > 0 {
+			timeout = time.Duration(uint(schema.Timeout)) * time.Second
+		}
+		vehicle = resource.NewExecVehicle(schema.Command, path, timeout, schema.SizeLimit)
 	case "inline":
 		return NewInlineProvider(name, schema.Payload, parser, hc)
 	default:
@@ -100,4 +126,33 @@ func ParseProxyProvider(name string, mapping map[string]any, tunnel C.Tunnel) (P
 	interval := time.Duration(uint(schema.Interval)) * time.Second
 
 	return NewProxySetProvider(name, interval, schema.Payload, parser, vehicle, hc)
+}
+
+func validateExecCommandRaw(mapping map[string]any) error {
+	rawCommand, ok := mapping["command"]
+	if !ok {
+		return errors.New("exec provider command is required")
+	}
+	switch value := rawCommand.(type) {
+	case []string:
+	case []any:
+		for _, item := range value {
+			if _, ok := item.(string); !ok {
+				return errors.New("exec provider command must be an array of strings")
+			}
+		}
+	default:
+		return errors.New("exec provider command must be an array of strings")
+	}
+	return nil
+}
+
+func validateExecCommand(command []string) error {
+	if len(command) == 0 {
+		return errors.New("exec provider command is required")
+	}
+	if !filepath.IsAbs(command[0]) {
+		return errors.New("exec provider command executable must be an absolute path")
+	}
+	return nil
 }

--- a/component/resource/vehicle.go
+++ b/component/resource/vehicle.go
@@ -1,11 +1,15 @@
 package resource
 
 import (
+	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/metacubex/mihomo/common/utils"
@@ -21,6 +25,8 @@ const (
 
 	fileMode os.FileMode = 0o666
 	dirMode  os.FileMode = 0o755
+
+	execStderrLimit = 4096
 )
 
 var (
@@ -178,6 +184,115 @@ func NewHTTPVehicle(url string, path string, proxy string, header http.Header, t
 		path:      path,
 		proxy:     proxy,
 		header:    header,
+		timeout:   timeout,
+		sizeLimit: sizeLimit,
+	}
+}
+
+type limitedBuffer struct {
+	buf   bytes.Buffer
+	limit int64
+}
+
+func (lb *limitedBuffer) Write(p []byte) (int, error) {
+	if lb.limit <= 0 {
+		return lb.buf.Write(p)
+	}
+
+	remain := lb.limit - int64(lb.buf.Len())
+	if remain > 0 {
+		if int64(len(p)) > remain {
+			_, _ = lb.buf.Write(p[:remain])
+		} else {
+			_, _ = lb.buf.Write(p)
+		}
+	}
+	return len(p), nil
+}
+
+func (lb *limitedBuffer) Bytes() []byte {
+	return lb.buf.Bytes()
+}
+
+func (lb *limitedBuffer) String() string {
+	return lb.buf.String()
+}
+
+type ExecVehicle struct {
+	command   []string
+	path      string
+	timeout   time.Duration
+	sizeLimit int64
+}
+
+func (e *ExecVehicle) Type() P.VehicleType {
+	return P.Exec
+}
+
+func (e *ExecVehicle) Path() string {
+	return e.path
+}
+
+func (e *ExecVehicle) Url() string {
+	if len(e.command) == 0 {
+		return "exec://"
+	}
+	return "exec://" + filepath.Base(e.command[0])
+}
+
+func (e *ExecVehicle) Proxy() string {
+	return ""
+}
+
+func (e *ExecVehicle) Write(buf []byte) error {
+	return safeWrite(e.path, buf)
+}
+
+func (e *ExecVehicle) Read(ctx context.Context, oldHash utils.HashType) (buf []byte, hash utils.HashType, err error) {
+	if len(e.command) == 0 {
+		err = errors.New("exec provider command is empty")
+		return
+	}
+
+	timeout := e.timeout
+	if timeout <= 0 {
+		timeout = DefaultHttpTimeout
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, e.command[0], e.command[1:]...)
+	var stdout limitedBuffer
+	stdout.limit = e.sizeLimit
+	var stderr limitedBuffer
+	stderr.limit = execStderrLimit
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	if runErr := cmd.Run(); runErr != nil {
+		if ctx.Err() != nil {
+			err = fmt.Errorf("exec provider command timed out: %w", ctx.Err())
+			return
+		}
+		errMsg := strings.TrimSpace(stderr.String())
+		if errMsg != "" {
+			err = fmt.Errorf("exec provider command failed: %w: %s", runErr, errMsg)
+		} else {
+			err = fmt.Errorf("exec provider command failed: %w", runErr)
+		}
+		return
+	}
+
+	buf = stdout.Bytes()
+	hash = utils.MakeHash(buf)
+	return
+}
+
+func NewExecVehicle(command []string, path string, timeout time.Duration, sizeLimit int64) *ExecVehicle {
+	return &ExecVehicle{
+		command:   append([]string(nil), command...),
+		path:      path,
 		timeout:   timeout,
 		sizeLimit: sizeLimit,
 	}

--- a/constant/provider/interface.go
+++ b/constant/provider/interface.go
@@ -14,6 +14,7 @@ const (
 	HTTP
 	Compatible
 	Inline
+	Exec
 )
 
 // VehicleType defined
@@ -29,6 +30,8 @@ func (v VehicleType) String() string {
 		return "Compatible"
 	case Inline:
 		return "Inline"
+	case Exec:
+		return "Exec"
 	default:
 		return "Unknown"
 	}


### PR DESCRIPTION
## Summary

Add a new `exec` proxy provider type that executes a local program and reads provider content from stdout.

This lets users generate proxy provider content with an external local tool while keeping mihomo's existing proxy provider parser and refresh pipeline.

Example:

```yaml
proxy-providers:
  generated:
    type: exec
    command:
      - /usr/local/bin/render-mihomo-proxies
      - --source
      - airport
    path: ./proxy_providers/generated.yaml
    interval: 3600
    size-limit: 10485760
```

## Behavior

- `command` is argv-only and does not invoke a shell.
- The executable path must be absolute.
- stdout is parsed by the existing proxy provider parser, so YAML `proxies:`, URI lists, and base64 subscription content continue to work.
- `filter`, `exclude-filter`, `exclude-type`, `dialer-proxy`, `override`, fallback `payload`, health checks, interval refresh, and cache writing reuse the existing proxy provider flow.
- `timeout` defaults to the existing HTTP provider timeout and can be configured in seconds.
- `size-limit` applies to stdout; `0` keeps the existing unlimited convention.
- stderr is captured only for error reporting and truncated.

## Notes

This is scoped to proxy providers only. Rule providers are unchanged.

## Testing

Manually tested `type: exec` with a local script that prints a `proxies:` payload to stdout; the generated proxies appeared in the selector group as expected.
