### PR TITLE
fix(xhttp): don't append trailing slash to file-like paths

### DIFF
--- a/transport/xhttp/config.go
+++ b/transport/xhttp/config.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"math/big"
+	pathpkg "path"
 	"strconv"
 	"strings"
 
@@ -96,7 +97,7 @@ func (c *Config) NormalizedPath() string {
 	if !strings.HasPrefix(path, "/") {
 		path = "/" + path
 	}
-	if !strings.HasSuffix(path, "/") {
+	if !strings.HasSuffix(path, "/") && !strings.Contains(pathpkg.Base(path), ".") {
 		path += "/"
 	}
 	return path


### PR DESCRIPTION
Backport of the NormalizedPath fix onto v1.19.27. A trailing slash was forced onto every xhttp path, breaking paths that point at a file (e.g. /foo.txt). Skip the trailing slash when the last path segment contains a dot.