### PR TITLE
feat: support OpenVPN CBC ciphers

### DIFF
--- a/adapter/outbound/openvpn.go
+++ b/adapter/outbound/openvpn.go
@@ -49,7 +49,7 @@ type OpenVPNOption struct {
 	CA       string `proxy:"ca"`
 	Cert     string `proxy:"cert,omitempty"`
 	Key      string `proxy:"key,omitempty"`
-	TLSCrypt string `proxy:"tls-crypt"`
+	TLSCrypt string `proxy:"tls-crypt,omitempty"`
 	Username string `proxy:"username,omitempty"`
 	Password string `proxy:"password,omitempty"`
 	MTU      int    `proxy:"mtu,omitempty"`

--- a/docs/config.yaml
+++ b/docs/config.yaml
@@ -1169,8 +1169,8 @@ proxies: # socks5
     port: 1194
     proto: udp # udp/tcp，默认 udp
     # dev: tun # 目前仅支持 tun，默认 tun
-    # cipher: AES-128-GCM # 支持 AES-128-GCM / AES-256-GCM / CHACHA20-POLY1305，默认 AES-128-GCM
-    # auth: SHA256 # 目前仅支持 SHA256，默认 SHA256
+    # cipher: AES-128-GCM # 支持 AES-128-GCM / AES-256-GCM / AES-128-CBC / AES-256-CBC / CHACHA20-POLY1305，默认 AES-128-GCM；AES-CBC 会按 AES-128-CBC 处理
+    # auth: SHA256 # 支持 SHA1 / SHA256，默认 SHA256；AEAD cipher 会忽略 auth
     # username / password: auth-user-pass 模式（与下方 cert+key 二选一，不能都不填）
     # username: "user"
     # password: "pass"
@@ -1189,12 +1189,12 @@ proxies: # socks5
       -----BEGIN PRIVATE KEY-----
       MIIE...example
       -----END PRIVATE KEY-----
-    # 从 .ovpn 中复制 <tls-crypt></tls-crypt> 内的内容，不需要保留 <tls-crypt> 标签
-    tls-crypt: |
-      -----BEGIN OpenVPN Static key V1-----
-      00000000000000000000000000000000
-      ...
-      -----END OpenVPN Static key V1-----
+    # 从 .ovpn 中复制 <tls-crypt></tls-crypt> 内的内容，不需要保留 <tls-crypt> 标签；没有 tls-crypt 的配置可省略
+    # tls-crypt: |
+    #   -----BEGIN OpenVPN Static key V1-----
+    #   00000000000000000000000000000000
+    #   ...
+    #   -----END OpenVPN Static key V1-----
     # mtu: 1500
     udp: true
     # 一个出站代理的标识。当值不为空时，将使用指定的 proxy 发出连接

--- a/transport/openvpn/client.go
+++ b/transport/openvpn/client.go
@@ -35,9 +35,13 @@ func NewClient(config *ClientConfig, io PacketIO) (*Client, error) {
 	if io == nil {
 		return nil, errors.New("nil openvpn packet io")
 	}
-	crypt, err := NewTLSCrypt(config.TLSCryptKey, true)
-	if err != nil {
-		return nil, err
+	var crypt *TLSCrypt
+	if len(config.TLSCryptKey) > 0 {
+		var err error
+		crypt, err = NewTLSCrypt(config.TLSCryptKey, true)
+		if err != nil {
+			return nil, err
+		}
 	}
 	local, err := NewSessionID()
 	if err != nil {
@@ -119,7 +123,7 @@ func (c *Client) Handshake(ctx context.Context) (*PushReply, error) {
 		return nil, err
 	}
 	c.push = push
-	c.data, err = NewDataChannel(keys, c.config.Cipher, push.PeerID)
+	c.data, err = NewDataChannel(keys, c.config.Cipher, c.config.Auth, push.PeerID)
 	if err != nil {
 		return nil, err
 	}

--- a/transport/openvpn/config.go
+++ b/transport/openvpn/config.go
@@ -17,7 +17,11 @@ const (
 
 	CipherAES128GCM        = "AES-128-GCM"
 	CipherAES256GCM        = "AES-256-GCM"
+	CipherAESCBC           = "AES-CBC"
+	CipherAES128CBC        = "AES-128-CBC"
+	CipherAES256CBC        = "AES-256-CBC"
 	CipherChaCha20Poly1305 = "CHACHA20-POLY1305"
+	AuthSHA1               = "SHA1"
 	AuthSHA256             = "SHA256"
 )
 
@@ -44,7 +48,7 @@ type ClientConfig struct {
 // DataCipherKeyLength returns the key size for the negotiated data cipher.
 func (c ClientConfig) DataCipherKeyLength() int {
 	switch c.Cipher {
-	case CipherAES256GCM, CipherChaCha20Poly1305:
+	case CipherAES256GCM, CipherAES256CBC, CipherChaCha20Poly1305:
 		return 32
 	default:
 		return 16
@@ -68,6 +72,28 @@ func normalizeProto(proto string) string {
 	}
 }
 
+func normalizeCipher(cipher string) string {
+	switch strings.ToUpper(strings.TrimSpace(cipher)) {
+	case "":
+		return CipherAES128GCM
+	case CipherAESCBC:
+		return CipherAES128CBC
+	default:
+		return strings.ToUpper(strings.TrimSpace(cipher))
+	}
+}
+
+func normalizeAuth(auth string) string {
+	switch strings.ToUpper(strings.TrimSpace(auth)) {
+	case "":
+		return AuthSHA256
+	case "SHA-1":
+		return AuthSHA1
+	default:
+		return strings.ToUpper(strings.TrimSpace(auth))
+	}
+}
+
 func (c *ClientConfig) Prepare() error {
 	if c == nil {
 		return errors.New("nil openvpn client config")
@@ -78,22 +104,18 @@ func (c *ClientConfig) Prepare() error {
 		c.Dev = "tun"
 	}
 	c.Dev = strings.ToLower(strings.TrimSpace(c.Dev))
-	if c.Cipher == "" {
-		c.Cipher = CipherAES128GCM
-	}
-	c.Cipher = strings.ToUpper(strings.TrimSpace(c.Cipher))
-	if c.Auth == "" {
-		c.Auth = AuthSHA256
-	}
-	c.Auth = strings.ToUpper(strings.TrimSpace(c.Auth))
+	c.Cipher = normalizeCipher(c.Cipher)
+	c.Auth = normalizeAuth(c.Auth)
 	if err := c.ValidateInstallScriptSubset(); err != nil {
 		return err
 	}
-	key, err := DecodeStaticKey(c.TLSCrypt)
-	if err != nil {
-		return fmt.Errorf("parse tls-crypt key: %w", err)
+	if len(bytes.TrimSpace(c.TLSCrypt)) > 0 {
+		key, err := DecodeStaticKey(c.TLSCrypt)
+		if err != nil {
+			return fmt.Errorf("parse tls-crypt key: %w", err)
+		}
+		c.TLSCryptKey = key
 	}
-	c.TLSCryptKey = key
 	return nil
 }
 
@@ -110,15 +132,14 @@ func (c *ClientConfig) ValidateInstallScriptSubset() error {
 	if c.Proto != ProtoUDP && c.Proto != ProtoTCP {
 		return fmt.Errorf("unsupported openvpn proto %q: only udp and tcp are supported", c.Proto)
 	}
-	if c.Cipher != CipherAES128GCM && c.Cipher != CipherAES256GCM && c.Cipher != CipherChaCha20Poly1305 {
-		return fmt.Errorf("unsupported openvpn cipher %q: only %s, %s and %s are supported", c.Cipher, CipherAES128GCM, CipherAES256GCM, CipherChaCha20Poly1305)
+	if c.Cipher != CipherAES128GCM && c.Cipher != CipherAES256GCM && c.Cipher != CipherAES128CBC && c.Cipher != CipherAES256CBC && c.Cipher != CipherChaCha20Poly1305 {
+		return fmt.Errorf("unsupported openvpn cipher %q: only %s, %s, %s, %s and %s are supported", c.Cipher, CipherAES128GCM, CipherAES256GCM, CipherAES128CBC, CipherAES256CBC, CipherChaCha20Poly1305)
 	}
-	if c.Auth != AuthSHA256 {
-		return fmt.Errorf("unsupported openvpn auth %q: only %s is supported", c.Auth, AuthSHA256)
+	if c.Auth != AuthSHA1 && c.Auth != AuthSHA256 {
+		return fmt.Errorf("unsupported openvpn auth %q: only %s and %s are supported", c.Auth, AuthSHA1, AuthSHA256)
 	}
 	for name, value := range map[string][]byte{
-		"ca":        c.CA,
-		"tls-crypt": c.TLSCrypt,
+		"ca": c.CA,
 	} {
 		if len(bytes.TrimSpace(value)) == 0 {
 			return fmt.Errorf("openvpn config requires inline <%s> block", name)

--- a/transport/openvpn/config_test.go
+++ b/transport/openvpn/config_test.go
@@ -89,15 +89,14 @@ func TestClientConfigRejectsUnsupportedProto(t *testing.T) {
 	}
 }
 
-func TestClientConfigRequiresTLSCrypt(t *testing.T) {
+func TestClientConfigAllowsMissingTLSCrypt(t *testing.T) {
 	cfg := yamlStyleConfig()
 	cfg.TLSCrypt = nil
-	err := cfg.Prepare()
-	if err == nil {
-		t.Fatal("expected missing tls-crypt error")
+	if err := cfg.Prepare(); err != nil {
+		t.Fatal(err)
 	}
-	if !strings.Contains(err.Error(), "tls-crypt") {
-		t.Fatalf("unexpected error: %v", err)
+	if len(cfg.TLSCryptKey) != 0 {
+		t.Fatalf("unexpected tls-crypt key length: %d", len(cfg.TLSCryptKey))
 	}
 }
 
@@ -121,6 +120,30 @@ func TestClientConfigAuthUserPassAES256(t *testing.T) {
 		t.Fatalf("unexpected cipher: %s", cfg.Cipher)
 	}
 	if cfg.DataCipherKeyLength() != 32 {
+		t.Fatalf("unexpected data key length helper: %d", cfg.DataCipherKeyLength())
+	}
+}
+
+func TestClientConfigAESCBCSHA1(t *testing.T) {
+	cfg := &ClientConfig{
+		RemoteHost: "vpn.example.com",
+		RemotePort: 1194,
+		Proto:      "udp",
+		Dev:        "tun",
+		Cipher:     "AES-CBC",
+		Auth:       "sha-1",
+		CA:         []byte(testCert),
+		Username:   "user",
+		Password:   "secret",
+		TLSCrypt:   []byte(testTLSCryptBlock()),
+	}
+	if err := cfg.Prepare(); err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Cipher != CipherAES128CBC || cfg.Auth != AuthSHA1 {
+		t.Fatalf("unexpected crypto: %s/%s", cfg.Cipher, cfg.Auth)
+	}
+	if cfg.DataCipherKeyLength() != 16 {
 		t.Fatalf("unexpected data key length helper: %d", cfg.DataCipherKeyLength())
 	}
 }

--- a/transport/openvpn/data.go
+++ b/transport/openvpn/data.go
@@ -3,24 +3,37 @@ package openvpn
 import (
 	"crypto/aes"
 	"crypto/cipher"
+	"crypto/hmac"
+	"crypto/rand"
+	"crypto/sha1"
+	"crypto/sha256"
 	"encoding/binary"
 	"errors"
 	"fmt"
+	"hash"
 	"sync"
 
 	"golang.org/x/crypto/chacha20poly1305"
 )
 
 const (
-	DataChannelTagSize = 16
-	DataChannelIVSize  = 12
+	DataChannelTagSize   = 16
+	DataChannelIVSize    = 12
+	DataChannelCBCIVSize = aes.BlockSize
 
 	PeerIDUnset uint32 = 0xffffff
 )
 
 type DataChannel struct {
-	send cipher.AEAD
-	recv cipher.AEAD
+	sendAEAD cipher.AEAD
+	recvAEAD cipher.AEAD
+
+	sendBlock   cipher.Block
+	recvBlock   cipher.Block
+	sendHMACKey []byte
+	recvHMACKey []byte
+	authHash    func() hash.Hash
+	authSize    int
 
 	sendImplicitIV [DataChannelIVSize]byte
 	recvImplicitIV [DataChannelIVSize]byte
@@ -34,29 +47,65 @@ type DataChannel struct {
 	recvSeen     bool
 }
 
-func NewDataChannel(keys *KeyMaterial, cipherName string, peerID uint32) (*DataChannel, error) {
+func NewDataChannel(keys *KeyMaterial, cipherName, authName string, peerID uint32) (*DataChannel, error) {
 	if keys == nil {
 		return nil, errors.New("nil openvpn key material")
 	}
-	send, err := newDataChannelAEAD(cipherName, keys.SendCipherKey)
+	if isDataChannelAEAD(cipherName) {
+		send, err := newDataChannelAEAD(cipherName, keys.SendCipherKey)
+		if err != nil {
+			return nil, fmt.Errorf("create send cipher: %w", err)
+		}
+		recv, err := newDataChannelAEAD(cipherName, keys.RecvCipherKey)
+		if err != nil {
+			return nil, fmt.Errorf("create recv cipher: %w", err)
+		}
+		if len(keys.SendHMACKey) < DataChannelIVSize-4 || len(keys.RecvHMACKey) < DataChannelIVSize-4 {
+			return nil, errors.New("openvpn implicit IV keys are too short")
+		}
+		d := &DataChannel{
+			sendAEAD: send,
+			recvAEAD: recv,
+			peerID:   peerID,
+		}
+		copy(d.sendImplicitIV[4:], keys.SendHMACKey[:DataChannelIVSize-4])
+		copy(d.recvImplicitIV[4:], keys.RecvHMACKey[:DataChannelIVSize-4])
+		return d, nil
+	}
+
+	send, err := newDataChannelCBC(cipherName, keys.SendCipherKey)
 	if err != nil {
 		return nil, fmt.Errorf("create send cipher: %w", err)
 	}
-	recv, err := newDataChannelAEAD(cipherName, keys.RecvCipherKey)
+	recv, err := newDataChannelCBC(cipherName, keys.RecvCipherKey)
 	if err != nil {
 		return nil, fmt.Errorf("create recv cipher: %w", err)
 	}
-	if len(keys.SendHMACKey) < DataChannelIVSize-4 || len(keys.RecvHMACKey) < DataChannelIVSize-4 {
-		return nil, errors.New("openvpn implicit IV keys are too short")
+	authHash, authSize, err := newDataChannelAuth(authName)
+	if err != nil {
+		return nil, err
 	}
-	d := &DataChannel{
-		send:   send,
-		recv:   recv,
-		peerID: peerID,
+	if len(keys.SendHMACKey) < authSize || len(keys.RecvHMACKey) < authSize {
+		return nil, errors.New("openvpn HMAC keys are too short")
 	}
-	copy(d.sendImplicitIV[4:], keys.SendHMACKey[:DataChannelIVSize-4])
-	copy(d.recvImplicitIV[4:], keys.RecvHMACKey[:DataChannelIVSize-4])
-	return d, nil
+	return &DataChannel{
+		sendBlock:   send,
+		recvBlock:   recv,
+		sendHMACKey: append([]byte(nil), keys.SendHMACKey[:authSize]...),
+		recvHMACKey: append([]byte(nil), keys.RecvHMACKey[:authSize]...),
+		authHash:    authHash,
+		authSize:    authSize,
+		peerID:      peerID,
+	}, nil
+}
+
+func isDataChannelAEAD(cipherName string) bool {
+	switch cipherName {
+	case CipherAES128GCM, CipherAES256GCM, CipherChaCha20Poly1305:
+		return true
+	default:
+		return false
+	}
 }
 
 func newDataChannelAEAD(cipherName string, key []byte) (cipher.AEAD, error) {
@@ -74,16 +123,39 @@ func newDataChannelAEAD(cipherName string, key []byte) (cipher.AEAD, error) {
 	}
 }
 
+func newDataChannelCBC(cipherName string, key []byte) (cipher.Block, error) {
+	switch cipherName {
+	case CipherAESCBC, CipherAES128CBC, CipherAES256CBC:
+		return aes.NewCipher(key)
+	default:
+		return nil, fmt.Errorf("unsupported openvpn cipher %q", cipherName)
+	}
+}
+
+func newDataChannelAuth(authName string) (func() hash.Hash, int, error) {
+	switch authName {
+	case AuthSHA1:
+		return sha1.New, sha1.Size, nil
+	case AuthSHA256:
+		return sha256.New, sha256.Size, nil
+	default:
+		return nil, 0, fmt.Errorf("unsupported openvpn auth %q", authName)
+	}
+}
+
 func (d *DataChannel) Encrypt(packet []byte) ([]byte, error) {
 	if d == nil {
 		return nil, errors.New("nil openvpn data channel")
 	}
 
-	d.mu.Lock()
-	d.sendPacketID++
-	packetID := d.sendPacketID
-	d.mu.Unlock()
+	packetID := d.nextPacketID()
+	if d.sendAEAD != nil {
+		return d.encryptAEAD(packet, packetID)
+	}
+	return d.encryptCBC(packet, packetID)
+}
 
+func (d *DataChannel) encryptAEAD(packet []byte, packetID uint32) ([]byte, error) {
 	header := d.dataHeader()
 	var packetIDBytes [4]byte
 	binary.BigEndian.PutUint32(packetIDBytes[:], packetID)
@@ -91,7 +163,7 @@ func (d *DataChannel) Encrypt(packet []byte) ([]byte, error) {
 	ad := make([]byte, 0, len(header)+len(packetIDBytes))
 	ad = append(ad, header...)
 	ad = append(ad, packetIDBytes[:]...)
-	sealed := d.send.Seal(nil, nonce[:], packet, ad)
+	sealed := d.sendAEAD.Seal(nil, nonce[:], packet, ad)
 
 	out := make([]byte, 0, len(header)+4+DataChannelTagSize+len(packet))
 	out = append(out, header...)
@@ -101,20 +173,49 @@ func (d *DataChannel) Encrypt(packet []byte) ([]byte, error) {
 	return out, nil
 }
 
+func (d *DataChannel) encryptCBC(packet []byte, packetID uint32) ([]byte, error) {
+	header := d.dataHeader()
+	iv := make([]byte, DataChannelCBCIVSize)
+	if _, err := rand.Read(iv); err != nil {
+		return nil, err
+	}
+
+	plain := make([]byte, 4+len(packet))
+	binary.BigEndian.PutUint32(plain[:4], packetID)
+	copy(plain[4:], packet)
+	padded := pkcs7Pad(plain, d.sendBlock.BlockSize())
+	ciphertext := make([]byte, len(padded))
+	cipher.NewCBCEncrypter(d.sendBlock, iv).CryptBlocks(ciphertext, padded)
+
+	authenticated := make([]byte, 0, len(iv)+len(ciphertext))
+	authenticated = append(authenticated, iv...)
+	authenticated = append(authenticated, ciphertext...)
+	tag := dataChannelHMAC(d.authHash, d.sendHMACKey, authenticated)
+
+	out := make([]byte, 0, len(header)+len(tag)+len(authenticated))
+	out = append(out, header...)
+	out = append(out, tag...)
+	out = append(out, authenticated...)
+	return out, nil
+}
+
 func (d *DataChannel) Decrypt(packet []byte) ([]byte, error) {
 	if d == nil {
 		return nil, errors.New("nil openvpn data channel")
 	}
+	headerSize, err := dataPacketHeaderSize(packet)
+	if err != nil {
+		return nil, err
+	}
+	if d.recvAEAD != nil {
+		return d.decryptAEAD(packet, headerSize)
+	}
+	return d.decryptCBC(packet, headerSize)
+}
+
+func (d *DataChannel) decryptAEAD(packet []byte, headerSize int) ([]byte, error) {
 	if len(packet) < 1 {
 		return nil, errors.New("empty openvpn data packet")
-	}
-	opcode, _ := parseOpcodeKeyID(packet[0])
-	headerSize := 1
-	if opcode == PDataV2 {
-		headerSize = 4
-	}
-	if opcode != PDataV1 && opcode != PDataV2 {
-		return nil, fmt.Errorf("not an openvpn data packet: %s", opcode)
 	}
 	if len(packet) < headerSize+4+DataChannelTagSize+1 {
 		return nil, errors.New("openvpn data packet too short")
@@ -132,20 +233,88 @@ func (d *DataChannel) Decrypt(packet []byte) ([]byte, error) {
 	ad = append(ad, packetIDBytes...)
 
 	nonce := d.nonce(packetID, d.recvImplicitIV)
-	plain, err := d.recv.Open(nil, nonce[:], combined, ad)
+	plain, err := d.recvAEAD.Open(nil, nonce[:], combined, ad)
 	if err != nil {
 		return nil, err
 	}
 
+	if err := d.acceptPacketID(packetID); err != nil {
+		return nil, err
+	}
+	return plain, nil
+}
+
+func (d *DataChannel) decryptCBC(packet []byte, headerSize int) ([]byte, error) {
+	blockSize := d.recvBlock.BlockSize()
+	minPacketLen := headerSize + d.authSize + blockSize + blockSize
+	if len(packet) < minPacketLen {
+		return nil, errors.New("openvpn CBC data packet too short")
+	}
+
+	body := packet[headerSize:]
+	tag := body[:d.authSize]
+	authenticated := body[d.authSize:]
+	expected := dataChannelHMAC(d.authHash, d.recvHMACKey, authenticated)
+	if !hmac.Equal(tag, expected) {
+		return nil, errors.New("openvpn CBC data packet HMAC authentication failed")
+	}
+
+	iv := authenticated[:blockSize]
+	ciphertext := authenticated[blockSize:]
+	if len(ciphertext) == 0 || len(ciphertext)%blockSize != 0 {
+		return nil, errors.New("invalid openvpn CBC ciphertext length")
+	}
+	padded := make([]byte, len(ciphertext))
+	cipher.NewCBCDecrypter(d.recvBlock, iv).CryptBlocks(padded, ciphertext)
+	plain, err := pkcs7Unpad(padded, blockSize)
+	if err != nil {
+		return nil, err
+	}
+	if len(plain) < 4 {
+		return nil, errors.New("openvpn CBC plaintext missing packet id")
+	}
+
+	packetID := binary.BigEndian.Uint32(plain[:4])
+	if err := d.acceptPacketID(packetID); err != nil {
+		return nil, err
+	}
+	return plain[4:], nil
+}
+
+func dataPacketHeaderSize(packet []byte) (int, error) {
+	if len(packet) < 1 {
+		return 0, errors.New("empty openvpn data packet")
+	}
+	opcode, _ := parseOpcodeKeyID(packet[0])
+	switch opcode {
+	case PDataV1:
+		return 1, nil
+	case PDataV2:
+		if len(packet) < 4 {
+			return 0, errors.New("openvpn P_DATA_V2 packet missing peer id")
+		}
+		return 4, nil
+	default:
+		return 0, fmt.Errorf("not an openvpn data packet: %s", opcode)
+	}
+}
+
+func (d *DataChannel) nextPacketID() uint32 {
 	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.sendPacketID++
+	return d.sendPacketID
+}
+
+func (d *DataChannel) acceptPacketID(packetID uint32) error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
 	if d.recvSeen && packetID <= d.recvHighest {
-		d.mu.Unlock()
-		return nil, fmt.Errorf("openvpn replayed data packet id %d", packetID)
+		return fmt.Errorf("openvpn replayed data packet id %d", packetID)
 	}
 	d.recvHighest = packetID
 	d.recvSeen = true
-	d.mu.Unlock()
-	return plain, nil
+	return nil
 }
 
 func (d *DataChannel) dataHeader() []byte {
@@ -164,6 +333,41 @@ func (d *DataChannel) nonce(packetID uint32, implicit [DataChannelIVSize]byte) [
 	nonce := implicit
 	binary.BigEndian.PutUint32(nonce[:4], binary.BigEndian.Uint32(nonce[:4])^packetID)
 	return nonce
+}
+
+func dataChannelHMAC(newHash func() hash.Hash, key, data []byte) []byte {
+	mac := hmac.New(newHash, key)
+	_, _ = mac.Write(data)
+	return mac.Sum(nil)
+}
+
+func pkcs7Pad(plain []byte, blockSize int) []byte {
+	padding := blockSize - len(plain)%blockSize
+	if padding == 0 {
+		padding = blockSize
+	}
+	out := make([]byte, len(plain)+padding)
+	copy(out, plain)
+	for i := len(plain); i < len(out); i++ {
+		out[i] = byte(padding)
+	}
+	return out
+}
+
+func pkcs7Unpad(padded []byte, blockSize int) ([]byte, error) {
+	if len(padded) == 0 || len(padded)%blockSize != 0 {
+		return nil, errors.New("invalid openvpn CBC padding length")
+	}
+	padding := int(padded[len(padded)-1])
+	if padding == 0 || padding > blockSize || padding > len(padded) {
+		return nil, errors.New("invalid openvpn CBC padding")
+	}
+	for _, b := range padded[len(padded)-padding:] {
+		if int(b) != padding {
+			return nil, errors.New("invalid openvpn CBC padding")
+		}
+	}
+	return padded[:len(padded)-padding], nil
 }
 
 func ParsePeerID(options string) uint32 {

--- a/transport/openvpn/data_test.go
+++ b/transport/openvpn/data_test.go
@@ -2,6 +2,8 @@ package openvpn
 
 import (
 	"bytes"
+	"crypto/aes"
+	"crypto/sha1"
 	"encoding/binary"
 	"testing"
 )
@@ -19,11 +21,11 @@ func TestDataChannelAESGCMV2RoundTrip(t *testing.T) {
 		RecvCipherKey: clientKeys.SendCipherKey,
 		RecvHMACKey:   clientKeys.SendHMACKey,
 	}
-	client, err := NewDataChannel(clientKeys, CipherAES128GCM, 7)
+	client, err := NewDataChannel(clientKeys, CipherAES128GCM, AuthSHA256, 7)
 	if err != nil {
 		t.Fatal(err)
 	}
-	server, err := NewDataChannel(serverKeys, CipherAES128GCM, 7)
+	server, err := NewDataChannel(serverKeys, CipherAES128GCM, AuthSHA256, 7)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -89,11 +91,11 @@ func TestDataChannelChaCha20Poly1305V2RoundTrip(t *testing.T) {
 		RecvCipherKey: clientKeys.SendCipherKey,
 		RecvHMACKey:   clientKeys.SendHMACKey,
 	}
-	client, err := NewDataChannel(clientKeys, CipherChaCha20Poly1305, 7)
+	client, err := NewDataChannel(clientKeys, CipherChaCha20Poly1305, AuthSHA256, 7)
 	if err != nil {
 		t.Fatal(err)
 	}
-	server, err := NewDataChannel(serverKeys, CipherChaCha20Poly1305, 7)
+	server, err := NewDataChannel(serverKeys, CipherChaCha20Poly1305, AuthSHA256, 7)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -113,5 +115,65 @@ func TestDataChannelChaCha20Poly1305V2RoundTrip(t *testing.T) {
 	encrypted[len(encrypted)-1] ^= 0xff
 	if _, err := server.Decrypt(encrypted); err == nil {
 		t.Fatal("expected authentication failure")
+	}
+}
+
+func TestDataChannelAESCBCSHA1V2RoundTrip(t *testing.T) {
+	clientKeys := &KeyMaterial{
+		SendCipherKey: bytes.Repeat([]byte{0x11}, 16),
+		SendHMACKey:   bytes.Repeat([]byte{0x22}, maxHMACKeyLength),
+		RecvCipherKey: bytes.Repeat([]byte{0x33}, 16),
+		RecvHMACKey:   bytes.Repeat([]byte{0x44}, maxHMACKeyLength),
+	}
+	serverKeys := &KeyMaterial{
+		SendCipherKey: clientKeys.RecvCipherKey,
+		SendHMACKey:   clientKeys.RecvHMACKey,
+		RecvCipherKey: clientKeys.SendCipherKey,
+		RecvHMACKey:   clientKeys.SendHMACKey,
+	}
+	client, err := NewDataChannel(clientKeys, CipherAES128CBC, AuthSHA1, 7)
+	if err != nil {
+		t.Fatal(err)
+	}
+	server, err := NewDataChannel(serverKeys, CipherAES128CBC, AuthSHA1, 7)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ipPacket := []byte{0x45, 0, 0, 20, 1, 2, 3, 4, 64, 6, 0, 0, 10, 8, 0, 2, 1, 1, 1, 1}
+	encrypted, err := client.Encrypt(ipPacket)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if opcode, _ := parseOpcodeKeyID(encrypted[0]); opcode != PDataV2 {
+		t.Fatalf("unexpected data opcode: %s", opcode)
+	}
+	headerSize := 4
+	if len(encrypted) < headerSize+sha1.Size+DataChannelCBCIVSize+aes.BlockSize {
+		t.Fatalf("encrypted CBC packet too short: %d", len(encrypted))
+	}
+	if len(encrypted[headerSize+sha1.Size+DataChannelCBCIVSize:])%aes.BlockSize != 0 {
+		t.Fatal("encrypted CBC payload is not block aligned")
+	}
+
+	plain, err := server.Decrypt(encrypted)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(plain, ipPacket) {
+		t.Fatalf("unexpected decrypted packet: %x", plain)
+	}
+	encrypted[len(encrypted)-1] ^= 0xff
+	if _, err := server.Decrypt(encrypted); err == nil {
+		t.Fatal("expected HMAC authentication failure")
+	}
+
+	encrypted, err = client.Encrypt(ipPacket)
+	if err != nil {
+		t.Fatal(err)
+	}
+	encrypted[headerSize+sha1.Size] ^= 0xff
+	if _, err := server.Decrypt(encrypted); err == nil {
+		t.Fatal("expected HMAC authentication failure after IV tamper")
 	}
 }

--- a/transport/openvpn/keymethod.go
+++ b/transport/openvpn/keymethod.go
@@ -159,7 +159,7 @@ func InstallScriptOptionsString(proto, cipher, auth string) string {
 		protoName = "TCPv4_CLIENT"
 	}
 	keysize := "128"
-	if cipher == CipherAES256GCM || cipher == CipherChaCha20Poly1305 {
+	if cipher == CipherAES256GCM || cipher == CipherAES256CBC || cipher == CipherChaCha20Poly1305 {
 		keysize = "256"
 	}
 	return fmt.Sprintf("V4,dev-type tun,link-mtu 1550,tun-mtu 1500,proto %s,cipher %s,auth %s,keysize %s,key-method 2,tls-client", protoName, cipher, auth, keysize)

--- a/transport/openvpn/keymethod_test.go
+++ b/transport/openvpn/keymethod_test.go
@@ -82,6 +82,15 @@ func TestKeyMethod2DeriveAES256(t *testing.T) {
 	}
 }
 
+func TestInstallScriptOptionsCBCSHA1(t *testing.T) {
+	options := InstallScriptOptionsString(ProtoTCP, CipherAES256CBC, AuthSHA1)
+	for _, want := range []string{"proto TCPv4_CLIENT", "cipher AES-256-CBC", "auth SHA1", "keysize 256"} {
+		if !bytes.Contains([]byte(options), []byte(want)) {
+			t.Fatalf("options missing %q: %s", want, options)
+		}
+	}
+}
+
 func TestParseServerKeyMethod2Record(t *testing.T) {
 	var packet []byte
 	packet = binary.BigEndian.AppendUint32(packet, 0)

--- a/transport/openvpn/packet.go
+++ b/transport/openvpn/packet.go
@@ -168,9 +168,6 @@ func DecodeControlPlain(opcode Opcode, plain []byte) (ackIDs []uint32, ackRemote
 }
 
 func (p ControlPacket) Encode(crypt *TLSCrypt, packetID uint32, unixTime uint32) ([]byte, error) {
-	if crypt == nil {
-		return nil, errors.New("tls-crypt is required")
-	}
 	plain, err := p.EncodePlain()
 	if err != nil {
 		return nil, err
@@ -179,12 +176,40 @@ func (p ControlPacket) Encode(crypt *TLSCrypt, packetID uint32, unixTime uint32)
 	header := make([]byte, TLSCryptHeaderSize)
 	header[0] = opcodeKeyID(p.Opcode, p.KeyID)
 	copy(header[1:], p.LocalSession[:])
+	if crypt == nil {
+		out := make([]byte, 0, len(header)+len(plain))
+		out = append(out, header...)
+		out = append(out, plain...)
+		return out, nil
+	}
 	return crypt.Wrap(header, packetID, unixTime, plain)
 }
 
 func DecodeControlPacket(crypt *TLSCrypt, packet []byte) (*ControlPacket, uint32, uint32, error) {
 	if crypt == nil {
-		return nil, 0, 0, errors.New("tls-crypt is required")
+		if len(packet) < TLSCryptHeaderSize+1 {
+			return nil, 0, 0, errors.New("control packet too short")
+		}
+		header := packet[:TLSCryptHeaderSize]
+		opcode, keyID := parseOpcodeKeyID(header[0])
+		if !opcode.IsControl() {
+			return nil, 0, 0, fmt.Errorf("opcode %s is not a control opcode", opcode)
+		}
+		var local SessionID
+		copy(local[:], header[1:])
+		ackIDs, ackRemote, messageID, payload, err := DecodeControlPlain(opcode, packet[TLSCryptHeaderSize:])
+		if err != nil {
+			return nil, 0, 0, err
+		}
+		return &ControlPacket{
+			Opcode:           opcode,
+			KeyID:            keyID,
+			LocalSession:     local,
+			AckIDs:           ackIDs,
+			AckRemoteSession: ackRemote,
+			MessageID:        messageID,
+			Payload:          payload,
+		}, 0, 0, nil
 	}
 	header, packetID, unixTime, plain, err := crypt.Unwrap(packet)
 	if err != nil {

--- a/transport/openvpn/packet_test.go
+++ b/transport/openvpn/packet_test.go
@@ -58,6 +58,52 @@ func TestControlPacketEncodeDecodeWithTLSCrypt(t *testing.T) {
 	}
 }
 
+func TestControlPacketEncodeDecodePlain(t *testing.T) {
+	var local SessionID
+	copy(local[:], []byte("client01"))
+	var remote SessionID
+	copy(remote[:], []byte("server01"))
+
+	packet := ControlPacket{
+		Opcode:           PControlV1,
+		KeyID:            1,
+		LocalSession:     local,
+		AckIDs:           []uint32{11},
+		AckRemoteSession: remote,
+		MessageID:        12,
+		Payload:          []byte("plain control"),
+	}
+	encoded, err := packet.Encode(nil, 0, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	decoded, packetID, unixTime, err := DecodeControlPacket(nil, encoded)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if packetID != 0 || unixTime != 0 {
+		t.Fatalf("unexpected plain packet id/time: %d/%d", packetID, unixTime)
+	}
+	if decoded.Opcode != packet.Opcode || decoded.KeyID != packet.KeyID {
+		t.Fatalf("unexpected opcode/key-id: %s/%d", decoded.Opcode, decoded.KeyID)
+	}
+	if decoded.LocalSession != local {
+		t.Fatalf("unexpected local session: %x", decoded.LocalSession)
+	}
+	if decoded.MessageID != packet.MessageID {
+		t.Fatalf("unexpected message id: %d", decoded.MessageID)
+	}
+	if !bytes.Equal(decoded.Payload, packet.Payload) {
+		t.Fatalf("unexpected payload: %q", decoded.Payload)
+	}
+	if len(decoded.AckIDs) != 1 || decoded.AckIDs[0] != 11 {
+		t.Fatalf("unexpected ack ids: %#v", decoded.AckIDs)
+	}
+	if decoded.AckRemoteSession != remote {
+		t.Fatalf("unexpected ack remote session: %x", decoded.AckRemoteSession)
+	}
+}
+
 func TestAckPacketRejectsTrailingPayload(t *testing.T) {
 	_, _, _, _, err := DecodeControlPlain(PAckV1, []byte{0, 1})
 	if err == nil {


### PR DESCRIPTION
## 变更说明

本 PR 继续完善 OpenVPN outbound 支持，主要补充对传统 OpenVPN / SoftEther / VPNGate 配置中常见加密组合的兼容性。

### 新增能力

- OpenVPN outbound 的 `cipher` 新增支持：
  - `AES-128-CBC`
  - `AES-256-CBC`
  - `AES-CBC` 作为 `AES-128-CBC` 的兼容别名
- OpenVPN outbound 的 `auth` 新增支持：
  - `SHA1`
  - `SHA-1` 作为 `SHA1` 的兼容写法
- OpenVPN data channel 新增 CBC 模式支持：
  - 使用随机 IV
  - 使用 HMAC-SHA1 / HMAC-SHA256 认证
  - 支持 CBC payload padding / unpadding
  - 保留现有 AEAD cipher 行为
- 支持不包含 `tls-crypt` 的 OpenVPN 配置，兼容部分 SoftEther / VPNGate 生成的 `.ovpn` 配置。
- 更新 `docs/config.yaml` 中 OpenVPN outbound 的配置说明。

### 测试

已测试：

```bash
go test -tags with_gvisor ./transport/openvpn ./adapter/outbound
```

并且，在 Windows 环境下使用多个 VPNGate / SoftEther 风格节点（使用的是如上所述新支持的加密认证方式）进行的实际连接测试皆成功，其中节点使用 AES-128-CBC + SHA1，可以正常连接和代理流量、进行分流。