### PR TITLE
fix: decodeBool should handle float and string in weakly typed mode

### DIFF
--- a/common/structure/structure.go
+++ b/common/structure/structure.go
@@ -240,6 +240,17 @@ func (d *Decoder) decodeBool(name string, data any, val reflect.Value) (err erro
 		val.SetBool(dataVal.Int() != 0)
 	case isUint(kind) && d.option.WeaklyTypedInput:
 		val.SetBool(dataVal.Uint() != 0)
+	case isFloat(kind) && d.option.WeaklyTypedInput:
+		val.SetBool(dataVal.Float() != 0)
+	case kind == reflect.String && d.option.WeaklyTypedInput:
+		s := dataVal.String()
+		if b, err2 := strconv.ParseBool(s); err2 == nil {
+			val.SetBool(b)
+		} else if f, err2 := strconv.ParseFloat(s, 64); err2 == nil {
+			val.SetBool(f != 0)
+		} else {
+			err = fmt.Errorf("cannot parse '%s' as bool: %s", name, s)
+		}
 	default:
 		err = fmt.Errorf(
 			"'%s' expected type '%s', got unconvertible type '%s'",


### PR DESCRIPTION
## Summary

`structure.decodeBool` only accepts `bool`/`int`/`uint`, while its sibling decoders `decodeInt`, `decodeUint` and `decodeFloat` all additionally handle `float` and `string` (incl. `json.Number`, whose `reflect.Kind` is `String`) under `WeaklyTypedInput`.

As a result, a `bool` plugin option such as `mux: 1` decodes fine when the value arrives as `int` (plain YAML), but fails with `expected type 'bool', got unconvertible type 'json.Number'` / `'float64'` when the config is parsed by a JSON decoder — e.g. an embedder that calls `json.Decoder.UseNumber()` before handing the proxy maps to `adapter.ParseProxy`.

This patch adds the missing `float` and `string` branches so `decodeBool` is consistent with the other numeric decoders:
- `float` → `!= 0`
- `string` → `strconv.ParseBool`, falling back to `strconv.ParseFloat(...) != 0` so numeric strings (`"0"`, `"1"`, `"2"`) keep the same `!= 0` semantics as the int/uint/float branches.

## Test plan

- [x] `go build ./common/structure/`
- [x] `go vet ./common/structure/`
- [x] `go test ./common/structure/`