### PR TITLE
feat: support custom peer-info for openvpn outbound (+ handshake timeout fix)

### DIFF
--- a/adapter/outbound/openvpn.go
+++ b/adapter/outbound/openvpn.go
@@ -42,24 +42,25 @@ type OpenVPN struct {
 
 type OpenVPNOption struct {
 	BasicOption
-	Name        string `proxy:"name"`
-	Server      string `proxy:"server"`
-	Port        int    `proxy:"port"`
-	Proto       string `proxy:"proto,omitempty"`
-	Dev         string `proxy:"dev,omitempty"`
-	Cipher      string `proxy:"cipher,omitempty"`
-	Auth        string `proxy:"auth,omitempty"`
-	CompLZO     string `proxy:"comp-lzo,omitempty"`
-	CA          string `proxy:"ca"`
-	Cert        string `proxy:"cert,omitempty"`
-	Key         string `proxy:"key,omitempty"`
-	TLSCrypt    string `proxy:"tls-crypt,omitempty"`
-	Username    string `proxy:"username,omitempty"`
-	Password    string `proxy:"password,omitempty"`
-	Ping        int    `proxy:"ping,omitempty"`
-	PingRestart int    `proxy:"ping-restart,omitempty"`
-	MTU         int    `proxy:"mtu,omitempty"`
-	UDP         bool   `proxy:"udp,omitempty"`
+	Name        string            `proxy:"name"`
+	Server      string            `proxy:"server"`
+	Port        int               `proxy:"port"`
+	Proto       string            `proxy:"proto,omitempty"`
+	Dev         string            `proxy:"dev,omitempty"`
+	Cipher      string            `proxy:"cipher,omitempty"`
+	Auth        string            `proxy:"auth,omitempty"`
+	CompLZO     string            `proxy:"comp-lzo,omitempty"`
+	CA          string            `proxy:"ca"`
+	Cert        string            `proxy:"cert,omitempty"`
+	Key         string            `proxy:"key,omitempty"`
+	TLSCrypt    string            `proxy:"tls-crypt,omitempty"`
+	Username    string            `proxy:"username,omitempty"`
+	Password    string            `proxy:"password,omitempty"`
+	PeerInfo    map[string]string `proxy:"peer-info,omitempty"`
+	Ping        int               `proxy:"ping,omitempty"`
+	PingRestart int               `proxy:"ping-restart,omitempty"`
+	MTU         int               `proxy:"mtu,omitempty"`
+	UDP         bool              `proxy:"udp,omitempty"`
 
 	RemoteDnsResolve bool     `proxy:"remote-dns-resolve,omitempty"`
 	Dns              []string `proxy:"dns,omitempty"`
@@ -80,6 +81,7 @@ func NewOpenVPN(option OpenVPNOption) (*OpenVPN, error) {
 		TLSCrypt:     []byte(option.TLSCrypt),
 		Username:     option.Username,
 		Password:     option.Password,
+		PeerInfo:     option.PeerInfo,
 		PingInterval: time.Duration(option.Ping) * time.Second,
 		PingRestart:  time.Duration(option.PingRestart) * time.Second,
 	}

--- a/adapter/outbound/openvpn.go
+++ b/adapter/outbound/openvpn.go
@@ -123,6 +123,8 @@ func (o *OpenVPN) DialContext(ctx context.Context, metadata *C.Metadata) (_ C.Co
 	if err != nil {
 		return nil, err
 	}
+	ctx, cancel := o.afterRunContext(ctx)
+	defer cancel()
 	var conn net.Conn
 	if !metadata.Resolved() || r != nil {
 		if r == nil {
@@ -150,6 +152,8 @@ func (o *OpenVPN) ListenPacketContext(ctx context.Context, metadata *C.Metadata)
 	if err != nil {
 		return nil, err
 	}
+	ctx, cancel := o.afterRunContext(ctx)
+	defer cancel()
 	if err = o.resolveUDP(ctx, metadata, r); err != nil {
 		return nil, err
 	}
@@ -168,6 +172,8 @@ func (o *OpenVPN) ResolveUDP(ctx context.Context, metadata *C.Metadata) error {
 	if err != nil {
 		return err
 	}
+	ctx, cancel := o.afterRunContext(ctx)
+	defer cancel()
 	return o.resolveUDP(ctx, metadata, r)
 }
 
@@ -304,12 +310,25 @@ func (o *OpenVPN) lockRun(ctx context.Context) error {
 }
 
 func (o *OpenVPN) handshakeContext(ctx context.Context) (context.Context, context.CancelFunc) {
-	handshakeCtx, handshakeCancel := context.WithTimeout(ctx, ovpn.DefaultHandshakeTimeout)
-	stop := contextutils.AfterFunc(o.runCtx, handshakeCancel)
-	return handshakeCtx, func() {
-		stop()
-		handshakeCancel()
+	// The OpenVPN tunnel is a shared, long-lived resource established once and
+	// reused by every connection. Its handshake must not be bound by the short
+	// per-dial timeout of whichever connection happens to trigger it (which is
+	// far shorter than the handshake of a server that performs push-peer-info /
+	// PAM checks), so use the outbound's run context with the full handshake
+	// timeout instead.
+	return context.WithTimeout(o.runCtx, ovpn.DefaultHandshakeTimeout)
+}
+
+// afterRunContext refreshes the dial deadline once the tunnel is established.
+// The first request that triggers the one-time handshake would otherwise have
+// spent most of its (short) dial budget building the tunnel, leaving too little
+// for the actual dial and failing the triggering request. Since the tunnel is
+// shared infrastructure, give the subsequent dial a fresh budget instead.
+func (o *OpenVPN) afterRunContext(ctx context.Context) (context.Context, context.CancelFunc) {
+	if deadline, ok := ctx.Deadline(); ok && time.Until(deadline) < C.DefaultTCPTimeout {
+		return context.WithTimeout(context.WithoutCancel(ctx), C.DefaultTCPTimeout)
 	}
+	return ctx, func() {}
 }
 
 func (o *OpenVPN) contextErr(ctx context.Context) error {

--- a/docs/config.yaml
+++ b/docs/config.yaml
@@ -1204,6 +1204,9 @@ proxies: # socks5
     #   00000000000000000000000000000000
     #   ...
     #   -----END OpenVPN Static key V1-----
+    # peer-info: # 透传给服务端的 peer-info 键值对，追加在内置 IV_VER/IV_PROTO/IV_CIPHERS 之后；用于服务端通过 --client-connect / PAM 基于 peer-info 做准入决策
+    #   IV_HWADDR: "52:54:00:ff:72:87"
+    #   UV_DEVICE_ID: "laptop-001"
     # ping: 10 # 默认值为 0
     # ping-restart: 60 # 默认值为 0
     # mtu: 1500

--- a/transport/openvpn/client.go
+++ b/transport/openvpn/client.go
@@ -103,7 +103,7 @@ func (c *Client) Handshake(ctx context.Context) (*PushReply, error) {
 
 	clientRecord, err := NewClientKeyMethod2Record(
 		InstallScriptOptionsString(c.config.Proto, c.config.Cipher, c.config.Auth, c.config.CompLZO),
-		InstallScriptPeerInfo(c.config.Cipher, c.config.CompLZO),
+		InstallScriptPeerInfo(c.config.Cipher, c.config.CompLZO, c.config.PeerInfo),
 		strings.TrimSpace(c.config.Username),
 		c.config.Password,
 	)

--- a/transport/openvpn/config.go
+++ b/transport/openvpn/config.go
@@ -51,6 +51,8 @@ type ClientConfig struct {
 	Username string
 	Password string
 
+	PeerInfo map[string]string
+
 	PingInterval time.Duration
 	PingRestart  time.Duration
 

--- a/transport/openvpn/keymethod.go
+++ b/transport/openvpn/keymethod.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"hash"
+	"sort"
 )
 
 const (
@@ -171,12 +172,23 @@ func InstallScriptOptionsString(proto, cipher, auth string, compLZO string) stri
 	return fmt.Sprintf("V4,dev-type tun,link-mtu %s,tun-mtu 1500,proto %s,%scipher %s,auth %s,keysize %s,key-method 2,tls-client", mtu, protoName, comp, cipher, auth, keysize)
 }
 
-func InstallScriptPeerInfo(cipher string, compLZO string) string {
+func InstallScriptPeerInfo(cipher string, compLZO string, peerInfo map[string]string) string {
 	lzo := ""
 	if compLZO == CompLzoYes {
 		lzo = "IV_LZO=1\n"
 	}
-	return fmt.Sprintf("IV_VER=mihomo-openvpn\nIV_PROTO=6\n%sIV_CIPHERS=%s\n", lzo, cipher)
+	info := fmt.Sprintf("IV_VER=mihomo-openvpn\nIV_PROTO=6\n%sIV_CIPHERS=%s\n", lzo, cipher)
+	// Append user-defined peer-info entries (e.g. IV_HWADDR, UV_*) after the
+	// built-in fields. Keys are sorted so the output is deterministic.
+	keys := make([]string, 0, len(peerInfo))
+	for key := range peerInfo {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		info += fmt.Sprintf("%s=%s\n", key, peerInfo[key])
+	}
+	return info
 }
 
 func appendOpenVPNString(out []byte, s string) []byte {

--- a/transport/openvpn/keymethod_test.go
+++ b/transport/openvpn/keymethod_test.go
@@ -9,7 +9,7 @@ import (
 func TestKeyMethod2ClientMarshalAndDerive(t *testing.T) {
 	record := &KeyMethod2Record{
 		Options:  InstallScriptOptionsString(ProtoUDP, CipherAES128GCM, AuthSHA256, ""),
-		PeerInfo: InstallScriptPeerInfo(CipherAES128GCM, ""),
+		PeerInfo: InstallScriptPeerInfo(CipherAES128GCM, "", nil),
 	}
 	for i := range record.Sources.Client.PreMaster {
 		record.Sources.Client.PreMaster[i] = byte(i + 1)
@@ -53,7 +53,7 @@ func TestKeyMethod2ClientMarshalAndDerive(t *testing.T) {
 func TestKeyMethod2DeriveAES256(t *testing.T) {
 	record := &KeyMethod2Record{
 		Options:  InstallScriptOptionsString(ProtoUDP, CipherAES256GCM, AuthSHA256, ""),
-		PeerInfo: InstallScriptPeerInfo(CipherAES256GCM, ""),
+		PeerInfo: InstallScriptPeerInfo(CipherAES256GCM, "", nil),
 	}
 	for i := range record.Sources.Client.PreMaster {
 		record.Sources.Client.PreMaster[i] = byte(i + 1)
@@ -88,6 +88,24 @@ func TestInstallScriptOptionsCBCSHA1(t *testing.T) {
 		if !bytes.Contains([]byte(options), []byte(want)) {
 			t.Fatalf("options missing %q: %s", want, options)
 		}
+	}
+}
+
+func TestInstallScriptPeerInfo(t *testing.T) {
+	// Without user-defined peer-info the output is unchanged (backward compatible).
+	base := InstallScriptPeerInfo(CipherAES128GCM, "", nil)
+	if base != "IV_VER=mihomo-openvpn\nIV_PROTO=6\nIV_CIPHERS=AES-128-GCM\n" {
+		t.Fatalf("unexpected default peer-info: %q", base)
+	}
+
+	// User-defined entries are appended after the built-in fields, sorted by key.
+	info := InstallScriptPeerInfo(CipherAES128GCM, "", map[string]string{
+		"UV_DEVICE_ID": "laptop-001",
+		"IV_HWADDR":    "52:54:00:ff:72:87",
+	})
+	want := base + "IV_HWADDR=52:54:00:ff:72:87\nUV_DEVICE_ID=laptop-001\n"
+	if info != want {
+		t.Fatalf("unexpected peer-info:\n got %q\nwant %q", info, want)
 	}
 }
 


### PR DESCRIPTION
Closes #2919

This PR makes the OpenVPN outbound usable against standard OpenVPN servers that gate clients via `push-peer-info` (e.g. an `--client-connect` script or PAM plugin checking `IV_HWADDR`). It contains two related commits.

### 1. feat: support custom peer-info (`068a885f`)

Adds a `peer-info` map to the OpenVPN outbound so users can send custom peer-info entries (e.g. `IV_HWADDR`, `UV_*`) during the key-method-2 handshake. Entries are appended after the built-in `IV_VER`/`IV_PROTO`/`IV_CIPHERS` and sorted by key for deterministic output. Fully backward compatible — when `peer-info` is omitted the emitted bytes are identical to before.

```yaml
proxies:
  - name: "openvpn"
    type: openvpn
    server: vpn.example.com
    port: 1194
    ca: |
      -----BEGIN CERTIFICATE-----
      ...
      -----END CERTIFICATE-----
    peer-info:
      IV_HWADDR: "52:54:00:ff:72:87"
      UV_DEVICE_ID: "laptop-001"
```

### 2. fix: handshake must not inherit the per-dial timeout (`1dfb0e0d`)

**Why a second commit is needed:** peer-info alone is not enough. A server that runs `push-peer-info` / PAM / `--client-connect` checks needs longer to finish the control-channel handshake than the single connection's dial timeout (`C.DefaultTCPTimeout`, 5s) that happens to trigger it. `handshakeContext` was derived from that dial context, so the 30s `DefaultHandshakeTimeout` was effectively capped at ~5s, and the handshake (key-method-2 exchange + `PUSH_REPLY`) timed out before it could finish — even with correct credentials and peer-info.

- Run the handshake under the outbound's run context with the full handshake timeout, since the tunnel is shared infrastructure reused by every connection rather than owned by the dial that triggers it.
- After the tunnel is established, refresh the dial deadline so the very first request (which paid for the one-time handshake) is not failed for exhausting its own budget.

### Testing

Verified against a real OpenVPN server that gates clients by `IV_HWADDR`:
- With **both** commits: the outbound connects — handshake completes and traffic flows on the first request.
- With **only** the peer-info commit: the first dial times out during the handshake (the 5s cap fires before `PUSH_REPLY`).

`go test ./transport/openvpn/` passes.

---

本 PR 让 OpenVPN 出站能连通那些用 `push-peer-info`(如 `--client-connect` 脚本 / PAM 插件校验 `IV_HWADDR`)做设备准入的标准 OpenVPN 服务端,包含两个相关 commit。

**1. feat: 支持自定义 peer-info(`068a885f`)** — 新增 `peer-info` map,可在 key-method-2 握手时上送 `IV_HWADDR`、`UV_*` 等自定义条目,追加在内置 `IV_VER`/`IV_PROTO`/`IV_CIPHERS` 之后并按 key 排序;不填时与改动前逐字节一致,完全向后兼容。

**2. fix: 握手不应继承单次拨号超时(`1dfb0e0d`)** — 为什么需要第二个 commit:仅有 peer-info 不够。运行 `push-peer-info` / PAM / `--client-connect` 校验的服务端,完成控制信道握手所需时间比「恰好触发它的那条连接」的拨号超时(`C.DefaultTCPTimeout`,5s)更久。而 `handshakeContext` 继承自该拨号 context,导致 30s 的 `DefaultHandshakeTimeout` 实际被压到 ~5s,握手(key-method-2 交换 + `PUSH_REPLY`)在完成前就超时 —— 即使账密和 peer-info 都正确。修复:握手改用 outbound 的 run context(隧道是被所有连接复用的共享资源,而非由触发它的拨号拥有)跑满完整握手超时;隧道建立后刷新拨号 deadline,使「为一次性握手买单」的首个请求不因自身预算耗尽而失败。

验证:针对真实按 `IV_HWADDR` 做准入的 OpenVPN 服务端 —— 两个 commit 都在时首个请求即连通;仅 peer-info commit 时首次拨号在握手中超时。`go test ./transport/openvpn/` 通过。
