### PR TITLE
feat(openvpn): support tls-auth and in-place rekey

### DIFF
--- a/adapter/outbound/openvpn.go
+++ b/adapter/outbound/openvpn.go
@@ -42,24 +42,26 @@ type OpenVPN struct {
 
 type OpenVPNOption struct {
 	BasicOption
-	Name        string `proxy:"name"`
-	Server      string `proxy:"server"`
-	Port        int    `proxy:"port"`
-	Proto       string `proxy:"proto,omitempty"`
-	Dev         string `proxy:"dev,omitempty"`
-	Cipher      string `proxy:"cipher,omitempty"`
-	Auth        string `proxy:"auth,omitempty"`
-	CompLZO     string `proxy:"comp-lzo,omitempty"`
-	CA          string `proxy:"ca"`
-	Cert        string `proxy:"cert,omitempty"`
-	Key         string `proxy:"key,omitempty"`
-	TLSCrypt    string `proxy:"tls-crypt,omitempty"`
-	Username    string `proxy:"username,omitempty"`
-	Password    string `proxy:"password,omitempty"`
-	Ping        int    `proxy:"ping,omitempty"`
-	PingRestart int    `proxy:"ping-restart,omitempty"`
-	MTU         int    `proxy:"mtu,omitempty"`
-	UDP         bool   `proxy:"udp,omitempty"`
+	Name         string `proxy:"name"`
+	Server       string `proxy:"server"`
+	Port         int    `proxy:"port"`
+	Proto        string `proxy:"proto,omitempty"`
+	Dev          string `proxy:"dev,omitempty"`
+	Cipher       string `proxy:"cipher,omitempty"`
+	Auth         string `proxy:"auth,omitempty"`
+	CompLZO      string `proxy:"comp-lzo,omitempty"`
+	CA           string `proxy:"ca"`
+	Cert         string `proxy:"cert,omitempty"`
+	Key          string `proxy:"key,omitempty"`
+	TLSCrypt     string `proxy:"tls-crypt,omitempty"`
+	TLSAuth      string `proxy:"tls-auth,omitempty"`
+	KeyDirection int    `proxy:"key-direction,omitempty"`
+	Username     string `proxy:"username,omitempty"`
+	Password     string `proxy:"password,omitempty"`
+	Ping         int    `proxy:"ping,omitempty"`
+	PingRestart  int    `proxy:"ping-restart,omitempty"`
+	MTU          int    `proxy:"mtu,omitempty"`
+	UDP          bool   `proxy:"udp,omitempty"`
 
 	RemoteDnsResolve bool     `proxy:"remote-dns-resolve,omitempty"`
 	Dns              []string `proxy:"dns,omitempty"`
@@ -67,21 +69,23 @@ type OpenVPNOption struct {
 
 func NewOpenVPN(option OpenVPNOption) (*OpenVPN, error) {
 	cfg := &ovpn.ClientConfig{
-		RemoteHost:   option.Server,
-		RemotePort:   uint16(option.Port),
-		Proto:        option.Proto,
-		Dev:          option.Dev,
-		Cipher:       option.Cipher,
-		Auth:         option.Auth,
-		CompLZO:      option.CompLZO,
-		CA:           []byte(option.CA),
-		Cert:         []byte(option.Cert),
-		Key:          []byte(option.Key),
-		TLSCrypt:     []byte(option.TLSCrypt),
-		Username:     option.Username,
-		Password:     option.Password,
-		PingInterval: time.Duration(option.Ping) * time.Second,
-		PingRestart:  time.Duration(option.PingRestart) * time.Second,
+		RemoteHost:       option.Server,
+		RemotePort:       uint16(option.Port),
+		Proto:            option.Proto,
+		Dev:              option.Dev,
+		Cipher:           option.Cipher,
+		Auth:             option.Auth,
+		CompLZO:          option.CompLZO,
+		CA:               []byte(option.CA),
+		Cert:             []byte(option.Cert),
+		Key:              []byte(option.Key),
+		TLSCrypt:         []byte(option.TLSCrypt),
+		TLSAuth:          []byte(option.TLSAuth),
+		TLSAuthDirection: option.KeyDirection,
+		Username:         option.Username,
+		Password:         option.Password,
+		PingInterval:     time.Duration(option.Ping) * time.Second,
+		PingRestart:      time.Duration(option.PingRestart) * time.Second,
 	}
 	if err := cfg.Prepare(); err != nil {
 		return nil, err
@@ -198,19 +202,9 @@ func (o *OpenVPN) Close() error {
 		o.runCancel()
 	}
 	_ = o.runLock.Acquire(context.Background(), 1)
-	client := o.client
-	tunDevice := o.tunDevice
-	o.client = nil
-	o.tunDevice = nil
-	o.running = false
+	o.closeRunningLocked()
 	o.runLock.Release(1)
 
-	if client != nil {
-		_ = client.Close()
-	}
-	if tunDevice != nil {
-		return tunDevice.Close()
-	}
 	return nil
 }
 
@@ -285,6 +279,20 @@ func (o *OpenVPN) run(ctx context.Context) (wireguard.Device, resolver.Resolver,
 	return o.tunDevice, o.resolver, nil
 }
 
+func (o *OpenVPN) closeRunningLocked() {
+	client := o.client
+	tunDevice := o.tunDevice
+	o.client = nil
+	o.tunDevice = nil
+	o.running = false
+	if client != nil {
+		_ = client.Close()
+	}
+	if tunDevice != nil {
+		_ = tunDevice.Close()
+	}
+}
+
 func (o *OpenVPN) lockRun(ctx context.Context) error {
 	lockCtx, cancel := context.WithCancel(ctx)
 	stop := contextutils.AfterFunc(o.runCtx, cancel)
@@ -301,8 +309,8 @@ func (o *OpenVPN) lockRun(ctx context.Context) error {
 	return nil
 }
 
-func (o *OpenVPN) handshakeContext(ctx context.Context) (context.Context, context.CancelFunc) {
-	handshakeCtx, handshakeCancel := context.WithTimeout(ctx, ovpn.DefaultHandshakeTimeout)
+func (o *OpenVPN) handshakeContext(_ context.Context) (context.Context, context.CancelFunc) {
+	handshakeCtx, handshakeCancel := context.WithTimeout(context.Background(), ovpn.DefaultHandshakeTimeout)
 	stop := contextutils.AfterFunc(o.runCtx, handshakeCancel)
 	return handshakeCtx, func() {
 		stop()
@@ -453,4 +461,13 @@ func (o *OpenVPN) startPacketLoops() {
 			}
 		}()
 	}
+
+	go func() {
+		defer stop()
+		if err := client.RunControlLoop(runCtx); errors.Is(err, ovpn.ErrControlRestart) {
+			log.Infoln("[OpenVPN](%s) control loop requested reconnect: %v", o.name, err)
+		} else if err != nil && !errors.Is(err, context.Canceled) && !errors.Is(err, net.ErrClosed) && !errors.Is(err, os.ErrClosed) {
+			log.Warnln("[OpenVPN](%s) control loop stopped: %v", o.name, err)
+		}
+	}()
 }

--- a/transport/openvpn/client.go
+++ b/transport/openvpn/client.go
@@ -12,6 +12,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/metacubex/mihomo/log"
 	"github.com/metacubex/tls"
 	"golang.org/x/sync/semaphore"
 )
@@ -19,16 +20,29 @@ import (
 const (
 	DefaultHandshakeTimeout = 30 * time.Second
 	ControlRetransmitDelay  = time.Second
+	DefaultControlPollDelay = time.Second
 )
+
+var (
+	ErrControlRestart = errors.New("openvpn control channel requested restart")
+)
+
+type controlStream interface {
+	Read([]byte) (int, error)
+	Write([]byte) (int, error)
+	SetReadDeadline(time.Time) error
+	SetWriteDeadline(time.Time) error
+}
 
 type Client struct {
 	config *ClientConfig
 	mux    *PacketMux
 
-	control *ControlChannel
-	tlsConn *tls.Conn
-	data    *DataChannel
-	push    *PushReply
+	control  *ControlChannel
+	tlsConn  *tls.Conn
+	data     *DataChannel
+	push     *PushReply
+	activity *remoteActivity
 
 	cancel context.CancelFunc
 
@@ -38,6 +52,34 @@ type Client struct {
 	lastReceiveNano atomic.Int64
 }
 
+type remoteActivity struct {
+	lastUnixNano atomic.Int64
+}
+
+func newRemoteActivity() *remoteActivity {
+	activity := &remoteActivity{}
+	activity.Mark()
+	return activity
+}
+
+func (a *remoteActivity) Mark() {
+	if a == nil {
+		return
+	}
+	a.lastUnixNano.Store(time.Now().UnixNano())
+}
+
+func (a *remoteActivity) Last() time.Time {
+	if a == nil {
+		return time.Now()
+	}
+	nanos := a.lastUnixNano.Load()
+	if nanos == 0 {
+		return time.Now()
+	}
+	return time.Unix(0, nanos)
+}
+
 func NewClient(config *ClientConfig, io PacketIO) (*Client, error) {
 	if config == nil {
 		return nil, errors.New("nil openvpn client config")
@@ -45,13 +87,23 @@ func NewClient(config *ClientConfig, io PacketIO) (*Client, error) {
 	if io == nil {
 		return nil, errors.New("nil openvpn packet io")
 	}
-	var crypt *TLSCrypt
+	var crypt ControlProtection
 	if len(config.TLSCryptKey) > 0 {
 		var err error
 		crypt, err = NewTLSCrypt(config.TLSCryptKey, true)
 		if err != nil {
 			return nil, err
 		}
+		log.Debugln("[OpenVPN] control protection=tls-crypt remote=%s", config.RemoteAddress())
+	} else if len(config.TLSAuthKey) > 0 {
+		var err error
+		crypt, err = NewTLSAuth(config.TLSAuthKey, config.Auth, config.TLSAuthDirection, true)
+		if err != nil {
+			return nil, err
+		}
+		log.Debugln("[OpenVPN] control protection=tls-auth auth=%s key-direction=%d remote=%s", config.Auth, config.TLSAuthDirection, config.RemoteAddress())
+	} else {
+		log.Debugln("[OpenVPN] control protection=none remote=%s", config.RemoteAddress())
 	}
 	local, err := NewSessionID()
 	if err != nil {
@@ -61,10 +113,11 @@ func NewClient(config *ClientConfig, io PacketIO) (*Client, error) {
 	mux := NewPacketMux(io)
 	go mux.Run(runCtx)
 	client := &Client{
-		config:  config,
-		mux:     mux,
-		control: NewControlChannel(mux, crypt, local),
-		cancel:  cancel,
+		config:   config,
+		mux:      mux,
+		control:  NewControlChannel(mux, crypt, local),
+		activity: newRemoteActivity(),
+		cancel:   cancel,
 	}
 	client.markSend()
 	client.markReceive()
@@ -80,12 +133,15 @@ func (c *Client) Handshake(ctx context.Context) (*PushReply, error) {
 		ctx, cancel = context.WithTimeout(ctx, DefaultHandshakeTimeout)
 		defer cancel()
 	}
+	log.Debugln("[OpenVPN] sending hard reset to %s", c.config.RemoteAddress())
 	if err := c.control.SendReset(ctx); err != nil {
 		return nil, fmt.Errorf("send hard reset: %w", err)
 	}
+	log.Debugln("[OpenVPN] waiting for hard reset response from %s", c.config.RemoteAddress())
 	if err := c.waitServerReset(ctx); err != nil {
 		return nil, err
 	}
+	log.Debugln("[OpenVPN] hard reset response received from %s", c.config.RemoteAddress())
 
 	tlsConfig, err := c.tlsConfig()
 	if err != nil {
@@ -96,12 +152,14 @@ func (c *Client) Handshake(ctx context.Context) (*PushReply, error) {
 	if deadline, ok := ctx.Deadline(); ok {
 		_ = c.tlsConn.SetDeadline(deadline)
 	}
+	log.Debugln("[OpenVPN] starting TLS handshake with %s", c.config.RemoteAddress())
 	if err := c.tlsConn.HandshakeContext(ctx); err != nil {
 		return nil, fmt.Errorf("openvpn tls handshake: %w", err)
 	}
+	log.Debugln("[OpenVPN] TLS handshake complete with %s", c.config.RemoteAddress())
 
 	clientRecord, err := NewClientKeyMethod2Record(
-		InstallScriptOptionsString(c.config.Proto, c.config.Cipher, c.config.Auth, c.config.CompLZO),
+		InstallScriptOptionsString(c.config.Proto, c.config.Cipher, c.config.Auth, c.config.CompLZO, len(c.config.TLSAuthKey) > 0, c.config.TLSAuthDirection),
 		InstallScriptPeerInfo(c.config.Cipher, c.config.CompLZO),
 		strings.TrimSpace(c.config.Username),
 		c.config.Password,
@@ -116,10 +174,12 @@ func (c *Client) Handshake(ctx context.Context) (*PushReply, error) {
 	if _, err := c.tlsConn.Write(clientBytes); err != nil {
 		return nil, fmt.Errorf("write key method 2 client record: %w", err)
 	}
+	log.Debugln("[OpenVPN] waiting for key method 2 server record from %s", c.config.RemoteAddress())
 	serverRecord, err := c.readServerKeyMethod(ctx)
 	if err != nil {
 		return nil, err
 	}
+	log.Debugln("[OpenVPN] key method 2 server record received from %s", c.config.RemoteAddress())
 
 	sources := clientRecord.Sources
 	sources.Server = serverRecord.Sources.Server
@@ -131,10 +191,12 @@ func (c *Client) Handshake(ctx context.Context) (*PushReply, error) {
 	if _, err := c.tlsConn.Write([]byte(PushRequest + "\x00")); err != nil {
 		return nil, fmt.Errorf("write push request: %w", err)
 	}
+	log.Debugln("[OpenVPN] waiting for push reply from %s", c.config.RemoteAddress())
 	push, err := c.readPushReply(ctx)
 	if err != nil {
 		return nil, err
 	}
+	log.Debugln("[OpenVPN] push reply received from %s", c.config.RemoteAddress())
 	c.push = push
 	c.data, err = NewDataChannel(keys, c.config.Cipher, c.config.Auth, push.PeerID)
 	if err != nil {
@@ -142,7 +204,19 @@ func (c *Client) Handshake(ctx context.Context) (*PushReply, error) {
 	}
 	c.markSend()
 	c.markReceive()
+	c.activity.Mark()
+	_ = c.tlsConn.SetDeadline(time.Time{})
 	return push, nil
+}
+
+func (c *Client) RunControlLoop(ctx context.Context) error {
+	if c == nil {
+		return errors.New("nil openvpn client")
+	}
+	if c.tlsConn == nil || c.push == nil {
+		return errors.New("openvpn control channel is not ready")
+	}
+	return runControlLoop(ctx, c.tlsConn, c.push, c.config.RemoteAddress(), c.activity)
 }
 
 func (c *Client) WriteIPPacket(ctx context.Context, packet []byte) error {
@@ -194,6 +268,7 @@ func (c *Client) ReadIPPacket(ctx context.Context) ([]byte, error) {
 			continue
 		}
 		c.markReceive()
+		c.activity.Mark()
 		if IsPingPacket(plain) {
 			continue
 		}
@@ -291,17 +366,30 @@ func (c *Client) readServerKeyMethod(ctx context.Context) (*KeyMethod2Record, er
 
 func (c *Client) readPushReply(ctx context.Context) (*PushReply, error) {
 	var buf []byte
+	var pushOptions []string
 	tmp := make([]byte, 4096)
+	retransmits := 0
 	for {
 		if deadline, ok := ctx.Deadline(); ok {
-			_ = c.tlsConn.SetReadDeadline(deadline)
+			readDeadline := time.Now().Add(ControlRetransmitDelay)
+			if deadline.Before(readDeadline) {
+				readDeadline = deadline
+			}
+			_ = c.tlsConn.SetReadDeadline(readDeadline)
 		}
 		n, err := c.tlsConn.Read(tmp)
 		if err != nil {
+			if ne, ok := err.(net.Error); ok && ne.Timeout() && ctx.Err() == nil {
+				if _, writeErr := c.tlsConn.Write([]byte(PushRequest + "\x00")); writeErr != nil {
+					return nil, fmt.Errorf("retransmit push request after %d retransmits: %w", retransmits, writeErr)
+				}
+				retransmits++
+				continue
+			}
 			if errors.Is(err, io.EOF) && len(buf) > 0 {
 				break
 			}
-			return nil, fmt.Errorf("read push reply: %w", err)
+			return nil, fmt.Errorf("read push reply after %d retransmits: %w", retransmits, err)
 		}
 		buf = append(buf, tmp[:n]...)
 		if bytes.Contains(buf, []byte("\x00")) || strings.Contains(string(buf), "PUSH_REPLY") {
@@ -309,12 +397,153 @@ func (c *Client) readPushReply(ctx context.Context) (*PushReply, error) {
 			if idx := strings.IndexByte(msg, 0); idx >= 0 {
 				msg = msg[:idx]
 			}
-			if reply, err := ParsePushReply(msg); err == nil {
-				return reply, nil
+			if strings.HasPrefix(msg, "PUSH_REPLY") {
+				options, continuation := splitPushReplyOptions(msg)
+				pushOptions = append(pushOptions, options...)
+				buf = nil
+				if continuation == 2 {
+					continue
+				}
+				return ParsePushReply(joinPushReplyOptions(pushOptions))
+			}
+			if strings.HasPrefix(msg, "AUTH_FAILED") {
+				return nil, fmt.Errorf("openvpn authentication failed: %s", msg)
+			}
+			if strings.HasPrefix(msg, "AUTH_PENDING") {
+				log.Debugln("[OpenVPN] auth pending from %s: %s", c.config.RemoteAddress(), msg)
+				buf = nil
+				continue
+			}
+			if strings.TrimSpace(msg) != "" {
+				return nil, fmt.Errorf("unexpected openvpn control message while waiting for push reply: %s", msg)
 			}
 		}
 	}
 	return nil, ctx.Err()
+}
+
+func runControlLoop(ctx context.Context, stream controlStream, push *PushReply, remote string, activity *remoteActivity) error {
+	if push == nil {
+		return errors.New("nil openvpn push reply")
+	}
+	pingInterval := push.PingInterval
+	if pingInterval <= 0 && push.PingRestart > 0 {
+		pingInterval = push.PingRestart / 2
+	}
+	pingRestart := push.PingRestart
+	renegotiateAt := time.Time{}
+	if push.RenegotiateAfter > 0 {
+		renegotiateAt = time.Now().Add(push.RenegotiateAfter)
+	}
+
+	buf := make([]byte, 0, 4096)
+	tmp := make([]byte, 4096)
+	lastReceived := activity.Last()
+	lastPingSent := time.Now()
+
+	for {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		now := time.Now()
+		lastReceived = activity.Last()
+		if !renegotiateAt.IsZero() && !now.Before(renegotiateAt) {
+			return fmt.Errorf("%w: reneg-sec elapsed", ErrControlRestart)
+		}
+		if pingRestart > 0 && !lastReceived.Add(pingRestart).After(now) {
+			return fmt.Errorf("%w: ping-restart elapsed without control traffic from %s", ErrControlRestart, remote)
+		}
+		if pingInterval > 0 && !lastPingSent.Add(pingInterval).After(now) {
+			if err := writeControlMessage(ctx, stream, "PING"); err != nil {
+				return fmt.Errorf("write openvpn ping: %w", err)
+			}
+			lastPingSent = time.Now()
+		}
+
+		deadline := nextControlDeadline(time.Now(), lastReceived, lastPingSent, pingInterval, pingRestart, renegotiateAt)
+		if err := stream.SetReadDeadline(deadline); err != nil {
+			return err
+		}
+		n, err := stream.Read(tmp)
+		if err != nil {
+			if errors.Is(err, ErrControlRestart) {
+				return err
+			}
+			if ne, ok := err.(net.Error); ok && ne.Timeout() {
+				continue
+			}
+			if errors.Is(err, io.EOF) || errors.Is(err, net.ErrClosed) {
+				return fmt.Errorf("%w: control channel closed", ErrControlRestart)
+			}
+			if ctxErr := ctx.Err(); ctxErr != nil {
+				return ctxErr
+			}
+			return fmt.Errorf("read openvpn control message: %w", err)
+		}
+		if n == 0 {
+			continue
+		}
+		activity.Mark()
+		lastReceived = activity.Last()
+		buf = append(buf, tmp[:n]...)
+		for {
+			idx := bytes.IndexByte(buf, 0)
+			if idx < 0 {
+				if len(buf) > 64*1024 {
+					return errors.New("openvpn control message buffer exceeded 64KiB")
+				}
+				break
+			}
+			msg := strings.TrimSpace(string(buf[:idx]))
+			buf = buf[idx+1:]
+			if err := handleControlMessage(msg, remote); err != nil {
+				return err
+			}
+		}
+	}
+}
+
+func nextControlDeadline(now, lastReceived, lastPingSent time.Time, pingInterval, pingRestart time.Duration, renegotiateAt time.Time) time.Time {
+	deadline := now.Add(DefaultControlPollDelay)
+	if pingInterval > 0 {
+		if nextPing := lastPingSent.Add(pingInterval); nextPing.Before(deadline) {
+			deadline = nextPing
+		}
+	}
+	if pingRestart > 0 {
+		if restart := lastReceived.Add(pingRestart); restart.Before(deadline) {
+			deadline = restart
+		}
+	}
+	if !renegotiateAt.IsZero() && renegotiateAt.Before(deadline) {
+		deadline = renegotiateAt
+	}
+	return deadline
+}
+
+func writeControlMessage(ctx context.Context, stream controlStream, message string) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if err := stream.SetWriteDeadline(time.Now().Add(ControlRetransmitDelay)); err != nil {
+		return err
+	}
+	_, err := stream.Write([]byte(message + "\x00"))
+	_ = stream.SetWriteDeadline(time.Time{})
+	return err
+}
+
+func handleControlMessage(message, remote string) error {
+	if message == "" || message == "PING" || strings.HasPrefix(message, "INFO") || strings.HasPrefix(message, "WARNING") || strings.HasPrefix(message, "PUSH_REPLY") {
+		return nil
+	}
+	if strings.HasPrefix(message, "AUTH_FAILED") {
+		return fmt.Errorf("openvpn authentication failed after handshake from %s: %s", remote, message)
+	}
+	if strings.HasPrefix(message, "RESTART") || strings.HasPrefix(message, "HALT") {
+		return fmt.Errorf("%w: %s", ErrControlRestart, message)
+	}
+	return nil
 }
 
 func (c *Client) tlsConfig() (*tls.Config, error) {
@@ -340,6 +569,8 @@ func (c *Client) tlsConfig() (*tls.Config, error) {
 	cfg := &tls.Config{
 		InsecureSkipVerify: true,
 		VerifyConnection:   verify,
+		MinVersion:         tls.VersionTLS12,
+		MaxVersion:         tls.VersionTLS12,
 	}
 	certPEM := bytes.TrimSpace(c.config.Cert)
 	keyPEM := bytes.TrimSpace(c.config.Key)

--- a/transport/openvpn/client.go
+++ b/transport/openvpn/client.go
@@ -21,10 +21,12 @@ const (
 	DefaultHandshakeTimeout = 30 * time.Second
 	ControlRetransmitDelay  = time.Second
 	DefaultControlPollDelay = time.Second
+	dataChannelRekeyOverlap = ControlRetransmitDelay
 )
 
 var (
-	ErrControlRestart = errors.New("openvpn control channel requested restart")
+	ErrControlRestart   = errors.New("openvpn control channel requested restart")
+	ErrControlSoftReset = errors.New("openvpn control channel requested soft reset")
 )
 
 type controlStream interface {
@@ -32,6 +34,10 @@ type controlStream interface {
 	Write([]byte) (int, error)
 	SetReadDeadline(time.Time) error
 	SetWriteDeadline(time.Time) error
+}
+
+type controlLoopHooks struct {
+	rekey func(context.Context, string) (*PushReply, controlStream, error)
 }
 
 type Client struct {
@@ -143,11 +149,34 @@ func (c *Client) Handshake(ctx context.Context) (*PushReply, error) {
 	}
 	log.Debugln("[OpenVPN] hard reset response received from %s", c.config.RemoteAddress())
 
+	return c.negotiateDataSession(ctx, false)
+}
+
+func (c *Client) Renegotiate(ctx context.Context, reason string) (*PushReply, error) {
+	if c == nil {
+		return nil, errors.New("nil openvpn client")
+	}
+	if _, ok := ctx.Deadline(); !ok {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, DefaultHandshakeTimeout)
+		defer cancel()
+	}
+	log.Debugln("[OpenVPN] starting soft reset for %s: %s", c.config.RemoteAddress(), reason)
+	if err := c.control.SendSoftReset(ctx); err != nil {
+		return nil, fmt.Errorf("send soft reset: %w", err)
+	}
+	return c.negotiateDataSession(ctx, true)
+}
+
+func (c *Client) negotiateDataSession(ctx context.Context, rekey bool) (*PushReply, error) {
 	tlsConfig, err := c.tlsConfig()
 	if err != nil {
 		return nil, err
 	}
 	controlConn := NewControlConn(c.control)
+	if rekey {
+		controlConn = NewSoftResetControlConn(c.control)
+	}
 	c.tlsConn = tls.Client(controlConn, tlsConfig)
 	if deadline, ok := ctx.Deadline(); ok {
 		_ = c.tlsConn.SetDeadline(deadline)
@@ -197,16 +226,49 @@ func (c *Client) Handshake(ctx context.Context) (*PushReply, error) {
 		return nil, err
 	}
 	log.Debugln("[OpenVPN] push reply received from %s", c.config.RemoteAddress())
-	c.push = push
-	c.data, err = NewDataChannel(keys, c.config.Cipher, c.config.Auth, push.PeerID)
-	if err != nil {
+	if err := c.installDataChannel(keys, push, rekey); err != nil {
 		return nil, err
 	}
-	c.markSend()
-	c.markReceive()
-	c.activity.Mark()
 	_ = c.tlsConn.SetDeadline(time.Time{})
 	return push, nil
+}
+
+func (c *Client) installDataChannel(keys *KeyMaterial, push *PushReply, rekey bool) error {
+	if c == nil {
+		return errors.New("nil openvpn client")
+	}
+	if push == nil {
+		return errors.New("nil openvpn push reply")
+	}
+	if rekey && c.data != nil {
+		if err := c.data.Rekey(keys, c.config.Cipher, c.config.Auth, push.PeerID, c.config.CompLZO); err != nil {
+			return err
+		}
+		c.schedulePreviousKeyRetirement()
+	} else {
+		data, err := NewDataChannel(keys, c.config.Cipher, c.config.Auth, push.PeerID, c.config.CompLZO)
+		if err != nil {
+			return err
+		}
+		c.data = data
+	}
+	c.push = push
+	c.activity.Mark()
+	return nil
+}
+
+func (c *Client) schedulePreviousKeyRetirement() {
+	if c == nil || c.data == nil {
+		return
+	}
+	data := c.data
+	generation, ok := data.activeGeneration()
+	if !ok {
+		return
+	}
+	time.AfterFunc(dataChannelRekeyOverlap, func() {
+		data.RetirePreviousKeysForGeneration(generation)
+	})
 }
 
 func (c *Client) RunControlLoop(ctx context.Context) error {
@@ -216,7 +278,15 @@ func (c *Client) RunControlLoop(ctx context.Context) error {
 	if c.tlsConn == nil || c.push == nil {
 		return errors.New("openvpn control channel is not ready")
 	}
-	return runControlLoop(ctx, c.tlsConn, c.push, c.config.RemoteAddress(), c.activity)
+	return runControlLoopWithHooks(ctx, c.tlsConn, c.push, c.config.RemoteAddress(), c.activity, controlLoopHooks{
+		rekey: func(ctx context.Context, reason string) (*PushReply, controlStream, error) {
+			push, err := c.Renegotiate(ctx, reason)
+			if err != nil {
+				return nil, nil, err
+			}
+			return push, c.tlsConn, nil
+		},
+	})
 }
 
 func (c *Client) WriteIPPacket(ctx context.Context, packet []byte) error {
@@ -423,6 +493,10 @@ func (c *Client) readPushReply(ctx context.Context) (*PushReply, error) {
 }
 
 func runControlLoop(ctx context.Context, stream controlStream, push *PushReply, remote string, activity *remoteActivity) error {
+	return runControlLoopWithHooks(ctx, stream, push, remote, activity, controlLoopHooks{})
+}
+
+func runControlLoopWithHooks(ctx context.Context, stream controlStream, push *PushReply, remote string, activity *remoteActivity, hooks controlLoopHooks) error {
 	if push == nil {
 		return errors.New("nil openvpn push reply")
 	}
@@ -448,7 +522,26 @@ func runControlLoop(ctx context.Context, stream controlStream, push *PushReply, 
 		now := time.Now()
 		lastReceived = activity.Last()
 		if !renegotiateAt.IsZero() && !now.Before(renegotiateAt) {
-			return fmt.Errorf("%w: reneg-sec elapsed", ErrControlRestart)
+			nextPush, nextStream, err := runControlLoopRekey(ctx, hooks, "reneg-sec elapsed")
+			if err != nil {
+				return err
+			}
+			if nextStream != nil {
+				stream = nextStream
+			}
+			push = nextPush
+			pingInterval = push.PingInterval
+			if pingInterval <= 0 && push.PingRestart > 0 {
+				pingInterval = push.PingRestart / 2
+			}
+			pingRestart = push.PingRestart
+			renegotiateAt = time.Time{}
+			if push.RenegotiateAfter > 0 {
+				renegotiateAt = time.Now().Add(push.RenegotiateAfter)
+			}
+			lastReceived = activity.Last()
+			lastPingSent = time.Now()
+			continue
 		}
 		if pingRestart > 0 && !lastReceived.Add(pingRestart).After(now) {
 			return fmt.Errorf("%w: ping-restart elapsed without control traffic from %s", ErrControlRestart, remote)
@@ -466,6 +559,29 @@ func runControlLoop(ctx context.Context, stream controlStream, push *PushReply, 
 		}
 		n, err := stream.Read(tmp)
 		if err != nil {
+			if errors.Is(err, ErrControlSoftReset) {
+				nextPush, nextStream, err := runControlLoopRekey(ctx, hooks, "received P_CONTROL_SOFT_RESET_V1")
+				if err != nil {
+					return err
+				}
+				if nextStream != nil {
+					stream = nextStream
+				}
+				push = nextPush
+				pingInterval = push.PingInterval
+				if pingInterval <= 0 && push.PingRestart > 0 {
+					pingInterval = push.PingRestart / 2
+				}
+				pingRestart = push.PingRestart
+				renegotiateAt = time.Time{}
+				if push.RenegotiateAfter > 0 {
+					renegotiateAt = time.Now().Add(push.RenegotiateAfter)
+				}
+				lastReceived = activity.Last()
+				lastPingSent = time.Now()
+				buf = nil
+				continue
+			}
 			if errors.Is(err, ErrControlRestart) {
 				return err
 			}
@@ -496,11 +612,49 @@ func runControlLoop(ctx context.Context, stream controlStream, push *PushReply, 
 			}
 			msg := strings.TrimSpace(string(buf[:idx]))
 			buf = buf[idx+1:]
-			if err := handleControlMessage(msg, remote); err != nil {
+			rekeyReason, err := handleControlMessage(msg, remote)
+			if err != nil {
 				return err
+			}
+			if rekeyReason != "" {
+				nextPush, nextStream, err := runControlLoopRekey(ctx, hooks, rekeyReason)
+				if err != nil {
+					return err
+				}
+				if nextStream != nil {
+					stream = nextStream
+				}
+				push = nextPush
+				pingInterval = push.PingInterval
+				if pingInterval <= 0 && push.PingRestart > 0 {
+					pingInterval = push.PingRestart / 2
+				}
+				pingRestart = push.PingRestart
+				renegotiateAt = time.Time{}
+				if push.RenegotiateAfter > 0 {
+					renegotiateAt = time.Now().Add(push.RenegotiateAfter)
+				}
+				lastReceived = activity.Last()
+				lastPingSent = time.Now()
+				buf = nil
+				break
 			}
 		}
 	}
+}
+
+func runControlLoopRekey(ctx context.Context, hooks controlLoopHooks, reason string) (*PushReply, controlStream, error) {
+	if hooks.rekey == nil {
+		return nil, nil, fmt.Errorf("%w: %s", ErrControlRestart, reason)
+	}
+	nextPush, nextStream, err := hooks.rekey(ctx, reason)
+	if err != nil {
+		return nil, nil, fmt.Errorf("%w: rekey failed after %s: %v", ErrControlRestart, reason, err)
+	}
+	if nextPush == nil {
+		return nil, nil, fmt.Errorf("%w: rekey returned nil push reply after %s", ErrControlRestart, reason)
+	}
+	return nextPush, nextStream, nil
 }
 
 func nextControlDeadline(now, lastReceived, lastPingSent time.Time, pingInterval, pingRestart time.Duration, renegotiateAt time.Time) time.Time {
@@ -533,17 +687,20 @@ func writeControlMessage(ctx context.Context, stream controlStream, message stri
 	return err
 }
 
-func handleControlMessage(message, remote string) error {
+func handleControlMessage(message, remote string) (string, error) {
 	if message == "" || message == "PING" || strings.HasPrefix(message, "INFO") || strings.HasPrefix(message, "WARNING") || strings.HasPrefix(message, "PUSH_REPLY") {
-		return nil
+		return "", nil
 	}
 	if strings.HasPrefix(message, "AUTH_FAILED") {
-		return fmt.Errorf("openvpn authentication failed after handshake from %s: %s", remote, message)
+		return "", fmt.Errorf("openvpn authentication failed after handshake from %s: %s", remote, message)
+	}
+	if strings.HasPrefix(message, "RESTART,soft") {
+		return message, nil
 	}
 	if strings.HasPrefix(message, "RESTART") || strings.HasPrefix(message, "HALT") {
-		return fmt.Errorf("%w: %s", ErrControlRestart, message)
+		return "", fmt.Errorf("%w: %s", ErrControlRestart, message)
 	}
-	return nil
+	return "", nil
 }
 
 func (c *Client) tlsConfig() (*tls.Config, error) {

--- a/transport/openvpn/client_test.go
+++ b/transport/openvpn/client_test.go
@@ -1,8 +1,10 @@
 package openvpn
 
 import (
+	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"net"
 	"strings"
 	"sync"
@@ -91,6 +93,147 @@ func (timeoutError) Error() string   { return "timeout" }
 func (timeoutError) Timeout() bool   { return true }
 func (timeoutError) Temporary() bool { return true }
 
+type oneShotReadErrorStream struct {
+	*fakeControlStream
+
+	mu  sync.Mutex
+	err error
+}
+
+func newOneShotReadErrorStream(err error) *oneShotReadErrorStream {
+	return &oneShotReadErrorStream{
+		fakeControlStream: newFakeControlStream(),
+		err:               err,
+	}
+}
+
+func (s *oneShotReadErrorStream) Read(b []byte) (int, error) {
+	s.mu.Lock()
+	err := s.err
+	s.err = nil
+	s.mu.Unlock()
+	if err != nil {
+		return 0, err
+	}
+	return s.fakeControlStream.Read(b)
+}
+
+func TestClientInstallDataChannelRekeysWithoutReplacingDataChannel(t *testing.T) {
+	client := &Client{
+		config: &ClientConfig{
+			Cipher: CipherAES128GCM,
+			Auth:   AuthSHA256,
+		},
+		activity: newRemoteActivity(),
+	}
+	keys1 := &KeyMaterial{
+		SendCipherKey: bytes.Repeat([]byte{0x11}, 16),
+		SendHMACKey:   bytes.Repeat([]byte{0x22}, maxHMACKeyLength),
+		RecvCipherKey: bytes.Repeat([]byte{0x33}, 16),
+		RecvHMACKey:   bytes.Repeat([]byte{0x44}, maxHMACKeyLength),
+	}
+	keys2 := &KeyMaterial{
+		SendCipherKey: bytes.Repeat([]byte{0x55}, 16),
+		SendHMACKey:   bytes.Repeat([]byte{0x66}, maxHMACKeyLength),
+		RecvCipherKey: bytes.Repeat([]byte{0x77}, 16),
+		RecvHMACKey:   bytes.Repeat([]byte{0x88}, maxHMACKeyLength),
+	}
+	if err := client.installDataChannel(keys1, &PushReply{PeerID: 7}, false); err != nil {
+		t.Fatal(err)
+	}
+	initial := client.data
+	if initial == nil {
+		t.Fatal("expected initial data channel")
+	}
+	if err := client.installDataChannel(keys2, &PushReply{PeerID: 7}, true); err != nil {
+		t.Fatal(err)
+	}
+	if client.data != initial {
+		t.Fatal("expected in-place rekey to keep the data channel object")
+	}
+	encrypted, err := client.data.Encrypt([]byte{0x45, 0, 0, 20, 1, 2, 3, 4, 64, 6, 0, 0, 10, 8, 0, 2, 1, 1, 1, 1})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, keyID := parseOpcodeKeyID(encrypted[0]); keyID != 1 {
+		t.Fatalf("expected encrypted packets to use rekeyed key id 1, got %d", keyID)
+	}
+}
+
+func TestClientInstallDataChannelRetiresPreviousReceiveKeyAfterOverlap(t *testing.T) {
+	clientKeys1 := &KeyMaterial{
+		SendCipherKey: bytes.Repeat([]byte{0x11}, 16),
+		SendHMACKey:   bytes.Repeat([]byte{0x22}, maxHMACKeyLength),
+		RecvCipherKey: bytes.Repeat([]byte{0x33}, 16),
+		RecvHMACKey:   bytes.Repeat([]byte{0x44}, maxHMACKeyLength),
+	}
+	serverKeys1 := &KeyMaterial{
+		SendCipherKey: clientKeys1.RecvCipherKey,
+		SendHMACKey:   clientKeys1.RecvHMACKey,
+		RecvCipherKey: clientKeys1.SendCipherKey,
+		RecvHMACKey:   clientKeys1.SendHMACKey,
+	}
+	clientKeys2 := &KeyMaterial{
+		SendCipherKey: bytes.Repeat([]byte{0x55}, 16),
+		SendHMACKey:   bytes.Repeat([]byte{0x66}, maxHMACKeyLength),
+		RecvCipherKey: bytes.Repeat([]byte{0x77}, 16),
+		RecvHMACKey:   bytes.Repeat([]byte{0x88}, maxHMACKeyLength),
+	}
+	serverKeys2 := &KeyMaterial{
+		SendCipherKey: clientKeys2.RecvCipherKey,
+		SendHMACKey:   clientKeys2.RecvHMACKey,
+		RecvCipherKey: clientKeys2.SendCipherKey,
+		RecvHMACKey:   clientKeys2.SendHMACKey,
+	}
+	client := &Client{
+		config: &ClientConfig{
+			Cipher: CipherAES128GCM,
+			Auth:   AuthSHA256,
+		},
+		activity: newRemoteActivity(),
+	}
+	if err := client.installDataChannel(clientKeys1, &PushReply{PeerID: 7}, false); err != nil {
+		t.Fatal(err)
+	}
+	server, err := NewDataChannel(serverKeys1, CipherAES128GCM, AuthSHA256, 7, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	oldPacketDuringOverlap := []byte{0x45, 0, 0, 20, 1, 2, 3, 4, 64, 6, 0, 0, 10, 8, 0, 2, 1, 1, 1, 1}
+	oldEncryptedDuringOverlap, err := server.Encrypt(oldPacketDuringOverlap)
+	if err != nil {
+		t.Fatal(err)
+	}
+	oldPacketAfterOverlap := []byte{0x45, 0, 0, 20, 1, 2, 3, 6, 64, 6, 0, 0, 10, 8, 0, 2, 1, 1, 1, 1}
+	oldEncryptedAfterOverlap, err := server.Encrypt(oldPacketAfterOverlap)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := client.installDataChannel(clientKeys2, &PushReply{PeerID: 7}, true); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := client.data.Decrypt(oldEncryptedDuringOverlap); err != nil {
+		t.Fatalf("expected old receive key to remain during overlap: %v", err)
+	}
+	if err := server.Rekey(serverKeys2, CipherAES128GCM, AuthSHA256, 7, ""); err != nil {
+		t.Fatal(err)
+	}
+	newPacket := []byte{0x45, 0, 0, 20, 1, 2, 3, 5, 64, 6, 0, 0, 10, 8, 0, 2, 1, 1, 1, 1}
+	newEncrypted, err := server.Encrypt(newPacket)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	time.Sleep(dataChannelRekeyOverlap + 100*time.Millisecond)
+
+	if _, err := client.data.Decrypt(oldEncryptedAfterOverlap); err == nil {
+		t.Fatal("expected old receive key to be retired after overlap")
+	}
+	if _, err := client.data.Decrypt(newEncrypted); err != nil {
+		t.Fatalf("expected active receive key to remain after overlap: %v", err)
+	}
+}
+
 func TestRunControlLoopSendsPing(t *testing.T) {
 	stream := newFakeControlStream()
 	ctx, cancel := context.WithCancel(context.Background())
@@ -133,13 +276,92 @@ func TestRunControlLoopRestartsOnPingTimeout(t *testing.T) {
 	}
 }
 
-func TestRunControlLoopRestartsOnServerRestartMessage(t *testing.T) {
+func TestRunControlLoopRekeysOnRenegSec(t *testing.T) {
+	stream := newFakeControlStream()
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	rekeys := 0
+	err := runControlLoopWithHooks(ctx, stream, &PushReply{RenegotiateAfter: time.Millisecond}, "test", newRemoteActivity(), controlLoopHooks{
+		rekey: func(context.Context, string) (*PushReply, controlStream, error) {
+			rekeys++
+			cancel()
+			return &PushReply{RenegotiateAfter: time.Hour}, stream, nil
+		},
+	})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context cancellation after successful rekey, got %v", err)
+	}
+	if rekeys != 1 {
+		t.Fatalf("expected one in-place rekey, got %d", rekeys)
+	}
+}
+
+func TestRunControlLoopFallsBackWhenRekeyFails(t *testing.T) {
+	stream := newFakeControlStream()
+	err := runControlLoopWithHooks(context.Background(), stream, &PushReply{RenegotiateAfter: time.Millisecond}, "test", newRemoteActivity(), controlLoopHooks{
+		rekey: func(context.Context, string) (*PushReply, controlStream, error) {
+			return nil, nil, errors.New("boom")
+		},
+	})
+	if !errors.Is(err, ErrControlRestart) {
+		t.Fatalf("expected reconnect fallback, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "rekey failed") {
+		t.Fatalf("expected rekey failure reason, got %v", err)
+	}
+}
+
+func TestRunControlLoopRekeysOnServerSoftRestartMessage(t *testing.T) {
 	stream := newFakeControlStream()
 	stream.readCh <- []byte("RESTART,soft\x00")
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	rekeys := 0
+	err := runControlLoopWithHooks(ctx, stream, &PushReply{}, "test", newRemoteActivity(), controlLoopHooks{
+		rekey: func(context.Context, string) (*PushReply, controlStream, error) {
+			rekeys++
+			cancel()
+			return &PushReply{RenegotiateAfter: time.Hour}, stream, nil
+		},
+	})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context cancellation after successful soft restart rekey, got %v", err)
+	}
+	if rekeys != 1 {
+		t.Fatalf("expected one in-place rekey, got %d", rekeys)
+	}
+}
+
+func TestRunControlLoopRekeysOnServerSoftResetPacket(t *testing.T) {
+	stream := newOneShotReadErrorStream(fmt.Errorf("%w: %w: received P_CONTROL_SOFT_RESET_V1", ErrControlRestart, ErrControlSoftReset))
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	rekeys := 0
+	err := runControlLoopWithHooks(ctx, stream, &PushReply{}, "test", newRemoteActivity(), controlLoopHooks{
+		rekey: func(context.Context, string) (*PushReply, controlStream, error) {
+			rekeys++
+			cancel()
+			return &PushReply{RenegotiateAfter: time.Hour}, stream, nil
+		},
+	})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context cancellation after successful soft reset rekey, got %v", err)
+	}
+	if rekeys != 1 {
+		t.Fatalf("expected one in-place rekey, got %d", rekeys)
+	}
+}
+
+func TestRunControlLoopRestartsOnServerHardRestartMessage(t *testing.T) {
+	stream := newFakeControlStream()
+	stream.readCh <- []byte("HALT,server-exit\x00")
 
 	err := runControlLoop(context.Background(), stream, &PushReply{}, "test", newRemoteActivity())
 	if !errors.Is(err, ErrControlRestart) {
-		t.Fatalf("expected restart on server RESTART, got %v", err)
+		t.Fatalf("expected restart on server HALT, got %v", err)
 	}
 }
 

--- a/transport/openvpn/client_test.go
+++ b/transport/openvpn/client_test.go
@@ -1,0 +1,180 @@
+package openvpn
+
+import (
+	"context"
+	"errors"
+	"net"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+type fakeControlStream struct {
+	readCh  chan []byte
+	writeCh chan []byte
+
+	mu           sync.Mutex
+	readDeadline time.Time
+	closed       bool
+}
+
+func newFakeControlStream() *fakeControlStream {
+	return &fakeControlStream{
+		readCh:  make(chan []byte, 8),
+		writeCh: make(chan []byte, 8),
+	}
+}
+
+func (f *fakeControlStream) Read(b []byte) (int, error) {
+	f.mu.Lock()
+	deadline := f.readDeadline
+	closed := f.closed
+	f.mu.Unlock()
+	if closed {
+		return 0, net.ErrClosed
+	}
+	if deadline.IsZero() {
+		msg, ok := <-f.readCh
+		if !ok {
+			return 0, net.ErrClosed
+		}
+		return copy(b, msg), nil
+	}
+	timer := time.NewTimer(time.Until(deadline))
+	defer timer.Stop()
+	select {
+	case msg, ok := <-f.readCh:
+		if !ok {
+			return 0, net.ErrClosed
+		}
+		return copy(b, msg), nil
+	case <-timer.C:
+		return 0, timeoutError{}
+	}
+}
+
+func (f *fakeControlStream) Write(b []byte) (int, error) {
+	f.mu.Lock()
+	closed := f.closed
+	f.mu.Unlock()
+	if closed {
+		return 0, net.ErrClosed
+	}
+	f.writeCh <- cloneBytes(b)
+	return len(b), nil
+}
+
+func (f *fakeControlStream) SetReadDeadline(t time.Time) error {
+	f.mu.Lock()
+	f.readDeadline = t
+	f.mu.Unlock()
+	return nil
+}
+
+func (f *fakeControlStream) SetWriteDeadline(time.Time) error {
+	return nil
+}
+
+func (f *fakeControlStream) Close() {
+	f.mu.Lock()
+	if !f.closed {
+		f.closed = true
+		close(f.readCh)
+	}
+	f.mu.Unlock()
+}
+
+type timeoutError struct{}
+
+func (timeoutError) Error() string   { return "timeout" }
+func (timeoutError) Timeout() bool   { return true }
+func (timeoutError) Temporary() bool { return true }
+
+func TestRunControlLoopSendsPing(t *testing.T) {
+	stream := newFakeControlStream()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- runControlLoop(ctx, stream, &PushReply{
+			PingInterval: 20 * time.Millisecond,
+			PingRestart:  200 * time.Millisecond,
+		}, "test", newRemoteActivity())
+	}()
+
+	select {
+	case msg := <-stream.writeCh:
+		if got := string(msg); got != "PING\x00" {
+			t.Fatalf("unexpected ping payload: %q", got)
+		}
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("control loop did not send PING")
+	}
+
+	cancel()
+	if err := <-errCh; !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context cancellation, got %v", err)
+	}
+}
+
+func TestRunControlLoopRestartsOnPingTimeout(t *testing.T) {
+	stream := newFakeControlStream()
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	err := runControlLoop(ctx, stream, &PushReply{PingRestart: 30 * time.Millisecond}, "test", newRemoteActivity())
+	if !errors.Is(err, ErrControlRestart) {
+		t.Fatalf("expected restart on ping timeout, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "ping-restart") {
+		t.Fatalf("expected ping-restart reason, got %v", err)
+	}
+}
+
+func TestRunControlLoopRestartsOnServerRestartMessage(t *testing.T) {
+	stream := newFakeControlStream()
+	stream.readCh <- []byte("RESTART,soft\x00")
+
+	err := runControlLoop(context.Background(), stream, &PushReply{}, "test", newRemoteActivity())
+	if !errors.Is(err, ErrControlRestart) {
+		t.Fatalf("expected restart on server RESTART, got %v", err)
+	}
+}
+
+func TestRunControlLoopReturnsAuthFailure(t *testing.T) {
+	stream := newFakeControlStream()
+	stream.readCh <- []byte("AUTH_FAILED,denied\x00")
+
+	err := runControlLoop(context.Background(), stream, &PushReply{}, "test", newRemoteActivity())
+	if err == nil || !strings.Contains(err.Error(), "authentication failed") {
+		t.Fatalf("expected auth failure, got %v", err)
+	}
+}
+
+func TestRunControlLoopDataActivityPreventsPingRestart(t *testing.T) {
+	stream := newFakeControlStream()
+	activity := newRemoteActivity()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- runControlLoop(ctx, stream, &PushReply{PingRestart: 60 * time.Millisecond}, "test", activity)
+	}()
+
+	time.Sleep(40 * time.Millisecond)
+	activity.Mark()
+
+	select {
+	case err := <-errCh:
+		t.Fatalf("control loop stopped despite data-channel activity: %v", err)
+	case <-time.After(40 * time.Millisecond):
+	}
+
+	cancel()
+	if err := <-errCh; !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context cancellation, got %v", err)
+	}
+}

--- a/transport/openvpn/config.go
+++ b/transport/openvpn/config.go
@@ -47,6 +47,7 @@ type ClientConfig struct {
 	Cert     []byte
 	Key      []byte
 	TLSCrypt []byte
+	TLSAuth  []byte
 
 	Username string
 	Password string
@@ -54,7 +55,9 @@ type ClientConfig struct {
 	PingInterval time.Duration
 	PingRestart  time.Duration
 
-	TLSCryptKey []byte
+	TLSCryptKey      []byte
+	TLSAuthKey       []byte
+	TLSAuthDirection int
 }
 
 // DataCipherKeyLength returns the key size for the negotiated data cipher.
@@ -140,6 +143,13 @@ func (c *ClientConfig) Prepare() error {
 		}
 		c.TLSCryptKey = key
 	}
+	if len(bytes.TrimSpace(c.TLSAuth)) > 0 {
+		key, err := DecodeStaticKey(c.TLSAuth)
+		if err != nil {
+			return fmt.Errorf("parse tls-auth key: %w", err)
+		}
+		c.TLSAuthKey = key
+	}
 	return nil
 }
 
@@ -161,6 +171,12 @@ func (c *ClientConfig) ValidateInstallScriptSubset() error {
 	}
 	if c.Auth != AuthMD5 && c.Auth != AuthSHA1 && c.Auth != AuthSHA256 && c.Auth != AuthSHA384 && c.Auth != AuthSHA512 {
 		return fmt.Errorf("unsupported openvpn auth %q: only %s, %s, %s, %s and %s are supported", c.Auth, AuthMD5, AuthSHA1, AuthSHA256, AuthSHA384, AuthSHA512)
+	}
+	if len(bytes.TrimSpace(c.TLSCrypt)) > 0 && len(bytes.TrimSpace(c.TLSAuth)) > 0 {
+		return errors.New("openvpn tls-crypt and tls-auth are mutually exclusive")
+	}
+	if c.TLSAuthDirection != 0 && c.TLSAuthDirection != 1 {
+		return fmt.Errorf("unsupported openvpn key-direction %d: only 0 and 1 are supported", c.TLSAuthDirection)
 	}
 	for name, value := range map[string][]byte{
 		"ca": c.CA,

--- a/transport/openvpn/config_test.go
+++ b/transport/openvpn/config_test.go
@@ -100,6 +100,31 @@ func TestClientConfigAllowsMissingTLSCrypt(t *testing.T) {
 	}
 }
 
+func TestClientConfigTLSAuth(t *testing.T) {
+	cfg := yamlStyleConfig()
+	cfg.TLSCrypt = nil
+	cfg.TLSAuth = []byte(testTLSCryptBlock())
+	cfg.TLSAuthDirection = 1
+	if err := cfg.Prepare(); err != nil {
+		t.Fatal(err)
+	}
+	if len(cfg.TLSAuthKey) != 256 {
+		t.Fatalf("unexpected tls-auth key length: %d", len(cfg.TLSAuthKey))
+	}
+}
+
+func TestClientConfigRejectsTLSCryptWithTLSAuth(t *testing.T) {
+	cfg := yamlStyleConfig()
+	cfg.TLSAuth = []byte(testTLSCryptBlock())
+	err := cfg.Prepare()
+	if err == nil {
+		t.Fatal("expected mutually exclusive tls-crypt/tls-auth error")
+	}
+	if !strings.Contains(err.Error(), "mutually exclusive") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestClientConfigAuthUserPassAES256(t *testing.T) {
 	cfg := &ClientConfig{
 		RemoteHost: "vpn.example.com",

--- a/transport/openvpn/control.go
+++ b/transport/openvpn/control.go
@@ -71,6 +71,19 @@ func (c *ControlChannel) SendReset(ctx context.Context) error {
 	return err
 }
 
+func (c *ControlChannel) SendSoftReset(ctx context.Context) error {
+	c.mu.Lock()
+	c.keyID = (c.keyID + 1) & KeyIDMask
+	c.sendMessage = 0
+	c.recvMessage = 0
+	c.ackPending = nil
+	c.pending = make(map[uint32]*ControlPacket)
+	c.recvPending = make(map[uint32]*ControlPacket)
+	c.mu.Unlock()
+	_, err := c.Send(ctx, PControlSoftResetV1, nil)
+	return err
+}
+
 func (c *ControlChannel) Send(ctx context.Context, opcode Opcode, payload []byte) (uint32, error) {
 	if !opcode.HasMessageID() {
 		return 0, fmt.Errorf("opcode %s cannot carry a reliable message", opcode)
@@ -138,6 +151,11 @@ func (c *ControlChannel) Read(ctx context.Context) (*ControlPacket, error) {
 		c.mu.Lock()
 		if c.remote == (SessionID{}) && packet.LocalSession != c.local {
 			c.remote = packet.LocalSession
+		}
+		if packet.Opcode == PControlSoftResetV1 {
+			c.recvMessage = 0
+			c.recvPending = make(map[uint32]*ControlPacket)
+			c.ackPending = nil
 		}
 		for _, ackID := range packet.AckIDs {
 			delete(c.pending, ackID)
@@ -282,14 +300,19 @@ func appendAck(acks []uint32, ack uint32) []uint32 {
 }
 
 type ControlConn struct {
-	channel *ControlChannel
-	readBuf []byte
-	closed  bool
-	mu      sync.Mutex
+	channel         *ControlChannel
+	acceptSoftReset bool
+	readBuf         []byte
+	closed          bool
+	mu              sync.Mutex
 }
 
 func NewControlConn(channel *ControlChannel) *ControlConn {
 	return &ControlConn{channel: channel}
+}
+
+func NewSoftResetControlConn(channel *ControlChannel) *ControlConn {
+	return &ControlConn{channel: channel, acceptSoftReset: true}
 }
 
 func (c *ControlConn) Read(b []byte) (int, error) {
@@ -333,7 +356,15 @@ func (c *ControlConn) Read(b []byte) (int, error) {
 			return 0, err
 		}
 		switch packet.Opcode {
-		case PControlSoftResetV1, PControlHardResetServerV1, PControlHardResetServerV2:
+		case PControlSoftResetV1:
+			if err := c.channel.SendAck(context.Background()); err != nil {
+				return 0, err
+			}
+			if c.acceptSoftReset {
+				continue
+			}
+			return 0, fmt.Errorf("%w: %w: received %s", ErrControlRestart, ErrControlSoftReset, packet.Opcode)
+		case PControlHardResetServerV1, PControlHardResetServerV2:
 			if err := c.channel.SendAck(context.Background()); err != nil {
 				return 0, err
 			}

--- a/transport/openvpn/control.go
+++ b/transport/openvpn/control.go
@@ -22,7 +22,7 @@ type PacketIO interface {
 
 type ControlChannel struct {
 	io     PacketIO
-	crypt  *TLSCrypt
+	crypt  ControlProtection
 	clock  func() time.Time
 	keyID  uint8
 	local  SessionID
@@ -39,7 +39,7 @@ type ControlChannel struct {
 	writeDeadline time.Time
 }
 
-func NewControlChannel(io PacketIO, crypt *TLSCrypt, local SessionID) *ControlChannel {
+func NewControlChannel(io PacketIO, crypt ControlProtection, local SessionID) *ControlChannel {
 	return &ControlChannel{
 		io:          io,
 		crypt:       crypt,
@@ -227,6 +227,9 @@ func (c *ControlChannel) readControlPacket(ctx context.Context) (*ControlPacket,
 	deadline := c.readDeadline
 	c.mu.Unlock()
 
+	if ctxDeadline, ok := ctx.Deadline(); ok && (deadline.IsZero() || ctxDeadline.Before(deadline)) {
+		deadline = ctxDeadline
+	}
 	if !deadline.IsZero() {
 		var cancel context.CancelFunc
 		ctx, cancel = context.WithDeadline(ctx, deadline)
@@ -254,6 +257,12 @@ func (c *ControlChannel) SetReadDeadline(t time.Time) error {
 	c.readDeadline = t
 	c.mu.Unlock()
 	return nil
+}
+
+func (c *ControlChannel) ReadDeadline() time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.readDeadline
 }
 
 func (c *ControlChannel) SetWriteDeadline(t time.Time) error {
@@ -298,9 +307,37 @@ func (c *ControlConn) Read(b []byte) (int, error) {
 	c.mu.Unlock()
 
 	for {
-		packet, err := c.channel.Read(context.Background())
+		readCtx := context.Background()
+		cancel := func() {}
+		readDeadline := c.channel.ReadDeadline()
+		if !readDeadline.IsZero() {
+			now := time.Now()
+			if !readDeadline.After(now) {
+				return 0, context.DeadlineExceeded
+			}
+			nextDeadline := now.Add(ControlRetransmitDelay)
+			if readDeadline.Before(nextDeadline) {
+				nextDeadline = readDeadline
+			}
+			readCtx, cancel = context.WithDeadline(context.Background(), nextDeadline)
+		}
+		packet, err := c.channel.Read(readCtx)
+		cancel()
 		if err != nil {
+			if errors.Is(err, context.DeadlineExceeded) && !readDeadline.IsZero() && readDeadline.After(time.Now()) {
+				if retransmitErr := c.channel.RetransmitPending(context.Background()); retransmitErr != nil {
+					return 0, retransmitErr
+				}
+				continue
+			}
 			return 0, err
+		}
+		switch packet.Opcode {
+		case PControlSoftResetV1, PControlHardResetServerV1, PControlHardResetServerV2:
+			if err := c.channel.SendAck(context.Background()); err != nil {
+				return 0, err
+			}
+			return 0, fmt.Errorf("%w: received %s", ErrControlRestart, packet.Opcode)
 		}
 		if packet.Opcode != PControlV1 {
 			if err := c.channel.SendAck(context.Background()); err != nil {

--- a/transport/openvpn/control_test.go
+++ b/transport/openvpn/control_test.go
@@ -121,6 +121,38 @@ func TestControlChannelResetAndAck(t *testing.T) {
 	}
 }
 
+func TestControlChannelSoftResetAdvancesKeyIDAndCounters(t *testing.T) {
+	client, server := newTestChannels(t)
+
+	if err := client.SendReset(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	packet, err := server.Read(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if packet.Opcode != PControlHardResetClientV2 || packet.KeyID != 0 || packet.MessageID != 0 {
+		t.Fatalf("unexpected hard reset packet: %s key=%d message=%d", packet.Opcode, packet.KeyID, packet.MessageID)
+	}
+	if err := server.SendAck(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	_, _ = client.Read(ctx)
+	cancel()
+
+	if err := client.SendSoftReset(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	packet, err = server.Read(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if packet.Opcode != PControlSoftResetV1 || packet.KeyID != 1 || packet.MessageID != 0 {
+		t.Fatalf("unexpected soft reset packet: %s key=%d message=%d", packet.Opcode, packet.KeyID, packet.MessageID)
+	}
+}
+
 func TestControlConnCarriesTLSBytes(t *testing.T) {
 	client, server := newTestChannels(t)
 	client.SetRemoteSessionID(server.LocalSessionID())
@@ -204,6 +236,48 @@ func TestControlChannelReordersReliableMessages(t *testing.T) {
 	}
 	if packet.MessageID != 1 || string(packet.Payload) != "second" {
 		t.Fatalf("unexpected second delivered packet: id=%d payload=%q", packet.MessageID, packet.Payload)
+	}
+}
+
+func TestSoftResetControlConnContinuesAfterSoftResetPacket(t *testing.T) {
+	client, server := newTestChannels(t)
+	client.SetRemoteSessionID(server.LocalSessionID())
+	server.SetRemoteSessionID(client.LocalSessionID())
+	clientConn := NewSoftResetControlConn(client)
+
+	if _, err := server.Send(context.Background(), PControlSoftResetV1, nil); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := server.Send(context.Background(), PControlV1, []byte("new tls record")); err != nil {
+		t.Fatal(err)
+	}
+
+	buf := make([]byte, 64)
+	n, err := clientConn.Read(buf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := string(buf[:n]); got != "new tls record" {
+		t.Fatalf("unexpected payload after soft reset: %q", got)
+	}
+}
+
+func TestControlConnReportsSoftResetOutsideRekeyHandshake(t *testing.T) {
+	client, server := newTestChannels(t)
+	client.SetRemoteSessionID(server.LocalSessionID())
+	server.SetRemoteSessionID(client.LocalSessionID())
+	clientConn := NewControlConn(client)
+
+	if _, err := server.Send(context.Background(), PControlSoftResetV1, nil); err != nil {
+		t.Fatal(err)
+	}
+	buf := make([]byte, 64)
+	_, err := clientConn.Read(buf)
+	if !errors.Is(err, ErrControlRestart) {
+		t.Fatalf("expected soft reset restart signal, got %v", err)
+	}
+	if !errors.Is(err, ErrControlSoftReset) {
+		t.Fatalf("expected soft reset sentinel, got %v", err)
 	}
 }
 

--- a/transport/openvpn/data.go
+++ b/transport/openvpn/data.go
@@ -42,6 +42,13 @@ func IsPingPacket(packet []byte) bool {
 }
 
 type DataChannel struct {
+	mu         sync.RWMutex
+	active     *dataChannelKey
+	recvKeys   map[uint8]*dataChannelKey
+	generation uint64
+}
+
+type dataChannelKey struct {
 	sendAEAD cipher.AEAD
 	recvAEAD cipher.AEAD
 
@@ -57,9 +64,10 @@ type DataChannel struct {
 	sendImplicitIV [DataChannelIVSize]byte
 	recvImplicitIV [DataChannelIVSize]byte
 
-	keyID  uint8
-	peerID uint32
-	header []byte
+	keyID   uint8
+	peerID  uint32
+	header  []byte
+	compLZO string
 
 	mu           sync.Mutex
 	sendPacketID uint32
@@ -72,7 +80,20 @@ type DataChannel struct {
 	randOffset int
 }
 
-func NewDataChannel(keys *KeyMaterial, cipherName, authName string, peerID uint32) (*DataChannel, error) {
+func NewDataChannel(keys *KeyMaterial, cipherName, authName string, peerID uint32, compLZO string) (*DataChannel, error) {
+	key, err := newDataChannelKey(keys, cipherName, authName, peerID, compLZO, 0)
+	if err != nil {
+		return nil, err
+	}
+	return &DataChannel{
+		active: key,
+		recvKeys: map[uint8]*dataChannelKey{
+			0: key,
+		},
+	}, nil
+}
+
+func newDataChannelKey(keys *KeyMaterial, cipherName, authName string, peerID uint32, compLZO string, keyID uint8) (*dataChannelKey, error) {
 	if keys == nil {
 		return nil, errors.New("nil openvpn key material")
 	}
@@ -88,11 +109,13 @@ func NewDataChannel(keys *KeyMaterial, cipherName, authName string, peerID uint3
 		if len(keys.SendHMACKey) < DataChannelIVSize-4 || len(keys.RecvHMACKey) < DataChannelIVSize-4 {
 			return nil, errors.New("openvpn implicit IV keys are too short")
 		}
-		d := &DataChannel{
+		d := &dataChannelKey{
 			sendAEAD: send,
 			recvAEAD: recv,
+			keyID:    keyID,
 			peerID:   peerID,
-			header:   dataHeader(peerID, 0),
+			header:   dataHeader(peerID, keyID),
+			compLZO:  compLZO,
 		}
 		copy(d.sendImplicitIV[4:], keys.SendHMACKey[:DataChannelIVSize-4])
 		copy(d.recvImplicitIV[4:], keys.RecvHMACKey[:DataChannelIVSize-4])
@@ -114,15 +137,17 @@ func NewDataChannel(keys *KeyMaterial, cipherName, authName string, peerID uint3
 	if len(keys.SendHMACKey) < authSize || len(keys.RecvHMACKey) < authSize {
 		return nil, errors.New("openvpn HMAC keys are too short")
 	}
-	d := &DataChannel{
+	d := &dataChannelKey{
 		sendBlock:   send,
 		recvBlock:   recv,
 		sendHMACKey: append([]byte(nil), keys.SendHMACKey[:authSize]...),
 		recvHMACKey: append([]byte(nil), keys.RecvHMACKey[:authSize]...),
 		authHash:    authHash,
 		authSize:    authSize,
+		keyID:       keyID,
 		peerID:      peerID,
-		header:      dataHeader(peerID, 0),
+		header:      dataHeader(peerID, keyID),
+		compLZO:     compLZO,
 	}
 	d.sendMACPool.New = func() any {
 		return hmac.New(d.authHash, d.sendHMACKey)
@@ -187,7 +212,137 @@ func (d *DataChannel) Encrypt(packet []byte) ([]byte, error) {
 	if d == nil {
 		return nil, errors.New("nil openvpn data channel")
 	}
+	key := d.activeKey()
+	if key == nil {
+		return nil, errors.New("openvpn data channel has no active key")
+	}
 
+	// Prepend comp-lzo header (0xfa = not compressed) to satisfy servers expecting the framing.
+	if key.compLZO == CompLzoYes {
+		lzoPacket := make([]byte, 1+len(packet))
+		lzoPacket[0] = lzoCompressNone
+		copy(lzoPacket[1:], packet)
+		packet = lzoPacket
+	}
+
+	return key.Encrypt(packet)
+}
+
+func (d *DataChannel) Decrypt(packet []byte) ([]byte, error) {
+	if d == nil {
+		return nil, errors.New("nil openvpn data channel")
+	}
+	keyID, err := dataPacketKeyID(packet)
+	if err != nil {
+		return nil, err
+	}
+	key := d.recvKey(keyID)
+	if key == nil {
+		return nil, fmt.Errorf("openvpn data packet uses unavailable key id %d", keyID)
+	}
+	plain, err := key.Decrypt(packet)
+	if err != nil {
+		return nil, err
+	}
+	if key.compLZO == CompLzoYes && len(plain) > 0 {
+		decompressed, err := lzo1xDecompressSafe(plain)
+		if err != nil {
+			return nil, err
+		}
+		if len(decompressed) > 0 {
+			return decompressed, nil
+		}
+	}
+	return plain, nil
+}
+
+func (d *DataChannel) Rekey(keys *KeyMaterial, cipherName, authName string, peerID uint32, compLZO string) error {
+	if d == nil {
+		return errors.New("nil openvpn data channel")
+	}
+	active := d.activeKey()
+	nextKeyID := uint8(0)
+	if active != nil {
+		nextKeyID = (active.keyID + 1) & KeyIDMask
+	}
+	next, err := newDataChannelKey(keys, cipherName, authName, peerID, compLZO, nextKeyID)
+	if err != nil {
+		return err
+	}
+	d.mu.Lock()
+	if d.recvKeys == nil {
+		d.recvKeys = make(map[uint8]*dataChannelKey)
+	}
+	d.active = next
+	d.generation++
+	d.recvKeys[nextKeyID] = next
+	previousKeyID := (nextKeyID - 1) & KeyIDMask
+	for keyID := range d.recvKeys {
+		if keyID != nextKeyID && keyID != previousKeyID {
+			delete(d.recvKeys, keyID)
+		}
+	}
+	d.mu.Unlock()
+	return nil
+}
+
+func (d *DataChannel) RetirePreviousKeys() {
+	if d == nil {
+		return
+	}
+	d.mu.Lock()
+	d.retirePreviousKeysLocked()
+	d.mu.Unlock()
+}
+
+func (d *DataChannel) RetirePreviousKeysForGeneration(generation uint64) bool {
+	if d == nil {
+		return false
+	}
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if d.generation != generation {
+		return false
+	}
+	d.retirePreviousKeysLocked()
+	return true
+}
+
+func (d *DataChannel) activeGeneration() (uint64, bool) {
+	if d == nil {
+		return 0, false
+	}
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+	if d.active == nil {
+		return 0, false
+	}
+	return d.generation, true
+}
+
+func (d *DataChannel) retirePreviousKeysLocked() {
+	if d.active == nil {
+		d.recvKeys = nil
+		return
+	}
+	d.recvKeys = map[uint8]*dataChannelKey{
+		d.active.keyID: d.active,
+	}
+}
+
+func (d *DataChannel) activeKey() *dataChannelKey {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+	return d.active
+}
+
+func (d *DataChannel) recvKey(keyID uint8) *dataChannelKey {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+	return d.recvKeys[keyID]
+}
+
+func (d *dataChannelKey) Encrypt(packet []byte) ([]byte, error) {
 	packetID := d.nextPacketID()
 	if d.sendAEAD != nil {
 		return d.encryptAEAD(packet, packetID)
@@ -195,7 +350,7 @@ func (d *DataChannel) Encrypt(packet []byte) ([]byte, error) {
 	return d.encryptCBC(packet, packetID)
 }
 
-func (d *DataChannel) encryptAEAD(packet []byte, packetID uint32) ([]byte, error) {
+func (d *dataChannelKey) encryptAEAD(packet []byte, packetID uint32) ([]byte, error) {
 	header := d.header
 	var packetIDBytes [4]byte
 	binary.BigEndian.PutUint32(packetIDBytes[:], packetID)
@@ -213,7 +368,7 @@ func (d *DataChannel) encryptAEAD(packet []byte, packetID uint32) ([]byte, error
 	return out, nil
 }
 
-func (d *DataChannel) encryptCBC(packet []byte, packetID uint32) ([]byte, error) {
+func (d *dataChannelKey) encryptCBC(packet []byte, packetID uint32) ([]byte, error) {
 	header := d.header
 	blockSize := d.sendBlock.BlockSize()
 	plainLen := 4 + len(packet)
@@ -239,21 +394,24 @@ func (d *DataChannel) encryptCBC(packet []byte, packetID uint32) ([]byte, error)
 	return out, nil
 }
 
-func (d *DataChannel) Decrypt(packet []byte) ([]byte, error) {
-	if d == nil {
-		return nil, errors.New("nil openvpn data channel")
-	}
+func (d *dataChannelKey) Decrypt(packet []byte) ([]byte, error) {
 	headerSize, err := dataPacketHeaderSize(packet)
 	if err != nil {
 		return nil, err
 	}
+	var plain []byte
 	if d.recvAEAD != nil {
-		return d.decryptAEAD(packet, headerSize)
+		plain, err = d.decryptAEAD(packet, headerSize)
+	} else {
+		plain, err = d.decryptCBC(packet, headerSize)
 	}
-	return d.decryptCBC(packet, headerSize)
+	if err != nil {
+		return nil, err
+	}
+	return plain, nil
 }
 
-func (d *DataChannel) decryptAEAD(packet []byte, headerSize int) ([]byte, error) {
+func (d *dataChannelKey) decryptAEAD(packet []byte, headerSize int) ([]byte, error) {
 	if len(packet) < 1 {
 		return nil, errors.New("empty openvpn data packet")
 	}
@@ -284,7 +442,7 @@ func (d *DataChannel) decryptAEAD(packet []byte, headerSize int) ([]byte, error)
 	return plain, nil
 }
 
-func (d *DataChannel) decryptCBC(packet []byte, headerSize int) ([]byte, error) {
+func (d *dataChannelKey) decryptCBC(packet []byte, headerSize int) ([]byte, error) {
 	blockSize := d.recvBlock.BlockSize()
 	minPacketLen := headerSize + d.authSize + blockSize + blockSize
 	if len(packet) < minPacketLen {
@@ -339,14 +497,32 @@ func dataPacketHeaderSize(packet []byte) (int, error) {
 	}
 }
 
-func (d *DataChannel) nextPacketID() uint32 {
+func dataPacketKeyID(packet []byte) (uint8, error) {
+	if len(packet) < 1 {
+		return 0, errors.New("empty openvpn data packet")
+	}
+	opcode, keyID := parseOpcodeKeyID(packet[0])
+	switch opcode {
+	case PDataV1:
+		return keyID, nil
+	case PDataV2:
+		if len(packet) < 4 {
+			return 0, errors.New("openvpn P_DATA_V2 packet missing peer id")
+		}
+		return keyID, nil
+	default:
+		return 0, fmt.Errorf("not an openvpn data packet: %s", opcode)
+	}
+}
+
+func (d *dataChannelKey) nextPacketID() uint32 {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 	d.sendPacketID++
 	return d.sendPacketID
 }
 
-func (d *DataChannel) acceptPacketID(packetID uint32) error {
+func (d *dataChannelKey) acceptPacketID(packetID uint32) error {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 
@@ -392,13 +568,13 @@ func dataHeader(peerID uint32, keyID uint8) []byte {
 	return []byte{opcodeKeyID(PDataV1, keyID)}
 }
 
-func (d *DataChannel) nonce(packetID uint32, implicit [DataChannelIVSize]byte) [DataChannelIVSize]byte {
+func (d *dataChannelKey) nonce(packetID uint32, implicit [DataChannelIVSize]byte) [DataChannelIVSize]byte {
 	nonce := implicit
 	binary.BigEndian.PutUint32(nonce[:4], binary.BigEndian.Uint32(nonce[:4])^packetID)
 	return nonce
 }
 
-func (d *DataChannel) fillCBCIV(iv []byte) error {
+func (d *dataChannelKey) fillCBCIV(iv []byte) error {
 	d.randMu.Lock()
 	defer d.randMu.Unlock()
 
@@ -429,7 +605,7 @@ func dataChannelHMACAppend(newHash func() hash.Hash, key, data, dst []byte) []by
 	return mac.Sum(dst)
 }
 
-func (d *DataChannel) hmacAppend(pool *sync.Pool, data, dst []byte) []byte {
+func (d *dataChannelKey) hmacAppend(pool *sync.Pool, data, dst []byte) []byte {
 	mac := pool.Get().(hash.Hash)
 	defer pool.Put(mac)
 	mac.Reset()

--- a/transport/openvpn/data_test.go
+++ b/transport/openvpn/data_test.go
@@ -21,11 +21,11 @@ func TestDataChannelAESGCMV2RoundTrip(t *testing.T) {
 		RecvCipherKey: clientKeys.SendCipherKey,
 		RecvHMACKey:   clientKeys.SendHMACKey,
 	}
-	client, err := NewDataChannel(clientKeys, CipherAES128GCM, AuthSHA256, 7)
+	client, err := NewDataChannel(clientKeys, CipherAES128GCM, AuthSHA256, 7, "")
 	if err != nil {
 		t.Fatal(err)
 	}
-	server, err := NewDataChannel(serverKeys, CipherAES128GCM, AuthSHA256, 7)
+	server, err := NewDataChannel(serverKeys, CipherAES128GCM, AuthSHA256, 7, "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -62,6 +62,166 @@ func TestDataChannelAESGCMV2RoundTrip(t *testing.T) {
 	}
 }
 
+func TestDataChannelRekeyRotatesSendKeyAndKeepsReceiveOverlap(t *testing.T) {
+	clientKeys1 := &KeyMaterial{
+		SendCipherKey: bytes.Repeat([]byte{0x11}, 16),
+		SendHMACKey:   bytes.Repeat([]byte{0x22}, maxHMACKeyLength),
+		RecvCipherKey: bytes.Repeat([]byte{0x33}, 16),
+		RecvHMACKey:   bytes.Repeat([]byte{0x44}, maxHMACKeyLength),
+	}
+	serverKeys1 := &KeyMaterial{
+		SendCipherKey: clientKeys1.RecvCipherKey,
+		SendHMACKey:   clientKeys1.RecvHMACKey,
+		RecvCipherKey: clientKeys1.SendCipherKey,
+		RecvHMACKey:   clientKeys1.SendHMACKey,
+	}
+	clientKeys2 := &KeyMaterial{
+		SendCipherKey: bytes.Repeat([]byte{0x55}, 16),
+		SendHMACKey:   bytes.Repeat([]byte{0x66}, maxHMACKeyLength),
+		RecvCipherKey: bytes.Repeat([]byte{0x77}, 16),
+		RecvHMACKey:   bytes.Repeat([]byte{0x88}, maxHMACKeyLength),
+	}
+	serverKeys2 := &KeyMaterial{
+		SendCipherKey: clientKeys2.RecvCipherKey,
+		SendHMACKey:   clientKeys2.RecvHMACKey,
+		RecvCipherKey: clientKeys2.SendCipherKey,
+		RecvHMACKey:   clientKeys2.SendHMACKey,
+	}
+	client, err := NewDataChannel(clientKeys1, CipherAES128GCM, AuthSHA256, 7, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	server, err := NewDataChannel(serverKeys1, CipherAES128GCM, AuthSHA256, 7, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	oldPacket := []byte{0x45, 0, 0, 20, 1, 2, 3, 4, 64, 6, 0, 0, 10, 8, 0, 2, 1, 1, 1, 1}
+	oldEncrypted, err := client.Encrypt(oldPacket)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, keyID := parseOpcodeKeyID(oldEncrypted[0]); keyID != 0 {
+		t.Fatalf("unexpected initial key id: %d", keyID)
+	}
+
+	if err := client.Rekey(clientKeys2, CipherAES128GCM, AuthSHA256, 7, ""); err != nil {
+		t.Fatal(err)
+	}
+	if err := server.Rekey(serverKeys2, CipherAES128GCM, AuthSHA256, 7, ""); err != nil {
+		t.Fatal(err)
+	}
+	newPacket := []byte{0x45, 0, 0, 20, 1, 2, 3, 5, 64, 6, 0, 0, 10, 8, 0, 2, 1, 1, 1, 1}
+	newEncrypted, err := client.Encrypt(newPacket)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, keyID := parseOpcodeKeyID(newEncrypted[0]); keyID != 1 {
+		t.Fatalf("unexpected rotated key id: %d", keyID)
+	}
+
+	plain, err := server.Decrypt(oldEncrypted)
+	if err != nil {
+		t.Fatalf("old key overlap decrypt failed: %v", err)
+	}
+	if !bytes.Equal(plain, oldPacket) {
+		t.Fatalf("unexpected old plaintext: %x", plain)
+	}
+	plain, err = server.Decrypt(newEncrypted)
+	if err != nil {
+		t.Fatalf("new key decrypt failed: %v", err)
+	}
+	if !bytes.Equal(plain, newPacket) {
+		t.Fatalf("unexpected new plaintext: %x", plain)
+	}
+}
+
+func TestDataChannelRetiresPreviousReceiveKeys(t *testing.T) {
+	clientKeys1 := &KeyMaterial{
+		SendCipherKey: bytes.Repeat([]byte{0x11}, 16),
+		SendHMACKey:   bytes.Repeat([]byte{0x22}, maxHMACKeyLength),
+		RecvCipherKey: bytes.Repeat([]byte{0x33}, 16),
+		RecvHMACKey:   bytes.Repeat([]byte{0x44}, maxHMACKeyLength),
+	}
+	serverKeys1 := &KeyMaterial{
+		SendCipherKey: clientKeys1.RecvCipherKey,
+		SendHMACKey:   clientKeys1.RecvHMACKey,
+		RecvCipherKey: clientKeys1.SendCipherKey,
+		RecvHMACKey:   clientKeys1.SendHMACKey,
+	}
+	clientKeys2 := &KeyMaterial{
+		SendCipherKey: bytes.Repeat([]byte{0x55}, 16),
+		SendHMACKey:   bytes.Repeat([]byte{0x66}, maxHMACKeyLength),
+		RecvCipherKey: bytes.Repeat([]byte{0x77}, 16),
+		RecvHMACKey:   bytes.Repeat([]byte{0x88}, maxHMACKeyLength),
+	}
+	serverKeys2 := &KeyMaterial{
+		SendCipherKey: clientKeys2.RecvCipherKey,
+		SendHMACKey:   clientKeys2.RecvHMACKey,
+		RecvCipherKey: clientKeys2.SendCipherKey,
+		RecvHMACKey:   clientKeys2.SendHMACKey,
+	}
+	client, err := NewDataChannel(clientKeys1, CipherAES128GCM, AuthSHA256, 7, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	server, err := NewDataChannel(serverKeys1, CipherAES128GCM, AuthSHA256, 7, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	oldEncrypted, err := client.Encrypt([]byte{0x45, 0, 0, 20, 1, 2, 3, 4, 64, 6, 0, 0, 10, 8, 0, 2, 1, 1, 1, 1})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := server.Rekey(serverKeys2, CipherAES128GCM, AuthSHA256, 7, ""); err != nil {
+		t.Fatal(err)
+	}
+	server.RetirePreviousKeys()
+	if _, err := server.Decrypt(oldEncrypted); err == nil {
+		t.Fatal("expected retired old key to reject packet")
+	}
+}
+
+func TestDataChannelKeepsOnlyImmediatePreviousReceiveKey(t *testing.T) {
+	keys1 := &KeyMaterial{
+		SendCipherKey: bytes.Repeat([]byte{0x11}, 16),
+		SendHMACKey:   bytes.Repeat([]byte{0x22}, maxHMACKeyLength),
+		RecvCipherKey: bytes.Repeat([]byte{0x33}, 16),
+		RecvHMACKey:   bytes.Repeat([]byte{0x44}, maxHMACKeyLength),
+	}
+	keys2 := &KeyMaterial{
+		SendCipherKey: bytes.Repeat([]byte{0x55}, 16),
+		SendHMACKey:   bytes.Repeat([]byte{0x66}, maxHMACKeyLength),
+		RecvCipherKey: bytes.Repeat([]byte{0x77}, 16),
+		RecvHMACKey:   bytes.Repeat([]byte{0x88}, maxHMACKeyLength),
+	}
+	keys3 := &KeyMaterial{
+		SendCipherKey: bytes.Repeat([]byte{0x99}, 16),
+		SendHMACKey:   bytes.Repeat([]byte{0xaa}, maxHMACKeyLength),
+		RecvCipherKey: bytes.Repeat([]byte{0xbb}, 16),
+		RecvHMACKey:   bytes.Repeat([]byte{0xcc}, maxHMACKeyLength),
+	}
+	channel, err := NewDataChannel(keys1, CipherAES128GCM, AuthSHA256, 7, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := channel.Rekey(keys2, CipherAES128GCM, AuthSHA256, 7, ""); err != nil {
+		t.Fatal(err)
+	}
+	if err := channel.Rekey(keys3, CipherAES128GCM, AuthSHA256, 7, ""); err != nil {
+		t.Fatal(err)
+	}
+	if channel.recvKey(0) != nil {
+		t.Fatal("expected key id 0 to be retired after two rekeys")
+	}
+	if channel.recvKey(1) == nil {
+		t.Fatal("expected key id 1 to remain as immediate previous key")
+	}
+	if channel.recvKey(2) == nil {
+		t.Fatal("expected key id 2 to be active")
+	}
+}
+
 func TestDataChannelAcceptsOutOfOrderPacketsWithinReplayWindow(t *testing.T) {
 	clientKeys := &KeyMaterial{
 		SendCipherKey: bytes.Repeat([]byte{0x11}, 16),
@@ -75,11 +235,11 @@ func TestDataChannelAcceptsOutOfOrderPacketsWithinReplayWindow(t *testing.T) {
 		RecvCipherKey: clientKeys.SendCipherKey,
 		RecvHMACKey:   clientKeys.SendHMACKey,
 	}
-	client, err := NewDataChannel(clientKeys, CipherAES128GCM, AuthSHA256, 7)
+	client, err := NewDataChannel(clientKeys, CipherAES128GCM, AuthSHA256, 7, "")
 	if err != nil {
 		t.Fatal(err)
 	}
-	server, err := NewDataChannel(serverKeys, CipherAES128GCM, AuthSHA256, 7)
+	server, err := NewDataChannel(serverKeys, CipherAES128GCM, AuthSHA256, 7, "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -154,11 +314,11 @@ func TestDataChannelChaCha20Poly1305V2RoundTrip(t *testing.T) {
 		RecvCipherKey: clientKeys.SendCipherKey,
 		RecvHMACKey:   clientKeys.SendHMACKey,
 	}
-	client, err := NewDataChannel(clientKeys, CipherChaCha20Poly1305, AuthSHA256, 7)
+	client, err := NewDataChannel(clientKeys, CipherChaCha20Poly1305, AuthSHA256, 7, "")
 	if err != nil {
 		t.Fatal(err)
 	}
-	server, err := NewDataChannel(serverKeys, CipherChaCha20Poly1305, AuthSHA256, 7)
+	server, err := NewDataChannel(serverKeys, CipherChaCha20Poly1305, AuthSHA256, 7, "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -194,11 +354,11 @@ func TestDataChannelAESCBCSHA1V2RoundTrip(t *testing.T) {
 		RecvCipherKey: clientKeys.SendCipherKey,
 		RecvHMACKey:   clientKeys.SendHMACKey,
 	}
-	client, err := NewDataChannel(clientKeys, CipherAES128CBC, AuthSHA1, 7)
+	client, err := NewDataChannel(clientKeys, CipherAES128CBC, AuthSHA1, 7, "")
 	if err != nil {
 		t.Fatal(err)
 	}
-	server, err := NewDataChannel(serverKeys, CipherAES128CBC, AuthSHA1, 7)
+	server, err := NewDataChannel(serverKeys, CipherAES128CBC, AuthSHA1, 7, "")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/transport/openvpn/keymethod.go
+++ b/transport/openvpn/keymethod.go
@@ -153,7 +153,7 @@ func DeriveClientKeyMaterial(sources KeySource2, clientSession, serverSession Se
 	}, nil
 }
 
-func InstallScriptOptionsString(proto, cipher, auth string, compLZO string) string {
+func InstallScriptOptionsString(proto, cipher, auth string, compLZO string, tlsAuth bool, keyDirection int) string {
 	protoName := "UDPv4"
 	if proto == ProtoTCP {
 		protoName = "TCPv4_CLIENT"
@@ -168,7 +168,11 @@ func InstallScriptOptionsString(proto, cipher, auth string, compLZO string) stri
 		mtu = "1544"
 		comp = "comp-lzo,"
 	}
-	return fmt.Sprintf("V4,dev-type tun,link-mtu %s,tun-mtu 1500,proto %s,%scipher %s,auth %s,keysize %s,key-method 2,tls-client", mtu, protoName, comp, cipher, auth, keysize)
+	tlsAuthOptions := ""
+	if tlsAuth {
+		tlsAuthOptions = fmt.Sprintf("keydir %d,tls-auth,", keyDirection)
+	}
+	return fmt.Sprintf("V4,dev-type tun,link-mtu %s,tun-mtu 1500,proto %s,%s%scipher %s,auth %s,keysize %s,key-method 2,tls-client", mtu, protoName, comp, tlsAuthOptions, cipher, auth, keysize)
 }
 
 func InstallScriptPeerInfo(cipher string, compLZO string) string {
@@ -176,7 +180,7 @@ func InstallScriptPeerInfo(cipher string, compLZO string) string {
 	if compLZO == CompLzoYes {
 		lzo = "IV_LZO=1\n"
 	}
-	return fmt.Sprintf("IV_VER=mihomo-openvpn\nIV_PROTO=6\n%sIV_CIPHERS=%s\n", lzo, cipher)
+	return fmt.Sprintf("IV_VER=mihomo-openvpn\nIV_PROTO=6\nIV_NCP=2\n%sIV_CIPHERS=%s\n", lzo, cipher)
 }
 
 func appendOpenVPNString(out []byte, s string) []byte {

--- a/transport/openvpn/keymethod_test.go
+++ b/transport/openvpn/keymethod_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestKeyMethod2ClientMarshalAndDerive(t *testing.T) {
 	record := &KeyMethod2Record{
-		Options:  InstallScriptOptionsString(ProtoUDP, CipherAES128GCM, AuthSHA256, ""),
+		Options:  InstallScriptOptionsString(ProtoUDP, CipherAES128GCM, AuthSHA256, "", false, 0),
 		PeerInfo: InstallScriptPeerInfo(CipherAES128GCM, ""),
 	}
 	for i := range record.Sources.Client.PreMaster {
@@ -52,7 +52,7 @@ func TestKeyMethod2ClientMarshalAndDerive(t *testing.T) {
 
 func TestKeyMethod2DeriveAES256(t *testing.T) {
 	record := &KeyMethod2Record{
-		Options:  InstallScriptOptionsString(ProtoUDP, CipherAES256GCM, AuthSHA256, ""),
+		Options:  InstallScriptOptionsString(ProtoUDP, CipherAES256GCM, AuthSHA256, "", false, 0),
 		PeerInfo: InstallScriptPeerInfo(CipherAES256GCM, ""),
 	}
 	for i := range record.Sources.Client.PreMaster {
@@ -83,8 +83,17 @@ func TestKeyMethod2DeriveAES256(t *testing.T) {
 }
 
 func TestInstallScriptOptionsCBCSHA1(t *testing.T) {
-	options := InstallScriptOptionsString(ProtoTCP, CipherAES256CBC, AuthSHA1, "")
+	options := InstallScriptOptionsString(ProtoTCP, CipherAES256CBC, AuthSHA1, "", false, 0)
 	for _, want := range []string{"proto TCPv4_CLIENT", "cipher AES-256-CBC", "auth SHA1", "keysize 256"} {
+		if !bytes.Contains([]byte(options), []byte(want)) {
+			t.Fatalf("options missing %q: %s", want, options)
+		}
+	}
+}
+
+func TestInstallScriptOptionsTLSAuth(t *testing.T) {
+	options := InstallScriptOptionsString(ProtoUDP, CipherAES256CBC, AuthSHA256, "", true, 1)
+	for _, want := range []string{"proto UDPv4", "keydir 1", "tls-auth", "cipher AES-256-CBC", "auth SHA256"} {
 		if !bytes.Contains([]byte(options), []byte(want)) {
 			t.Fatalf("options missing %q: %s", want, options)
 		}

--- a/transport/openvpn/packet.go
+++ b/transport/openvpn/packet.go
@@ -167,7 +167,7 @@ func DecodeControlPlain(opcode Opcode, plain []byte) (ackIDs []uint32, ackRemote
 	return ackIDs, ackRemote, messageID, payload, nil
 }
 
-func (p ControlPacket) Encode(crypt *TLSCrypt, packetID uint32, unixTime uint32) ([]byte, error) {
+func (p ControlPacket) Encode(crypt ControlProtection, packetID uint32, unixTime uint32) ([]byte, error) {
 	plain, err := p.EncodePlain()
 	if err != nil {
 		return nil, err
@@ -185,7 +185,7 @@ func (p ControlPacket) Encode(crypt *TLSCrypt, packetID uint32, unixTime uint32)
 	return crypt.Wrap(header, packetID, unixTime, plain)
 }
 
-func DecodeControlPacket(crypt *TLSCrypt, packet []byte) (*ControlPacket, uint32, uint32, error) {
+func DecodeControlPacket(crypt ControlProtection, packet []byte) (*ControlPacket, uint32, uint32, error) {
 	if crypt == nil {
 		if len(packet) < TLSCryptHeaderSize+1 {
 			return nil, 0, 0, errors.New("control packet too short")

--- a/transport/openvpn/packet_test.go
+++ b/transport/openvpn/packet_test.go
@@ -58,6 +58,59 @@ func TestControlPacketEncodeDecodeWithTLSCrypt(t *testing.T) {
 	}
 }
 
+func TestControlPacketEncodeDecodeWithTLSAuth(t *testing.T) {
+	authClient, err := NewTLSAuth(testStaticKey(), AuthSHA256, 1, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	authServer, err := NewTLSAuth(testStaticKey(), AuthSHA256, 1, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var local SessionID
+	copy(local[:], []byte("client01"))
+	var remote SessionID
+	copy(remote[:], []byte("server01"))
+
+	packet := ControlPacket{
+		Opcode:           PControlV1,
+		KeyID:            0,
+		LocalSession:     local,
+		AckIDs:           []uint32{3, 4},
+		AckRemoteSession: remote,
+		MessageID:        9,
+		Payload:          []byte("tls-auth plaintext"),
+	}
+	encoded, err := packet.Encode(authClient, 77, 1714567890)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	decoded, packetID, unixTime, err := DecodeControlPacket(authServer, encoded)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if packetID != 77 || unixTime != 1714567890 {
+		t.Fatalf("unexpected tls-auth packet id/time: %d/%d", packetID, unixTime)
+	}
+	if decoded.Opcode != packet.Opcode || decoded.KeyID != packet.KeyID {
+		t.Fatalf("unexpected opcode/key-id: %s/%d", decoded.Opcode, decoded.KeyID)
+	}
+	if decoded.LocalSession != local {
+		t.Fatalf("unexpected local session: %x", decoded.LocalSession)
+	}
+	if !bytes.Equal(decoded.Payload, packet.Payload) {
+		t.Fatalf("unexpected payload: %q", decoded.Payload)
+	}
+	if len(decoded.AckIDs) != 2 || decoded.AckIDs[0] != 3 || decoded.AckIDs[1] != 4 {
+		t.Fatalf("unexpected ack ids: %#v", decoded.AckIDs)
+	}
+	if decoded.AckRemoteSession != remote {
+		t.Fatalf("unexpected ack remote session: %x", decoded.AckRemoteSession)
+	}
+}
+
 func TestControlPacketEncodeDecodePlain(t *testing.T) {
 	var local SessionID
 	copy(local[:], []byte("client01"))

--- a/transport/openvpn/push.go
+++ b/transport/openvpn/push.go
@@ -5,18 +5,24 @@ import (
 	"net/netip"
 	"strconv"
 	"strings"
+	"time"
 )
 
 const PushRequest = "PUSH_REQUEST"
 
 type PushReply struct {
-	Raw       string
-	Prefixes  []netip.Prefix
-	Routes    []netip.Prefix
-	DNS       []netip.Addr
-	PeerID    uint32
-	Redirect  bool
-	BlockIPv6 bool
+	Raw                string
+	Prefixes           []netip.Prefix
+	Routes             []netip.Prefix
+	DNS                []netip.Addr
+	PeerID             uint32
+	Redirect           bool
+	BlockIPv6          bool
+	PingInterval       time.Duration
+	PingRestart        time.Duration
+	RenegotiateAfter   time.Duration
+	InactiveAfter      time.Duration
+	ExplicitExitNotify bool
 }
 
 func ParsePushReply(message string) (*PushReply, error) {
@@ -84,12 +90,46 @@ func ParsePushReply(message string) (*PushReply, error) {
 			reply.Redirect = true
 		case "block-ipv6":
 			reply.BlockIPv6 = true
+		case "ping":
+			if len(fields) >= 2 {
+				if d, ok := parsePushDurationSeconds(fields[1]); ok {
+					reply.PingInterval = d
+				}
+			}
+		case "ping-restart":
+			if len(fields) >= 2 {
+				if d, ok := parsePushDurationSeconds(fields[1]); ok {
+					reply.PingRestart = d
+				}
+			}
+		case "reneg-sec":
+			if len(fields) >= 2 {
+				if d, ok := parsePushDurationSeconds(fields[1]); ok {
+					reply.RenegotiateAfter = d
+				}
+			}
+		case "inactive":
+			if len(fields) >= 2 {
+				if d, ok := parsePushDurationSeconds(fields[1]); ok {
+					reply.InactiveAfter = d
+				}
+			}
+		case "explicit-exit-notify":
+			reply.ExplicitExitNotify = true
 		}
 	}
 	if len(reply.Prefixes) == 0 {
 		return nil, fmt.Errorf("openvpn push reply missing ifconfig address")
 	}
 	return reply, nil
+}
+
+func parsePushDurationSeconds(value string) (time.Duration, bool) {
+	seconds, err := strconv.Atoi(value)
+	if err != nil || seconds <= 0 {
+		return 0, false
+	}
+	return time.Duration(seconds) * time.Second, true
 }
 
 func splitPushOptions(message string) []string {
@@ -106,6 +146,30 @@ func splitPushOptions(message string) []string {
 		}
 	}
 	return out
+}
+
+func splitPushReplyOptions(message string) ([]string, int) {
+	options := splitPushOptions(message)
+	out := options[:0]
+	continuation := 0
+	for _, option := range options {
+		fields := strings.Fields(option)
+		if len(fields) == 2 && fields[0] == "push-continuation" {
+			if value, err := strconv.Atoi(fields[1]); err == nil {
+				continuation = value
+			}
+			continue
+		}
+		out = append(out, option)
+	}
+	return out, continuation
+}
+
+func joinPushReplyOptions(options []string) string {
+	if len(options) == 0 {
+		return "PUSH_REPLY"
+	}
+	return "PUSH_REPLY," + strings.Join(options, ",")
 }
 
 func parseIPv4Ifconfig(address, maskOrPeer string) (netip.Prefix, error) {

--- a/transport/openvpn/push_test.go
+++ b/transport/openvpn/push_test.go
@@ -1,0 +1,55 @@
+package openvpn
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestPushReplyContinuation(t *testing.T) {
+	part1 := "PUSH_REPLY,route 198.51.100.0 255.255.255.0,dhcp-option DNS 203.0.113.10,push-continuation 2"
+	part2 := "PUSH_REPLY,ifconfig 198.51.100.44 255.255.255.0,peer-id 7,push-continuation 1"
+
+	options1, continuation1 := splitPushReplyOptions(part1)
+	if continuation1 != 2 {
+		t.Fatalf("unexpected first continuation: %d", continuation1)
+	}
+	options2, continuation2 := splitPushReplyOptions(part2)
+	if continuation2 != 1 {
+		t.Fatalf("unexpected second continuation: %d", continuation2)
+	}
+	combined := joinPushReplyOptions(append(options1, options2...))
+	if strings.Contains(combined, "push-continuation") {
+		t.Fatalf("combined push reply should not contain continuation markers: %s", combined)
+	}
+
+	reply, err := ParsePushReply(combined)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(reply.Prefixes) != 1 || reply.PeerID != 7 || len(reply.DNS) != 1 {
+		t.Fatalf("unexpected parsed continuation reply: %#v", reply)
+	}
+}
+
+func TestParsePushReplyKeepaliveAndRekeyOptions(t *testing.T) {
+	reply, err := ParsePushReply("PUSH_REPLY,ifconfig 198.51.100.2 255.255.255.0,peer-id 9,ping 10,ping-restart 60,reneg-sec 3600,inactive 7200 0,explicit-exit-notify")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if reply.PingInterval != 10*time.Second {
+		t.Fatalf("unexpected ping interval: %s", reply.PingInterval)
+	}
+	if reply.PingRestart != time.Minute {
+		t.Fatalf("unexpected ping restart: %s", reply.PingRestart)
+	}
+	if reply.RenegotiateAfter != time.Hour {
+		t.Fatalf("unexpected reneg-sec: %s", reply.RenegotiateAfter)
+	}
+	if reply.InactiveAfter != 2*time.Hour {
+		t.Fatalf("unexpected inactive timeout: %s", reply.InactiveAfter)
+	}
+	if !reply.ExplicitExitNotify {
+		t.Fatal("expected explicit-exit-notify to be parsed")
+	}
+}

--- a/transport/openvpn/tlsauth.go
+++ b/transport/openvpn/tlsauth.go
@@ -1,0 +1,128 @@
+package openvpn
+
+import (
+	"crypto/hmac"
+	"crypto/md5"
+	"crypto/sha1"
+	"crypto/sha256"
+	"crypto/sha512"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"hash"
+)
+
+type TLSAuth struct {
+	signKey    []byte
+	verifyKey  []byte
+	newHash    func() hash.Hash
+	digestSize int
+}
+
+func NewTLSAuth(staticKey []byte, auth string, keyDirection int, client bool) (*TLSAuth, error) {
+	if len(staticKey) != staticKeySize {
+		return nil, fmt.Errorf("invalid tls-auth static key length %d, expected %d", len(staticKey), staticKeySize)
+	}
+	if keyDirection != 0 && keyDirection != 1 {
+		return nil, fmt.Errorf("unsupported tls-auth key-direction %d: only 0 and 1 are supported", keyDirection)
+	}
+	newHash, digestSize, err := tlsAuthHash(auth)
+	if err != nil {
+		return nil, err
+	}
+
+	key0 := staticKey[:keySlotSize]
+	key1 := staticKey[keySlotSize:]
+	sign := key0
+	verify := key1
+	if client {
+		if keyDirection == 1 {
+			sign = key1
+			verify = key0
+		}
+	} else if keyDirection == 1 {
+		sign = key0
+		verify = key1
+	}
+
+	return &TLSAuth{
+		signKey:    cloneBytes(sign[64 : 64+digestSize]),
+		verifyKey:  cloneBytes(verify[64 : 64+digestSize]),
+		newHash:    newHash,
+		digestSize: digestSize,
+	}, nil
+}
+
+func tlsAuthHash(auth string) (func() hash.Hash, int, error) {
+	switch normalizeAuth(auth) {
+	case AuthMD5:
+		return md5.New, md5.Size, nil
+	case AuthSHA1:
+		return sha1.New, sha1.Size, nil
+	case AuthSHA256:
+		return sha256.New, sha256.Size, nil
+	case AuthSHA384:
+		return sha512.New384, sha512.Size384, nil
+	case AuthSHA512:
+		return sha512.New, sha512.Size, nil
+	default:
+		return nil, 0, fmt.Errorf("unsupported tls-auth digest %q", auth)
+	}
+}
+
+func (a *TLSAuth) Wrap(header []byte, packetID uint32, unixTime uint32, plaintext []byte) ([]byte, error) {
+	if len(header) != TLSCryptHeaderSize {
+		return nil, fmt.Errorf("invalid tls-auth header length %d, expected %d", len(header), TLSCryptHeaderSize)
+	}
+
+	var pid [TLSCryptPIDSize]byte
+	binary.BigEndian.PutUint32(pid[:4], packetID)
+	binary.BigEndian.PutUint32(pid[4:], unixTime)
+	tag := a.hmac(pid[:], header, plaintext)
+
+	out := make([]byte, 0, len(header)+len(tag)+len(pid)+len(plaintext))
+	out = append(out, header...)
+	out = append(out, tag...)
+	out = append(out, pid[:]...)
+	out = append(out, plaintext...)
+	return out, nil
+}
+
+func (a *TLSAuth) Unwrap(packet []byte) (header []byte, packetID uint32, unixTime uint32, plaintext []byte, err error) {
+	if len(packet) < TLSCryptHeaderSize+a.digestSize+TLSCryptPIDSize+1 {
+		return nil, 0, 0, nil, errors.New("tls-auth packet too short")
+	}
+
+	header = cloneBytes(packet[:TLSCryptHeaderSize])
+	tagStart := TLSCryptHeaderSize
+	tagEnd := tagStart + a.digestSize
+	pidEnd := tagEnd + TLSCryptPIDSize
+	tag := packet[tagStart:tagEnd]
+	pid := packet[tagEnd:pidEnd]
+	plaintext = packet[pidEnd:]
+
+	tagCheck := a.verifyHMAC(pid, header, plaintext)
+	if !hmac.Equal(tag, tagCheck) {
+		return nil, 0, 0, nil, errors.New("tls-auth authentication failed")
+	}
+
+	packetID = binary.BigEndian.Uint32(pid[:4])
+	unixTime = binary.BigEndian.Uint32(pid[4:])
+	return header, packetID, unixTime, cloneBytes(plaintext), nil
+}
+
+func (a *TLSAuth) hmac(parts ...[]byte) []byte {
+	mac := hmac.New(a.newHash, a.signKey)
+	for _, part := range parts {
+		_, _ = mac.Write(part)
+	}
+	return mac.Sum(nil)
+}
+
+func (a *TLSAuth) verifyHMAC(parts ...[]byte) []byte {
+	mac := hmac.New(a.newHash, a.verifyKey)
+	for _, part := range parts {
+		_, _ = mac.Write(part)
+	}
+	return mac.Sum(nil)
+}

--- a/transport/openvpn/tlsauth_test.go
+++ b/transport/openvpn/tlsauth_test.go
@@ -1,0 +1,95 @@
+package openvpn
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestTLSAuthClientServerRoundTrip(t *testing.T) {
+	client, err := NewTLSAuth(testStaticKey(), AuthSHA256, 1, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(client.signKey) != 32 {
+		t.Fatalf("unexpected SHA256 tls-auth signing key length: %d", len(client.signKey))
+	}
+	server, err := NewTLSAuth(testStaticKey(), AuthSHA256, 1, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	header := []byte{0x38, 1, 2, 3, 4, 5, 6, 7, 8}
+	plaintext := []byte("client hello over openvpn control channel")
+	packet, err := client.Wrap(header, 7, 1714567890, plaintext)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := TLSCryptHeaderSize + 32 + TLSCryptPIDSize + len(plaintext); len(packet) != want {
+		t.Fatalf("unexpected tls-auth packet length: got %d, want %d", len(packet), want)
+	}
+
+	gotHeader, packetID, unixTime, gotPlaintext, err := server.Unwrap(packet)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(gotHeader, header) {
+		t.Fatalf("unexpected header: %x", gotHeader)
+	}
+	if packetID != 7 || unixTime != 1714567890 {
+		t.Fatalf("unexpected packet id/time: %d/%d", packetID, unixTime)
+	}
+	if !bytes.Equal(gotPlaintext, plaintext) {
+		t.Fatalf("unexpected plaintext: %q", gotPlaintext)
+	}
+}
+
+func TestTLSAuthServerClientRoundTrip(t *testing.T) {
+	client, err := NewTLSAuth(testStaticKey(), AuthSHA256, 1, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	server, err := NewTLSAuth(testStaticKey(), AuthSHA256, 1, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	header := []byte{0x40, 8, 7, 6, 5, 4, 3, 2, 1}
+	plaintext := []byte("server hello over openvpn control channel")
+	packet, err := server.Wrap(header, 9, 1714567900, plaintext)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, packetID, unixTime, gotPlaintext, err := client.Unwrap(packet)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if packetID != 9 || unixTime != 1714567900 {
+		t.Fatalf("unexpected packet id/time: %d/%d", packetID, unixTime)
+	}
+	if !bytes.Equal(gotPlaintext, plaintext) {
+		t.Fatalf("unexpected plaintext: %q", gotPlaintext)
+	}
+}
+
+func TestTLSAuthRejectsTamperedPacket(t *testing.T) {
+	client, err := NewTLSAuth(testStaticKey(), AuthSHA256, 1, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	server, err := NewTLSAuth(testStaticKey(), AuthSHA256, 1, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	packet, err := client.Wrap([]byte{0x38, 1, 2, 3, 4, 5, 6, 7, 8}, 7, 1714567890, []byte("hello"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	packet[len(packet)-1] ^= 0xff
+
+	_, _, _, _, err = server.Unwrap(packet)
+	if err == nil {
+		t.Fatal("expected authentication failure")
+	}
+}

--- a/transport/openvpn/tlscrypt.go
+++ b/transport/openvpn/tlscrypt.go
@@ -28,6 +28,11 @@ type TLSCrypt struct {
 	decryptHMACKey   []byte
 }
 
+type ControlProtection interface {
+	Wrap(header []byte, packetID uint32, unixTime uint32, plaintext []byte) ([]byte, error)
+	Unwrap(packet []byte) (header []byte, packetID uint32, unixTime uint32, plaintext []byte, err error)
+}
+
 func NewTLSCrypt(staticKey []byte, client bool) (*TLSCrypt, error) {
 	if len(staticKey) != staticKeySize {
 		return nil, fmt.Errorf("invalid tls-crypt static key length %d, expected %d", len(staticKey), staticKeySize)


### PR DESCRIPTION
## Summary

This PR improves OpenVPN interoperability in two areas:

- adds `tls-auth` / `key-direction` support and advertises the matching key-method options
- keeps the OpenVPN control channel alive, parses pushed keepalive/renegotiation options, and supports in-place soft rekey instead of forcing a full reconnect
- rotates data-channel key IDs during rekey and keeps the previous receive key for a short overlap window

The changes are limited to the OpenVPN outbound/runtime and tests.

## Tests

```bash
go test ./transport/openvpn ./adapter/outbound
```