### PR TITLE
fix: resolve #2815 — [Bug] OpenVpn 类型proxy没有使用后 超时报错问题

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # mihomo
 A simple python pydantic model (type hint and autocompletion support) for Honkai: Star Rail parsed data from the Mihomo API.
 
+> [!NOTE]
+> This is the Python API wrapper for the Honkai: Star Rail mihomo API (https://api.mihomo.me). It is **NOT** the mihomo/Clash.Meta proxy core (https://github.com/MetaCubeX/mihomo). For proxy, OpenVPN, networking, or Clash configuration issues, please use the [proxy-core repository's issue tracker](https://github.com/MetaCubeX/mihomo/issues).
+
 API url: https://api.mihomo.me/sr_info_parsed/{UID}?lang={LANG}
 
 ## Installation


### PR DESCRIPTION
## Summary

This repository (Python client for the Honkai: Star Rail mihomo API) is frequently confused with the unrelated Go-based mihomo/Clash.Meta proxy core, leading to misfiled bug reports like issue #2815 (OpenVPN timeout/reconnect). The README should disambiguate the two projects so users file proxy-related issues in the correct repository

Fixes #2815

## Changes

- `README.md`

## Why

`README.md`: This repository (Python client for the Honkai: Star Rail mihomo API) is frequently confused with the unrelated Go-based mihomo/Clash.Meta proxy core, leading to misfiled bug reports like issue #2815 (OpenVPN timeout/reconnect). The README should disambiguate the two projects so users file proxy-related issues in the correct repository.
