### PR TITLE
fix: guard snell pooled connection reuse state

### DIFF
--- a/adapter/outbound/snell.go
+++ b/adapter/outbound/snell.go
@@ -91,6 +91,9 @@ func (s *Snell) DialContext(ctx context.Context, metadata *C.Metadata) (_ C.Conn
 			_ = c.Close()
 			return nil, err
 		}
+		if pc, ok := c.(*snell.PoolConn); ok {
+			pc.MarkReusable()
+		}
 		return NewConn(c, s), err
 	}
 

--- a/transport/snell/pool.go
+++ b/transport/snell/pool.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"net"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/metacubex/mihomo/component/pool"
@@ -14,6 +15,12 @@ import (
 type Pool struct {
 	pool *pool.Pool[*Snell]
 }
+
+const (
+	poolConnNew int32 = iota
+	poolConnReusable
+	poolConnClosed
+)
 
 func (p *Pool) Get() (net.Conn, error) {
 	return p.GetContext(context.Background())
@@ -43,11 +50,13 @@ func (p *Pool) put(conn *Snell) {
 
 type PoolConn struct {
 	*Snell
-	pool           *Pool
-	closeWriteOnce sync.Once
-	closeWriteErr  error
-	closeOnce      sync.Once
-	closeErr       error
+	pool               *Pool
+	closeWriteOnce     sync.Once
+	closeWriteReusable bool
+	closeWriteErr      error
+	closeOnce          sync.Once
+	closeErr           error
+	reusableState      atomic.Int32
 }
 
 func (pc *PoolConn) Read(b []byte) (int, error) {
@@ -62,18 +71,37 @@ func (pc *PoolConn) Write(b []byte) (int, error) {
 	return pc.Snell.Write(b)
 }
 
+// MarkReusable allows Close to return this request to the pool after the request header is committed.
+func (pc *PoolConn) MarkReusable() {
+	pc.reusableState.CompareAndSwap(poolConnNew, poolConnReusable)
+}
+
 func (pc *PoolConn) CloseWrite() error {
+	_, err := pc.closeWrite()
+	return err
+}
+
+func (pc *PoolConn) closeWrite() (bool, error) {
 	pc.closeWriteOnce.Do(func() {
+		if pc.reusableState.Swap(poolConnClosed) != poolConnReusable {
+			pc.closeWriteErr = pc.Snell.Close()
+			return
+		}
+		pc.closeWriteReusable = true
 		pc.closeWriteErr = writeZeroChunk(pc.Snell)
 	})
-	return pc.closeWriteErr
+	return pc.closeWriteReusable, pc.closeWriteErr
 }
 
 func (pc *PoolConn) Close() error {
 	pc.closeOnce.Do(func() {
-		if err := pc.CloseWrite(); err != nil {
+		reusable, err := pc.closeWrite()
+		if err != nil {
 			pc.closeErr = err
 			_ = pc.Snell.Close()
+			return
+		}
+		if !reusable {
 			return
 		}
 

--- a/transport/snell/pool_test.go
+++ b/transport/snell/pool_test.go
@@ -19,6 +19,10 @@ func TestPoolConnCloseIsIdempotent(t *testing.T) {
 	})
 	conn := &PoolConn{Snell: pooledConn, pool: pool}
 
+	if _, err := conn.Write([]byte{Version, CommandConnectV2, 0}); err != nil {
+		t.Fatal(err)
+	}
+	conn.MarkReusable()
 	if err := conn.Close(); err != nil {
 		t.Fatal(err)
 	}
@@ -26,8 +30,8 @@ func TestPoolConnCloseIsIdempotent(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if rawConn.writes != 1 {
-		t.Fatalf("close should send one half-close record, got %d", rawConn.writes)
+	if rawConn.writes != 2 {
+		t.Fatalf("close should send the request and one half-close record, got %d writes", rawConn.writes)
 	}
 
 	got, err := pool.pool.Get()
@@ -36,6 +40,103 @@ func TestPoolConnCloseIsIdempotent(t *testing.T) {
 	}
 	if got != pooledConn {
 		t.Fatal("pooled connection mismatch")
+	}
+}
+
+func TestPoolConnCloseBeforeRequestClosesRawConnection(t *testing.T) {
+	rawConn := &recordingConn{}
+	pooledConn := &Snell{Conn: rawConn}
+	factoryConn := &Snell{Conn: &recordingConn{}}
+	pool := NewPool(func(context.Context) (*Snell, error) {
+		return factoryConn, nil
+	})
+	conn := &PoolConn{Snell: pooledConn, pool: pool}
+
+	if err := conn.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := conn.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	if rawConn.writes != 0 {
+		t.Fatalf("close before request should not send half-close record, got %d writes", rawConn.writes)
+	}
+	if !rawConn.closed {
+		t.Fatal("close before request should close the raw connection")
+	}
+
+	got, err := pool.pool.Get()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != factoryConn {
+		t.Fatal("unstarted connection should not be returned to the pool")
+	}
+}
+
+func TestPoolConnCloseAfterRequestBeforeReusableClosesRawConnection(t *testing.T) {
+	rawConn := &recordingConn{}
+	pooledConn := &Snell{Conn: rawConn}
+	factoryConn := &Snell{Conn: &recordingConn{}}
+	pool := NewPool(func(context.Context) (*Snell, error) {
+		return factoryConn, nil
+	})
+	conn := &PoolConn{Snell: pooledConn, pool: pool}
+
+	if _, err := conn.Write([]byte{Version, CommandConnectV2, 0}); err != nil {
+		t.Fatal(err)
+	}
+	if err := conn.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	if rawConn.writes != 1 {
+		t.Fatalf("close before reusable should only send the request, got %d writes", rawConn.writes)
+	}
+	if !rawConn.closed {
+		t.Fatal("close before reusable should close the raw connection")
+	}
+
+	got, err := pool.pool.Get()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != factoryConn {
+		t.Fatal("connection closed before reusable should not be returned to the pool")
+	}
+}
+
+func TestPoolConnCloseWriteBeforeRequestClosesRawConnection(t *testing.T) {
+	rawConn := &recordingConn{}
+	pooledConn := &Snell{Conn: rawConn}
+	factoryConn := &Snell{Conn: &recordingConn{}}
+	pool := NewPool(func(context.Context) (*Snell, error) {
+		return factoryConn, nil
+	})
+	conn := &PoolConn{Snell: pooledConn, pool: pool}
+
+	if err := conn.CloseWrite(); err != nil {
+		t.Fatal(err)
+	}
+	if rawConn.writes != 0 {
+		t.Fatalf("CloseWrite before request should not send half-close record, got %d writes", rawConn.writes)
+	}
+	if !rawConn.closed {
+		t.Fatal("CloseWrite before request should close the raw connection")
+	}
+
+	// MarkReusable must not revive a connection that already took the raw-close path.
+	conn.MarkReusable()
+	if err := conn.Close(); err != nil {
+		t.Fatal(err)
+	}
+	got, err := pool.pool.Get()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != factoryConn {
+		t.Fatal("unstarted connection should not be returned to the pool")
 	}
 }
 
@@ -48,6 +149,10 @@ func TestPoolConnCloseWriteDoesNotReturnConnectionToPool(t *testing.T) {
 	})
 	conn := &PoolConn{Snell: pooledConn, pool: pool}
 
+	if _, err := conn.Write([]byte{Version, CommandConnectV2, 0}); err != nil {
+		t.Fatal(err)
+	}
+	conn.MarkReusable()
 	if err := conn.CloseWrite(); err != nil {
 		t.Fatal(err)
 	}
@@ -59,8 +164,8 @@ func TestPoolConnCloseWriteDoesNotReturnConnectionToPool(t *testing.T) {
 	if got != factoryConn {
 		t.Fatal("CloseWrite should not put the active connection back into the pool")
 	}
-	if rawConn.writes != 1 {
-		t.Fatalf("CloseWrite should send one half-close record, got %d", rawConn.writes)
+	if rawConn.writes != 2 {
+		t.Fatalf("CloseWrite should send the request and one half-close record, got %d writes", rawConn.writes)
 	}
 	if !pooledConn.reply {
 		t.Fatal("CloseWrite should not reset reply while the read side may still be active")
@@ -76,8 +181,8 @@ func TestPoolConnCloseWriteDoesNotReturnConnectionToPool(t *testing.T) {
 	if got != pooledConn {
 		t.Fatal("Close should return the connection to the pool after CloseWrite")
 	}
-	if rawConn.writes != 1 {
-		t.Fatalf("Close after CloseWrite should not send another half-close record, got %d", rawConn.writes)
+	if rawConn.writes != 2 {
+		t.Fatalf("Close after CloseWrite should not send another half-close record, got %d writes", rawConn.writes)
 	}
 	if pooledConn.reply {
 		t.Fatal("Close should reset reply before returning the connection to the pool")


### PR DESCRIPTION
当前 mihomo 使用 Snell reuse 连接官方 snell-server 时，在某些提前关闭路径下可能触发服务端报错：

```
Recevie client EOF before command, abort
Error: signal 11
```