### PR TITLE
fix: improve OpenVPN transport reliability

### DIFF
--- a/adapter/outbound/openvpn.go
+++ b/adapter/outbound/openvpn.go
@@ -8,6 +8,7 @@ import (
 	"net/netip"
 	"os"
 	"sync"
+	"time"
 
 	"github.com/metacubex/mihomo/component/dialer"
 	"github.com/metacubex/mihomo/component/resolver"
@@ -30,12 +31,18 @@ type OpenVPN struct {
 	client    *ovpn.Client
 	resolver  resolver.Resolver
 	dns       []dns.NameServer
+	hasIPv6   bool
 
 	runCtx    context.Context
 	runCancel context.CancelFunc
 	runMutex  sync.Mutex
 	running   bool
 }
+
+const (
+	openVPNHandshakeTimeout = 30 * time.Second
+	openVPNSocketBufferSize = 4 * 1024 * 1024
+)
 
 type OpenVPNOption struct {
 	BasicOption
@@ -111,16 +118,20 @@ func (o *OpenVPN) DialContext(ctx context.Context, metadata *C.Metadata) (_ C.Co
 		return nil, err
 	}
 	var conn net.Conn
-	if !metadata.Resolved() || o.resolver != nil {
+	shouldResolve := !metadata.Resolved() || o.resolver != nil || (!o.hasIPv6 && metadata.Host != "" && openVPNAddrIsIPv6(metadata.DstIP))
+	if shouldResolve {
 		r := resolver.DefaultResolver
 		if o.resolver != nil {
 			r = o.resolver
 		}
-		options := o.DialOptions()
+		options := o.tunnelDialOptions()
 		options = append(options, dialer.WithResolver(r))
 		options = append(options, dialer.WithNetDialer(wgNetDialer{tunDevice: o.tunDevice}))
 		conn, err = dialer.NewDialer(options...).DialContext(ctx, "tcp", metadata.RemoteAddress())
 	} else {
+		if !o.hasIPv6 && openVPNAddrIsIPv6(metadata.DstIP) {
+			return nil, E.New("openvpn outbound has no IPv6 address")
+		}
 		conn, err = o.tunDevice.DialContext(ctx, "tcp", M.SocksaddrFrom(metadata.DstIP, metadata.DstPort).Unwrap())
 	}
 	if err != nil {
@@ -156,11 +167,14 @@ func (o *OpenVPN) ResolveUDP(ctx context.Context, metadata *C.Metadata) error {
 		if o.resolver != nil {
 			r = o.resolver
 		}
-		ip, err := resolveIPWithResolver(ctx, metadata.Host, o.prefer, r)
+		ip, err := resolveIPWithResolver(ctx, metadata.Host, o.tunnelDNSPrefer(), r)
 		if err != nil {
 			return fmt.Errorf("can't resolve ip: %w", err)
 		}
 		metadata.DstIP = ip
+	}
+	if !o.hasIPv6 && openVPNAddrIsIPv6(metadata.DstIP) {
+		return fmt.Errorf("openvpn outbound has no IPv6 address")
 	}
 	return nil
 }
@@ -184,6 +198,7 @@ func (o *OpenVPN) Close() error {
 	tunDevice := o.tunDevice
 	o.client = nil
 	o.tunDevice = nil
+	o.hasIPv6 = false
 	o.running = false
 	o.runMutex.Unlock()
 
@@ -196,7 +211,7 @@ func (o *OpenVPN) Close() error {
 	return nil
 }
 
-func (o *OpenVPN) run(ctx context.Context) error {
+func (o *OpenVPN) run(_ context.Context) error {
 	o.runMutex.Lock()
 	defer o.runMutex.Unlock()
 	if o.running {
@@ -206,20 +221,24 @@ func (o *OpenVPN) run(ctx context.Context) error {
 		return o.runCtx.Err()
 	}
 
-	packetIO, err := o.openPacketIO(ctx)
+	handshakeCtx, cancel := context.WithTimeout(o.runCtx, openVPNHandshakeTimeout)
+	defer cancel()
+
+	packetIO, err := o.openPacketIO(handshakeCtx)
 	if err != nil {
-		return err
+		return E.Cause(err, "connect OpenVPN server")
 	}
 	client, err := ovpn.NewClient(o.config, packetIO)
 	if err != nil {
 		_ = packetIO.Close()
 		return err
 	}
-	push, err := client.Handshake(ctx)
+	push, err := client.Handshake(handshakeCtx)
 	if err != nil {
 		_ = client.Close()
-		return err
+		return E.Cause(err, "OpenVPN handshake")
 	}
+	hasIPv6 := openVPNPrefixesHas6(push.Prefixes)
 	log.Debugln("[OpenVPN](%s) handshake complete: prefixes=%v peer-id=%d dns=%v redirect=%t block-ipv6=%t", o.name, push.Prefixes, push.PeerID, push.DNS, push.Redirect, push.BlockIPv6)
 
 	mtu := o.option.MTU
@@ -238,6 +257,7 @@ func (o *OpenVPN) run(ctx context.Context) error {
 	}
 	o.client = client
 	o.tunDevice = tunDevice
+	o.hasIPv6 = hasIPv6
 	o.running = true
 	if o.option.RemoteDnsResolve && len(o.dns) > 0 && o.resolver == nil {
 		nss := append([]dns.NameServer(nil), o.dns...)
@@ -246,7 +266,7 @@ func (o *OpenVPN) run(ctx context.Context) error {
 		}
 		o.resolver = dns.NewResolver(dns.Config{
 			Main: nss,
-			IPv6: openVPNPrefixesHas6(push.Prefixes),
+			IPv6: hasIPv6,
 		})
 	}
 	o.startPacketLoops()
@@ -262,6 +282,25 @@ func openVPNPrefixesHas6(prefixes []netip.Prefix) bool {
 	return false
 }
 
+func openVPNAddrIsIPv6(addr netip.Addr) bool {
+	return addr.IsValid() && !addr.Unmap().Is4()
+}
+
+func (o *OpenVPN) tunnelDNSPrefer() C.DNSPrefer {
+	if !o.hasIPv6 {
+		return C.IPv4Only
+	}
+	return o.prefer
+}
+
+func (o *OpenVPN) tunnelDialOptions() []dialer.Option {
+	options := o.DialOptions()
+	if !o.hasIPv6 {
+		options = append(options, dialer.WithOnlySingleStack(true))
+	}
+	return options
+}
+
 func (o *OpenVPN) openPacketIO(ctx context.Context) (ovpn.PacketIO, error) {
 	switch o.config.Proto {
 	case ovpn.ProtoUDP:
@@ -269,15 +308,33 @@ func (o *OpenVPN) openPacketIO(ctx context.Context) (ovpn.PacketIO, error) {
 		if err != nil {
 			return nil, err
 		}
+		setOpenVPNSocketBuffers(o.name, conn)
 		return ovpn.NewDatagramPacketIO(conn), nil
 	case ovpn.ProtoTCP:
 		conn, err := o.dialer.DialContext(ctx, "tcp", o.addr)
 		if err != nil {
 			return nil, err
 		}
+		setOpenVPNSocketBuffers(o.name, conn)
 		return ovpn.NewTCPPacketIO(conn), nil
 	default:
 		return nil, fmt.Errorf("unsupported openvpn proto %q", o.config.Proto)
+	}
+}
+
+func setOpenVPNSocketBuffers(name string, conn net.Conn) {
+	bufferConn, ok := conn.(interface {
+		SetReadBuffer(bytes int) error
+		SetWriteBuffer(bytes int) error
+	})
+	if !ok {
+		return
+	}
+	if err := bufferConn.SetReadBuffer(openVPNSocketBufferSize); err != nil {
+		log.Debugln("[OpenVPN](%s) failed to set read buffer: %v", name, err)
+	}
+	if err := bufferConn.SetWriteBuffer(openVPNSocketBufferSize); err != nil {
+		log.Debugln("[OpenVPN](%s) failed to set write buffer: %v", name, err)
 	}
 }
 
@@ -295,6 +352,7 @@ func (o *OpenVPN) startPacketLoops() {
 			if o.client == client {
 				o.client = nil
 				o.tunDevice = nil
+				o.hasIPv6 = false
 				o.running = false
 			}
 			o.runMutex.Unlock()

--- a/adapter/outbound/openvpn.go
+++ b/adapter/outbound/openvpn.go
@@ -31,7 +31,6 @@ type OpenVPN struct {
 	client    *ovpn.Client
 	resolver  resolver.Resolver
 	dns       []dns.NameServer
-	hasIPv6   bool
 
 	runCtx    context.Context
 	runCancel context.CancelFunc
@@ -39,10 +38,7 @@ type OpenVPN struct {
 	running   bool
 }
 
-const (
-	openVPNHandshakeTimeout = 30 * time.Second
-	openVPNSocketBufferSize = 4 * 1024 * 1024
-)
+const openVPNHandshakeTimeout = 30 * time.Second
 
 type OpenVPNOption struct {
 	BasicOption
@@ -118,20 +114,16 @@ func (o *OpenVPN) DialContext(ctx context.Context, metadata *C.Metadata) (_ C.Co
 		return nil, err
 	}
 	var conn net.Conn
-	shouldResolve := !metadata.Resolved() || o.resolver != nil || (!o.hasIPv6 && metadata.Host != "" && openVPNAddrIsIPv6(metadata.DstIP))
-	if shouldResolve {
+	if !metadata.Resolved() || o.resolver != nil {
 		r := resolver.DefaultResolver
 		if o.resolver != nil {
 			r = o.resolver
 		}
-		options := o.tunnelDialOptions()
+		options := o.DialOptions()
 		options = append(options, dialer.WithResolver(r))
 		options = append(options, dialer.WithNetDialer(wgNetDialer{tunDevice: o.tunDevice}))
 		conn, err = dialer.NewDialer(options...).DialContext(ctx, "tcp", metadata.RemoteAddress())
 	} else {
-		if !o.hasIPv6 && openVPNAddrIsIPv6(metadata.DstIP) {
-			return nil, E.New("openvpn outbound has no IPv6 address")
-		}
 		conn, err = o.tunDevice.DialContext(ctx, "tcp", M.SocksaddrFrom(metadata.DstIP, metadata.DstPort).Unwrap())
 	}
 	if err != nil {
@@ -167,14 +159,11 @@ func (o *OpenVPN) ResolveUDP(ctx context.Context, metadata *C.Metadata) error {
 		if o.resolver != nil {
 			r = o.resolver
 		}
-		ip, err := resolveIPWithResolver(ctx, metadata.Host, o.tunnelDNSPrefer(), r)
+		ip, err := resolveIPWithResolver(ctx, metadata.Host, o.prefer, r)
 		if err != nil {
 			return fmt.Errorf("can't resolve ip: %w", err)
 		}
 		metadata.DstIP = ip
-	}
-	if !o.hasIPv6 && openVPNAddrIsIPv6(metadata.DstIP) {
-		return fmt.Errorf("openvpn outbound has no IPv6 address")
 	}
 	return nil
 }
@@ -198,7 +187,6 @@ func (o *OpenVPN) Close() error {
 	tunDevice := o.tunDevice
 	o.client = nil
 	o.tunDevice = nil
-	o.hasIPv6 = false
 	o.running = false
 	o.runMutex.Unlock()
 
@@ -238,7 +226,6 @@ func (o *OpenVPN) run(_ context.Context) error {
 		_ = client.Close()
 		return E.Cause(err, "OpenVPN handshake")
 	}
-	hasIPv6 := openVPNPrefixesHas6(push.Prefixes)
 	log.Debugln("[OpenVPN](%s) handshake complete: prefixes=%v peer-id=%d dns=%v redirect=%t block-ipv6=%t", o.name, push.Prefixes, push.PeerID, push.DNS, push.Redirect, push.BlockIPv6)
 
 	mtu := o.option.MTU
@@ -257,7 +244,6 @@ func (o *OpenVPN) run(_ context.Context) error {
 	}
 	o.client = client
 	o.tunDevice = tunDevice
-	o.hasIPv6 = hasIPv6
 	o.running = true
 	if o.option.RemoteDnsResolve && len(o.dns) > 0 && o.resolver == nil {
 		nss := append([]dns.NameServer(nil), o.dns...)
@@ -266,7 +252,7 @@ func (o *OpenVPN) run(_ context.Context) error {
 		}
 		o.resolver = dns.NewResolver(dns.Config{
 			Main: nss,
-			IPv6: hasIPv6,
+			IPv6: openVPNPrefixesHas6(push.Prefixes),
 		})
 	}
 	o.startPacketLoops()
@@ -282,25 +268,6 @@ func openVPNPrefixesHas6(prefixes []netip.Prefix) bool {
 	return false
 }
 
-func openVPNAddrIsIPv6(addr netip.Addr) bool {
-	return addr.IsValid() && !addr.Unmap().Is4()
-}
-
-func (o *OpenVPN) tunnelDNSPrefer() C.DNSPrefer {
-	if !o.hasIPv6 {
-		return C.IPv4Only
-	}
-	return o.prefer
-}
-
-func (o *OpenVPN) tunnelDialOptions() []dialer.Option {
-	options := o.DialOptions()
-	if !o.hasIPv6 {
-		options = append(options, dialer.WithOnlySingleStack(true))
-	}
-	return options
-}
-
 func (o *OpenVPN) openPacketIO(ctx context.Context) (ovpn.PacketIO, error) {
 	switch o.config.Proto {
 	case ovpn.ProtoUDP:
@@ -308,33 +275,15 @@ func (o *OpenVPN) openPacketIO(ctx context.Context) (ovpn.PacketIO, error) {
 		if err != nil {
 			return nil, err
 		}
-		setOpenVPNSocketBuffers(o.name, conn)
 		return ovpn.NewDatagramPacketIO(conn), nil
 	case ovpn.ProtoTCP:
 		conn, err := o.dialer.DialContext(ctx, "tcp", o.addr)
 		if err != nil {
 			return nil, err
 		}
-		setOpenVPNSocketBuffers(o.name, conn)
 		return ovpn.NewTCPPacketIO(conn), nil
 	default:
 		return nil, fmt.Errorf("unsupported openvpn proto %q", o.config.Proto)
-	}
-}
-
-func setOpenVPNSocketBuffers(name string, conn net.Conn) {
-	bufferConn, ok := conn.(interface {
-		SetReadBuffer(bytes int) error
-		SetWriteBuffer(bytes int) error
-	})
-	if !ok {
-		return
-	}
-	if err := bufferConn.SetReadBuffer(openVPNSocketBufferSize); err != nil {
-		log.Debugln("[OpenVPN](%s) failed to set read buffer: %v", name, err)
-	}
-	if err := bufferConn.SetWriteBuffer(openVPNSocketBufferSize); err != nil {
-		log.Debugln("[OpenVPN](%s) failed to set write buffer: %v", name, err)
 	}
 }
 
@@ -352,7 +301,6 @@ func (o *OpenVPN) startPacketLoops() {
 			if o.client == client {
 				o.client = nil
 				o.tunDevice = nil
-				o.hasIPv6 = false
 				o.running = false
 			}
 			o.runMutex.Unlock()

--- a/adapter/outbound/openvpn.go
+++ b/adapter/outbound/openvpn.go
@@ -8,7 +8,6 @@ import (
 	"net/netip"
 	"os"
 	"sync"
-	"time"
 
 	"github.com/metacubex/mihomo/common/contextutils"
 	"github.com/metacubex/mihomo/component/dialer"

--- a/adapter/outbound/openvpn.go
+++ b/adapter/outbound/openvpn.go
@@ -208,12 +208,6 @@ func (o *OpenVPN) Close() error {
 }
 
 func (o *OpenVPN) run(ctx context.Context) (wireguard.Device, resolver.Resolver, error) {
-	if ctx == nil {
-		ctx = context.Background()
-	}
-	if err := ctx.Err(); err != nil {
-		return nil, nil, err
-	}
 	if err := o.lockRun(ctx); err != nil {
 		return nil, nil, err
 	}

--- a/adapter/outbound/openvpn.go
+++ b/adapter/outbound/openvpn.go
@@ -38,7 +38,10 @@ type OpenVPN struct {
 	running   bool
 }
 
-const openVPNHandshakeTimeout = 30 * time.Second
+const (
+	openVPNHandshakeTimeout     = 30 * time.Second
+	openVPNRunLockRetryInterval = 10 * time.Millisecond
+)
 
 type OpenVPNOption struct {
 	BasicOption
@@ -113,18 +116,21 @@ func (o *OpenVPN) DialContext(ctx context.Context, metadata *C.Metadata) (_ C.Co
 	if err = o.run(ctx); err != nil {
 		return nil, err
 	}
+	tunDevice, r, err := o.stackDevice()
+	if err != nil {
+		return nil, err
+	}
 	var conn net.Conn
-	if !metadata.Resolved() || o.resolver != nil {
-		r := resolver.DefaultResolver
-		if o.resolver != nil {
-			r = o.resolver
+	if !metadata.Resolved() || r != nil {
+		if r == nil {
+			r = resolver.DefaultResolver
 		}
 		options := o.DialOptions()
 		options = append(options, dialer.WithResolver(r))
-		options = append(options, dialer.WithNetDialer(wgNetDialer{tunDevice: o.tunDevice}))
+		options = append(options, dialer.WithNetDialer(wgNetDialer{tunDevice: tunDevice}))
 		conn, err = dialer.NewDialer(options...).DialContext(ctx, "tcp", metadata.RemoteAddress())
 	} else {
-		conn, err = o.tunDevice.DialContext(ctx, "tcp", M.SocksaddrFrom(metadata.DstIP, metadata.DstPort).Unwrap())
+		conn, err = tunDevice.DialContext(ctx, "tcp", M.SocksaddrFrom(metadata.DstIP, metadata.DstPort).Unwrap())
 	}
 	if err != nil {
 		return nil, err
@@ -140,10 +146,14 @@ func (o *OpenVPN) ListenPacketContext(ctx context.Context, metadata *C.Metadata)
 	if err = o.run(ctx); err != nil {
 		return nil, err
 	}
+	tunDevice, _, err := o.stackDevice()
+	if err != nil {
+		return nil, err
+	}
 	if err = o.ResolveUDP(ctx, metadata); err != nil {
 		return nil, err
 	}
-	pc, err = o.tunDevice.ListenPacket(ctx, M.SocksaddrFrom(metadata.DstIP, metadata.DstPort).Unwrap())
+	pc, err = tunDevice.ListenPacket(ctx, M.SocksaddrFrom(metadata.DstIP, metadata.DstPort).Unwrap())
 	if err != nil {
 		return nil, err
 	}
@@ -154,10 +164,13 @@ func (o *OpenVPN) ListenPacketContext(ctx context.Context, metadata *C.Metadata)
 }
 
 func (o *OpenVPN) ResolveUDP(ctx context.Context, metadata *C.Metadata) error {
-	if (!metadata.Resolved() || o.resolver != nil) && metadata.Host != "" {
-		r := resolver.DefaultResolver
-		if o.resolver != nil {
-			r = o.resolver
+	_, r, err := o.stackDevice()
+	if err != nil {
+		return err
+	}
+	if (!metadata.Resolved() || r != nil) && metadata.Host != "" {
+		if r == nil {
+			r = resolver.DefaultResolver
 		}
 		ip, err := resolveIPWithResolver(ctx, metadata.Host, o.prefer, r)
 		if err != nil {
@@ -199,8 +212,16 @@ func (o *OpenVPN) Close() error {
 	return nil
 }
 
-func (o *OpenVPN) run(_ context.Context) error {
-	o.runMutex.Lock()
+func (o *OpenVPN) run(ctx context.Context) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if err := o.lockRun(ctx); err != nil {
+		return err
+	}
 	defer o.runMutex.Unlock()
 	if o.running {
 		return nil
@@ -209,11 +230,14 @@ func (o *OpenVPN) run(_ context.Context) error {
 		return o.runCtx.Err()
 	}
 
-	handshakeCtx, cancel := context.WithTimeout(o.runCtx, openVPNHandshakeTimeout)
+	handshakeCtx, cancel := o.handshakeContext(ctx)
 	defer cancel()
 
 	packetIO, err := o.openPacketIO(handshakeCtx)
 	if err != nil {
+		if ctxErr := o.contextErr(ctx); ctxErr != nil {
+			return ctxErr
+		}
 		return E.Cause(err, "connect OpenVPN server")
 	}
 	client, err := ovpn.NewClient(o.config, packetIO)
@@ -224,6 +248,9 @@ func (o *OpenVPN) run(_ context.Context) error {
 	push, err := client.Handshake(handshakeCtx)
 	if err != nil {
 		_ = client.Close()
+		if ctxErr := o.contextErr(ctx); ctxErr != nil {
+			return ctxErr
+		}
 		return E.Cause(err, "OpenVPN handshake")
 	}
 	log.Debugln("[OpenVPN](%s) handshake complete: prefixes=%v peer-id=%d dns=%v redirect=%t block-ipv6=%t", o.name, push.Prefixes, push.PeerID, push.DNS, push.Redirect, push.BlockIPv6)
@@ -257,6 +284,59 @@ func (o *OpenVPN) run(_ context.Context) error {
 	}
 	o.startPacketLoops()
 	return nil
+}
+
+func (o *OpenVPN) lockRun(ctx context.Context) error {
+	if o.runMutex.TryLock() {
+		return nil
+	}
+	timer := time.NewTimer(openVPNRunLockRetryInterval)
+	defer timer.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-o.runCtx.Done():
+			return o.runCtx.Err()
+		case <-timer.C:
+			if o.runMutex.TryLock() {
+				return nil
+			}
+			timer.Reset(openVPNRunLockRetryInterval)
+		}
+	}
+}
+
+func (o *OpenVPN) handshakeContext(ctx context.Context) (context.Context, context.CancelFunc) {
+	baseCtx, baseCancel := context.WithCancel(o.runCtx)
+	go func() {
+		select {
+		case <-ctx.Done():
+			baseCancel()
+		case <-baseCtx.Done():
+		}
+	}()
+	handshakeCtx, handshakeCancel := context.WithTimeout(baseCtx, openVPNHandshakeTimeout)
+	return handshakeCtx, func() {
+		handshakeCancel()
+		baseCancel()
+	}
+}
+
+func (o *OpenVPN) contextErr(ctx context.Context) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	return o.runCtx.Err()
+}
+
+func (o *OpenVPN) stackDevice() (wireguard.Device, resolver.Resolver, error) {
+	o.runMutex.Lock()
+	defer o.runMutex.Unlock()
+	if o.tunDevice == nil {
+		return nil, nil, net.ErrClosed
+	}
+	return o.tunDevice, o.resolver, nil
 }
 
 func openVPNPrefixesHas6(prefixes []netip.Prefix) bool {

--- a/adapter/outbound/openvpn.go
+++ b/adapter/outbound/openvpn.go
@@ -224,7 +224,10 @@ func (o *OpenVPN) run(ctx context.Context) (wireguard.Device, resolver.Resolver,
 	}
 	defer o.runLock.Release(1)
 	if o.running {
-		return o.deviceSnapshot()
+		if o.tunDevice == nil {
+			return nil, nil, net.ErrClosed
+		}
+		return o.tunDevice, o.resolver, nil
 	}
 	if o.runCtx.Err() != nil {
 		return nil, nil, o.runCtx.Err()
@@ -283,7 +286,7 @@ func (o *OpenVPN) run(ctx context.Context) (wireguard.Device, resolver.Resolver,
 		})
 	}
 	o.startPacketLoops()
-	return o.deviceSnapshot()
+	return o.tunDevice, o.resolver, nil
 }
 
 func (o *OpenVPN) lockRun(ctx context.Context) error {
@@ -303,18 +306,11 @@ func (o *OpenVPN) lockRun(ctx context.Context) error {
 }
 
 func (o *OpenVPN) handshakeContext(ctx context.Context) (context.Context, context.CancelFunc) {
-	baseCtx, baseCancel := context.WithCancel(o.runCtx)
-	go func() {
-		select {
-		case <-ctx.Done():
-			baseCancel()
-		case <-baseCtx.Done():
-		}
-	}()
-	handshakeCtx, handshakeCancel := context.WithTimeout(baseCtx, openVPNHandshakeTimeout)
+	handshakeCtx, handshakeCancel := context.WithTimeout(ctx, openVPNHandshakeTimeout)
+	stop := contextutils.AfterFunc(o.runCtx, handshakeCancel)
 	return handshakeCtx, func() {
+		stop()
 		handshakeCancel()
-		baseCancel()
 	}
 }
 
@@ -323,13 +319,6 @@ func (o *OpenVPN) contextErr(ctx context.Context) error {
 		return err
 	}
 	return o.runCtx.Err()
-}
-
-func (o *OpenVPN) deviceSnapshot() (wireguard.Device, resolver.Resolver, error) {
-	if o.tunDevice == nil {
-		return nil, nil, net.ErrClosed
-	}
-	return o.tunDevice, o.resolver, nil
 }
 
 func openVPNPrefixesHas6(prefixes []netip.Prefix) bool {

--- a/adapter/outbound/openvpn.go
+++ b/adapter/outbound/openvpn.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/metacubex/mihomo/common/contextutils"
 	"github.com/metacubex/mihomo/component/dialer"
 	"github.com/metacubex/mihomo/component/resolver"
 	C "github.com/metacubex/mihomo/constant"
@@ -20,6 +21,7 @@ import (
 	wireguard "github.com/metacubex/sing-wireguard"
 	E "github.com/metacubex/sing/common/exceptions"
 	M "github.com/metacubex/sing/common/metadata"
+	"golang.org/x/sync/semaphore"
 )
 
 type OpenVPN struct {
@@ -34,13 +36,12 @@ type OpenVPN struct {
 
 	runCtx    context.Context
 	runCancel context.CancelFunc
-	runMutex  sync.Mutex
+	runLock   *semaphore.Weighted
 	running   bool
 }
 
 const (
-	openVPNHandshakeTimeout     = 30 * time.Second
-	openVPNRunLockRetryInterval = 10 * time.Millisecond
+	openVPNHandshakeTimeout = 30 * time.Second
 )
 
 type OpenVPNOption struct {
@@ -97,8 +98,9 @@ func NewOpenVPN(option OpenVPNOption) (*OpenVPN, error) {
 			RoutingMark:  option.RoutingMark,
 			Prefer:       option.IPVersion,
 		}),
-		option: &option,
-		config: cfg,
+		option:  &option,
+		config:  cfg,
+		runLock: semaphore.NewWeighted(1),
 	}
 	if option.RemoteDnsResolve && len(option.Dns) > 0 {
 		nss, err := dns.ParseNameServer(option.Dns)
@@ -113,10 +115,7 @@ func NewOpenVPN(option OpenVPNOption) (*OpenVPN, error) {
 }
 
 func (o *OpenVPN) DialContext(ctx context.Context, metadata *C.Metadata) (_ C.Conn, err error) {
-	if err = o.run(ctx); err != nil {
-		return nil, err
-	}
-	tunDevice, r, err := o.stackDevice()
+	tunDevice, r, err := o.run(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -143,14 +142,11 @@ func (o *OpenVPN) DialContext(ctx context.Context, metadata *C.Metadata) (_ C.Co
 
 func (o *OpenVPN) ListenPacketContext(ctx context.Context, metadata *C.Metadata) (_ C.PacketConn, err error) {
 	var pc net.PacketConn
-	if err = o.run(ctx); err != nil {
-		return nil, err
-	}
-	tunDevice, _, err := o.stackDevice()
+	tunDevice, r, err := o.run(ctx)
 	if err != nil {
 		return nil, err
 	}
-	if err = o.ResolveUDP(ctx, metadata); err != nil {
+	if err = o.resolveUDP(ctx, metadata, r); err != nil {
 		return nil, err
 	}
 	pc, err = tunDevice.ListenPacket(ctx, M.SocksaddrFrom(metadata.DstIP, metadata.DstPort).Unwrap())
@@ -164,10 +160,14 @@ func (o *OpenVPN) ListenPacketContext(ctx context.Context, metadata *C.Metadata)
 }
 
 func (o *OpenVPN) ResolveUDP(ctx context.Context, metadata *C.Metadata) error {
-	_, r, err := o.stackDevice()
+	_, r, err := o.run(ctx)
 	if err != nil {
 		return err
 	}
+	return o.resolveUDP(ctx, metadata, r)
+}
+
+func (o *OpenVPN) resolveUDP(ctx context.Context, metadata *C.Metadata, r resolver.Resolver) error {
 	if (!metadata.Resolved() || r != nil) && metadata.Host != "" {
 		if r == nil {
 			r = resolver.DefaultResolver
@@ -195,13 +195,13 @@ func (o *OpenVPN) Close() error {
 	if o.runCancel != nil {
 		o.runCancel()
 	}
-	o.runMutex.Lock()
+	_ = o.runLock.Acquire(context.Background(), 1)
 	client := o.client
 	tunDevice := o.tunDevice
 	o.client = nil
 	o.tunDevice = nil
 	o.running = false
-	o.runMutex.Unlock()
+	o.runLock.Release(1)
 
 	if client != nil {
 		_ = client.Close()
@@ -212,22 +212,22 @@ func (o *OpenVPN) Close() error {
 	return nil
 }
 
-func (o *OpenVPN) run(ctx context.Context) error {
+func (o *OpenVPN) run(ctx context.Context) (wireguard.Device, resolver.Resolver, error) {
 	if ctx == nil {
 		ctx = context.Background()
 	}
 	if err := ctx.Err(); err != nil {
-		return err
+		return nil, nil, err
 	}
 	if err := o.lockRun(ctx); err != nil {
-		return err
+		return nil, nil, err
 	}
-	defer o.runMutex.Unlock()
+	defer o.runLock.Release(1)
 	if o.running {
-		return nil
+		return o.deviceSnapshot()
 	}
 	if o.runCtx.Err() != nil {
-		return o.runCtx.Err()
+		return nil, nil, o.runCtx.Err()
 	}
 
 	handshakeCtx, cancel := o.handshakeContext(ctx)
@@ -236,22 +236,22 @@ func (o *OpenVPN) run(ctx context.Context) error {
 	packetIO, err := o.openPacketIO(handshakeCtx)
 	if err != nil {
 		if ctxErr := o.contextErr(ctx); ctxErr != nil {
-			return ctxErr
+			return nil, nil, ctxErr
 		}
-		return E.Cause(err, "connect OpenVPN server")
+		return nil, nil, E.Cause(err, "connect OpenVPN server")
 	}
 	client, err := ovpn.NewClient(o.config, packetIO)
 	if err != nil {
 		_ = packetIO.Close()
-		return err
+		return nil, nil, err
 	}
 	push, err := client.Handshake(handshakeCtx)
 	if err != nil {
 		_ = client.Close()
 		if ctxErr := o.contextErr(ctx); ctxErr != nil {
-			return ctxErr
+			return nil, nil, ctxErr
 		}
-		return E.Cause(err, "OpenVPN handshake")
+		return nil, nil, E.Cause(err, "OpenVPN handshake")
 	}
 	log.Debugln("[OpenVPN](%s) handshake complete: prefixes=%v peer-id=%d dns=%v redirect=%t block-ipv6=%t", o.name, push.Prefixes, push.PeerID, push.DNS, push.Redirect, push.BlockIPv6)
 
@@ -262,12 +262,12 @@ func (o *OpenVPN) run(ctx context.Context) error {
 	tunDevice, err := wireguard.NewStackDevice(push.Prefixes, uint32(mtu))
 	if err != nil {
 		_ = client.Close()
-		return E.Cause(err, "create OpenVPN stack device")
+		return nil, nil, E.Cause(err, "create OpenVPN stack device")
 	}
 	if err := tunDevice.Start(); err != nil {
 		_ = client.Close()
 		_ = tunDevice.Close()
-		return err
+		return nil, nil, err
 	}
 	o.client = client
 	o.tunDevice = tunDevice
@@ -283,28 +283,23 @@ func (o *OpenVPN) run(ctx context.Context) error {
 		})
 	}
 	o.startPacketLoops()
-	return nil
+	return o.deviceSnapshot()
 }
 
 func (o *OpenVPN) lockRun(ctx context.Context) error {
-	if o.runMutex.TryLock() {
-		return nil
-	}
-	timer := time.NewTimer(openVPNRunLockRetryInterval)
-	defer timer.Stop()
-	for {
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		case <-o.runCtx.Done():
-			return o.runCtx.Err()
-		case <-timer.C:
-			if o.runMutex.TryLock() {
-				return nil
-			}
-			timer.Reset(openVPNRunLockRetryInterval)
+	lockCtx, cancel := context.WithCancel(ctx)
+	stop := contextutils.AfterFunc(o.runCtx, cancel)
+	defer func() {
+		stop()
+		cancel()
+	}()
+	if err := o.runLock.Acquire(lockCtx, 1); err != nil {
+		if ctxErr := o.contextErr(ctx); ctxErr != nil {
+			return ctxErr
 		}
+		return err
 	}
+	return nil
 }
 
 func (o *OpenVPN) handshakeContext(ctx context.Context) (context.Context, context.CancelFunc) {
@@ -330,9 +325,7 @@ func (o *OpenVPN) contextErr(ctx context.Context) error {
 	return o.runCtx.Err()
 }
 
-func (o *OpenVPN) stackDevice() (wireguard.Device, resolver.Resolver, error) {
-	o.runMutex.Lock()
-	defer o.runMutex.Unlock()
+func (o *OpenVPN) deviceSnapshot() (wireguard.Device, resolver.Resolver, error) {
 	if o.tunDevice == nil {
 		return nil, nil, net.ErrClosed
 	}
@@ -377,13 +370,13 @@ func (o *OpenVPN) startPacketLoops() {
 			runCancel()
 			_ = client.Close()
 			_ = tunDevice.Close()
-			o.runMutex.Lock()
+			_ = o.runLock.Acquire(context.Background(), 1)
 			if o.client == client {
 				o.client = nil
 				o.tunDevice = nil
 				o.running = false
 			}
-			o.runMutex.Unlock()
+			o.runLock.Release(1)
 		})
 	}
 	go func() {

--- a/adapter/outbound/openvpn.go
+++ b/adapter/outbound/openvpn.go
@@ -40,10 +40,6 @@ type OpenVPN struct {
 	running   bool
 }
 
-const (
-	openVPNHandshakeTimeout = 30 * time.Second
-)
-
 type OpenVPNOption struct {
 	BasicOption
 	Name     string `proxy:"name"`
@@ -306,7 +302,7 @@ func (o *OpenVPN) lockRun(ctx context.Context) error {
 }
 
 func (o *OpenVPN) handshakeContext(ctx context.Context) (context.Context, context.CancelFunc) {
-	handshakeCtx, handshakeCancel := context.WithTimeout(ctx, openVPNHandshakeTimeout)
+	handshakeCtx, handshakeCancel := context.WithTimeout(ctx, ovpn.DefaultHandshakeTimeout)
 	stop := contextutils.AfterFunc(o.runCtx, handshakeCancel)
 	return handshakeCtx, func() {
 		stop()

--- a/transport/openvpn/client.go
+++ b/transport/openvpn/client.go
@@ -15,8 +15,8 @@ import (
 )
 
 const (
-	defaultHandshakeTimeout = 30 * time.Second
-	controlRetransmitDelay  = time.Second
+	DefaultHandshakeTimeout = 30 * time.Second
+	ControlRetransmitDelay  = time.Second
 )
 
 type Client struct {
@@ -67,7 +67,7 @@ func (c *Client) Handshake(ctx context.Context) (*PushReply, error) {
 	}
 	if _, ok := ctx.Deadline(); !ok {
 		var cancel context.CancelFunc
-		ctx, cancel = context.WithTimeout(ctx, defaultHandshakeTimeout)
+		ctx, cancel = context.WithTimeout(ctx, DefaultHandshakeTimeout)
 		defer cancel()
 	}
 	if err := c.control.SendReset(ctx); err != nil {
@@ -180,7 +180,7 @@ func (c *Client) waitServerReset(ctx context.Context) error {
 		readCtx := ctx
 		cancel := func() {}
 		if c.config.Proto == ProtoUDP {
-			readCtx, cancel = context.WithTimeout(ctx, controlRetransmitDelay)
+			readCtx, cancel = context.WithTimeout(ctx, ControlRetransmitDelay)
 		}
 		packet, err := c.control.Read(readCtx)
 		cancel()

--- a/transport/openvpn/client.go
+++ b/transport/openvpn/client.go
@@ -14,7 +14,10 @@ import (
 	"github.com/metacubex/tls"
 )
 
-const defaultHandshakeTimeout = 30 * time.Second
+const (
+	defaultHandshakeTimeout = 30 * time.Second
+	controlRetransmitDelay  = time.Second
+)
 
 type Client struct {
 	config *ClientConfig
@@ -172,10 +175,24 @@ func (c *Client) Close() error {
 }
 
 func (c *Client) waitServerReset(ctx context.Context) error {
+	retransmits := 0
 	for {
-		packet, err := c.control.Read(ctx)
+		readCtx := ctx
+		cancel := func() {}
+		if c.config.Proto == ProtoUDP {
+			readCtx, cancel = context.WithTimeout(ctx, controlRetransmitDelay)
+		}
+		packet, err := c.control.Read(readCtx)
+		cancel()
 		if err != nil {
-			return fmt.Errorf("read hard reset response: %w", err)
+			if c.config.Proto == ProtoUDP && errors.Is(err, context.DeadlineExceeded) && ctx.Err() == nil {
+				if err := c.control.RetransmitPending(ctx); err != nil {
+					return fmt.Errorf("retransmit hard reset: %w", err)
+				}
+				retransmits++
+				continue
+			}
+			return fmt.Errorf("read hard reset response after %d retransmits: %w", retransmits, err)
 		}
 		switch packet.Opcode {
 		case PControlHardResetServerV2:

--- a/transport/openvpn/control.go
+++ b/transport/openvpn/control.go
@@ -18,6 +18,13 @@ type PacketIO interface {
 	RemoteAddr() net.Addr
 }
 
+var streamPacketFramePool = sync.Pool{
+	New: func() any {
+		frame := make([]byte, 0, 64*1024+2)
+		return &frame
+	},
+}
+
 type ControlChannel struct {
 	io     PacketIO
 	crypt  *TLSCrypt
@@ -29,19 +36,22 @@ type ControlChannel struct {
 	mu            sync.Mutex
 	sendPacketID  uint32
 	sendMessage   uint32
+	recvMessage   uint32
 	ackPending    []uint32
 	pending       map[uint32]*ControlPacket
+	recvPending   map[uint32]*ControlPacket
 	readDeadline  time.Time
 	writeDeadline time.Time
 }
 
 func NewControlChannel(io PacketIO, crypt *TLSCrypt, local SessionID) *ControlChannel {
 	return &ControlChannel{
-		io:      io,
-		crypt:   crypt,
-		clock:   time.Now,
-		local:   local,
-		pending: make(map[uint32]*ControlPacket),
+		io:          io,
+		crypt:       crypt,
+		clock:       time.Now,
+		local:       local,
+		pending:     make(map[uint32]*ControlPacket),
+		recvPending: make(map[uint32]*ControlPacket),
 	}
 }
 
@@ -113,10 +123,22 @@ func (c *ControlChannel) SendAck(ctx context.Context) error {
 
 func (c *ControlChannel) Read(ctx context.Context) (*ControlPacket, error) {
 	for {
+		c.mu.Lock()
+		if packet, ok := c.recvPending[c.recvMessage]; ok {
+			delete(c.recvPending, c.recvMessage)
+			c.recvMessage++
+			c.mu.Unlock()
+			return packet, nil
+		}
+		c.mu.Unlock()
+
 		packet, err := c.readControlPacket(ctx)
 		if err != nil {
 			return nil, err
 		}
+
+		var deliver *ControlPacket
+		sendAck := false
 
 		c.mu.Lock()
 		if c.remote == (SessionID{}) && packet.LocalSession != c.local {
@@ -128,12 +150,33 @@ func (c *ControlChannel) Read(ctx context.Context) (*ControlPacket, error) {
 		if packet.Opcode.HasMessageID() {
 			c.ackPending = appendAck(c.ackPending, packet.MessageID)
 		}
+
+		switch {
+		case packet.Opcode == PAckV1:
+		case !packet.Opcode.HasMessageID():
+			deliver = packet
+		case packet.MessageID < c.recvMessage:
+			sendAck = true
+		case packet.MessageID == c.recvMessage:
+			deliver = packet
+			c.recvMessage++
+		default:
+			if _, exists := c.recvPending[packet.MessageID]; !exists {
+				c.recvPending[packet.MessageID] = packet
+			}
+			sendAck = true
+		}
+
 		c.mu.Unlock()
 
-		if packet.Opcode == PAckV1 {
-			continue
+		if deliver != nil {
+			return deliver, nil
 		}
-		return packet, nil
+		if sendAck {
+			if err := c.SendAck(ctx); err != nil {
+				return nil, err
+			}
+		}
 	}
 }
 
@@ -332,11 +375,18 @@ func (c *ControlConn) SetWriteDeadline(t time.Time) error {
 }
 
 type streamPacketIO struct {
-	conn net.Conn
+	conn          net.Conn
+	deadlineMu    sync.Mutex
+	writeMu       sync.Mutex
+	readDeadline  time.Time
+	writeDeadline time.Time
 }
 
 type datagramPacketIO struct {
-	conn net.Conn
+	conn          net.Conn
+	deadlineMu    sync.Mutex
+	readDeadline  time.Time
+	writeDeadline time.Time
 }
 
 func NewDatagramPacketIO(conn net.Conn) PacketIO {
@@ -344,40 +394,23 @@ func NewDatagramPacketIO(conn net.Conn) PacketIO {
 }
 
 func (d *datagramPacketIO) ReadPacket(ctx context.Context) ([]byte, error) {
-	done := make(chan struct{})
-	var (
-		packet []byte
-		err    error
-	)
-	go func() {
-		defer close(done)
-		buf := make([]byte, 64*1024)
-		var n int
-		n, err = d.conn.Read(buf)
-		if err == nil {
-			packet = cloneBytes(buf[:n])
-		}
-	}()
-	select {
-	case <-ctx.Done():
-		return nil, ctx.Err()
-	case <-done:
-		return packet, err
+	if err := setReadDeadlineFromContext(d.conn, ctx, &d.deadlineMu, &d.readDeadline); err != nil {
+		return nil, err
 	}
+	buf := make([]byte, 64*1024)
+	n, err := d.conn.Read(buf)
+	if err != nil {
+		return nil, contextIOError(ctx, err)
+	}
+	return buf[:n], nil
 }
 
 func (d *datagramPacketIO) WritePacket(ctx context.Context, packet []byte) error {
-	done := make(chan error, 1)
-	go func() {
-		_, err := d.conn.Write(packet)
-		done <- err
-	}()
-	select {
-	case <-ctx.Done():
-		return ctx.Err()
-	case err := <-done:
+	if err := setWriteDeadlineFromContext(d.conn, ctx, &d.deadlineMu, &d.writeDeadline); err != nil {
 		return err
 	}
+	_, err := d.conn.Write(packet)
+	return contextIOError(ctx, err)
 }
 
 func (d *datagramPacketIO) Close() error {
@@ -397,52 +430,51 @@ func NewTCPPacketIO(conn net.Conn) PacketIO {
 }
 
 func (s *streamPacketIO) ReadPacket(ctx context.Context) ([]byte, error) {
-	done := make(chan struct{})
-	var (
-		packet []byte
-		err    error
-	)
-	go func() {
-		defer close(done)
-		var lenBuf [2]byte
-		if _, err = io.ReadFull(s.conn, lenBuf[:]); err != nil {
-			return
-		}
-		size := int(lenBuf[0])<<8 | int(lenBuf[1])
-		if size == 0 {
-			err = errors.New("empty openvpn tcp packet")
-			return
-		}
-		packet = make([]byte, size)
-		_, err = io.ReadFull(s.conn, packet)
-	}()
-	select {
-	case <-ctx.Done():
-		return nil, ctx.Err()
-	case <-done:
-		return packet, err
+	if err := setReadDeadlineFromContext(s.conn, ctx, &s.deadlineMu, &s.readDeadline); err != nil {
+		return nil, err
 	}
+	var lenBuf [2]byte
+	if _, err := io.ReadFull(s.conn, lenBuf[:]); err != nil {
+		return nil, contextIOError(ctx, err)
+	}
+	size := int(lenBuf[0])<<8 | int(lenBuf[1])
+	if size == 0 {
+		return nil, errors.New("empty openvpn tcp packet")
+	}
+	packet := make([]byte, size)
+	if _, err := io.ReadFull(s.conn, packet); err != nil {
+		return nil, contextIOError(ctx, err)
+	}
+	return packet, nil
 }
 
 func (s *streamPacketIO) WritePacket(ctx context.Context, packet []byte) error {
 	if len(packet) > 0xffff {
 		return fmt.Errorf("openvpn tcp packet too large: %d", len(packet))
 	}
-	done := make(chan error, 1)
-	go func() {
-		frame := make([]byte, 2+len(packet))
-		frame[0] = byte(len(packet) >> 8)
-		frame[1] = byte(len(packet))
-		copy(frame[2:], packet)
-		_, err := s.conn.Write(frame)
-		done <- err
+	framePtr := streamPacketFramePool.Get().(*[]byte)
+	frame := *framePtr
+	frameLen := 2 + len(packet)
+	if cap(frame) < frameLen {
+		frame = make([]byte, frameLen)
+	} else {
+		frame = frame[:frameLen]
+	}
+	defer func() {
+		*framePtr = frame[:0]
+		streamPacketFramePool.Put(framePtr)
 	}()
-	select {
-	case <-ctx.Done():
-		return ctx.Err()
-	case err := <-done:
+
+	s.writeMu.Lock()
+	defer s.writeMu.Unlock()
+	if err := setWriteDeadlineFromContext(s.conn, ctx, &s.deadlineMu, &s.writeDeadline); err != nil {
 		return err
 	}
+	frame[0] = byte(len(packet) >> 8)
+	frame[1] = byte(len(packet))
+	copy(frame[2:], packet)
+	_, err := s.conn.Write(frame)
+	return contextIOError(ctx, err)
 }
 
 func (s *streamPacketIO) Close() error {
@@ -455,4 +487,51 @@ func (s *streamPacketIO) LocalAddr() net.Addr {
 
 func (s *streamPacketIO) RemoteAddr() net.Addr {
 	return s.conn.RemoteAddr()
+}
+
+func setReadDeadlineFromContext(conn net.Conn, ctx context.Context, mu *sync.Mutex, current *time.Time) error {
+	deadline, hasDeadline := ctx.Deadline()
+	mu.Lock()
+	defer mu.Unlock()
+	if current.Equal(deadline) {
+		return nil
+	}
+	if hasDeadline {
+		if err := conn.SetReadDeadline(deadline); err != nil {
+			return err
+		}
+	} else if err := conn.SetReadDeadline(time.Time{}); err != nil {
+		return err
+	}
+	*current = deadline
+	return nil
+}
+
+func setWriteDeadlineFromContext(conn net.Conn, ctx context.Context, mu *sync.Mutex, current *time.Time) error {
+	deadline, hasDeadline := ctx.Deadline()
+	mu.Lock()
+	defer mu.Unlock()
+	if current.Equal(deadline) {
+		return nil
+	}
+	if hasDeadline {
+		if err := conn.SetWriteDeadline(deadline); err != nil {
+			return err
+		}
+	} else if err := conn.SetWriteDeadline(time.Time{}); err != nil {
+		return err
+	}
+	*current = deadline
+	return nil
+}
+
+func contextIOError(ctx context.Context, err error) error {
+	if err == nil {
+		return nil
+	}
+	var netErr net.Error
+	if errors.As(err, &netErr) && netErr.Timeout() && ctx.Err() != nil {
+		return ctx.Err()
+	}
+	return err
 }

--- a/transport/openvpn/control.go
+++ b/transport/openvpn/control.go
@@ -8,6 +8,8 @@ import (
 	"net"
 	"sync"
 	"time"
+
+	"github.com/metacubex/mihomo/common/pool"
 )
 
 type PacketIO interface {
@@ -16,13 +18,6 @@ type PacketIO interface {
 	Close() error
 	LocalAddr() net.Addr
 	RemoteAddr() net.Addr
-}
-
-var streamPacketFramePool = sync.Pool{
-	New: func() any {
-		frame := make([]byte, 0, 64*1024+2)
-		return &frame
-	},
 }
 
 type ControlChannel struct {
@@ -377,7 +372,6 @@ func (c *ControlConn) SetWriteDeadline(t time.Time) error {
 type streamPacketIO struct {
 	conn          net.Conn
 	deadlineMu    sync.Mutex
-	writeMu       sync.Mutex
 	readDeadline  time.Time
 	writeDeadline time.Time
 }
@@ -452,24 +446,11 @@ func (s *streamPacketIO) WritePacket(ctx context.Context, packet []byte) error {
 	if len(packet) > 0xffff {
 		return fmt.Errorf("openvpn tcp packet too large: %d", len(packet))
 	}
-	framePtr := streamPacketFramePool.Get().(*[]byte)
-	frame := *framePtr
-	frameLen := 2 + len(packet)
-	if cap(frame) < frameLen {
-		frame = make([]byte, frameLen)
-	} else {
-		frame = frame[:frameLen]
-	}
-	defer func() {
-		*framePtr = frame[:0]
-		streamPacketFramePool.Put(framePtr)
-	}()
-
-	s.writeMu.Lock()
-	defer s.writeMu.Unlock()
 	if err := setWriteDeadlineFromContext(s.conn, ctx, &s.deadlineMu, &s.writeDeadline); err != nil {
 		return err
 	}
+	frame := pool.Get(2 + len(packet))
+	defer pool.Put(frame)
 	frame[0] = byte(len(packet) >> 8)
 	frame[1] = byte(len(packet))
 	copy(frame[2:], packet)

--- a/transport/openvpn/control_test.go
+++ b/transport/openvpn/control_test.go
@@ -157,6 +157,116 @@ func TestControlConnCarriesTLSBytes(t *testing.T) {
 	}
 }
 
+func TestControlChannelReordersReliableMessages(t *testing.T) {
+	packets := make(chan []byte, 4)
+	acks := make(chan []byte, 4)
+	io := &memoryPacketIO{in: packets, out: acks, closed: make(chan struct{})}
+	var clientID SessionID
+	copy(clientID[:], []byte("client01"))
+	var serverID SessionID
+	copy(serverID[:], []byte("server01"))
+	server := NewControlChannel(io, nil, serverID)
+
+	second, err := (ControlPacket{
+		Opcode:       PControlV1,
+		LocalSession: clientID,
+		MessageID:    1,
+		Payload:      []byte("second"),
+	}).Encode(nil, 0, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	first, err := (ControlPacket{
+		Opcode:       PControlV1,
+		LocalSession: clientID,
+		MessageID:    0,
+		Payload:      []byte("first"),
+	}).Encode(nil, 0, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	packets <- second
+	packets <- first
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	packet, err := server.Read(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if packet.MessageID != 0 || string(packet.Payload) != "first" {
+		t.Fatalf("unexpected first delivered packet: id=%d payload=%q", packet.MessageID, packet.Payload)
+	}
+	packet, err = server.Read(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if packet.MessageID != 1 || string(packet.Payload) != "second" {
+		t.Fatalf("unexpected second delivered packet: id=%d payload=%q", packet.MessageID, packet.Payload)
+	}
+}
+
+func TestClientWaitServerResetRetransmitsUDP(t *testing.T) {
+	clientIO, serverIO := newMemoryPacketPair()
+	var clientID SessionID
+	copy(clientID[:], []byte("client01"))
+	var serverID SessionID
+	copy(serverID[:], []byte("server01"))
+
+	clientControl := NewControlChannel(clientIO, nil, clientID)
+	serverControl := NewControlChannel(serverIO, nil, serverID)
+	client := &Client{
+		config:  &ClientConfig{Proto: ProtoUDP},
+		control: clientControl,
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := clientControl.SendReset(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	errCh := make(chan error, 1)
+	go func() {
+		packet, err := serverControl.Read(ctx)
+		if err != nil {
+			errCh <- err
+			return
+		}
+		if packet.Opcode != PControlHardResetClientV2 {
+			errCh <- errors.New("unexpected reset opcode")
+			return
+		}
+		raw, err := serverIO.ReadPacket(ctx)
+		if err != nil {
+			errCh <- err
+			return
+		}
+		packet, _, _, err = DecodeControlPacket(nil, raw)
+		if err != nil {
+			errCh <- err
+			return
+		}
+		if packet.Opcode != PControlHardResetClientV2 || packet.MessageID != 0 {
+			errCh <- errors.New("unexpected retransmitted reset packet")
+			return
+		}
+		_, err = serverControl.Send(ctx, PControlHardResetServerV2, nil)
+		errCh <- err
+	}()
+
+	if err := client.waitServerReset(ctx); err != nil {
+		t.Fatal(err)
+	}
+	if err := <-errCh; err != nil {
+		t.Fatal(err)
+	}
+	if clientControl.PendingMessages() != 0 {
+		t.Fatalf("expected client reset to be acked, pending=%d", clientControl.PendingMessages())
+	}
+}
+
 func TestTCPPacketIOFraming(t *testing.T) {
 	client, server := net.Pipe()
 	defer client.Close()

--- a/transport/openvpn/data.go
+++ b/transport/openvpn/data.go
@@ -17,9 +17,11 @@ import (
 )
 
 const (
-	DataChannelTagSize   = 16
-	DataChannelIVSize    = 12
-	DataChannelCBCIVSize = aes.BlockSize
+	DataChannelTagSize      = 16
+	DataChannelIVSize       = 12
+	DataChannelCBCIVSize    = aes.BlockSize
+	dataChannelIVRandBuf    = 32 * 1024
+	dataChannelReplayWindow = 64
 
 	PeerIDUnset uint32 = 0xffffff
 )
@@ -34,17 +36,25 @@ type DataChannel struct {
 	recvHMACKey []byte
 	authHash    func() hash.Hash
 	authSize    int
+	sendMACPool sync.Pool
+	recvMACPool sync.Pool
 
 	sendImplicitIV [DataChannelIVSize]byte
 	recvImplicitIV [DataChannelIVSize]byte
 
 	keyID  uint8
 	peerID uint32
+	header []byte
 
 	mu           sync.Mutex
 	sendPacketID uint32
 	recvHighest  uint32
+	recvWindow   uint64
 	recvSeen     bool
+
+	randMu     sync.Mutex
+	randBuf    []byte
+	randOffset int
 }
 
 func NewDataChannel(keys *KeyMaterial, cipherName, authName string, peerID uint32) (*DataChannel, error) {
@@ -67,6 +77,7 @@ func NewDataChannel(keys *KeyMaterial, cipherName, authName string, peerID uint3
 			sendAEAD: send,
 			recvAEAD: recv,
 			peerID:   peerID,
+			header:   dataHeader(peerID, 0),
 		}
 		copy(d.sendImplicitIV[4:], keys.SendHMACKey[:DataChannelIVSize-4])
 		copy(d.recvImplicitIV[4:], keys.RecvHMACKey[:DataChannelIVSize-4])
@@ -88,7 +99,7 @@ func NewDataChannel(keys *KeyMaterial, cipherName, authName string, peerID uint3
 	if len(keys.SendHMACKey) < authSize || len(keys.RecvHMACKey) < authSize {
 		return nil, errors.New("openvpn HMAC keys are too short")
 	}
-	return &DataChannel{
+	d := &DataChannel{
 		sendBlock:   send,
 		recvBlock:   recv,
 		sendHMACKey: append([]byte(nil), keys.SendHMACKey[:authSize]...),
@@ -96,7 +107,15 @@ func NewDataChannel(keys *KeyMaterial, cipherName, authName string, peerID uint3
 		authHash:    authHash,
 		authSize:    authSize,
 		peerID:      peerID,
-	}, nil
+		header:      dataHeader(peerID, 0),
+	}
+	d.sendMACPool.New = func() any {
+		return hmac.New(d.authHash, d.sendHMACKey)
+	}
+	d.recvMACPool.New = func() any {
+		return hmac.New(d.authHash, d.recvHMACKey)
+	}
+	return d, nil
 }
 
 func isDataChannelAEAD(cipherName string) bool {
@@ -156,7 +175,7 @@ func (d *DataChannel) Encrypt(packet []byte) ([]byte, error) {
 }
 
 func (d *DataChannel) encryptAEAD(packet []byte, packetID uint32) ([]byte, error) {
-	header := d.dataHeader()
+	header := d.header
 	var packetIDBytes [4]byte
 	binary.BigEndian.PutUint32(packetIDBytes[:], packetID)
 	nonce := d.nonce(packetID, d.sendImplicitIV)
@@ -174,28 +193,28 @@ func (d *DataChannel) encryptAEAD(packet []byte, packetID uint32) ([]byte, error
 }
 
 func (d *DataChannel) encryptCBC(packet []byte, packetID uint32) ([]byte, error) {
-	header := d.dataHeader()
-	iv := make([]byte, DataChannelCBCIVSize)
-	if _, err := rand.Read(iv); err != nil {
+	header := d.header
+	blockSize := d.sendBlock.BlockSize()
+	plainLen := 4 + len(packet)
+	padding := blockSize - plainLen%blockSize
+	if padding == 0 {
+		padding = blockSize
+	}
+	out := make([]byte, len(header)+d.authSize+DataChannelCBCIVSize+plainLen+padding)
+	copy(out, header)
+	authenticated := out[len(header)+d.authSize:]
+	iv := authenticated[:DataChannelCBCIVSize]
+	if err := d.fillCBCIV(iv); err != nil {
 		return nil, err
 	}
-
-	plain := make([]byte, 4+len(packet))
-	binary.BigEndian.PutUint32(plain[:4], packetID)
-	copy(plain[4:], packet)
-	padded := pkcs7Pad(plain, d.sendBlock.BlockSize())
-	ciphertext := make([]byte, len(padded))
-	cipher.NewCBCEncrypter(d.sendBlock, iv).CryptBlocks(ciphertext, padded)
-
-	authenticated := make([]byte, 0, len(iv)+len(ciphertext))
-	authenticated = append(authenticated, iv...)
-	authenticated = append(authenticated, ciphertext...)
-	tag := dataChannelHMAC(d.authHash, d.sendHMACKey, authenticated)
-
-	out := make([]byte, 0, len(header)+len(tag)+len(authenticated))
-	out = append(out, header...)
-	out = append(out, tag...)
-	out = append(out, authenticated...)
+	ciphertext := authenticated[DataChannelCBCIVSize:]
+	binary.BigEndian.PutUint32(ciphertext[:4], packetID)
+	copy(ciphertext[4:], packet)
+	for i := plainLen; i < len(ciphertext); i++ {
+		ciphertext[i] = byte(padding)
+	}
+	cipher.NewCBCEncrypter(d.sendBlock, iv).CryptBlocks(ciphertext, ciphertext)
+	_ = d.hmacAppend(&d.sendMACPool, authenticated, out[len(header):len(header)])
 	return out, nil
 }
 
@@ -254,7 +273,8 @@ func (d *DataChannel) decryptCBC(packet []byte, headerSize int) ([]byte, error) 
 	body := packet[headerSize:]
 	tag := body[:d.authSize]
 	authenticated := body[d.authSize:]
-	expected := dataChannelHMAC(d.authHash, d.recvHMACKey, authenticated)
+	var expectedBuf [sha256.Size]byte
+	expected := d.hmacAppend(&d.recvMACPool, authenticated, expectedBuf[:0])
 	if !hmac.Equal(tag, expected) {
 		return nil, errors.New("openvpn CBC data packet HMAC authentication failed")
 	}
@@ -264,9 +284,8 @@ func (d *DataChannel) decryptCBC(packet []byte, headerSize int) ([]byte, error) 
 	if len(ciphertext) == 0 || len(ciphertext)%blockSize != 0 {
 		return nil, errors.New("invalid openvpn CBC ciphertext length")
 	}
-	padded := make([]byte, len(ciphertext))
-	cipher.NewCBCDecrypter(d.recvBlock, iv).CryptBlocks(padded, ciphertext)
-	plain, err := pkcs7Unpad(padded, blockSize)
+	cipher.NewCBCDecrypter(d.recvBlock, iv).CryptBlocks(ciphertext, ciphertext)
+	plain, err := pkcs7Unpad(ciphertext, blockSize)
 	if err != nil {
 		return nil, err
 	}
@@ -309,24 +328,47 @@ func (d *DataChannel) nextPacketID() uint32 {
 func (d *DataChannel) acceptPacketID(packetID uint32) error {
 	d.mu.Lock()
 	defer d.mu.Unlock()
-	if d.recvSeen && packetID <= d.recvHighest {
+
+	if !d.recvSeen {
+		d.recvHighest = packetID
+		d.recvWindow = 1
+		d.recvSeen = true
+		return nil
+	}
+
+	if packetID > d.recvHighest {
+		shift := packetID - d.recvHighest
+		if shift >= dataChannelReplayWindow {
+			d.recvWindow = 1
+		} else {
+			d.recvWindow = d.recvWindow<<shift | 1
+		}
+		d.recvHighest = packetID
+		return nil
+	}
+
+	diff := d.recvHighest - packetID
+	if diff >= dataChannelReplayWindow {
 		return fmt.Errorf("openvpn replayed data packet id %d", packetID)
 	}
-	d.recvHighest = packetID
-	d.recvSeen = true
+	mask := uint64(1) << diff
+	if d.recvWindow&mask != 0 {
+		return fmt.Errorf("openvpn replayed data packet id %d", packetID)
+	}
+	d.recvWindow |= mask
 	return nil
 }
 
-func (d *DataChannel) dataHeader() []byte {
-	if d.peerID != PeerIDUnset {
+func dataHeader(peerID uint32, keyID uint8) []byte {
+	if peerID != PeerIDUnset {
 		return []byte{
-			opcodeKeyID(PDataV2, d.keyID),
-			byte(d.peerID >> 16),
-			byte(d.peerID >> 8),
-			byte(d.peerID),
+			opcodeKeyID(PDataV2, keyID),
+			byte(peerID >> 16),
+			byte(peerID >> 8),
+			byte(peerID),
 		}
 	}
-	return []byte{opcodeKeyID(PDataV1, d.keyID)}
+	return []byte{opcodeKeyID(PDataV1, keyID)}
 }
 
 func (d *DataChannel) nonce(packetID uint32, implicit [DataChannelIVSize]byte) [DataChannelIVSize]byte {
@@ -335,10 +377,43 @@ func (d *DataChannel) nonce(packetID uint32, implicit [DataChannelIVSize]byte) [
 	return nonce
 }
 
+func (d *DataChannel) fillCBCIV(iv []byte) error {
+	d.randMu.Lock()
+	defer d.randMu.Unlock()
+
+	for len(iv) > 0 {
+		if d.randOffset == len(d.randBuf) {
+			if d.randBuf == nil {
+				d.randBuf = make([]byte, dataChannelIVRandBuf)
+			}
+			if _, err := rand.Read(d.randBuf); err != nil {
+				return err
+			}
+			d.randOffset = 0
+		}
+		n := copy(iv, d.randBuf[d.randOffset:])
+		d.randOffset += n
+		iv = iv[n:]
+	}
+	return nil
+}
+
 func dataChannelHMAC(newHash func() hash.Hash, key, data []byte) []byte {
+	return dataChannelHMACAppend(newHash, key, data, nil)
+}
+
+func dataChannelHMACAppend(newHash func() hash.Hash, key, data, dst []byte) []byte {
 	mac := hmac.New(newHash, key)
 	_, _ = mac.Write(data)
-	return mac.Sum(nil)
+	return mac.Sum(dst)
+}
+
+func (d *DataChannel) hmacAppend(pool *sync.Pool, data, dst []byte) []byte {
+	mac := pool.Get().(hash.Hash)
+	defer pool.Put(mac)
+	mac.Reset()
+	_, _ = mac.Write(data)
+	return mac.Sum(dst)
 }
 
 func pkcs7Pad(plain []byte, blockSize int) []byte {

--- a/transport/openvpn/data_test.go
+++ b/transport/openvpn/data_test.go
@@ -62,6 +62,56 @@ func TestDataChannelAESGCMV2RoundTrip(t *testing.T) {
 	}
 }
 
+func TestDataChannelAcceptsOutOfOrderPacketsWithinReplayWindow(t *testing.T) {
+	clientKeys := &KeyMaterial{
+		SendCipherKey: bytes.Repeat([]byte{0x11}, 16),
+		SendHMACKey:   bytes.Repeat([]byte{0x22}, maxHMACKeyLength),
+		RecvCipherKey: bytes.Repeat([]byte{0x33}, 16),
+		RecvHMACKey:   bytes.Repeat([]byte{0x44}, maxHMACKeyLength),
+	}
+	serverKeys := &KeyMaterial{
+		SendCipherKey: clientKeys.RecvCipherKey,
+		SendHMACKey:   clientKeys.RecvHMACKey,
+		RecvCipherKey: clientKeys.SendCipherKey,
+		RecvHMACKey:   clientKeys.SendHMACKey,
+	}
+	client, err := NewDataChannel(clientKeys, CipherAES128GCM, AuthSHA256, 7)
+	if err != nil {
+		t.Fatal(err)
+	}
+	server, err := NewDataChannel(serverKeys, CipherAES128GCM, AuthSHA256, 7)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	packets := [][]byte{
+		{0x45, 0, 0, 20, 1, 2, 3, 4, 64, 6, 0, 0, 10, 8, 0, 2, 1, 1, 1, 1},
+		{0x45, 0, 0, 20, 1, 2, 3, 5, 64, 6, 0, 0, 10, 8, 0, 2, 1, 1, 1, 1},
+		{0x45, 0, 0, 20, 1, 2, 3, 6, 64, 6, 0, 0, 10, 8, 0, 2, 1, 1, 1, 1},
+	}
+	encrypted := make([][]byte, 0, len(packets))
+	for _, packet := range packets {
+		out, err := client.Encrypt(packet)
+		if err != nil {
+			t.Fatal(err)
+		}
+		encrypted = append(encrypted, out)
+	}
+
+	for _, index := range []int{0, 2, 1} {
+		plain, err := server.Decrypt(encrypted[index])
+		if err != nil {
+			t.Fatalf("decrypt packet %d: %v", index+1, err)
+		}
+		if !bytes.Equal(plain, packets[index]) {
+			t.Fatalf("unexpected packet %d plaintext: %x", index+1, plain)
+		}
+	}
+	if _, err := server.Decrypt(encrypted[1]); err == nil {
+		t.Fatal("expected duplicate packet to be rejected")
+	}
+}
+
 func TestParsePushReply(t *testing.T) {
 	reply, err := ParsePushReply("PUSH_REPLY,redirect-gateway def1,dhcp-option DNS 8.8.8.8,ifconfig 10.8.0.2 255.255.255.0,peer-id 3,block-ipv6\x00")
 	if err != nil {
@@ -74,6 +124,19 @@ func TestParsePushReply(t *testing.T) {
 		t.Fatalf("unexpected push flags: %#v", reply)
 	}
 	if len(reply.DNS) != 1 || reply.DNS[0].String() != "8.8.8.8" {
+		t.Fatalf("unexpected DNS: %#v", reply.DNS)
+	}
+}
+
+func TestParsePushReplyPointToPointIfconfig(t *testing.T) {
+	reply, err := ParsePushReply("PUSH_REPLY,redirect-gateway def1,dhcp-option DNS 10.211.254.254,ifconfig 10.211.1.37 10.211.254.254,peer-id 16777215\x00")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(reply.Prefixes) != 1 || reply.Prefixes[0].String() != "10.211.1.37/32" {
+		t.Fatalf("unexpected prefixes: %#v", reply.Prefixes)
+	}
+	if len(reply.DNS) != 1 || reply.DNS[0].String() != "10.211.254.254" {
 		t.Fatalf("unexpected DNS: %#v", reply.DNS)
 	}
 }

--- a/transport/openvpn/mux.go
+++ b/transport/openvpn/mux.go
@@ -18,8 +18,8 @@ type PacketMux struct {
 func NewPacketMux(io PacketIO) *PacketMux {
 	return &PacketMux{
 		io:      io,
-		control: make(chan []byte, 64),
-		data:    make(chan []byte, 256),
+		control: make(chan []byte, 256),
+		data:    make(chan []byte, 1024),
 		done:    make(chan struct{}),
 	}
 }

--- a/transport/openvpn/mux.go
+++ b/transport/openvpn/mux.go
@@ -18,8 +18,8 @@ type PacketMux struct {
 func NewPacketMux(io PacketIO) *PacketMux {
 	return &PacketMux{
 		io:      io,
-		control: make(chan []byte, 256),
-		data:    make(chan []byte, 1024),
+		control: make(chan []byte, 64),
+		data:    make(chan []byte, 256),
 		done:    make(chan struct{}),
 	}
 }

--- a/transport/openvpn/push.go
+++ b/transport/openvpn/push.go
@@ -91,27 +91,44 @@ func splitPushOptions(message string) []string {
 	return out
 }
 
-func parseIPv4Ifconfig(address, mask string) (netip.Prefix, error) {
+func parseIPv4Ifconfig(address, maskOrPeer string) (netip.Prefix, error) {
 	addr, err := netip.ParseAddr(address)
 	if err != nil {
 		return netip.Prefix{}, fmt.Errorf("parse pushed ipv4 address %q: %w", address, err)
 	}
-	maskAddr, err := netip.ParseAddr(mask)
+	maskAddr, err := netip.ParseAddr(maskOrPeer)
 	if err != nil {
-		return netip.Prefix{}, fmt.Errorf("parse pushed ipv4 mask %q: %w", mask, err)
+		return netip.Prefix{}, fmt.Errorf("parse pushed ipv4 mask %q: %w", maskOrPeer, err)
 	}
 	if !addr.Is4() || !maskAddr.Is4() {
 		return netip.Prefix{}, fmt.Errorf("openvpn ifconfig requires ipv4 address and mask")
 	}
-	maskBytes := maskAddr.As4()
+
+	if ones, ok := ipv4MaskSize(maskAddr); ok {
+		return netip.PrefixFrom(addr, ones), nil
+	}
+
+	// Some servers, including SoftEther/VPNGate in net30/p2p mode, push
+	// "ifconfig <local> <remote>" rather than "ifconfig <local> <netmask>".
+	// Use a host prefix for that local tunnel address.
+	return netip.PrefixFrom(addr, 32), nil
+}
+
+func ipv4MaskSize(mask netip.Addr) (int, bool) {
+	maskBytes := mask.As4()
 	ones := 0
+	seenZero := false
 	for _, b := range maskBytes {
 		for i := 7; i >= 0; i-- {
 			if b&(1<<i) == 0 {
-				return netip.PrefixFrom(addr, ones), nil
+				seenZero = true
+				continue
+			}
+			if seenZero {
+				return 0, false
 			}
 			ones++
 		}
 	}
-	return netip.PrefixFrom(addr, ones), nil
+	return ones, true
 }


### PR DESCRIPTION
## 变更说明

本 PR 在现有 OpenVPN outbound 支持的基础上，补充了一批稳定性、兼容性和性能改进，主要用于提升 OpenVPN TCP/UDP 节点在真实使用场景下的可用性。

## 主要改动

### OpenVPN 连接稳定性

- 为 OpenVPN 握手增加超时控制，避免底层连接异常时长时间阻塞。
- 对 OpenVPN 底层 TCP/UDP socket 设置更大的读写缓冲区，改善高吞吐场景下的收发稳定性。
- 修复 UDP 模式下控制信道可靠包乱序时可能导致 TLS/control channel 解析失败的问题。
- 增加 UDP 控制包重传逻辑，提升部分服务端握手阶段的兼容性。
- 扩大 OpenVPN packet mux 缓冲区，减少高并发收发时控制包/数据包被阻塞的概率。

### IPv4-only 隧道处理

- 记录服务端 push 下发的地址前缀是否包含 IPv6。
- 当 OpenVPN 隧道没有 IPv6 地址时，DNS 解析和拨号逻辑优先限制为 IPv4。
- 避免在 IPv4-only OpenVPN 隧道中尝试连接 IPv6 地址，减少 `network is unreachable` 一类错误。

### CBC 数据通道性能优化

- 优化 AES-CBC 数据通道的加密路径，减少每个数据包的内存分配和拷贝。
- 优化 AES-CBC 解密路径，支持在接收缓冲上原地解密，减少下载方向的分配压力。
- 复用 HMAC 对象和 TCP frame 缓冲，降低高吞吐场景下的 GC 压力。
- 缓存 CBC IV 随机数据读取，减少频繁调用系统随机源带来的开销。

### 数据包乱序兼容

- 为 OpenVPN data channel 增加 replay window。
- 允许一定窗口内的数据包乱序到达，同时继续拒绝重复包和过旧包。
- 这可以改善 UDP 模式下部分网络环境中由于包乱序导致的数据通道异常。

### SoftEther / VPNGate 兼容性

- 改进 `ifconfig` push 解析逻辑。
- 支持 SoftEther / VPNGate 常见的 `ifconfig <local> <peer>` 点对点格式。
- 避免将 peer address 错误解析为 netmask，从而生成异常前缀。

## 测试

已在本地执行：

```bash
go test -tags with_gvisor ./transport/openvpn ./adapter/outbound
```

测试通过。

此外，也使用多个 VPNGate OpenVPN TCP/UDP 节点进行了手动连通性测试，验证了：

- TCP 节点可正常握手和代理访问。
- UDP 节点可正常握手和代理访问。
- AES-CBC / SHA1 配置可正常使用。
- 常见网页访问、Telegram、分流规则等基础使用场景可正常工作。

## 备注

本 PR 主要目标是提升当前 OpenVPN outbound 的稳定性和兼容性，并减少数据通道热路径上的明显分配开销。OpenVPN 的整体吞吐仍然会受到 gVisor 用户态网络栈、Go 实现的数据通道处理以及本地代理转发路径影响，因此性能 **不能** 达到官方 OpenVPN 客户端水平。推翻先前几次PR建立的架构并试图完全移植 OpenVPN 的官方实现架构以追求达成与官方客户端相近的性能并不现实，作为一个简单的PR这么做并不合理，并且目前的架构实现的性能对于测试性质的用途已经够用，故不会考虑推倒重做。