### PR TITLE
fix(openvpn): initialize client write semaphore

### DIFF
--- a/transport/openvpn/client.go
+++ b/transport/openvpn/client.go
@@ -61,10 +61,11 @@ func NewClient(config *ClientConfig, io PacketIO) (*Client, error) {
 	mux := NewPacketMux(io)
 	go mux.Run(runCtx)
 	client := &Client{
-		config:  config,
-		mux:     mux,
-		control: NewControlChannel(mux, crypt, local),
-		cancel:  cancel,
+		config:   config,
+		mux:      mux,
+		control:  NewControlChannel(mux, crypt, local),
+		cancel:   cancel,
+		writeSem: *semaphore.NewWeighted(1),
 	}
 	client.markSend()
 	client.markReceive()

--- a/transport/openvpn/client_test.go
+++ b/transport/openvpn/client_test.go
@@ -1,0 +1,41 @@
+package openvpn
+
+import (
+	"bytes"
+	"context"
+	"testing"
+	"time"
+)
+
+func TestClientWriteIPPacketDoesNotWaitForContextDeadline(t *testing.T) {
+	clientIO, peerIO := newMemoryPacketPair()
+	client, err := NewClient(&ClientConfig{Cipher: CipherAES128GCM, Auth: AuthSHA256}, clientIO)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer client.Close()
+
+	clientKeys := &KeyMaterial{
+		SendCipherKey: bytes.Repeat([]byte{0x11}, 16),
+		SendHMACKey:   bytes.Repeat([]byte{0x22}, maxHMACKeyLength),
+		RecvCipherKey: bytes.Repeat([]byte{0x33}, 16),
+		RecvHMACKey:   bytes.Repeat([]byte{0x44}, maxHMACKeyLength),
+	}
+	client.data, err = NewDataChannel(clientKeys, CipherAES128GCM, AuthSHA256, 7)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+	if err := client.WriteIPPacket(ctx, []byte{0x45, 0, 0, 20}); err != nil {
+		t.Fatal(err)
+	}
+	packet, err := peerIO.ReadPacket(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(packet) == 0 {
+		t.Fatal("expected encrypted packet")
+	}
+}


### PR DESCRIPTION
Summary:
- initialize Client.writeSem in NewClient
- add regression test that WriteIPPacket does not wait for the context deadline

Tests:
- go test ./transport/openvpn