### PR TITLE
feat: add ping keepalive support for OpenVPN

### DIFF
--- a/adapter/outbound/openvpn.go
+++ b/adapter/outbound/openvpn.go
@@ -8,6 +8,7 @@ import (
 	"net/netip"
 	"os"
 	"sync"
+	"time"
 
 	"github.com/metacubex/mihomo/common/contextutils"
 	"github.com/metacubex/mihomo/component/dialer"
@@ -41,22 +42,24 @@ type OpenVPN struct {
 
 type OpenVPNOption struct {
 	BasicOption
-	Name     string `proxy:"name"`
-	Server   string `proxy:"server"`
-	Port     int    `proxy:"port"`
-	Proto    string `proxy:"proto,omitempty"`
-	Dev      string `proxy:"dev,omitempty"`
-	Cipher   string `proxy:"cipher,omitempty"`
-	Auth     string `proxy:"auth,omitempty"`
-	CompLZO  string `proxy:"comp-lzo,omitempty"`
-	CA       string `proxy:"ca"`
-	Cert     string `proxy:"cert,omitempty"`
-	Key      string `proxy:"key,omitempty"`
-	TLSCrypt string `proxy:"tls-crypt,omitempty"`
-	Username string `proxy:"username,omitempty"`
-	Password string `proxy:"password,omitempty"`
-	MTU      int    `proxy:"mtu,omitempty"`
-	UDP      bool   `proxy:"udp,omitempty"`
+	Name        string `proxy:"name"`
+	Server      string `proxy:"server"`
+	Port        int    `proxy:"port"`
+	Proto       string `proxy:"proto,omitempty"`
+	Dev         string `proxy:"dev,omitempty"`
+	Cipher      string `proxy:"cipher,omitempty"`
+	Auth        string `proxy:"auth,omitempty"`
+	CompLZO     string `proxy:"comp-lzo,omitempty"`
+	CA          string `proxy:"ca"`
+	Cert        string `proxy:"cert,omitempty"`
+	Key         string `proxy:"key,omitempty"`
+	TLSCrypt    string `proxy:"tls-crypt,omitempty"`
+	Username    string `proxy:"username,omitempty"`
+	Password    string `proxy:"password,omitempty"`
+	MTU         int    `proxy:"mtu,omitempty"`
+	UDP         bool   `proxy:"udp,omitempty"`
+	Ping        int    `proxy:"ping,omitempty"`
+	PingRestart int    `proxy:"ping-restart,omitempty"`
 
 	RemoteDnsResolve bool     `proxy:"remote-dns-resolve,omitempty"`
 	Dns              []string `proxy:"dns,omitempty"`
@@ -64,19 +67,21 @@ type OpenVPNOption struct {
 
 func NewOpenVPN(option OpenVPNOption) (*OpenVPN, error) {
 	cfg := &ovpn.ClientConfig{
-		RemoteHost: option.Server,
-		RemotePort: uint16(option.Port),
-		Proto:      option.Proto,
-		Dev:        option.Dev,
-		Cipher:     option.Cipher,
-		Auth:       option.Auth,
-		CompLZO:    option.CompLZO,
-		CA:         []byte(option.CA),
-		Cert:       []byte(option.Cert),
-		Key:        []byte(option.Key),
-		TLSCrypt:   []byte(option.TLSCrypt),
-		Username:   option.Username,
-		Password:   option.Password,
+		RemoteHost:   option.Server,
+		RemotePort:   uint16(option.Port),
+		Proto:        option.Proto,
+		Dev:          option.Dev,
+		Cipher:       option.Cipher,
+		Auth:         option.Auth,
+		CompLZO:      option.CompLZO,
+		CA:           []byte(option.CA),
+		Cert:         []byte(option.Cert),
+		Key:          []byte(option.Key),
+		TLSCrypt:     []byte(option.TLSCrypt),
+		Username:     option.Username,
+		Password:     option.Password,
+		PingInterval: openVPNDurationSeconds(option.Ping),
+		PingRestart:  openVPNDurationSeconds(option.PingRestart),
 	}
 	if err := cfg.Prepare(); err != nil {
 		return nil, err
@@ -401,4 +406,62 @@ func (o *OpenVPN) startPacketLoops() {
 			}
 		}
 	}()
+
+	if o.config.PingInterval > 0 || o.config.PingRestart > 0 {
+		go func() {
+			defer stop()
+			ticker := time.NewTicker(openVPNKeepAliveTickInterval(o.config.PingInterval, o.config.PingRestart))
+			defer ticker.Stop()
+			for runCtx.Err() == nil {
+				select {
+				case <-ticker.C:
+					now := time.Now()
+					if o.config.PingRestart > 0 && now.Sub(client.LastReceive()) >= o.config.PingRestart {
+						log.Warnln(
+							"[OpenVPN](%s) ping-restart timeout: no packet received for %s",
+							o.name,
+							now.Sub(client.LastReceive()).Round(time.Second),
+						)
+						return
+					}
+					sendIdle := now.Sub(client.LastSend())
+					if o.config.PingInterval > 0 && sendIdle >= o.config.PingInterval {
+						if err := client.WritePing(runCtx); err != nil {
+							if !errors.Is(err, context.Canceled) && !errors.Is(err, net.ErrClosed) {
+								log.Warnln("[OpenVPN](%s) error writing ping packet: %v", o.name, err)
+							}
+							return
+						}
+						log.Debugln("[OpenVPN](%s) sent ping packet after %s idle", o.name, sendIdle.Round(time.Second))
+					}
+				case <-runCtx.Done():
+					return
+				}
+			}
+		}()
+	}
+}
+
+func openVPNDurationSeconds(seconds int) time.Duration {
+	if seconds <= 0 {
+		return 0
+	}
+	return time.Duration(seconds) * time.Second
+}
+
+func openVPNKeepAliveTickInterval(pingInterval, pingRestart time.Duration) time.Duration {
+	tick := 10 * time.Second
+	for _, value := range []time.Duration{pingInterval, pingRestart} {
+		if value <= 0 {
+			continue
+		}
+		candidate := value / 2
+		if candidate < time.Second {
+			candidate = time.Second
+		}
+		if candidate < tick {
+			tick = candidate
+		}
+	}
+	return tick
 }

--- a/adapter/outbound/openvpn.go
+++ b/adapter/outbound/openvpn.go
@@ -80,8 +80,8 @@ func NewOpenVPN(option OpenVPNOption) (*OpenVPN, error) {
 		TLSCrypt:     []byte(option.TLSCrypt),
 		Username:     option.Username,
 		Password:     option.Password,
-		PingInterval: openVPNDurationSeconds(option.Ping),
-		PingRestart:  openVPNDurationSeconds(option.PingRestart),
+		PingInterval: time.Duration(option.Ping) * time.Second,
+		PingRestart:  time.Duration(option.PingRestart) * time.Second,
 	}
 	if err := cfg.Prepare(); err != nil {
 		return nil, err
@@ -410,29 +410,29 @@ func (o *OpenVPN) startPacketLoops() {
 	if o.config.PingInterval > 0 || o.config.PingRestart > 0 {
 		go func() {
 			defer stop()
-			ticker := time.NewTicker(openVPNKeepAliveTickInterval(o.config.PingInterval, o.config.PingRestart))
+			ticker := time.NewTicker(o.config.KeepAliveTickInterval())
 			defer ticker.Stop()
 			for runCtx.Err() == nil {
 				select {
 				case <-ticker.C:
-					now := time.Now()
-					if o.config.PingRestart > 0 && now.Sub(client.LastReceive()) >= o.config.PingRestart {
+					sinceReceive := client.SinceReceive()
+					if o.config.PingRestart > 0 && sinceReceive >= o.config.PingRestart {
 						log.Warnln(
 							"[OpenVPN](%s) ping-restart timeout: no packet received for %s",
 							o.name,
-							now.Sub(client.LastReceive()).Round(time.Second),
+							sinceReceive.Round(time.Second),
 						)
 						return
 					}
-					sendIdle := now.Sub(client.LastSend())
-					if o.config.PingInterval > 0 && sendIdle >= o.config.PingInterval {
+					sinceSend := client.SinceSend()
+					if o.config.PingInterval > 0 && sinceSend >= o.config.PingInterval {
 						if err := client.WritePing(runCtx); err != nil {
 							if !errors.Is(err, context.Canceled) && !errors.Is(err, net.ErrClosed) {
 								log.Warnln("[OpenVPN](%s) error writing ping packet: %v", o.name, err)
 							}
 							return
 						}
-						log.Debugln("[OpenVPN](%s) sent ping packet after %s idle", o.name, sendIdle.Round(time.Second))
+						log.Debugln("[OpenVPN](%s) sent ping packet after %s idle", o.name, sinceSend.Round(time.Second))
 					}
 				case <-runCtx.Done():
 					return
@@ -440,28 +440,4 @@ func (o *OpenVPN) startPacketLoops() {
 			}
 		}()
 	}
-}
-
-func openVPNDurationSeconds(seconds int) time.Duration {
-	if seconds <= 0 {
-		return 0
-	}
-	return time.Duration(seconds) * time.Second
-}
-
-func openVPNKeepAliveTickInterval(pingInterval, pingRestart time.Duration) time.Duration {
-	tick := 10 * time.Second
-	for _, value := range []time.Duration{pingInterval, pingRestart} {
-		if value <= 0 {
-			continue
-		}
-		candidate := value / 2
-		if candidate < time.Second {
-			candidate = time.Second
-		}
-		if candidate < tick {
-			tick = candidate
-		}
-	}
-	return tick
 }

--- a/adapter/outbound/openvpn.go
+++ b/adapter/outbound/openvpn.go
@@ -407,25 +407,15 @@ func (o *OpenVPN) startPacketLoops() {
 		}
 	}()
 
-	if o.config.PingInterval > 0 || o.config.PingRestart > 0 {
+	if o.config.PingInterval > 0 {
 		go func() {
 			defer stop()
-			ticker := time.NewTicker(o.config.KeepAliveTickInterval())
+			ticker := time.NewTicker(o.config.PingInterval)
 			defer ticker.Stop()
 			for runCtx.Err() == nil {
 				select {
 				case <-ticker.C:
-					sinceReceive := client.SinceReceive()
-					if o.config.PingRestart > 0 && sinceReceive >= o.config.PingRestart {
-						log.Warnln(
-							"[OpenVPN](%s) ping-restart timeout: no packet received for %s",
-							o.name,
-							sinceReceive.Round(time.Second),
-						)
-						return
-					}
-					sinceSend := client.SinceSend()
-					if o.config.PingInterval > 0 && sinceSend >= o.config.PingInterval {
+					if sinceSend := client.SinceSend(); sinceSend >= o.config.PingInterval {
 						if err := client.WritePing(runCtx); err != nil {
 							if !errors.Is(err, context.Canceled) && !errors.Is(err, net.ErrClosed) {
 								log.Warnln("[OpenVPN](%s) error writing ping packet: %v", o.name, err)
@@ -433,6 +423,29 @@ func (o *OpenVPN) startPacketLoops() {
 							return
 						}
 						log.Debugln("[OpenVPN](%s) sent ping packet after %s idle", o.name, sinceSend.Round(time.Second))
+					}
+				case <-runCtx.Done():
+					return
+				}
+			}
+		}()
+	}
+
+	if o.config.PingRestart > 0 {
+		go func() {
+			defer stop()
+			ticker := time.NewTicker(o.config.PingRestart)
+			defer ticker.Stop()
+			for runCtx.Err() == nil {
+				select {
+				case <-ticker.C:
+					if sinceReceive := client.SinceReceive(); sinceReceive >= o.config.PingRestart {
+						log.Warnln(
+							"[OpenVPN](%s) ping-restart timeout: no packet received for %s",
+							o.name,
+							sinceReceive.Round(time.Second),
+						)
+						return
 					}
 				case <-runCtx.Done():
 					return

--- a/adapter/outbound/openvpn.go
+++ b/adapter/outbound/openvpn.go
@@ -56,10 +56,10 @@ type OpenVPNOption struct {
 	TLSCrypt    string `proxy:"tls-crypt,omitempty"`
 	Username    string `proxy:"username,omitempty"`
 	Password    string `proxy:"password,omitempty"`
-	MTU         int    `proxy:"mtu,omitempty"`
-	UDP         bool   `proxy:"udp,omitempty"`
 	Ping        int    `proxy:"ping,omitempty"`
 	PingRestart int    `proxy:"ping-restart,omitempty"`
+	MTU         int    `proxy:"mtu,omitempty"`
+	UDP         bool   `proxy:"udp,omitempty"`
 
 	RemoteDnsResolve bool     `proxy:"remote-dns-resolve,omitempty"`
 	Dns              []string `proxy:"dns,omitempty"`

--- a/docs/config.yaml
+++ b/docs/config.yaml
@@ -1199,6 +1199,8 @@ proxies: # socks5
     #   00000000000000000000000000000000
     #   ...
     #   -----END OpenVPN Static key V1-----
+    # ping: 10 # 默认值为 0
+    # ping-restart: 60 # 默认值为 0
     # mtu: 1500
     udp: true
     # 一个出站代理的标识。当值不为空时，将使用指定的 proxy 发出连接

--- a/transport/openvpn/client.go
+++ b/transport/openvpn/client.go
@@ -133,7 +133,7 @@ func (c *Client) Handshake(ctx context.Context) (*PushReply, error) {
 		return nil, err
 	}
 	c.push = push
-	c.data, err = NewDataChannel(keys, c.config.Cipher, c.config.Auth, push.PeerID, c.config.CompLZO)
+	c.data, err = NewDataChannel(keys, c.config.Cipher, c.config.Auth, push.PeerID)
 	if err != nil {
 		return nil, err
 	}
@@ -154,17 +154,19 @@ func (c *Client) writeDataPacket(ctx context.Context, packet []byte, compress bo
 	if c.data == nil {
 		return errors.New("openvpn data channel is not ready")
 	}
-	var encrypted []byte
-	var err error
-	if compress {
-		encrypted, err = c.data.Encrypt(packet)
-	} else {
-		encrypted, err = c.data.EncryptRaw(packet)
+	if compress && c.config.CompLZO == CompLzoYes {
+		compressed, err := lzo1xCompressSafe(packet)
+		if err != nil {
+			return err
+		}
+		packet = compressed
 	}
+	encrypted, err := c.data.Encrypt(packet)
 	if err != nil {
 		return err
 	}
-	if err := c.mux.WritePacket(ctx, encrypted); err != nil {
+	err = c.mux.WritePacket(ctx, encrypted)
+	if err != nil {
 		return err
 	}
 	c.markSend()
@@ -188,25 +190,33 @@ func (c *Client) ReadIPPacket(ctx context.Context) ([]byte, error) {
 		if IsPingPacket(plain) {
 			continue
 		}
+		if c.config.CompLZO == CompLzoYes && len(plain) > 0 {
+			return lzo1xDecompressSafe(plain)
+		}
 		return plain, nil
 	}
 }
 
-func (c *Client) LastSend() time.Time {
-	return time.Unix(0, c.lastSendNano.Load())
+func (c *Client) SinceSend() time.Duration {
+	return time.Duration(int64(time.Since(start)) - c.lastSendNano.Load())
 }
 
-func (c *Client) LastReceive() time.Time {
-	return time.Unix(0, c.lastReceiveNano.Load())
+func (c *Client) SinceReceive() time.Duration {
+	return time.Duration(int64(time.Since(start)) - c.lastReceiveNano.Load())
 }
 
 func (c *Client) markSend() {
-	c.lastSendNano.Store(time.Now().UnixNano())
+	c.lastSendNano.Store(int64(time.Since(start)))
 }
 
 func (c *Client) markReceive() {
-	c.lastReceiveNano.Store(time.Now().UnixNano())
+	c.lastReceiveNano.Store(int64(time.Since(start)))
 }
+
+// The absolute value doesn't matter, but it should be in the past,
+// so that every timestamp obtained with Now() is non-zero,
+// even on systems with low timer resolutions (e.g. Windows).
+var start = time.Now().Add(-time.Hour)
 
 func (c *Client) Close() error {
 	if c.cancel != nil {

--- a/transport/openvpn/client.go
+++ b/transport/openvpn/client.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"net"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/metacubex/tls"
@@ -29,6 +30,9 @@ type Client struct {
 	push    *PushReply
 
 	cancel context.CancelFunc
+
+	lastSendNano    atomic.Int64
+	lastReceiveNano atomic.Int64
 }
 
 func NewClient(config *ClientConfig, io PacketIO) (*Client, error) {
@@ -53,12 +57,15 @@ func NewClient(config *ClientConfig, io PacketIO) (*Client, error) {
 	runCtx, cancel := context.WithCancel(context.Background())
 	mux := NewPacketMux(io)
 	go mux.Run(runCtx)
-	return &Client{
+	client := &Client{
 		config:  config,
 		mux:     mux,
 		control: NewControlChannel(mux, crypt, local),
 		cancel:  cancel,
-	}, nil
+	}
+	client.markSend()
+	client.markReceive()
+	return client, nil
 }
 
 func (c *Client) Handshake(ctx context.Context) (*PushReply, error) {
@@ -130,18 +137,38 @@ func (c *Client) Handshake(ctx context.Context) (*PushReply, error) {
 	if err != nil {
 		return nil, err
 	}
+	c.markSend()
+	c.markReceive()
 	return push, nil
 }
 
 func (c *Client) WriteIPPacket(ctx context.Context, packet []byte) error {
+	return c.writeDataPacket(ctx, packet, true)
+}
+
+func (c *Client) WritePing(ctx context.Context) error {
+	return c.writeDataPacket(ctx, openVPNPingPacket, false)
+}
+
+func (c *Client) writeDataPacket(ctx context.Context, packet []byte, compress bool) error {
 	if c.data == nil {
 		return errors.New("openvpn data channel is not ready")
 	}
-	encrypted, err := c.data.Encrypt(packet)
+	var encrypted []byte
+	var err error
+	if compress {
+		encrypted, err = c.data.Encrypt(packet)
+	} else {
+		encrypted, err = c.data.EncryptRaw(packet)
+	}
 	if err != nil {
 		return err
 	}
-	return c.mux.WritePacket(ctx, encrypted)
+	if err := c.mux.WritePacket(ctx, encrypted); err != nil {
+		return err
+	}
+	c.markSend()
+	return nil
 }
 
 func (c *Client) ReadIPPacket(ctx context.Context) ([]byte, error) {
@@ -157,8 +184,28 @@ func (c *Client) ReadIPPacket(ctx context.Context) ([]byte, error) {
 		if err != nil {
 			continue
 		}
+		c.markReceive()
+		if IsPingPacket(plain) {
+			continue
+		}
 		return plain, nil
 	}
+}
+
+func (c *Client) LastSend() time.Time {
+	return time.Unix(0, c.lastSendNano.Load())
+}
+
+func (c *Client) LastReceive() time.Time {
+	return time.Unix(0, c.lastReceiveNano.Load())
+}
+
+func (c *Client) markSend() {
+	c.lastSendNano.Store(time.Now().UnixNano())
+}
+
+func (c *Client) markReceive() {
+	c.lastReceiveNano.Store(time.Now().UnixNano())
 }
 
 func (c *Client) Close() error {

--- a/transport/openvpn/client.go
+++ b/transport/openvpn/client.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/metacubex/tls"
+	"golang.org/x/sync/semaphore"
 )
 
 const (
@@ -30,6 +31,8 @@ type Client struct {
 	push    *PushReply
 
 	cancel context.CancelFunc
+
+	writeSem semaphore.Weighted
 
 	lastSendNano    atomic.Int64
 	lastReceiveNano atomic.Int64
@@ -154,6 +157,10 @@ func (c *Client) writeDataPacket(ctx context.Context, packet []byte, compress bo
 	if c.data == nil {
 		return errors.New("openvpn data channel is not ready")
 	}
+	if err := c.writeSem.Acquire(ctx, 1); err != nil {
+		return err
+	}
+	defer c.writeSem.Release(1)
 	if compress && c.config.CompLZO == CompLzoYes {
 		compressed, err := lzo1xCompressSafe(packet)
 		if err != nil {

--- a/transport/openvpn/config.go
+++ b/transport/openvpn/config.go
@@ -189,6 +189,23 @@ func (c *ClientConfig) ValidateInstallScriptSubset() error {
 	return nil
 }
 
+func (c *ClientConfig) KeepAliveTickInterval() time.Duration {
+	tick := 10 * time.Second
+	for _, value := range []time.Duration{c.PingInterval, c.PingRestart} {
+		if value <= 0 {
+			continue
+		}
+		candidate := value / 2
+		if candidate < time.Second {
+			candidate = time.Second
+		}
+		if candidate < tick {
+			tick = candidate
+		}
+	}
+	return tick
+}
+
 func DecodeStaticKey(block []byte) ([]byte, error) {
 	var hexLines []string
 	for _, raw := range strings.Split(string(block), "\n") {

--- a/transport/openvpn/config.go
+++ b/transport/openvpn/config.go
@@ -192,9 +192,6 @@ func (c *ClientConfig) ValidateInstallScriptSubset() error {
 	if c.PingRestart < 0 {
 		return errors.New("openvpn ping restart must be positive")
 	}
-	if c.PingRestart < c.PingInterval {
-		return errors.New("openvpn ping restart must be greater than ping interval")
-	}
 	return nil
 }
 

--- a/transport/openvpn/config.go
+++ b/transport/openvpn/config.go
@@ -186,24 +186,16 @@ func (c *ClientConfig) ValidateInstallScriptSubset() error {
 	} else if strings.TrimSpace(c.Username) == "" {
 		return errors.New("openvpn requires either cert+key or username (auth-user-pass)")
 	}
-	return nil
-}
-
-func (c *ClientConfig) KeepAliveTickInterval() time.Duration {
-	tick := 10 * time.Second
-	for _, value := range []time.Duration{c.PingInterval, c.PingRestart} {
-		if value <= 0 {
-			continue
-		}
-		candidate := value / 2
-		if candidate < time.Second {
-			candidate = time.Second
-		}
-		if candidate < tick {
-			tick = candidate
-		}
+	if c.PingInterval < 0 {
+		return errors.New("openvpn ping interval must be positive")
 	}
-	return tick
+	if c.PingRestart < 0 {
+		return errors.New("openvpn ping restart must be positive")
+	}
+	if c.PingRestart < c.PingInterval {
+		return errors.New("openvpn ping restart must be greater than ping interval")
+	}
+	return nil
 }
 
 func DecodeStaticKey(block []byte) ([]byte, error) {

--- a/transport/openvpn/config.go
+++ b/transport/openvpn/config.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"strconv"
 	"strings"
+	"time"
 )
 
 const (
@@ -49,6 +50,9 @@ type ClientConfig struct {
 
 	Username string
 	Password string
+
+	PingInterval time.Duration
+	PingRestart  time.Duration
 
 	TLSCryptKey []byte
 }

--- a/transport/openvpn/data.go
+++ b/transport/openvpn/data.go
@@ -57,10 +57,9 @@ type DataChannel struct {
 	sendImplicitIV [DataChannelIVSize]byte
 	recvImplicitIV [DataChannelIVSize]byte
 
-	keyID   uint8
-	peerID  uint32
-	header  []byte
-	compLZO string
+	keyID  uint8
+	peerID uint32
+	header []byte
 
 	mu           sync.Mutex
 	sendPacketID uint32
@@ -73,7 +72,7 @@ type DataChannel struct {
 	randOffset int
 }
 
-func NewDataChannel(keys *KeyMaterial, cipherName, authName string, peerID uint32, compLZO string) (*DataChannel, error) {
+func NewDataChannel(keys *KeyMaterial, cipherName, authName string, peerID uint32) (*DataChannel, error) {
 	if keys == nil {
 		return nil, errors.New("nil openvpn key material")
 	}
@@ -94,7 +93,6 @@ func NewDataChannel(keys *KeyMaterial, cipherName, authName string, peerID uint3
 			recvAEAD: recv,
 			peerID:   peerID,
 			header:   dataHeader(peerID, 0),
-			compLZO:  compLZO,
 		}
 		copy(d.sendImplicitIV[4:], keys.SendHMACKey[:DataChannelIVSize-4])
 		copy(d.recvImplicitIV[4:], keys.RecvHMACKey[:DataChannelIVSize-4])
@@ -125,7 +123,6 @@ func NewDataChannel(keys *KeyMaterial, cipherName, authName string, peerID uint3
 		authSize:    authSize,
 		peerID:      peerID,
 		header:      dataHeader(peerID, 0),
-		compLZO:     compLZO,
 	}
 	d.sendMACPool.New = func() any {
 		return hmac.New(d.authHash, d.sendHMACKey)
@@ -187,24 +184,8 @@ func newDataChannelAuth(authName string) (func() hash.Hash, int, error) {
 }
 
 func (d *DataChannel) Encrypt(packet []byte) ([]byte, error) {
-	return d.encrypt(packet, true)
-}
-
-func (d *DataChannel) EncryptRaw(packet []byte) ([]byte, error) {
-	return d.encrypt(packet, false)
-}
-
-func (d *DataChannel) encrypt(packet []byte, compress bool) ([]byte, error) {
 	if d == nil {
 		return nil, errors.New("nil openvpn data channel")
-	}
-
-	// Prepend comp-lzo header (0xfa = not compressed) to satisfy servers expecting the framing.
-	if compress && d.compLZO == CompLzoYes {
-		lzoPacket := make([]byte, 1+len(packet))
-		lzoPacket[0] = lzoCompressNone
-		copy(lzoPacket[1:], packet)
-		packet = lzoPacket
 	}
 
 	packetID := d.nextPacketID()
@@ -266,28 +247,10 @@ func (d *DataChannel) Decrypt(packet []byte) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	var plain []byte
 	if d.recvAEAD != nil {
-		plain, err = d.decryptAEAD(packet, headerSize)
-	} else {
-		plain, err = d.decryptCBC(packet, headerSize)
+		return d.decryptAEAD(packet, headerSize)
 	}
-	if err != nil {
-		return nil, err
-	}
-	if IsPingPacket(plain) {
-		return plain, nil
-	}
-	if d.compLZO == CompLzoYes && len(plain) > 0 {
-		decompressed, err := lzo1xDecompressSafe(plain)
-		if err != nil {
-			return nil, err
-		}
-		if len(decompressed) > 0 {
-			return decompressed, nil
-		}
-	}
-	return plain, nil
+	return d.decryptCBC(packet, headerSize)
 }
 
 func (d *DataChannel) decryptAEAD(packet []byte, headerSize int) ([]byte, error) {

--- a/transport/openvpn/data.go
+++ b/transport/openvpn/data.go
@@ -1,6 +1,7 @@
 package openvpn
 
 import (
+	"bytes"
 	"crypto/aes"
 	"crypto/cipher"
 	"crypto/hmac"
@@ -27,6 +28,18 @@ const (
 
 	PeerIDUnset uint32 = 0xffffff
 )
+
+// OpenVPN data-channel ping payload, matching PING_STRING in upstream OpenVPN.
+var openVPNPingPacket = []byte{
+	0x2a, 0x18, 0x7b, 0xf3,
+	0x64, 0x1e, 0xb4, 0xcb,
+	0x07, 0xed, 0x2d, 0x0a,
+	0x98, 0x1f, 0xc7, 0x48,
+}
+
+func IsPingPacket(packet []byte) bool {
+	return bytes.Equal(packet, openVPNPingPacket)
+}
 
 type DataChannel struct {
 	sendAEAD cipher.AEAD
@@ -174,12 +187,20 @@ func newDataChannelAuth(authName string) (func() hash.Hash, int, error) {
 }
 
 func (d *DataChannel) Encrypt(packet []byte) ([]byte, error) {
+	return d.encrypt(packet, true)
+}
+
+func (d *DataChannel) EncryptRaw(packet []byte) ([]byte, error) {
+	return d.encrypt(packet, false)
+}
+
+func (d *DataChannel) encrypt(packet []byte, compress bool) ([]byte, error) {
 	if d == nil {
 		return nil, errors.New("nil openvpn data channel")
 	}
 
 	// Prepend comp-lzo header (0xfa = not compressed) to satisfy servers expecting the framing.
-	if d.compLZO == CompLzoYes {
+	if compress && d.compLZO == CompLzoYes {
 		lzoPacket := make([]byte, 1+len(packet))
 		lzoPacket[0] = lzoCompressNone
 		copy(lzoPacket[1:], packet)
@@ -253,6 +274,9 @@ func (d *DataChannel) Decrypt(packet []byte) ([]byte, error) {
 	}
 	if err != nil {
 		return nil, err
+	}
+	if IsPingPacket(plain) {
+		return plain, nil
 	}
 	if d.compLZO == CompLzoYes && len(plain) > 0 {
 		decompressed, err := lzo1xDecompressSafe(plain)

--- a/transport/openvpn/data_test.go
+++ b/transport/openvpn/data_test.go
@@ -21,11 +21,11 @@ func TestDataChannelAESGCMV2RoundTrip(t *testing.T) {
 		RecvCipherKey: clientKeys.SendCipherKey,
 		RecvHMACKey:   clientKeys.SendHMACKey,
 	}
-	client, err := NewDataChannel(clientKeys, CipherAES128GCM, AuthSHA256, 7, "")
+	client, err := NewDataChannel(clientKeys, CipherAES128GCM, AuthSHA256, 7)
 	if err != nil {
 		t.Fatal(err)
 	}
-	server, err := NewDataChannel(serverKeys, CipherAES128GCM, AuthSHA256, 7, "")
+	server, err := NewDataChannel(serverKeys, CipherAES128GCM, AuthSHA256, 7)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -62,41 +62,6 @@ func TestDataChannelAESGCMV2RoundTrip(t *testing.T) {
 	}
 }
 
-func TestDataChannelPingRoundTripWithCompLZO(t *testing.T) {
-	clientKeys := &KeyMaterial{
-		SendCipherKey: bytes.Repeat([]byte{0x11}, 16),
-		SendHMACKey:   bytes.Repeat([]byte{0x22}, maxHMACKeyLength),
-		RecvCipherKey: bytes.Repeat([]byte{0x33}, 16),
-		RecvHMACKey:   bytes.Repeat([]byte{0x44}, maxHMACKeyLength),
-	}
-	serverKeys := &KeyMaterial{
-		SendCipherKey: clientKeys.RecvCipherKey,
-		SendHMACKey:   clientKeys.RecvHMACKey,
-		RecvCipherKey: clientKeys.SendCipherKey,
-		RecvHMACKey:   clientKeys.SendHMACKey,
-	}
-	client, err := NewDataChannel(clientKeys, CipherAES128GCM, AuthSHA256, 7, CompLzoYes)
-	if err != nil {
-		t.Fatal(err)
-	}
-	server, err := NewDataChannel(serverKeys, CipherAES128GCM, AuthSHA256, 7, CompLzoYes)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	encrypted, err := client.EncryptRaw(openVPNPingPacket)
-	if err != nil {
-		t.Fatal(err)
-	}
-	plain, err := server.Decrypt(encrypted)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !IsPingPacket(plain) {
-		t.Fatalf("unexpected ping plaintext: %x", plain)
-	}
-}
-
 func TestDataChannelAcceptsOutOfOrderPacketsWithinReplayWindow(t *testing.T) {
 	clientKeys := &KeyMaterial{
 		SendCipherKey: bytes.Repeat([]byte{0x11}, 16),
@@ -110,11 +75,11 @@ func TestDataChannelAcceptsOutOfOrderPacketsWithinReplayWindow(t *testing.T) {
 		RecvCipherKey: clientKeys.SendCipherKey,
 		RecvHMACKey:   clientKeys.SendHMACKey,
 	}
-	client, err := NewDataChannel(clientKeys, CipherAES128GCM, AuthSHA256, 7, "")
+	client, err := NewDataChannel(clientKeys, CipherAES128GCM, AuthSHA256, 7)
 	if err != nil {
 		t.Fatal(err)
 	}
-	server, err := NewDataChannel(serverKeys, CipherAES128GCM, AuthSHA256, 7, "")
+	server, err := NewDataChannel(serverKeys, CipherAES128GCM, AuthSHA256, 7)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -189,11 +154,11 @@ func TestDataChannelChaCha20Poly1305V2RoundTrip(t *testing.T) {
 		RecvCipherKey: clientKeys.SendCipherKey,
 		RecvHMACKey:   clientKeys.SendHMACKey,
 	}
-	client, err := NewDataChannel(clientKeys, CipherChaCha20Poly1305, AuthSHA256, 7, "")
+	client, err := NewDataChannel(clientKeys, CipherChaCha20Poly1305, AuthSHA256, 7)
 	if err != nil {
 		t.Fatal(err)
 	}
-	server, err := NewDataChannel(serverKeys, CipherChaCha20Poly1305, AuthSHA256, 7, "")
+	server, err := NewDataChannel(serverKeys, CipherChaCha20Poly1305, AuthSHA256, 7)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -229,11 +194,11 @@ func TestDataChannelAESCBCSHA1V2RoundTrip(t *testing.T) {
 		RecvCipherKey: clientKeys.SendCipherKey,
 		RecvHMACKey:   clientKeys.SendHMACKey,
 	}
-	client, err := NewDataChannel(clientKeys, CipherAES128CBC, AuthSHA1, 7, "")
+	client, err := NewDataChannel(clientKeys, CipherAES128CBC, AuthSHA1, 7)
 	if err != nil {
 		t.Fatal(err)
 	}
-	server, err := NewDataChannel(serverKeys, CipherAES128CBC, AuthSHA1, 7, "")
+	server, err := NewDataChannel(serverKeys, CipherAES128CBC, AuthSHA1, 7)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/transport/openvpn/data_test.go
+++ b/transport/openvpn/data_test.go
@@ -62,6 +62,41 @@ func TestDataChannelAESGCMV2RoundTrip(t *testing.T) {
 	}
 }
 
+func TestDataChannelPingRoundTripWithCompLZO(t *testing.T) {
+	clientKeys := &KeyMaterial{
+		SendCipherKey: bytes.Repeat([]byte{0x11}, 16),
+		SendHMACKey:   bytes.Repeat([]byte{0x22}, maxHMACKeyLength),
+		RecvCipherKey: bytes.Repeat([]byte{0x33}, 16),
+		RecvHMACKey:   bytes.Repeat([]byte{0x44}, maxHMACKeyLength),
+	}
+	serverKeys := &KeyMaterial{
+		SendCipherKey: clientKeys.RecvCipherKey,
+		SendHMACKey:   clientKeys.RecvHMACKey,
+		RecvCipherKey: clientKeys.SendCipherKey,
+		RecvHMACKey:   clientKeys.SendHMACKey,
+	}
+	client, err := NewDataChannel(clientKeys, CipherAES128GCM, AuthSHA256, 7, CompLzoYes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	server, err := NewDataChannel(serverKeys, CipherAES128GCM, AuthSHA256, 7, CompLzoYes)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	encrypted, err := client.EncryptRaw(openVPNPingPacket)
+	if err != nil {
+		t.Fatal(err)
+	}
+	plain, err := server.Decrypt(encrypted)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !IsPingPacket(plain) {
+		t.Fatalf("unexpected ping plaintext: %x", plain)
+	}
+}
+
 func TestDataChannelAcceptsOutOfOrderPacketsWithinReplayWindow(t *testing.T) {
 	clientKeys := &KeyMaterial{
 		SendCipherKey: bytes.Repeat([]byte{0x11}, 16),

--- a/transport/openvpn/lzo.go
+++ b/transport/openvpn/lzo.go
@@ -41,3 +41,12 @@ func lzo1xDecompressSafe(src []byte) ([]byte, error) {
 		return nil, ErrLZODecompress
 	}
 }
+
+// lzo1xCompressSafe handles OpenVPN comp-lzo data packets.
+// Prepend comp-lzo header (0xfa = not compressed) to satisfy servers expecting the framing.
+func lzo1xCompressSafe(src []byte) ([]byte, error) {
+	lzoPacket := make([]byte, 1+len(src))
+	lzoPacket[0] = lzoCompressNone
+	copy(lzoPacket[1:], src)
+	return lzoPacket, nil
+}

--- a/transport/openvpn/lzo_test.go
+++ b/transport/openvpn/lzo_test.go
@@ -1,0 +1,23 @@
+package openvpn
+
+import (
+	"bytes"
+	"crypto/rand"
+	"testing"
+)
+
+func TestLzo1xSafe(t *testing.T) {
+	data := make([]byte, 1024)
+	rand.Read(data)
+	compressed, err := lzo1xCompressSafe(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	decompressed, err := lzo1xDecompressSafe(compressed)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(data, decompressed) {
+		t.Fatal("decompressed data is not equal to original")
+	}
+}


### PR DESCRIPTION
## Summary
- add OpenVPN outbound options for ping and ping-restart
- send OpenVPN data-channel ping packets after idle send intervals
- restart the OpenVPN session when no packets are received before ping-restart
- skip received OpenVPN ping packets before IP packet handling

## Tests
- go test ./transport/openvpn ./adapter/outbound