### PR TITLE
增加PASS-RULE内置出站

### DIFF
--- a/adapter/outbound/reject.go
+++ b/adapter/outbound/reject.go
@@ -88,6 +88,17 @@ func NewPass() *Reject {
 	}
 }
 
+func NewPassRule() *Reject {
+	return &Reject{
+		Base: &Base{
+			name:   "PASS-RULE",
+			tp:     C.PassRule,
+			udp:    true,
+			prefer: C.DualStack,
+		},
+	}
+}
+
 type nopConn struct{}
 
 func (rw nopConn) Read(b []byte) (int, error) { return 0, io.EOF }

--- a/config/config.go
+++ b/config/config.go
@@ -880,6 +880,7 @@ func parseProxies(cfg *RawConfig) (proxies map[string]C.Proxy, providersMap map[
 	proxies["REJECT-DROP"] = adapter.NewProxy(outbound.NewRejectDrop())
 	proxies["COMPATIBLE"] = adapter.NewProxy(outbound.NewCompatible())
 	proxies["PASS"] = adapter.NewProxy(outbound.NewPass())
+	proxies["PASS-RULE"] = adapter.NewProxy(outbound.NewPassRule())
 	proxyList = append(proxyList, "DIRECT", "REJECT")
 
 	// parse proxy
@@ -950,7 +951,7 @@ func parseProxies(cfg *RawConfig) (proxies map[string]C.Proxy, providersMap map[
 
 	var ps []C.Proxy
 	for _, v := range proxyList {
-		if proxies[v].Type() == C.Pass {
+		if proxies[v].Type() == C.Pass || proxies[v].Type() == C.PassRule {
 			continue
 		}
 		ps = append(ps, proxies[v])

--- a/constant/adapters.go
+++ b/constant/adapters.go
@@ -21,6 +21,7 @@ const (
 	RejectDrop
 	Compatible
 	Pass
+	PassRule
 	Dns
 
 	Relay
@@ -183,6 +184,8 @@ func (at AdapterType) String() string {
 		return "Compatible"
 	case Pass:
 		return "Pass"
+	case PassRule:
+		return "PassRule"
 	case Dns:
 		return "Dns"
 	case Shadowsocks:

--- a/constant/adapters.go
+++ b/constant/adapters.go
@@ -62,6 +62,7 @@ const (
 )
 
 var ErrNotSupport = errors.New("no support")
+var CheckPassRule func(name string, metadata *Metadata) bool
 
 type Connection interface {
 	Chains() Chain

--- a/rules/logic/logic.go
+++ b/rules/logic/logic.go
@@ -182,8 +182,8 @@ func matchSubRules(metadata *C.Metadata, name string, subRules map[string][]C.Ru
 			if rule.RuleType() == C.SubRules {
 				m, a = matchSubRules(metadata, rule.Adapter(), subRules, helper)
 			}
-			if m && a == "PASS-RULE" {
-				continue
+			if m && (a == "PASS-RULE" || (C.CheckPassRule != nil && C.CheckPassRule(a, metadata))) {
+				continue 
 			}
 			return m, a
 		}

--- a/rules/logic/logic.go
+++ b/rules/logic/logic.go
@@ -180,10 +180,12 @@ func matchSubRules(metadata *C.Metadata, name string, subRules map[string][]C.Ru
 	for _, rule := range subRules[name] {
 		if m, a := rule.Match(metadata, helper); m {
 			if rule.RuleType() == C.SubRules {
-				return matchSubRules(metadata, rule.Adapter(), subRules, helper)
-			} else {
-				return m, a
+				m, a = matchSubRules(metadata, rule.Adapter(), subRules, helper)
 			}
+			if m && a == "PASS-RULE" {
+				continue
+			}
+			return m, a
 		}
 	}
 	return false, ""

--- a/tunnel/tunnel.go
+++ b/tunnel/tunnel.go
@@ -721,3 +721,20 @@ func retry[T any](ctx context.Context, ft func(context.Context) (T, error), fe f
 	}
 	return
 }
+
+func init() {
+	C.CheckPassRule = func(name string, metadata *C.Metadata) bool {
+		configMux.RLock()
+		defer configMux.RUnlock()
+		adapter, ok := proxies[name]
+		if !ok {
+			return false
+		}
+		for a := adapter; a != nil; a = a.Unwrap(metadata, false) {
+			if a.Type() == C.PassRule {
+				return true
+			}
+		}
+		return false
+	}
+}

--- a/tunnel/tunnel.go
+++ b/tunnel/tunnel.go
@@ -651,7 +651,7 @@ func match(metadata *C.Metadata, helper C.RuleMatchHelper) (C.Proxy, C.Rule, err
 			// parse multi-layer nesting
 			passed := false
 			for adapter := adapter; adapter != nil; adapter = adapter.Unwrap(metadata, false) {
-				if adapter.Type() == C.Pass {
+				if adapter.Type() == C.Pass || adapter.Type() == C.PassRule {
 					passed = true
 					break
 				}


### PR DESCRIPTION
与PASS的区别是：在sub-rule中命中PASS-RULE时不会跳出子规则，仅跳过当前命中规则分支，继续在sub-rule中向后匹配规则。



参考用途示例：
rules:
  - DST-PORT,53/853,DNS劫持
  - DST-PORT,5228-5230,直接连接
  - RULE-SET,private_ip,直接连接,no-resolve
  - RULE-SET,private,直接连接
  - RULE-SET,ads,REJECT
  - SUB-RULE,(RULE-SET,ai),sub-ai
  - SUB-RULE,(RULE-SET,telegram),sub-telegram
  - RULE-SET,proxy@direct,直接连接
  - SUB-RULE,(RULE-SET,proxy-lite),sub-proxy
  - RULE-SET,cn-lite,直接连接
  - SUB-RULE,(RULE-SET,telegram_ip),sub-telegram
  - RULE-SET,cn_ip,直接连接
  - AND,((NETWORK,udp),(DST-PORT,443)),代理QUIC
  - MATCH,代理连接
sub-rules:
  sub-ai:
    - AND,((NETWORK,udp),(DST-PORT,443)),代理QUIC
    - MATCH,国外AI
  sub-telegram:
    - AND,((NETWORK,udp),(DST-PORT,443)),代理QUIC
    - MATCH,TELEGRAM
  sub-proxy:
    - AND,((NETWORK,udp),(DST-PORT,443)),代理QUIC
    - MATCH,代理连接

proxy-groups:
    - { name: 代理QUIC, type: select, proxies: [PASS-RULE,REJECT] }


优点：可通过策略组快速决定是否禁用代理QUIC流量；规则匹配效率高，可不重复匹配规则（之前想实现类似效果要么将禁用quic写死到规则中，要么需要匹配两次同一规则才行）

<img width="1264" height="2780" alt="Screenshot_2026-06-04-18-42-04-80_33f34bf0029ca15359ebd43d4b95def2" src="https://github.com/user-attachments/assets/9fc5378a-b81f-41ce-86a5-19017876d470" />


