### PR TITLE
feat: Add Support For tlsauth and openvpn scramble

### DIFF
--- a/adapter/outbound/openvpn.go
+++ b/adapter/outbound/openvpn.go
@@ -42,30 +42,44 @@ type OpenVPN struct {
 
 type OpenVPNOption struct {
 	BasicOption
-	Name        string `proxy:"name"`
-	Server      string `proxy:"server"`
-	Port        int    `proxy:"port"`
-	Proto       string `proxy:"proto,omitempty"`
-	Dev         string `proxy:"dev,omitempty"`
-	Cipher      string `proxy:"cipher,omitempty"`
-	Auth        string `proxy:"auth,omitempty"`
-	CompLZO     string `proxy:"comp-lzo,omitempty"`
-	CA          string `proxy:"ca"`
-	Cert        string `proxy:"cert,omitempty"`
-	Key         string `proxy:"key,omitempty"`
-	TLSCrypt    string `proxy:"tls-crypt,omitempty"`
-	Username    string `proxy:"username,omitempty"`
-	Password    string `proxy:"password,omitempty"`
-	Ping        int    `proxy:"ping,omitempty"`
-	PingRestart int    `proxy:"ping-restart,omitempty"`
-	MTU         int    `proxy:"mtu,omitempty"`
-	UDP         bool   `proxy:"udp,omitempty"`
+	Name         string `proxy:"name"`
+	Server       string `proxy:"server"`
+	Port         int    `proxy:"port"`
+	Proto        string `proxy:"proto,omitempty"`
+	Dev          string `proxy:"dev,omitempty"`
+	Cipher       string `proxy:"cipher,omitempty"`
+	Auth         string `proxy:"auth,omitempty"`
+	CompLZO      string `proxy:"comp-lzo,omitempty"`
+	CA           string `proxy:"ca"`
+	Cert         string `proxy:"cert,omitempty"`
+	Key          string `proxy:"key,omitempty"`
+	TLSCrypt     string `proxy:"tls-crypt,omitempty"`
+	TLSAuth      string `proxy:"tls-auth,omitempty"`
+	KeyDirection *int   `proxy:"key-direction,omitempty"`
+	Scramble     string `proxy:"scramble,omitempty"`
+	Username     string `proxy:"username,omitempty"`
+	Password     string `proxy:"password,omitempty"`
+	Ping         int    `proxy:"ping,omitempty"`
+	PingRestart  int    `proxy:"ping-restart,omitempty"`
+	MTU          int    `proxy:"mtu,omitempty"`
+	UDP          bool   `proxy:"udp,omitempty"`
 
 	RemoteDnsResolve bool     `proxy:"remote-dns-resolve,omitempty"`
 	Dns              []string `proxy:"dns,omitempty"`
 }
 
 func NewOpenVPN(option OpenVPNOption) (*OpenVPN, error) {
+	keyDirection := ovpn.KeyDirectionBidirectional
+	if option.KeyDirection != nil {
+		switch *option.KeyDirection {
+		case 0:
+			keyDirection = ovpn.KeyDirectionNormal
+		case 1:
+			keyDirection = ovpn.KeyDirectionInverse
+		default:
+			return nil, fmt.Errorf("unsupported openvpn key-direction %d", *option.KeyDirection)
+		}
+	}
 	cfg := &ovpn.ClientConfig{
 		RemoteHost:   option.Server,
 		RemotePort:   uint16(option.Port),
@@ -78,6 +92,9 @@ func NewOpenVPN(option OpenVPNOption) (*OpenVPN, error) {
 		Cert:         []byte(option.Cert),
 		Key:          []byte(option.Key),
 		TLSCrypt:     []byte(option.TLSCrypt),
+		TLSAuth:      []byte(option.TLSAuth),
+		KeyDirection: keyDirection,
+		ScrambleRaw:  option.Scramble,
 		Username:     option.Username,
 		Password:     option.Password,
 		PingInterval: time.Duration(option.Ping) * time.Second,
@@ -86,7 +103,6 @@ func NewOpenVPN(option OpenVPNOption) (*OpenVPN, error) {
 	if err := cfg.Prepare(); err != nil {
 		return nil, err
 	}
-
 	outbound := &OpenVPN{
 		Base: NewBase(BaseOption{
 			Name:         option.Name,
@@ -239,6 +255,7 @@ func (o *OpenVPN) run(ctx context.Context) (wireguard.Device, resolver.Resolver,
 		}
 		return nil, nil, E.Cause(err, "connect OpenVPN server")
 	}
+	log.Debugln("[OpenVPN](%s) connected %s over %s", o.name, o.addr, o.config.Proto)
 	client, err := ovpn.NewClient(o.config, packetIO)
 	if err != nil {
 		_ = packetIO.Close()
@@ -333,13 +350,13 @@ func (o *OpenVPN) openPacketIO(ctx context.Context) (ovpn.PacketIO, error) {
 		if err != nil {
 			return nil, err
 		}
-		return ovpn.NewDatagramPacketIO(conn), nil
+		return ovpn.NewScramblePacketIO(ovpn.NewDatagramPacketIO(conn), o.config.Scramble), nil
 	case ovpn.ProtoTCP:
 		conn, err := o.dialer.DialContext(ctx, "tcp", o.addr)
 		if err != nil {
 			return nil, err
 		}
-		return ovpn.NewTCPPacketIO(conn), nil
+		return ovpn.NewScramblePacketIO(ovpn.NewTCPPacketIO(conn), o.config.Scramble), nil
 	default:
 		return nil, fmt.Errorf("unsupported openvpn proto %q", o.config.Proto)
 	}
@@ -422,7 +439,6 @@ func (o *OpenVPN) startPacketLoops() {
 							}
 							return
 						}
-						log.Debugln("[OpenVPN](%s) sent ping packet after %s idle", o.name, sinceSend.Round(time.Second))
 					}
 				case <-runCtx.Done():
 					return

--- a/docs/config.yaml
+++ b/docs/config.yaml
@@ -107,13 +107,13 @@ external-doh-server: /dns-query
 
 # routing-mark:6666 # 配置 fwmark 仅用于 Linux
 experimental:
-  # Disable quic-go GSO support. This may result in reduced performance on Linux.
-  # This is not recommended for most users.
-  # Only users encountering issues with quic-go's internal implementation should enable this,
-  # and they should disable it as soon as the issue is resolved.
-  # This field will be removed when quic-go fixes all their issues in GSO.
-  # This equivalent to the environment variable QUIC_GO_DISABLE_GSO=1.
-  #quic-go-disable-gso: true
+# Disable quic-go GSO support. This may result in reduced performance on Linux.
+# This is not recommended for most users.
+# Only users encountering issues with quic-go's internal implementation should enable this,
+# and they should disable it as soon as the issue is resolved.
+# This field will be removed when quic-go fixes all their issues in GSO.
+# This equivalent to the environment variable QUIC_GO_DISABLE_GSO=1.
+#quic-go-disable-gso: true
 
 # 类似于 /etc/hosts, 仅支持配置单个 IP
 hosts:
@@ -579,12 +579,12 @@ proxies: # socks5
     password: [YOUR_SS_PASSWORD]
     client-fingerprint:
       chrome # One of: chrome, ios, firefox or safari
-      # 可以是 chrome, ios, firefox, safari 中的一个
+    # 可以是 chrome, ios, firefox, safari 中的一个
     plugin: restls
     plugin-opts:
       host:
         "www.microsoft.com" # Must be a TLS 1.3 server
-        # 应当是一个 TLS 1.3 服务器
+      # 应当是一个 TLS 1.3 服务器
       password: [YOUR_RESTLS_PASSWORD]
       version-hint: "tls13"
       # Control your post-handshake traffic through restls-script
@@ -602,12 +602,12 @@ proxies: # socks5
     password: [YOUR_SS_PASSWORD]
     client-fingerprint:
       chrome # One of: chrome, ios, firefox or safari
-      # 可以是 chrome, ios, firefox, safari 中的一个
+    # 可以是 chrome, ios, firefox, safari 中的一个
     plugin: restls
     plugin-opts:
       host:
         "vscode.dev" # Must be a TLS 1.2 server
-        # 应当是一个 TLS 1.2 服务器
+      # 应当是一个 TLS 1.2 服务器
       password: [YOUR_RESTLS_PASSWORD]
       version-hint: "tls12"
       restls-script: "1000?100<1,500~100,350~100,600~100,400~200"
@@ -654,29 +654,29 @@ proxies: # socks5
     uuid: uuid
     alterId: 32
     cipher: auto
-    # udp: true
-    # tls: true
-    # fingerprint: xxxx # 配置指纹将实现 SSL Pining 效果, 可使用 openssl x509 -noout -fingerprint -sha256 -inform pem -in yourcert.pem 获取
-    # 下面两项如果填写则开启 mTLS（需要同时填写）
-    # certificate: ./client.crt # 证书 PEM 格式，或者 证书的路径
-    # private-key: ./client.key # 证书对应的私钥 PEM 格式，或者私钥路径
-    # client-fingerprint: chrome    # Available: "chrome","firefox","safari","ios","random", currently only support TLS transport in TCP/GRPC/WS/HTTP for VLESS/Vmess and trojan.
-    # skip-cert-verify: true
-    # servername: example.com # priority over wss host
-    # network: ws
-    # ech-opts:
-    #   enable: true # 必须手动开启
-    #   # 如果config为空则通过dns解析，不为空则通过该值指定，格式为经过base64编码的ech参数（dig +short TYPE65 tls-ech.dev）
-    #   config: AEn+DQBFKwAgACABWIHUGj4u+PIggYXcR5JF0gYk3dCRioBW8uJq9H4mKAAIAAEAAQABAANAEnB1YmxpYy50bHMtZWNoLmRldgAA
-    #   # query-server-name: xxx.com # 可选项，不为空时用于指定通过dns解析时的域名
-    # ws-opts:
+      # udp: true
+      # tls: true
+      # fingerprint: xxxx # 配置指纹将实现 SSL Pining 效果, 可使用 openssl x509 -noout -fingerprint -sha256 -inform pem -in yourcert.pem 获取
+      # 下面两项如果填写则开启 mTLS（需要同时填写）
+      # certificate: ./client.crt # 证书 PEM 格式，或者 证书的路径
+      # private-key: ./client.key # 证书对应的私钥 PEM 格式，或者私钥路径
+      # client-fingerprint: chrome    # Available: "chrome","firefox","safari","ios","random", currently only support TLS transport in TCP/GRPC/WS/HTTP for VLESS/Vmess and trojan.
+      # skip-cert-verify: true
+      # servername: example.com # priority over wss host
+      # network: ws
+      # ech-opts:
+      #   enable: true # 必须手动开启
+      #   # 如果config为空则通过dns解析，不为空则通过该值指定，格式为经过base64编码的ech参数（dig +short TYPE65 tls-ech.dev）
+      #   config: AEn+DQBFKwAgACABWIHUGj4u+PIggYXcR5JF0gYk3dCRioBW8uJq9H4mKAAIAAEAAQABAANAEnB1YmxpYy50bHMtZWNoLmRldgAA
+      #   # query-server-name: xxx.com # 可选项，不为空时用于指定通过dns解析时的域名
+      # ws-opts:
       # path: /path
       # headers:
       #   Host: v2ray.com
       # max-early-data: 2048
       # early-data-header-name: Sec-WebSocket-Protocol
-      # v2ray-http-upgrade: false
-      # v2ray-http-upgrade-fast-open: false
+    # v2ray-http-upgrade: false
+    # v2ray-http-upgrade-fast-open: false
 
   - name: "vmess-h2"
     type: vmess
@@ -832,7 +832,7 @@ proxies: # socks5
       # max-connections: 1 # Maximum connections. Conflict with max-streams.
       # min-streams: 0 # Minimum multiplexed streams in a connection before opening a new connection. Conflict with max-streams.
       # max-streams: 0 # Maximum multiplexed streams in a connection before opening a new connection. Conflict with max-connections and min-streams.
-      
+
     reality-opts:
       public-key: CrrQSjAG_YkHLwvM2M-7XkKJilgL5upBKCp0od0tLhE
       short-id: 10f897e26c4b9478
@@ -1204,6 +1204,13 @@ proxies: # socks5
     #   00000000000000000000000000000000
     #   ...
     #   -----END OpenVPN Static key V1-----
+    # tls-auth: | # 从 .ovpn 中复制 <tls-auth></tls-auth> 内的内容；与 tls-crypt 二选一
+    #   -----BEGIN OpenVPN Static key V1-----
+    #   00000000000000000000000000000000
+    #   ...
+    #   -----END OpenVPN Static key V1-----
+    # key-direction: 1 # 对应 .ovpn 的 key-direction，可选值 0/1；省略表示双向 key
+    # scramble: obfuscate password # 支持 xormask <mask> / xorptrpos / reverse / obfuscate <mask>；scramble <mask> 等同 xormask
     # ping: 10 # 默认值为 0
     # ping-restart: 60 # 默认值为 0
     # mtu: 1500
@@ -1348,7 +1355,7 @@ proxies: # socks5
   - name: sudoku
     type: sudoku
     server: server_ip/domain # 1.2.3.4 or domain
-    port: 443 
+    port: 443
     key: "<client_key>" # 如果你使用sudoku生成的ED25519密钥对，请填写密钥对中的私钥，否则填入和服务端相同的uuid
     aead-method: chacha20-poly1305 # 可选：chacha20-poly1305、aes-128-gcm、none（不建议；none 不提供 AEAD 保护）
     padding-min: 2 # 最小填充率（0-100）
@@ -1406,7 +1413,7 @@ proxies: # socks5
     # min-streams: 5 # Minimum multiplexed streams in a connection before opening a new connection. Conflict with max-streams.
     # max-streams: 0 # Maximum multiplexed streams in a connection before opening a new connection. Conflict with max-connections and min-streams.
 
-# dns 出站会将请求劫持到内部 dns 模块，所有请求均在内部处理
+  # dns 出站会将请求劫持到内部 dns 模块，所有请求均在内部处理
   - name: "dns-out"
     type: dns
 
@@ -1503,8 +1510,8 @@ proxy-providers:
     # age-secret-key: AGE-SECRET-KEY-1ZTQLLN0A4U3ZTT3DCZKYN0CGZEZQLWX2DFTXUWMT4ZHR0N2UG6LSW9NT0N
     header:
       User-Agent:
-      - "Clash/v1.18.0"
-      - "mihomo/1.18.3"
+        - "Clash/v1.18.0"
+        - "mihomo/1.18.3"
       # Accept:
       # - 'application/vnd.github.v3.raw'
       # Authorization:
@@ -2179,14 +2186,14 @@ listeners:
     # proxy: proxy # 如果不为空则直接将该入站流量交由指定 proxy 处理 (当 proxy 不为空时，这里的 proxy 名称必须合法，否则会出错)
     stack: system # gvisor / mixed
     dns-hijack:
-    - 0.0.0.0:53 # 需要劫持的 DNS
+      - 0.0.0.0:53 # 需要劫持的 DNS
     # auto-detect-interface: false # 自动识别出口网卡
     # auto-route: false # 配置路由表
     # mtu: 9000 # 最大传输单元
     inet4-address: # 必须手动设置 ipv4 地址段
-    - 198.19.0.1/30
+      - 198.19.0.1/30
     inet6-address: # 必须手动设置 ipv6 地址段
-    - "fdfe:dcba:9877::1/126"
+      - "fdfe:dcba:9877::1/126"
     # strict-route: true # 将所有连接路由到 tun 来防止泄漏，但你的设备将无法其他设备被访问
     # inet4-route-address: # 启用 auto-route 时使用自定义路由而不是默认路由
     # - 0.0.0.0/1

--- a/transport/openvpn/client.go
+++ b/transport/openvpn/client.go
@@ -12,6 +12,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/metacubex/mihomo/log"
 	"github.com/metacubex/tls"
 	"golang.org/x/sync/semaphore"
 )
@@ -45,13 +46,21 @@ func NewClient(config *ClientConfig, io PacketIO) (*Client, error) {
 	if io == nil {
 		return nil, errors.New("nil openvpn packet io")
 	}
-	var crypt *TLSCrypt
+	var wrap ControlPacketWrapper
 	if len(config.TLSCryptKey) > 0 {
 		var err error
-		crypt, err = NewTLSCrypt(config.TLSCryptKey, true)
+		wrap, err = NewTLSCrypt(config.TLSCryptKey, true)
 		if err != nil {
 			return nil, err
 		}
+		log.Debugln("[OpenVPN] enabled tls-crypt control channel wrapping")
+	} else if len(config.TLSAuthKey) > 0 {
+		var err error
+		wrap, err = NewTLSAuth(config.TLSAuthKey, config.KeyDirection, config.Auth)
+		if err != nil {
+			return nil, err
+		}
+		log.Debugln("[OpenVPN] enabled tls-auth control channel authentication: auth=%s key-direction=%s", config.Auth, KeyDirectionString(config.KeyDirection))
 	}
 	local, err := NewSessionID()
 	if err != nil {
@@ -63,7 +72,7 @@ func NewClient(config *ClientConfig, io PacketIO) (*Client, error) {
 	client := &Client{
 		config:   config,
 		mux:      mux,
-		control:  NewControlChannel(mux, crypt, local),
+		control:  NewControlChannel(mux, wrap, local),
 		cancel:   cancel,
 		writeSem: semaphore.NewWeighted(1),
 	}
@@ -84,9 +93,11 @@ func (c *Client) Handshake(ctx context.Context) (*PushReply, error) {
 	if err := c.control.SendReset(ctx); err != nil {
 		return nil, fmt.Errorf("send hard reset: %w", err)
 	}
+	log.Debugln("[OpenVPN] sent hard reset to start handshake")
 	if err := c.waitServerReset(ctx); err != nil {
 		return nil, err
 	}
+	log.Debugln("[OpenVPN] received server hard reset")
 
 	tlsConfig, err := c.tlsConfig()
 	if err != nil {
@@ -100,6 +111,7 @@ func (c *Client) Handshake(ctx context.Context) (*PushReply, error) {
 	if err := c.tlsConn.HandshakeContext(ctx); err != nil {
 		return nil, fmt.Errorf("openvpn tls handshake: %w", err)
 	}
+	log.Debugln("[OpenVPN] TLS handshake complete")
 
 	clientRecord, err := NewClientKeyMethod2Record(
 		InstallScriptOptionsString(c.config.Proto, c.config.Cipher, c.config.Auth, c.config.CompLZO),
@@ -121,6 +133,7 @@ func (c *Client) Handshake(ctx context.Context) (*PushReply, error) {
 	if err != nil {
 		return nil, err
 	}
+	log.Debugln("[OpenVPN] received key method 2 server record: options=%q peer-info=%q", serverRecord.Options, serverRecord.PeerInfo)
 
 	sources := clientRecord.Sources
 	sources.Server = serverRecord.Sources.Server
@@ -136,6 +149,7 @@ func (c *Client) Handshake(ctx context.Context) (*PushReply, error) {
 	if err != nil {
 		return nil, err
 	}
+	log.Debugln("[OpenVPN] received PUSH_REPLY: peer-id=%d routes=%v prefixes=%v raw=%q", push.PeerID, push.Routes, push.Prefixes, push.Raw)
 	c.push = push
 	c.data, err = NewDataChannel(keys, c.config.Cipher, c.config.Auth, push.PeerID)
 	if err != nil {
@@ -162,7 +176,7 @@ func (c *Client) writeDataPacket(ctx context.Context, packet []byte, compress bo
 		return err
 	}
 	defer c.writeSem.Release(1)
-	if compress && c.config.CompLZO == CompLzoYes {
+	if compress && c.config.CompLZO != "" {
 		compressed, err := lzo1xCompressSafe(packet)
 		if err != nil {
 			return err
@@ -192,13 +206,14 @@ func (c *Client) ReadIPPacket(ctx context.Context) ([]byte, error) {
 		}
 		plain, err := c.data.Decrypt(packet)
 		if err != nil {
+			log.Debugln("[OpenVPN] discard data packet: len=%d err=%v", len(packet), err)
 			continue
 		}
 		c.markReceive()
 		if IsPingPacket(plain) {
 			continue
 		}
-		if c.config.CompLZO == CompLzoYes && len(plain) > 0 {
+		if c.config.CompLZO != "" && len(plain) > 0 {
 			return lzo1xDecompressSafe(plain)
 		}
 		return plain, nil

--- a/transport/openvpn/config.go
+++ b/transport/openvpn/config.go
@@ -47,6 +47,7 @@ type ClientConfig struct {
 	Cert     []byte
 	Key      []byte
 	TLSCrypt []byte
+	TLSAuth  []byte
 
 	Username string
 	Password string
@@ -54,7 +55,30 @@ type ClientConfig struct {
 	PingInterval time.Duration
 	PingRestart  time.Duration
 
-	TLSCryptKey []byte
+	TLSCryptKey  []byte
+	TLSAuthKey   []byte
+	KeyDirection int
+	ScrambleRaw  string
+	Scramble     ScrambleConfig
+}
+
+const (
+	KeyDirectionBidirectional = 0
+	KeyDirectionNormal        = 1
+	KeyDirectionInverse       = 2
+)
+
+func KeyDirectionString(keyDirection int) string {
+	switch keyDirection {
+	case KeyDirectionBidirectional:
+		return "bidirectional"
+	case KeyDirectionNormal:
+		return "0"
+	case KeyDirectionInverse:
+		return "1"
+	default:
+		return fmt.Sprintf("unknown(%d)", keyDirection)
+	}
 }
 
 // DataCipherKeyLength returns the key size for the negotiated data cipher.
@@ -130,15 +154,35 @@ func (c *ClientConfig) Prepare() error {
 	c.Cipher = normalizeCipher(c.Cipher)
 	c.Auth = normalizeAuth(c.Auth)
 	c.CompLZO = normalizeCompLZO(c.CompLZO)
+	if c.KeyDirection < KeyDirectionBidirectional || c.KeyDirection > KeyDirectionInverse {
+		return fmt.Errorf("unsupported openvpn key-direction %d", c.KeyDirection)
+	}
+	scramble, err := ParseScramble(c.ScrambleRaw)
+	if err != nil {
+		return err
+	}
+	c.Scramble = scramble
 	if err := c.ValidateInstallScriptSubset(); err != nil {
 		return err
 	}
-	if len(bytes.TrimSpace(c.TLSCrypt)) > 0 {
+	hasTLSCrypt := len(bytes.TrimSpace(c.TLSCrypt)) > 0
+	hasTLSAuth := len(bytes.TrimSpace(c.TLSAuth)) > 0
+	if hasTLSCrypt && hasTLSAuth {
+		return errors.New("openvpn tls-auth and tls-crypt are mutually exclusive")
+	}
+	if hasTLSCrypt {
 		key, err := DecodeStaticKey(c.TLSCrypt)
 		if err != nil {
 			return fmt.Errorf("parse tls-crypt key: %w", err)
 		}
 		c.TLSCryptKey = key
+	}
+	if hasTLSAuth {
+		key, err := DecodeStaticKey(c.TLSAuth)
+		if err != nil {
+			return fmt.Errorf("parse tls-auth key: %w", err)
+		}
+		c.TLSAuthKey = key
 	}
 	return nil
 }

--- a/transport/openvpn/control.go
+++ b/transport/openvpn/control.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/metacubex/mihomo/common/pool"
+	"github.com/metacubex/mihomo/log"
 )
 
 type PacketIO interface {
@@ -22,7 +23,7 @@ type PacketIO interface {
 
 type ControlChannel struct {
 	io     PacketIO
-	crypt  *TLSCrypt
+	wrap   ControlPacketWrapper
 	clock  func() time.Time
 	keyID  uint8
 	local  SessionID
@@ -39,10 +40,10 @@ type ControlChannel struct {
 	writeDeadline time.Time
 }
 
-func NewControlChannel(io PacketIO, crypt *TLSCrypt, local SessionID) *ControlChannel {
+func NewControlChannel(io PacketIO, wrap ControlPacketWrapper, local SessionID) *ControlChannel {
 	return &ControlChannel{
 		io:          io,
-		crypt:       crypt,
+		wrap:        wrap,
 		clock:       time.Now,
 		local:       local,
 		pending:     make(map[uint32]*ControlPacket),
@@ -215,10 +216,12 @@ func (c *ControlChannel) writeControlPacket(ctx context.Context, packet *Control
 		defer cancel()
 	}
 
-	encoded, err := packet.Encode(c.crypt, packetID, unixTime)
+	encoded, err := packet.Encode(c.wrap, packetID, unixTime)
 	if err != nil {
 		return err
 	}
+	log.Debugln("[OpenVPN] write control packet: opcode=%s message-id=%d ack-count=%d payload=%d wrapped-packet-id=%d",
+		packet.Opcode, packet.MessageID, len(packet.AckIDs), len(packet.Payload), packetID)
 	return c.io.WritePacket(ctx, encoded)
 }
 
@@ -237,7 +240,13 @@ func (c *ControlChannel) readControlPacket(ctx context.Context) (*ControlPacket,
 	if err != nil {
 		return nil, err
 	}
-	packet, _, _, err := DecodeControlPacket(c.crypt, raw)
+	packet, _, _, err := DecodeControlPacket(c.wrap, raw)
+	if err != nil {
+		log.Debugln("[OpenVPN] read control packet failed: raw=%d err=%v", len(raw), err)
+		return nil, err
+	}
+	log.Debugln("[OpenVPN] read control packet: opcode=%s message-id=%d ack-count=%d payload=%d",
+		packet.Opcode, packet.MessageID, len(packet.AckIDs), len(packet.Payload))
 	return packet, err
 }
 
@@ -278,6 +287,8 @@ type ControlConn struct {
 	closed  bool
 	mu      sync.Mutex
 }
+
+const maxControlPayloadSize = 1000
 
 func NewControlConn(channel *ControlChannel) *ControlConn {
 	return &ControlConn{channel: channel}
@@ -332,10 +343,19 @@ func (c *ControlConn) Write(b []byte) (int, error) {
 	}
 	c.mu.Unlock()
 
-	if _, err := c.channel.Send(context.Background(), PControlV1, b); err != nil {
-		return 0, err
+	written := 0
+	for len(b) > 0 {
+		n := len(b)
+		if n > maxControlPayloadSize {
+			n = maxControlPayloadSize
+		}
+		if _, err := c.channel.Send(context.Background(), PControlV1, b[:n]); err != nil {
+			return written, err
+		}
+		written += n
+		b = b[n:]
 	}
-	return len(b), nil
+	return written, nil
 }
 
 func (c *ControlConn) Close() error {

--- a/transport/openvpn/control_test.go
+++ b/transport/openvpn/control_test.go
@@ -1,294 +1,216 @@
 package openvpn
 
 import (
-	"context"
-	"errors"
-	"net"
-	"sync"
+	"strings"
 	"testing"
-	"time"
 )
 
-type memoryPacketIO struct {
-	in     <-chan []byte
-	out    chan<- []byte
-	closed chan struct{}
-	once   sync.Once
+const testCert = `-----BEGIN CERTIFICATE-----
+MIIBszCCAVmgAwIBAgIUQbG/Z7JQGg+Jb42bBYK6q8I4g5swCgYIKoZIzj0EAwIw
+EjEQMA4GA1UEAwwHbWlob21vMB4XDTI2MDUwMTAwMDAwMFoXDTM2MDQyOTAwMDAw
+MFowEjEQMA4GA1UEAwwHbWlob21vMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE
+hT8O8v9COiL0e7Gmab6r8jYxgB5xIvEtL10eF6QpJm+5ROK8f8yO8JHj2L2F6i1v
+g7CNgMCoX9YnZ9wqOqNTMFEwHQYDVR0OBBYEFDuK1nBI7w+Kz8o9hD7UzpJkq1N2
+MB8GA1UdIwQYMBaAFDuK1nBI7w+Kz8o9hD7UzpJkq1N2MA8GA1UdEwEB/wQFMAMB
+Af8wCgYIKoZIzj0EAwIDSAAwRQIhAJ4mquCRw+W1M7RCNzUVpV9qPzR9qYpK4SAi
+6pEh8FeaAiBKv+YbWBjjiWk0Yxch3v7y8W7S7e3pVtHh8x9n9+6w1Q==
+-----END CERTIFICATE-----`
+
+const testKey = `-----BEGIN EC PRIVATE KEY-----
+MHcCAQEEIG1paG9tb19vcGVudnBuX3Rlc3Rfa2V5XzEyMzQ1Njc4oAoGCCqGSM49
+AwEHoUQDQgAEhT8O8v9COiL0e7Gmab6r8jYxgB5xIvEtL10eF6QpJm+5ROK8f8yO
+8JHj2L2F6i1vg7CNgMCoX9YnZ9wqOg==
+-----END EC PRIVATE KEY-----`
+
+func testTLSCryptBlock() string {
+	return `-----BEGIN OpenVPN Static key V1-----
+` + strings.Repeat("00", 256) + `
+-----END OpenVPN Static key V1-----`
 }
 
-func newMemoryPacketPair() (*memoryPacketIO, *memoryPacketIO) {
-	aToB := make(chan []byte, 16)
-	bToA := make(chan []byte, 16)
-	a := &memoryPacketIO{in: bToA, out: aToB, closed: make(chan struct{})}
-	b := &memoryPacketIO{in: aToB, out: bToA, closed: make(chan struct{})}
-	return a, b
-}
-
-func (m *memoryPacketIO) ReadPacket(ctx context.Context) ([]byte, error) {
-	select {
-	case <-ctx.Done():
-		return nil, ctx.Err()
-	case <-m.closed:
-		return nil, net.ErrClosed
-	case packet := <-m.in:
-		return cloneBytes(packet), nil
-	}
-}
-
-func (m *memoryPacketIO) WritePacket(ctx context.Context, packet []byte) error {
-	select {
-	case <-ctx.Done():
-		return ctx.Err()
-	case <-m.closed:
-		return net.ErrClosed
-	case m.out <- cloneBytes(packet):
-		return nil
-	}
-}
-
-func (m *memoryPacketIO) Close() error {
-	m.once.Do(func() { close(m.closed) })
-	return nil
-}
-
-func (m *memoryPacketIO) LocalAddr() net.Addr {
-	return dummyAddr("local")
-}
-
-func (m *memoryPacketIO) RemoteAddr() net.Addr {
-	return dummyAddr("remote")
-}
-
-type dummyAddr string
-
-func (d dummyAddr) Network() string { return string(d) }
-func (d dummyAddr) String() string  { return string(d) }
-
-func newTestChannels(t *testing.T) (*ControlChannel, *ControlChannel) {
-	t.Helper()
-	clientIO, serverIO := newMemoryPacketPair()
-	clientCrypt, err := NewTLSCrypt(testStaticKey(), true)
-	if err != nil {
-		t.Fatal(err)
-	}
-	serverCrypt, err := NewTLSCrypt(testStaticKey(), false)
-	if err != nil {
-		t.Fatal(err)
-	}
-	var clientID SessionID
-	copy(clientID[:], []byte("client01"))
-	var serverID SessionID
-	copy(serverID[:], []byte("server01"))
-
-	client := NewControlChannel(clientIO, clientCrypt, clientID)
-	server := NewControlChannel(serverIO, serverCrypt, serverID)
-	client.clock = func() time.Time { return time.Unix(1714567890, 0) }
-	server.clock = func() time.Time { return time.Unix(1714567891, 0) }
-	return client, server
-}
-
-func TestControlChannelResetAndAck(t *testing.T) {
-	client, server := newTestChannels(t)
-
-	if err := client.SendReset(context.Background()); err != nil {
-		t.Fatal(err)
-	}
-	packet, err := server.Read(context.Background())
-	if err != nil {
-		t.Fatal(err)
-	}
-	if packet.Opcode != PControlHardResetClientV2 || packet.MessageID != 0 {
-		t.Fatalf("unexpected reset packet: %s/%d", packet.Opcode, packet.MessageID)
-	}
-	if packetID := client.sendPacketID; packetID != 1 {
-		t.Fatalf("unexpected first tls-crypt packet id: %d", packetID)
-	}
-	if server.RemoteSessionID() != client.LocalSessionID() {
-		t.Fatalf("server did not learn client session id")
-	}
-
-	if err := server.SendAck(context.Background()); err != nil {
-		t.Fatal(err)
-	}
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
-	defer cancel()
-	_, err = client.Read(ctx)
-	if !errors.Is(err, context.DeadlineExceeded) {
-		t.Fatalf("expected deadline after consuming pure ack, got %v", err)
-	}
-	if client.PendingMessages() != 0 {
-		t.Fatalf("expected client reset to be acked, pending=%d", client.PendingMessages())
+func yamlStyleConfig() *ClientConfig {
+	return &ClientConfig{
+		RemoteHost: "vpn.example.com",
+		RemotePort: 1194,
+		Proto:      "udp",
+		Dev:        "tun",
+		Cipher:     "AES-128-GCM",
+		Auth:       "SHA256",
+		CA:         []byte(testCert),
+		Cert:       []byte(testCert),
+		Key:        []byte(testKey),
+		TLSCrypt:   []byte(testTLSCryptBlock()),
 	}
 }
 
-func TestControlConnCarriesTLSBytes(t *testing.T) {
-	client, server := newTestChannels(t)
-	client.SetRemoteSessionID(server.LocalSessionID())
-	server.SetRemoteSessionID(client.LocalSessionID())
-
-	clientConn := NewControlConn(client)
-	serverConn := NewControlConn(server)
-
-	errCh := make(chan error, 1)
-	go func() {
-		_, err := clientConn.Write([]byte("client tls record"))
-		errCh <- err
-	}()
-
-	buf := make([]byte, 64)
-	n, err := serverConn.Read(buf)
-	if err != nil {
+func TestClientConfigYAMLStyleInstallScriptSubset(t *testing.T) {
+	cfg := yamlStyleConfig()
+	if err := cfg.Prepare(); err != nil {
 		t.Fatal(err)
 	}
-	if got := string(buf[:n]); got != "client tls record" {
-		t.Fatalf("unexpected payload: %q", got)
+	if cfg.RemoteAddress() != "vpn.example.com:1194" {
+		t.Fatalf("unexpected remote address: %s", cfg.RemoteAddress())
 	}
-	if err := <-errCh; err != nil {
-		t.Fatal(err)
+	if cfg.Proto != ProtoUDP {
+		t.Fatalf("unexpected proto: %s", cfg.Proto)
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
-	defer cancel()
-	_, err = client.Read(ctx)
-	if !errors.Is(err, context.DeadlineExceeded) {
-		t.Fatalf("expected deadline after consuming pure ack, got %v", err)
+	if cfg.Cipher != CipherAES128GCM || cfg.Auth != AuthSHA256 {
+		t.Fatalf("unexpected crypto: %s/%s", cfg.Cipher, cfg.Auth)
 	}
-	if client.PendingMessages() != 0 {
-		t.Fatalf("expected client message to be acked, pending=%d", client.PendingMessages())
+	if len(cfg.TLSCryptKey) != 256 {
+		t.Fatalf("unexpected tls-crypt key length: %d", len(cfg.TLSCryptKey))
 	}
 }
 
-func TestControlChannelReordersReliableMessages(t *testing.T) {
-	packets := make(chan []byte, 4)
-	acks := make(chan []byte, 4)
-	io := &memoryPacketIO{in: packets, out: acks, closed: make(chan struct{})}
-	var clientID SessionID
-	copy(clientID[:], []byte("client01"))
-	var serverID SessionID
-	copy(serverID[:], []byte("server01"))
-	server := NewControlChannel(io, nil, serverID)
+func TestClientConfigDefaults(t *testing.T) {
+	cfg := yamlStyleConfig()
+	cfg.Proto = ""
+	cfg.Dev = ""
+	cfg.Cipher = ""
+	cfg.Auth = ""
 
-	second, err := (ControlPacket{
-		Opcode:       PControlV1,
-		LocalSession: clientID,
-		MessageID:    1,
-		Payload:      []byte("second"),
-	}).Encode(nil, 0, 0)
-	if err != nil {
+	if err := cfg.Prepare(); err != nil {
 		t.Fatal(err)
 	}
-	first, err := (ControlPacket{
-		Opcode:       PControlV1,
-		LocalSession: clientID,
-		MessageID:    0,
-		Payload:      []byte("first"),
-	}).Encode(nil, 0, 0)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	packets <- second
-	packets <- first
-
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
-	defer cancel()
-	packet, err := server.Read(ctx)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if packet.MessageID != 0 || string(packet.Payload) != "first" {
-		t.Fatalf("unexpected first delivered packet: id=%d payload=%q", packet.MessageID, packet.Payload)
-	}
-	packet, err = server.Read(ctx)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if packet.MessageID != 1 || string(packet.Payload) != "second" {
-		t.Fatalf("unexpected second delivered packet: id=%d payload=%q", packet.MessageID, packet.Payload)
+	if cfg.Proto != ProtoUDP || cfg.Dev != "tun" || cfg.Cipher != CipherAES128GCM || cfg.Auth != AuthSHA256 {
+		t.Fatalf("unexpected defaults: proto=%s dev=%s cipher=%s auth=%s", cfg.Proto, cfg.Dev, cfg.Cipher, cfg.Auth)
 	}
 }
 
-func TestClientWaitServerResetRetransmitsUDP(t *testing.T) {
-	clientIO, serverIO := newMemoryPacketPair()
-	var clientID SessionID
-	copy(clientID[:], []byte("client01"))
-	var serverID SessionID
-	copy(serverID[:], []byte("server01"))
-
-	clientControl := NewControlChannel(clientIO, nil, clientID)
-	serverControl := NewControlChannel(serverIO, nil, serverID)
-	client := &Client{
-		config:  &ClientConfig{Proto: ProtoUDP},
-		control: clientControl,
+func TestClientConfigRejectsUnsupportedProto(t *testing.T) {
+	cfg := yamlStyleConfig()
+	cfg.Proto = "tcp-server"
+	err := cfg.Prepare()
+	if err == nil {
+		t.Fatal("expected unsupported proto error")
 	}
-
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-	if err := clientControl.SendReset(ctx); err != nil {
-		t.Fatal(err)
-	}
-
-	errCh := make(chan error, 1)
-	go func() {
-		packet, err := serverControl.Read(ctx)
-		if err != nil {
-			errCh <- err
-			return
-		}
-		if packet.Opcode != PControlHardResetClientV2 {
-			errCh <- errors.New("unexpected reset opcode")
-			return
-		}
-		raw, err := serverIO.ReadPacket(ctx)
-		if err != nil {
-			errCh <- err
-			return
-		}
-		packet, _, _, err = DecodeControlPacket(nil, raw)
-		if err != nil {
-			errCh <- err
-			return
-		}
-		if packet.Opcode != PControlHardResetClientV2 || packet.MessageID != 0 {
-			errCh <- errors.New("unexpected retransmitted reset packet")
-			return
-		}
-		_, err = serverControl.Send(ctx, PControlHardResetServerV2, nil)
-		errCh <- err
-	}()
-
-	if err := client.waitServerReset(ctx); err != nil {
-		t.Fatal(err)
-	}
-	if err := <-errCh; err != nil {
-		t.Fatal(err)
-	}
-	if clientControl.PendingMessages() != 0 {
-		t.Fatalf("expected client reset to be acked, pending=%d", clientControl.PendingMessages())
+	if !strings.Contains(err.Error(), "unsupported openvpn proto") {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }
 
-func TestTCPPacketIOFraming(t *testing.T) {
-	client, server := net.Pipe()
-	defer client.Close()
-	defer server.Close()
-
-	clientIO := NewTCPPacketIO(client)
-	serverIO := NewTCPPacketIO(server)
-	payload := []byte{1, 2, 3, 4}
-
-	errCh := make(chan error, 1)
-	go func() {
-		errCh <- clientIO.WritePacket(context.Background(), payload)
-	}()
-
-	got, err := serverIO.ReadPacket(context.Background())
-	if err != nil {
+func TestClientConfigAllowsMissingTLSCrypt(t *testing.T) {
+	cfg := yamlStyleConfig()
+	cfg.TLSCrypt = nil
+	if err := cfg.Prepare(); err != nil {
 		t.Fatal(err)
 	}
-	if string(got) != string(payload) {
-		t.Fatalf("unexpected payload: %v", got)
+	if len(cfg.TLSCryptKey) != 0 {
+		t.Fatalf("unexpected tls-crypt key length: %d", len(cfg.TLSCryptKey))
 	}
-	if err := <-errCh; err != nil {
+}
+
+func TestClientConfigTLSAuthAndScramble(t *testing.T) {
+	cfg := yamlStyleConfig()
+	cfg.TLSCrypt = nil
+	cfg.TLSAuth = []byte(testTLSCryptBlock())
+	cfg.KeyDirection = KeyDirectionInverse
+	cfg.ScrambleRaw = "obfuscate password"
+	if err := cfg.Prepare(); err != nil {
 		t.Fatal(err)
+	}
+	if len(cfg.TLSAuthKey) != 256 {
+		t.Fatalf("unexpected tls-auth key length: %d", len(cfg.TLSAuthKey))
+	}
+	if cfg.Scramble.Method != ScrambleObfuscate || string(cfg.Scramble.Mask) != "password" {
+		t.Fatalf("unexpected scramble config: %#v", cfg.Scramble)
+	}
+}
+
+func TestClientConfigRejectsTLSAuthWithTLSCrypt(t *testing.T) {
+	cfg := yamlStyleConfig()
+	cfg.TLSAuth = []byte(testTLSCryptBlock())
+	err := cfg.Prepare()
+	if err == nil {
+		t.Fatal("expected tls-auth/tls-crypt conflict")
+	}
+	if !strings.Contains(err.Error(), "mutually exclusive") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestClientConfigAuthUserPassAES256(t *testing.T) {
+	cfg := &ClientConfig{
+		RemoteHost: "vpn.example.com",
+		RemotePort: 31194,
+		Proto:      "udp",
+		Dev:        "tun",
+		Cipher:     "AES-256-GCM",
+		Auth:       "SHA256",
+		CA:         []byte(testCert),
+		Username:   "user",
+		Password:   "secret",
+		TLSCrypt:   []byte(testTLSCryptBlock()),
+	}
+	if err := cfg.Prepare(); err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Cipher != CipherAES256GCM {
+		t.Fatalf("unexpected cipher: %s", cfg.Cipher)
+	}
+	if cfg.DataCipherKeyLength() != 32 {
+		t.Fatalf("unexpected data key length helper: %d", cfg.DataCipherKeyLength())
+	}
+}
+
+func TestClientConfigAESCBCSHA1(t *testing.T) {
+	cfg := &ClientConfig{
+		RemoteHost: "vpn.example.com",
+		RemotePort: 1194,
+		Proto:      "udp",
+		Dev:        "tun",
+		Cipher:     "AES-CBC",
+		Auth:       "sha-1",
+		CA:         []byte(testCert),
+		Username:   "user",
+		Password:   "secret",
+		TLSCrypt:   []byte(testTLSCryptBlock()),
+	}
+	if err := cfg.Prepare(); err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Cipher != CipherAES128CBC || cfg.Auth != AuthSHA1 {
+		t.Fatalf("unexpected crypto: %s/%s", cfg.Cipher, cfg.Auth)
+	}
+	if cfg.DataCipherKeyLength() != 16 {
+		t.Fatalf("unexpected data key length helper: %d", cfg.DataCipherKeyLength())
+	}
+}
+
+func TestClientConfigRequiresAuth(t *testing.T) {
+	cfg := yamlStyleConfig()
+	cfg.Cert = nil
+	cfg.Key = nil
+	cfg.Username = ""
+	err := cfg.Prepare()
+	if err == nil {
+		t.Fatal("expected missing auth error")
+	}
+	if !strings.Contains(err.Error(), "cert+key or username") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestClientConfigAuthUserPassChaCha20Poly1305(t *testing.T) {
+	cfg := &ClientConfig{
+		RemoteHost: "vpn.example.com",
+		RemotePort: 31194,
+		Proto:      "udp",
+		Dev:        "tun",
+		Cipher:     "chacha20-poly1305",
+		Auth:       "SHA256",
+		CA:         []byte(testCert),
+		Username:   "user",
+		Password:   "secret",
+		TLSCrypt:   []byte(testTLSCryptBlock()),
+	}
+	if err := cfg.Prepare(); err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Cipher != CipherChaCha20Poly1305 {
+		t.Fatalf("unexpected cipher: %s", cfg.Cipher)
+	}
+	if cfg.DataCipherKeyLength() != 32 {
+		t.Fatalf("unexpected data key length helper: %d", cfg.DataCipherKeyLength())
 	}
 }

--- a/transport/openvpn/keymethod.go
+++ b/transport/openvpn/keymethod.go
@@ -164,7 +164,7 @@ func InstallScriptOptionsString(proto, cipher, auth string, compLZO string) stri
 	}
 	mtu := "1550"
 	comp := ""
-	if compLZO == CompLzoYes {
+	if compLZO != "" {
 		mtu = "1544"
 		comp = "comp-lzo,"
 	}
@@ -173,7 +173,7 @@ func InstallScriptOptionsString(proto, cipher, auth string, compLZO string) stri
 
 func InstallScriptPeerInfo(cipher string, compLZO string) string {
 	lzo := ""
-	if compLZO == CompLzoYes {
+	if compLZO != "" {
 		lzo = "IV_LZO=1\n"
 	}
 	return fmt.Sprintf("IV_VER=mihomo-openvpn\nIV_PROTO=6\n%sIV_CIPHERS=%s\n", lzo, cipher)

--- a/transport/openvpn/packet.go
+++ b/transport/openvpn/packet.go
@@ -23,8 +23,15 @@ const (
 	PControlHardResetClientV3 Opcode = 10
 	PControlWKCV1             Opcode = 11
 
-	SessionIDSize = 8
+	SessionIDSize       = 8
+	controlHeaderSize   = 1 + SessionIDSize
+	ControlPacketIDSize = 4 + 4
 )
+
+type ControlPacketWrapper interface {
+	Wrap(header []byte, packetID uint32, unixTime uint32, plaintext []byte) ([]byte, error)
+	Unwrap(packet []byte) (header []byte, packetID uint32, unixTime uint32, plaintext []byte, err error)
+}
 
 type Opcode uint8
 
@@ -167,37 +174,37 @@ func DecodeControlPlain(opcode Opcode, plain []byte) (ackIDs []uint32, ackRemote
 	return ackIDs, ackRemote, messageID, payload, nil
 }
 
-func (p ControlPacket) Encode(crypt *TLSCrypt, packetID uint32, unixTime uint32) ([]byte, error) {
+func (p ControlPacket) Encode(wrap ControlPacketWrapper, packetID uint32, unixTime uint32) ([]byte, error) {
 	plain, err := p.EncodePlain()
 	if err != nil {
 		return nil, err
 	}
 
-	header := make([]byte, TLSCryptHeaderSize)
+	header := make([]byte, controlHeaderSize)
 	header[0] = opcodeKeyID(p.Opcode, p.KeyID)
 	copy(header[1:], p.LocalSession[:])
-	if crypt == nil {
+	if wrap == nil {
 		out := make([]byte, 0, len(header)+len(plain))
 		out = append(out, header...)
 		out = append(out, plain...)
 		return out, nil
 	}
-	return crypt.Wrap(header, packetID, unixTime, plain)
+	return wrap.Wrap(header, packetID, unixTime, plain)
 }
 
-func DecodeControlPacket(crypt *TLSCrypt, packet []byte) (*ControlPacket, uint32, uint32, error) {
-	if crypt == nil {
-		if len(packet) < TLSCryptHeaderSize+1 {
+func DecodeControlPacket(wrap ControlPacketWrapper, packet []byte) (*ControlPacket, uint32, uint32, error) {
+	if wrap == nil {
+		if len(packet) < controlHeaderSize+1 {
 			return nil, 0, 0, errors.New("control packet too short")
 		}
-		header := packet[:TLSCryptHeaderSize]
+		header := packet[:controlHeaderSize]
 		opcode, keyID := parseOpcodeKeyID(header[0])
 		if !opcode.IsControl() {
 			return nil, 0, 0, fmt.Errorf("opcode %s is not a control opcode", opcode)
 		}
 		var local SessionID
 		copy(local[:], header[1:])
-		ackIDs, ackRemote, messageID, payload, err := DecodeControlPlain(opcode, packet[TLSCryptHeaderSize:])
+		ackIDs, ackRemote, messageID, payload, err := DecodeControlPlain(opcode, packet[controlHeaderSize:])
 		if err != nil {
 			return nil, 0, 0, err
 		}
@@ -211,11 +218,11 @@ func DecodeControlPacket(crypt *TLSCrypt, packet []byte) (*ControlPacket, uint32
 			Payload:          payload,
 		}, 0, 0, nil
 	}
-	header, packetID, unixTime, plain, err := crypt.Unwrap(packet)
+	header, packetID, unixTime, plain, err := wrap.Unwrap(packet)
 	if err != nil {
 		return nil, 0, 0, err
 	}
-	if len(header) != TLSCryptHeaderSize {
+	if len(header) != controlHeaderSize {
 		return nil, 0, 0, fmt.Errorf("invalid control header length %d", len(header))
 	}
 	opcode, keyID := parseOpcodeKeyID(header[0])

--- a/transport/openvpn/scramble.go
+++ b/transport/openvpn/scramble.go
@@ -1,0 +1,160 @@
+package openvpn
+
+import (
+	"context"
+	"fmt"
+	"strings"
+)
+
+const (
+	ScrambleNone ScrambleMethod = iota
+	ScrambleXORMask
+	ScrambleXORPtrPos
+	ScrambleReverse
+	ScrambleObfuscate
+)
+
+type ScrambleMethod uint8
+
+type ScrambleConfig struct {
+	Method ScrambleMethod
+	Mask   []byte
+}
+
+func (s ScrambleConfig) String() string {
+	switch s.Method {
+	case ScrambleNone:
+		return "none"
+	case ScrambleXORMask:
+		return "xormask"
+	case ScrambleXORPtrPos:
+		return "xorptrpos"
+	case ScrambleReverse:
+		return "reverse"
+	case ScrambleObfuscate:
+		return "obfuscate"
+	default:
+		return fmt.Sprintf("unknown(%d)", s.Method)
+	}
+}
+
+func ParseScramble(value string) (ScrambleConfig, error) {
+	fields := strings.Fields(value)
+	if len(fields) == 0 {
+		return ScrambleConfig{}, nil
+	}
+	switch fields[0] {
+	case "xormask":
+		if len(fields) != 2 {
+			return ScrambleConfig{}, errorsfScramble(value)
+		}
+		return ScrambleConfig{Method: ScrambleXORMask, Mask: []byte(fields[1])}, nil
+	case "xorptrpos":
+		if len(fields) != 1 {
+			return ScrambleConfig{}, errorsfScramble(value)
+		}
+		return ScrambleConfig{Method: ScrambleXORPtrPos}, nil
+	case "reverse":
+		if len(fields) != 1 {
+			return ScrambleConfig{}, errorsfScramble(value)
+		}
+		return ScrambleConfig{Method: ScrambleReverse}, nil
+	case "obfuscate":
+		if len(fields) != 2 {
+			return ScrambleConfig{}, errorsfScramble(value)
+		}
+		return ScrambleConfig{Method: ScrambleObfuscate, Mask: []byte(fields[1])}, nil
+	default:
+		if len(fields) != 1 {
+			return ScrambleConfig{}, errorsfScramble(value)
+		}
+		return ScrambleConfig{Method: ScrambleXORMask, Mask: []byte(fields[0])}, nil
+	}
+}
+
+func errorsfScramble(value string) error {
+	return fmt.Errorf("unsupported openvpn scramble %q", value)
+}
+
+func NewScramblePacketIO(io PacketIO, scramble ScrambleConfig) PacketIO {
+	if scramble.Method == ScrambleNone {
+		return io
+	}
+	return &scramblePacketIO{PacketIO: io, scramble: scramble}
+}
+
+type scramblePacketIO struct {
+	PacketIO
+	scramble ScrambleConfig
+}
+
+func (s *scramblePacketIO) ReadPacket(ctx context.Context) ([]byte, error) {
+	packet, err := s.PacketIO.ReadPacket(ctx)
+	if err != nil {
+		return nil, err
+	}
+	packet = cloneBytes(packet)
+	s.scramble.read(packet)
+	return packet, nil
+}
+
+func (s *scramblePacketIO) WritePacket(ctx context.Context, packet []byte) error {
+	packet = cloneBytes(packet)
+	s.scramble.write(packet)
+	return s.PacketIO.WritePacket(ctx, packet)
+}
+
+func (s ScrambleConfig) read(packet []byte) {
+	switch s.Method {
+	case ScrambleXORMask:
+		bufferMask(packet, s.Mask)
+	case ScrambleXORPtrPos:
+		bufferXORPtrPos(packet)
+	case ScrambleReverse:
+		bufferReverse(packet)
+	case ScrambleObfuscate:
+		bufferMask(packet, s.Mask)
+		bufferXORPtrPos(packet)
+		bufferReverse(packet)
+		bufferXORPtrPos(packet)
+	}
+}
+
+func (s ScrambleConfig) write(packet []byte) {
+	switch s.Method {
+	case ScrambleXORMask:
+		bufferMask(packet, s.Mask)
+	case ScrambleXORPtrPos:
+		bufferXORPtrPos(packet)
+	case ScrambleReverse:
+		bufferReverse(packet)
+	case ScrambleObfuscate:
+		bufferXORPtrPos(packet)
+		bufferReverse(packet)
+		bufferXORPtrPos(packet)
+		bufferMask(packet, s.Mask)
+	}
+}
+
+func bufferMask(packet, mask []byte) {
+	if len(mask) == 0 {
+		return
+	}
+	for i := range packet {
+		packet[i] ^= mask[i%len(mask)]
+	}
+}
+
+func bufferXORPtrPos(packet []byte) {
+	for i := range packet {
+		packet[i] ^= byte(i + 1)
+	}
+}
+
+func bufferReverse(packet []byte) {
+	for i, j := 1, len(packet)-1; i < j; i, j = i+1, j-1 {
+		packet[i], packet[j] = packet[j], packet[i]
+	}
+}
+
+var _ PacketIO = (*scramblePacketIO)(nil)

--- a/transport/openvpn/scramble_test.go
+++ b/transport/openvpn/scramble_test.go
@@ -1,0 +1,31 @@
+package openvpn
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestScrambleObfuscateRoundTrip(t *testing.T) {
+	scramble, err := ParseScramble("obfuscate password")
+	if err != nil {
+		t.Fatal(err)
+	}
+	packet := []byte{0x38, 1, 2, 3, 4, 5, 6, 7, 8, 9}
+	wire := cloneBytes(packet)
+	scramble.write(wire)
+	if bytes.Equal(wire, packet) {
+		t.Fatal("expected scrambled packet to differ")
+	}
+	scramble.read(wire)
+	if !bytes.Equal(wire, packet) {
+		t.Fatalf("unexpected unscrambled packet: %x", wire)
+	}
+}
+
+func TestScrambleReverseLeavesFirstByte(t *testing.T) {
+	packet := []byte("abcde")
+	bufferReverse(packet)
+	if got, want := string(packet), "aedcb"; got != want {
+		t.Fatalf("unexpected reverse result: got %q, want %q", got, want)
+	}
+}

--- a/transport/openvpn/tlsauth.go
+++ b/transport/openvpn/tlsauth.go
@@ -1,0 +1,96 @@
+package openvpn
+
+import (
+	"crypto/hmac"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"hash"
+)
+
+type TLSAuth struct {
+	encryptHMACKey []byte
+	decryptHMACKey []byte
+	newHash        func() hash.Hash
+	tagSize        int
+}
+
+const tlsAuthHMACKeySize = 64
+
+func NewTLSAuth(staticKey []byte, keyDirection int, authName string) (*TLSAuth, error) {
+	if len(staticKey) != staticKeySize {
+		return nil, fmt.Errorf("invalid tls-auth static key length %d, expected %d", len(staticKey), staticKeySize)
+	}
+	newHash, tagSize, err := newDataChannelAuth(authName)
+	if err != nil {
+		return nil, err
+	}
+	if tagSize > tlsAuthHMACKeySize {
+		return nil, fmt.Errorf("unsupported tls-auth HMAC size %d", tagSize)
+	}
+
+	key0 := staticKey[64 : 64+tlsAuthHMACKeySize]
+	key1 := staticKey[keySlotSize+64 : keySlotSize+64+tlsAuthHMACKeySize]
+	encrypt, decrypt := key0, key0
+	switch keyDirection {
+	case KeyDirectionBidirectional:
+	case KeyDirectionNormal:
+		encrypt, decrypt = key0, key1
+	case KeyDirectionInverse:
+		encrypt, decrypt = key1, key0
+	default:
+		return nil, fmt.Errorf("unsupported openvpn key-direction %d", keyDirection)
+	}
+
+	return &TLSAuth{
+		encryptHMACKey: cloneBytes(encrypt[:tagSize]),
+		decryptHMACKey: cloneBytes(decrypt[:tagSize]),
+		newHash:        newHash,
+		tagSize:        tagSize,
+	}, nil
+}
+
+func (a *TLSAuth) Wrap(header []byte, packetID uint32, unixTime uint32, plaintext []byte) ([]byte, error) {
+	if len(header) != controlHeaderSize {
+		return nil, fmt.Errorf("invalid tls-auth header length %d, expected %d", len(header), controlHeaderSize)
+	}
+	var pid [ControlPacketIDSize]byte
+	binary.BigEndian.PutUint32(pid[:4], packetID)
+	binary.BigEndian.PutUint32(pid[4:], unixTime)
+
+	tag := a.hmac(a.encryptHMACKey, pid[:], header, plaintext)
+	out := make([]byte, 0, len(header)+len(tag)+len(pid)+len(plaintext))
+	out = append(out, header...)
+	out = append(out, tag...)
+	out = append(out, pid[:]...)
+	out = append(out, plaintext...)
+	return out, nil
+}
+
+func (a *TLSAuth) Unwrap(packet []byte) (header []byte, packetID uint32, unixTime uint32, plaintext []byte, err error) {
+	if len(packet) < controlHeaderSize+a.tagSize+ControlPacketIDSize+1 {
+		return nil, 0, 0, nil, errors.New("tls-auth packet too short")
+	}
+	header = cloneBytes(packet[:controlHeaderSize])
+	tag := packet[controlHeaderSize : controlHeaderSize+a.tagSize]
+	pidStart := controlHeaderSize + a.tagSize
+	pidEnd := pidStart + ControlPacketIDSize
+	pid := packet[pidStart:pidEnd]
+	plaintext = cloneBytes(packet[pidEnd:])
+
+	tagCheck := a.hmac(a.decryptHMACKey, pid, header, plaintext)
+	if !hmac.Equal(tag, tagCheck) {
+		return nil, 0, 0, nil, errors.New("tls-auth authentication failed")
+	}
+	packetID = binary.BigEndian.Uint32(pid[:4])
+	unixTime = binary.BigEndian.Uint32(pid[4:])
+	return header, packetID, unixTime, plaintext, nil
+}
+
+func (a *TLSAuth) hmac(key []byte, parts ...[]byte) []byte {
+	mac := hmac.New(a.newHash, key)
+	for _, part := range parts {
+		_, _ = mac.Write(part)
+	}
+	return mac.Sum(nil)
+}

--- a/transport/openvpn/tlsauth_test.go
+++ b/transport/openvpn/tlsauth_test.go
@@ -1,0 +1,63 @@
+package openvpn
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestTLSAuthClientServerRoundTrip(t *testing.T) {
+	client, err := NewTLSAuth(testStaticKey(), KeyDirectionInverse, AuthSHA512)
+	if err != nil {
+		t.Fatal(err)
+	}
+	server, err := NewTLSAuth(testStaticKey(), KeyDirectionNormal, AuthSHA512)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	header := []byte{0x38, 1, 2, 3, 4, 5, 6, 7, 8}
+	plaintext := []byte("client hello over openvpn control channel")
+	packet, err := client.Wrap(header, 7, 1714567890, plaintext)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := controlHeaderSize + 64 + ControlPacketIDSize + len(plaintext); len(packet) != want {
+		t.Fatalf("unexpected tls-auth packet length: got %d, want %d", len(packet), want)
+	}
+
+	gotHeader, packetID, unixTime, gotPlaintext, err := server.Unwrap(packet)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(gotHeader, header) {
+		t.Fatalf("unexpected header: %x", gotHeader)
+	}
+	if packetID != 7 || unixTime != 1714567890 {
+		t.Fatalf("unexpected packet id/time: %d/%d", packetID, unixTime)
+	}
+	if !bytes.Equal(gotPlaintext, plaintext) {
+		t.Fatalf("unexpected plaintext: %q", gotPlaintext)
+	}
+}
+
+func TestTLSAuthRejectsTamperedPacket(t *testing.T) {
+	client, err := NewTLSAuth(testStaticKey(), KeyDirectionInverse, AuthSHA256)
+	if err != nil {
+		t.Fatal(err)
+	}
+	server, err := NewTLSAuth(testStaticKey(), KeyDirectionNormal, AuthSHA256)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	packet, err := client.Wrap([]byte{0x38, 1, 2, 3, 4, 5, 6, 7, 8}, 7, 1714567890, []byte("hello"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	packet[len(packet)-1] ^= 0xff
+
+	_, _, _, _, err = server.Unwrap(packet)
+	if err == nil {
+		t.Fatal("expected authentication failure")
+	}
+}

--- a/transport/openvpn/tlscrypt.go
+++ b/transport/openvpn/tlscrypt.go
@@ -11,8 +11,8 @@ import (
 )
 
 const (
-	TLSCryptHeaderSize = 1 + 8
-	TLSCryptPIDSize    = 4 + 4
+	TLSCryptHeaderSize = controlHeaderSize
+	TLSCryptPIDSize    = ControlPacketIDSize
 	TLSCryptTagSize    = sha256.Size
 
 	staticKeySize = 256


### PR DESCRIPTION
Add OpenVPN tls-auth support and scramble/obfuscate option support.

Changes:
- Add tls-auth related handling
- Add OpenVPN scramble option support
- Add related tests