### PR TITLE
feat: add built-in proxy PASS-RULE

### DIFF
--- a/adapter/outbound/reject.go
+++ b/adapter/outbound/reject.go
@@ -88,6 +88,17 @@ func NewPass() *Reject {
 	}
 }
 
+func NewPassRule() *Reject {
+	return &Reject{
+		Base: &Base{
+			name:   "PASS-RULE",
+			tp:     C.PassRule,
+			udp:    true,
+			prefer: C.DualStack,
+		},
+	}
+}
+
 type nopConn struct{}
 
 func (rw nopConn) Read(b []byte) (int, error) { return 0, io.EOF }

--- a/config/config.go
+++ b/config/config.go
@@ -880,6 +880,7 @@ func parseProxies(cfg *RawConfig) (proxies map[string]C.Proxy, providersMap map[
 	proxies["REJECT-DROP"] = adapter.NewProxy(outbound.NewRejectDrop())
 	proxies["COMPATIBLE"] = adapter.NewProxy(outbound.NewCompatible())
 	proxies["PASS"] = adapter.NewProxy(outbound.NewPass())
+	proxies["PASS-RULE"] = adapter.NewProxy(outbound.NewPassRule())
 	proxyList = append(proxyList, "DIRECT", "REJECT")
 
 	// parse proxy
@@ -950,7 +951,7 @@ func parseProxies(cfg *RawConfig) (proxies map[string]C.Proxy, providersMap map[
 
 	var ps []C.Proxy
 	for _, v := range proxyList {
-		if proxies[v].Type() == C.Pass {
+		if proxies[v].Type() == C.Pass || proxies[v].Type() == C.PassRule {
 			continue
 		}
 		ps = append(ps, proxies[v])

--- a/constant/adapters.go
+++ b/constant/adapters.go
@@ -21,6 +21,7 @@ const (
 	RejectDrop
 	Compatible
 	Pass
+	PassRule
 	Dns
 
 	Relay
@@ -183,6 +184,8 @@ func (at AdapterType) String() string {
 		return "Compatible"
 	case Pass:
 		return "Pass"
+	case PassRule:
+		return "PassRule"
 	case Dns:
 		return "Dns"
 	case Shadowsocks:

--- a/constant/rule.go
+++ b/constant/rule.go
@@ -152,6 +152,7 @@ type RuleWrapper interface {
 type RuleMatchHelper struct {
 	ResolveIP   func()
 	FindProcess func()
+	CheckPassRule func(adapterName string) bool
 }
 
 type RuleGroup interface {

--- a/rules/logic/logic.go
+++ b/rules/logic/logic.go
@@ -180,10 +180,12 @@ func matchSubRules(metadata *C.Metadata, name string, subRules map[string][]C.Ru
 	for _, rule := range subRules[name] {
 		if m, a := rule.Match(metadata, helper); m {
 			if rule.RuleType() == C.SubRules {
-				return matchSubRules(metadata, rule.Adapter(), subRules, helper)
-			} else {
-				return m, a
+				m, a = matchSubRules(metadata, rule.Adapter(), subRules, helper)
 			}
+			if m && (a == "PASS-RULE" || (helper.CheckPassRule != nil && helper.CheckPassRule(a))) {
+				continue 
+			}
+			return m, a
 		}
 	}
 	return false, ""

--- a/tunnel/tunnel.go
+++ b/tunnel/tunnel.go
@@ -374,6 +374,18 @@ func resolveMetadata(metadata *C.Metadata) (proxy C.Proxy, rule C.Rule, err erro
 				}
 			}
 		},
+		CheckPassRule: func(adapterName string) bool {
+			adapter, ok := proxies[adapterName]
+			if !ok {
+				return false
+			}
+			for a := adapter; a != nil; a = a.Unwrap(metadata, false) {
+				if a.Type() == C.PassRule {
+					return true
+				}
+			}
+			return false
+		},
 	}
 
 	switch FindProcessMode() {


### PR DESCRIPTION
与PASS的区别是：在sub-rule中命中PASS-RULE时不会跳出子规则，仅跳过当前命中规则分支，继续在sub-rule中向后匹配规则。

参考用途示例：
```
rules:
  - DST-PORT,53/853,DNS劫持
  - DST-PORT,5228-5230,直接连接
  - RULE-SET,private_ip,直接连接,no-resolve
  - RULE-SET,private,直接连接
  - RULE-SET,ads,REJECT
  - SUB-RULE,(RULE-SET,ai),sub-ai
  - SUB-RULE,(RULE-SET,telegram),sub-telegram
  - RULE-SET,proxy@direct,直接连接
  - SUB-RULE,(RULE-SET,proxy-lite),sub-proxy
  - RULE-SET,cn-lite,直接连接
  - SUB-RULE,(RULE-SET,telegram_ip),sub-telegram
  - RULE-SET,cn_ip,直接连接
  - AND,((NETWORK,udp),(DST-PORT,443)),代理QUIC
  - MATCH,代理连接
sub-rules:
  sub-ai:
    - AND,((NETWORK,udp),(DST-PORT,443)),代理QUIC
    - MATCH,国外AI
  sub-telegram:
    - AND,((NETWORK,udp),(DST-PORT,443)),代理QUIC
    - MATCH,TELEGRAM
  sub-proxy:
    - AND,((NETWORK,udp),(DST-PORT,443)),代理QUIC
    - MATCH,代理连接
proxy-groups:
- { name: 代理QUIC, type: select, proxies: [PASS-RULE,REJECT] }
```

优点：可通过策略组快速决定是否禁用代理QUIC流量；规则匹配效率高，可不重复匹配规则（之前想实现类似效果要么将禁用quic写死到规则中，要么需要匹配两次同一规则才行）
<img width="1264" height="2780" alt="Screenshot_2026-06-04-18-42-04-80_33f34bf0029ca15359ebd43d4b95def2" src="https://github.com/user-attachments/assets/1a9e6a50-d6da-4782-a901-a4f8d23c6282" />





