### PR TITLE
feat: support SRC-IP-CIDR in fake-ip filter rules

### DIFF
--- a/component/fakeip/skipper.go
+++ b/component/fakeip/skipper.go
@@ -1,6 +1,8 @@
 package fakeip
 
 import (
+	"net/netip"
+
 	C "github.com/metacubex/mihomo/constant"
 )
 
@@ -16,9 +18,9 @@ type Skipper struct {
 }
 
 // ShouldSkipped return if domain should be skipped
-func (p *Skipper) ShouldSkipped(domain string) bool {
+func (p *Skipper) ShouldSkipped(domain string, sourceIP netip.Addr) bool {
 	if len(p.Rules) > 0 {
-		metadata := &C.Metadata{Host: domain}
+		metadata := &C.Metadata{Host: domain, SrcIP: sourceIP}
 		for _, rule := range p.Rules {
 			if matched, action := rule.Match(metadata, C.RuleMatchHelper{}); matched {
 				return action == UseRealIP

--- a/component/fakeip/skipper_test.go
+++ b/component/fakeip/skipper_test.go
@@ -1,10 +1,12 @@
 package fakeip
 
 import (
+	"net/netip"
 	"testing"
 
 	"github.com/metacubex/mihomo/component/trie"
 	C "github.com/metacubex/mihomo/constant"
+	RC "github.com/metacubex/mihomo/rules/common"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -16,8 +18,8 @@ func TestSkipper_BlackList(t *testing.T) {
 	skipper := &Skipper{
 		Host: []C.DomainMatcher{tree.NewDomainSet()},
 	}
-	assert.True(t, skipper.ShouldSkipped("example.com"))
-	assert.False(t, skipper.ShouldSkipped("foo.com"))
+	assert.True(t, skipper.ShouldSkipped("example.com", netip.Addr{}))
+	assert.False(t, skipper.ShouldSkipped("foo.com", netip.Addr{}))
 	assert.False(t, skipper.shouldSkipped("baz.com"))
 }
 
@@ -29,7 +31,19 @@ func TestSkipper_WhiteList(t *testing.T) {
 		Host: []C.DomainMatcher{tree.NewDomainSet()},
 		Mode: C.FilterWhiteList,
 	}
-	assert.False(t, skipper.ShouldSkipped("example.com"))
-	assert.True(t, skipper.ShouldSkipped("foo.com"))
-	assert.True(t, skipper.ShouldSkipped("baz.com"))
+	assert.False(t, skipper.ShouldSkipped("example.com", netip.Addr{}))
+	assert.True(t, skipper.ShouldSkipped("foo.com", netip.Addr{}))
+	assert.True(t, skipper.ShouldSkipped("baz.com", netip.Addr{}))
+}
+
+func TestSkipper_RuleSourceIPCIDR(t *testing.T) {
+	rule, err := RC.NewIPCIDR("192.168.1.0/24", UseRealIP, RC.WithIPCIDRSourceIP(true), RC.WithIPCIDRNoResolve(true))
+	assert.NoError(t, err)
+
+	skipper := &Skipper{
+		Rules: []C.Rule{rule},
+	}
+
+	assert.True(t, skipper.ShouldSkipped("example.com", netip.MustParseAddr("192.168.1.10")))
+	assert.False(t, skipper.ShouldSkipped("example.com", netip.MustParseAddr("192.168.2.10")))
 }

--- a/config/config.go
+++ b/config/config.go
@@ -1613,7 +1613,7 @@ func parseFakeIPRules(rawRules []string, ruleProviders map[string]P.RuleProvider
 				case P.IPCIDR:
 					return nil, fmt.Errorf("dns.fake-ip-filter[%d] [%s] error: rule-set behavior is %s, must be domain or classical", idx, line, rp.Behavior())
 				case P.Classical:
-					log.Warnln("%s provider is %s, only matching domain rules in fake-ip-filter", rp.Name(), rp.Behavior())
+					log.Warnln("%s provider is %s, only matching domain and source IP rules in fake-ip-filter", rp.Name(), rp.Behavior())
 				default:
 				}
 			}
@@ -1624,8 +1624,8 @@ func parseFakeIPRules(rawRules []string, ruleProviders map[string]P.RuleProvider
 			return nil, fmt.Errorf("dns.fake-ip-filter[%d] [%s] error: %w", idx, line, err)
 		}
 
-		if !isDomainRule(parsed.RuleType()) && parsed.RuleType() != C.MATCH {
-			return nil, fmt.Errorf("dns.fake-ip-filter[%d] [%s] error: rule type '%s' not supported, only domain-based rules allowed", idx, line, tp)
+		if !isFakeIPFilterRule(parsed.RuleType()) {
+			return nil, fmt.Errorf("dns.fake-ip-filter[%d] [%s] error: rule type '%s' not supported, only domain-based rules, SRC-IP-CIDR and MATCH allowed", idx, line, tp)
 		}
 
 		rules = append(rules, parsed)
@@ -1634,9 +1634,9 @@ func parseFakeIPRules(rawRules []string, ruleProviders map[string]P.RuleProvider
 	return rules, nil
 }
 
-func isDomainRule(rt C.RuleType) bool {
+func isFakeIPFilterRule(rt C.RuleType) bool {
 	switch rt {
-	case C.Domain, C.DomainSuffix, C.DomainKeyword, C.DomainRegex, C.DomainWildcard, C.GEOSITE, C.RuleSet:
+	case C.Domain, C.DomainSuffix, C.DomainKeyword, C.DomainRegex, C.DomainWildcard, C.GEOSITE, C.RuleSet, C.SrcIPCIDR, C.MATCH:
 		return true
 	default:
 		return false

--- a/context/dns.go
+++ b/context/dns.go
@@ -2,6 +2,7 @@ package context
 
 import (
 	"context"
+	"net/netip"
 
 	"github.com/metacubex/mihomo/common/utils"
 
@@ -17,16 +18,30 @@ const (
 type DNSContext struct {
 	context.Context
 
-	id uuid.UUID
-	tp string
+	id       uuid.UUID
+	tp       string
+	sourceIP netip.Addr
+}
+
+type sourceIPKey struct{}
+
+func WithSourceIP(ctx context.Context, sourceIP netip.Addr) context.Context {
+	if !sourceIP.IsValid() {
+		return ctx
+	}
+	return context.WithValue(ctx, sourceIPKey{}, sourceIP)
 }
 
 func NewDNSContext(ctx context.Context) *DNSContext {
-	return &DNSContext{
+	dnsCtx := &DNSContext{
 		Context: ctx,
 
 		id: utils.NewUUIDV4(),
 	}
+	if sourceIP, ok := ctx.Value(sourceIPKey{}).(netip.Addr); ok {
+		dnsCtx.sourceIP = sourceIP
+	}
+	return dnsCtx
 }
 
 // ID implement C.PlainContext ID
@@ -42,4 +57,8 @@ func (c *DNSContext) SetType(tp string) {
 // Type return type of response
 func (c *DNSContext) Type() string {
 	return c.tp
+}
+
+func (c *DNSContext) SourceIP() netip.Addr {
+	return c.sourceIP
 }

--- a/dns/middleware.go
+++ b/dns/middleware.go
@@ -152,7 +152,7 @@ func withFakeIP(skipper *fakeip.Skipper, fakePool *fakeip.Pool, fakePool6 *fakei
 			q := r.Question[0]
 
 			host := strings.TrimRight(q.Name, ".")
-			if skipper.ShouldSkipped(host) {
+			if skipper.ShouldSkipped(host, ctx.SourceIP()) {
 				return next(ctx, r)
 			}
 

--- a/dns/server.go
+++ b/dns/server.go
@@ -3,10 +3,12 @@ package dns
 import (
 	"context"
 	"net"
+	"net/netip"
 
 	"github.com/metacubex/mihomo/common/sockopt"
 	"github.com/metacubex/mihomo/component/resolver"
 	C "github.com/metacubex/mihomo/constant"
+	icontext "github.com/metacubex/mihomo/context"
 	"github.com/metacubex/mihomo/log"
 
 	D "github.com/miekg/dns"
@@ -27,7 +29,11 @@ type Server struct {
 
 // ServeDNS implement D.Handler ServeDNS
 func (s *Server) ServeDNS(w D.ResponseWriter, r *D.Msg) {
-	msg, err := s.service.ServeMsg(context.Background(), r)
+	ctx := context.Background()
+	if sourceIP := dnsSourceIPFromAddr(w.RemoteAddr()); sourceIP.IsValid() {
+		ctx = icontext.WithSourceIP(ctx, sourceIP)
+	}
+	msg, err := s.service.ServeMsg(ctx, r)
 	if err != nil {
 		m := new(D.Msg)
 		m.SetRcode(r, D.RcodeServerFailure)
@@ -37,6 +43,21 @@ func (s *Server) ServeDNS(w D.ResponseWriter, r *D.Msg) {
 	}
 	msg.Compress = true
 	w.WriteMsg(msg)
+}
+
+func dnsSourceIPFromAddr(addr net.Addr) netip.Addr {
+	if addr == nil {
+		return netip.Addr{}
+	}
+	host, _, err := net.SplitHostPort(addr.String())
+	if err != nil {
+		return netip.Addr{}
+	}
+	sourceIP, err := netip.ParseAddr(host)
+	if err != nil {
+		return netip.Addr{}
+	}
+	return sourceIP.Unmap()
 }
 
 func (s *Server) SetService(service resolver.Service) {


### PR DESCRIPTION
Please consider adding rules based on SRC-IP-CIDR to the DNS fake IP mode rule.

I once suggested this as an idea here:
https://github.com/MetaCubeX/mihomo/discussions/2545
This would provide flexibility for those who use Mihomo as their DNS upstream on their network.

```yaml
dns:
  fake-ip-filter-mode: rule
  fake-ip-filter:
    - SRC-IP-CIDR,192.168.1.17/32,real-ip
    - MATCH,fake-ip
```    