### PR TITLE
feat: recognize managed-config / subscribed directive

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -66,6 +66,7 @@ type General struct {
 	KeepAliveIdle           int                     `json:"keep-alive-idle"`
 	KeepAliveInterval       int                     `json:"keep-alive-interval"`
 	DisableKeepAlive        bool                    `json:"disable-keep-alive"`
+	ManagedConfig           *ManagedConfig          `json:"managed-config,omitempty"`
 }
 
 // Inbound config
@@ -456,6 +457,9 @@ type RawConfig struct {
 	TLS           RawTLS                    `yaml:"tls" json:"tls"`
 
 	ClashForAndroid RawClashForAndroid `yaml:"clash-for-android" json:"clash-for-android"`
+
+	// ManagedConfig is parsed from a leading comment directive, not from YAML.
+	ManagedConfig ManagedConfig `yaml:"-" json:"-"`
 }
 
 // Parse config
@@ -599,6 +603,10 @@ func UnmarshalRawConfig(buf []byte) (*RawConfig, error) {
 		return nil, err
 	}
 
+	// yaml.Unmarshal discards the leading comment that carries the managed-config
+	// directive, so it is parsed from the raw bytes here.
+	rawCfg.ManagedConfig = parseManagedConfig(buf)
+
 	return rawCfg, nil
 }
 
@@ -612,6 +620,9 @@ func ParseRawConfig(rawCfg *RawConfig) (*Config, error) {
 		return nil, err
 	}
 	config.General = general
+	// Attach the managed-config directive before temporaryUpdateGeneral so it is
+	// exposed consistently with the other General fields during reload parsing.
+	config.General.ManagedConfig = rawCfg.ManagedConfig.pointerOrNil()
 
 	// We need to temporarily apply some configuration in general and roll back after parsing the complete configuration.
 	// The loading and downloading of geodata in the parseRules and parseRuleProviders rely on these.

--- a/config/managed_config.go
+++ b/config/managed_config.go
@@ -1,0 +1,105 @@
+package config
+
+import (
+	"bytes"
+	"strconv"
+	"strings"
+)
+
+// ManagedConfig describes a self-update subscription embedded as a leading
+// directive in the configuration file, compatible with Surge
+// (`#!MANAGED-CONFIG <url> [interval=<seconds>] [strict=<bool>]`) and Stash
+// (`#SUBSCRIBED <url>`).
+//
+// mihomo does not fetch the URL itself; the value is surfaced through the API
+// (GET /configs) so the controlling client can keep the configuration updated
+// even when the provider changes the subscription domain.
+type ManagedConfig struct {
+	URL      string `json:"url"`
+	Interval int    `json:"interval,omitempty"`
+	Strict   bool   `json:"strict,omitempty"`
+}
+
+// pointerOrNil returns a pointer to the value, or nil when no directive was
+// present (empty URL), so it is omitted from the General config / API output.
+func (mc ManagedConfig) pointerOrNil() *ManagedConfig {
+	if mc.URL == "" {
+		return nil
+	}
+	return &mc
+}
+
+const (
+	managedConfigDirective = "#!MANAGED-CONFIG" // Surge
+	subscribedDirective    = "#SUBSCRIBED"      // Stash
+)
+
+// parseManagedConfig scans the leading comment lines of a raw configuration for
+// a managed-config / subscribed directive. The first directive found wins;
+// scanning stops at the first non-comment, non-blank line so a stray match in
+// the configuration body is never picked up. Returns the zero value when no
+// directive is present.
+func parseManagedConfig(buf []byte) (mc ManagedConfig) {
+	for len(buf) > 0 {
+		var raw []byte
+		raw, buf, _ = bytes.Cut(buf, []byte{'\n'})
+
+		line := strings.TrimSpace(string(raw))
+		if line == "" {
+			continue
+		}
+		if !strings.HasPrefix(line, "#") {
+			break // reached the configuration body
+		}
+		upper := strings.ToUpper(line)
+
+		// match a directive keyword on a whole-token boundary. The keyword must
+		// directly follow '#' (no space), so ordinary comments such as
+		// "# SUBSCRIBED to ..." are not mistaken for a directive.
+		match := func(keyword string) (args string, ok bool) {
+			if !strings.HasPrefix(upper, keyword) {
+				return "", false
+			}
+			if len(line) == len(keyword) {
+				return "", true
+			}
+			switch line[len(keyword)] {
+			case ' ', '\t':
+				return line[len(keyword):], true
+			default:
+				return "", false
+			}
+		}
+
+		var args string
+		if a, ok := match(managedConfigDirective); ok {
+			args = a
+		} else if a, ok := match(subscribedDirective); ok {
+			args = a
+		} else {
+			continue
+		}
+
+		fields := strings.Fields(args)
+		if len(fields) == 0 {
+			continue
+		}
+		mc.URL = strings.Trim(fields[0], `"'`)
+		for _, field := range fields[1:] {
+			key, value, ok := strings.Cut(field, "=")
+			if !ok {
+				continue
+			}
+			switch strings.ToLower(key) {
+			case "interval":
+				if n, err := strconv.Atoi(value); err == nil {
+					mc.Interval = n
+				}
+			case "strict":
+				mc.Strict = strings.EqualFold(value, "true")
+			}
+		}
+		return mc
+	}
+	return mc
+}

--- a/config/managed_config_test.go
+++ b/config/managed_config_test.go
@@ -1,0 +1,93 @@
+package config
+
+import (
+	"testing"
+)
+
+func TestParseManagedConfig(t *testing.T) {
+	tests := []struct {
+		name string
+		buf  string
+		want ManagedConfig
+	}{
+		{
+			name: "surge managed-config with options",
+			buf:  "#!MANAGED-CONFIG https://example.com/sub interval=86400 strict=true\nmode: rule\n",
+			want: ManagedConfig{URL: "https://example.com/sub", Interval: 86400, Strict: true},
+		},
+		{
+			name: "surge managed-config url only",
+			buf:  "#!MANAGED-CONFIG https://example.com/sub\nmode: rule\n",
+			want: ManagedConfig{URL: "https://example.com/sub"},
+		},
+		{
+			name: "stash subscribed",
+			buf:  "#SUBSCRIBED https://example.com/sub\nmode: rule\n",
+			want: ManagedConfig{URL: "https://example.com/sub"},
+		},
+		{
+			name: "quoted url",
+			buf:  "#SUBSCRIBED \"https://example.com/sub\"\nmode: rule\n",
+			want: ManagedConfig{URL: "https://example.com/sub"},
+		},
+		{
+			name: "directive after leading meta comments",
+			buf:  "#!name=My Profile\n#!desc=demo\n#!MANAGED-CONFIG https://example.com/sub\nmode: rule\n",
+			want: ManagedConfig{URL: "https://example.com/sub"},
+		},
+		{
+			name: "leading blank lines",
+			buf:  "\n\n#SUBSCRIBED https://example.com/sub\nmode: rule\n",
+			want: ManagedConfig{URL: "https://example.com/sub"},
+		},
+		{
+			name: "no directive",
+			buf:  "mode: rule\nlog-level: info\n",
+			want: ManagedConfig{},
+		},
+		{
+			name: "plain comment is not a directive",
+			buf:  "# just a comment\nmode: rule\n",
+			want: ManagedConfig{},
+		},
+		{
+			name: "directive in body is ignored",
+			buf:  "mode: rule\n#SUBSCRIBED https://example.com/sub\n",
+			want: ManagedConfig{},
+		},
+		{
+			name: "keyword must be a whole token",
+			buf:  "#SUBSCRIBEDFOO https://example.com/sub\nmode: rule\n",
+			want: ManagedConfig{},
+		},
+		{
+			name: "space after hash is a plain comment (subscribed)",
+			buf:  "# SUBSCRIBED to this provider https://example.com/sub\nmode: rule\n",
+			want: ManagedConfig{},
+		},
+		{
+			name: "space after hash is a plain comment (managed-config)",
+			buf:  "# !MANAGED-CONFIG explains the format https://example.com/sub\nmode: rule\n",
+			want: ManagedConfig{},
+		},
+		{
+			name: "case insensitive keyword",
+			buf:  "#!managed-config https://example.com/sub interval=3600\nmode: rule\n",
+			want: ManagedConfig{URL: "https://example.com/sub", Interval: 3600},
+		},
+		{
+			name: "invalid interval ignored",
+			buf:  "#!MANAGED-CONFIG https://example.com/sub interval=abc\nmode: rule\n",
+			want: ManagedConfig{URL: "https://example.com/sub"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseManagedConfig([]byte(tt.buf))
+			if got != tt.want {
+				t.Fatalf("parseManagedConfig() = %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}

--- a/hub/executor/executor.go
+++ b/hub/executor/executor.go
@@ -14,6 +14,7 @@ import (
 	"github.com/metacubex/mihomo/adapter"
 	"github.com/metacubex/mihomo/adapter/inbound"
 	"github.com/metacubex/mihomo/adapter/outboundgroup"
+	"github.com/metacubex/mihomo/common/atomic"
 	"github.com/metacubex/mihomo/component/auth"
 	"github.com/metacubex/mihomo/component/ca"
 	"github.com/metacubex/mihomo/component/dialer"
@@ -44,6 +45,10 @@ import (
 )
 
 var mux sync.Mutex
+
+// currentManagedConfig holds the managed-config directive of the most recently
+// applied configuration so it can be surfaced through GetGeneral (GET /configs).
+var currentManagedConfig atomic.TypedValue[*config.ManagedConfig]
 
 func readConfig(path string) ([]byte, error) {
 	if _, err := os.Stat(path); os.IsNotExist(err) {
@@ -180,6 +185,7 @@ func GetGeneral() *config.General {
 		KeepAliveInterval:       int(keepalive.KeepAliveInterval() / time.Second),
 		KeepAliveIdle:           int(keepalive.KeepAliveIdle() / time.Second),
 		DisableKeepAlive:        keepalive.DisableKeepAlive(),
+		ManagedConfig:           currentManagedConfig.Load(),
 	}
 
 	return general
@@ -425,6 +431,7 @@ func updateGeneral(general *config.General, logging bool) {
 	geodata.SetASNUrl(general.GeoXUrl.ASN)
 	mihomoHttp.SetUA(general.GlobalUA)
 	resource.SetETag(general.ETagSupport)
+	currentManagedConfig.Store(general.ManagedConfig)
 
 	if general.GlobalClientFingerprint != "" {
 		log.Warnln("The `global-client-fingerprint` configuration is deprecated, please set `client-fingerprint` directly on the proxy instead")


### PR DESCRIPTION
## Motivation

Surge and Stash let a configuration carry its own self-update subscription URL as
a leading comment directive:

```
#!MANAGED-CONFIG https://example.com/sub interval=86400 strict=false   # Surge
#SUBSCRIBED https://example.com/sub                                    # Stash
```

This decouples *where the config is updated from* from *where the user originally
imported it*, so a provider can migrate the subscription domain without the
client losing its update source. These directives already appear in real configs
imported into mihomo (e.g. #1416), but `yaml.Unmarshal` treats the line as a
comment and drops it, so the information is lost.

## What this does

- Parses the `#!MANAGED-CONFIG` / `#SUBSCRIBED` directive from the raw config
  bytes (the first directive in the leading comment block; scanning stops at the
  first non-comment line).
- Exposes it via the existing API as `managed-config` on `GET /configs`:

  ```json
  { "managed-config": { "url": "https://example.com/sub", "interval": 86400, "strict": false } }
  ```

  The field is omitted entirely when no directive is present.

## What this deliberately does NOT do

mihomo does **not** fetch the URL or auto-reload from it. Subscription/profile
management stays the responsibility of the controlling client (GUI). This change
only preserves and surfaces metadata the core currently discards, so any client
can implement managed-config update uniformly — it does not change runtime
behavior.

## Notes

- The value is threaded through `RawConfig` and attached to `General` before
  `temporaryUpdateGeneral`, so during a reload it is exposed consistently with
  the other `General` fields (no transient gap), and stored via an atomic holder
  read back by `GetGeneral`.
- Directive matching requires the keyword to directly follow `#` on a whole-token
  boundary, so ordinary comments like `# SUBSCRIBED to ...` are not misread.

## Tests

`config/managed_config_test.go` covers Surge/Stash formats, options parsing,
quoted URLs, leading meta-comment lines, body-comment rejection, whole-token /
no-space-after-`#` guards, and the no-directive case. `go vet` and
`go build ./...` pass.