### PR TITLE
add disable-session-reuse to anytls

### DIFF
--- a/adapter/outbound/anytls.go
+++ b/adapter/outbound/anytls.go
@@ -40,6 +40,7 @@ type AnyTLSOption struct {
 	IdleSessionCheckInterval int        `proxy:"idle-session-check-interval,omitempty"`
 	IdleSessionTimeout       int        `proxy:"idle-session-timeout,omitempty"`
 	MinIdleSession           int        `proxy:"min-idle-session,omitempty"`
+	DisableSessionReuse      bool       `proxy:"disable-session-reuse,omitempty"`
 }
 
 func (t *AnyTLS) DialContext(ctx context.Context, metadata *C.Metadata) (_ C.Conn, err error) {
@@ -110,6 +111,7 @@ func NewAnyTLS(option AnyTLSOption) (*AnyTLS, error) {
 		IdleSessionCheckInterval: time.Duration(option.IdleSessionCheckInterval) * time.Second,
 		IdleSessionTimeout:       time.Duration(option.IdleSessionTimeout) * time.Second,
 		MinIdleSession:           option.MinIdleSession,
+		DisableSessionReuse:      option.DisableSessionReuse,
 	}
 	echConfig, err := option.ECHOpts.Parse()
 	if err != nil {

--- a/docs/config.yaml
+++ b/docs/config.yaml
@@ -1377,6 +1377,7 @@ proxies: # socks5
     # idle-session-check-interval: 30 # seconds
     # idle-session-timeout: 30 # seconds
     # min-idle-session: 0
+    # disable-session-reuse: true
     # sni: "example.com"
     # alpn:
     #   - h2

--- a/transport/anytls/client.go
+++ b/transport/anytls/client.go
@@ -22,6 +22,7 @@ type ClientConfig struct {
 	IdleSessionCheckInterval time.Duration
 	IdleSessionTimeout       time.Duration
 	MinIdleSession           int
+	DisableSessionReuse      bool
 	Server                   M.Socksaddr
 	Dialer                   N.Dialer
 	TLSConfig                *vmess.TLSConfig
@@ -46,7 +47,7 @@ func NewClient(ctx context.Context, config ClientConfig) *Client {
 	}
 	// Initialize the padding state of this client
 	padding.UpdatePaddingScheme(padding.DefaultPaddingScheme, &c.padding)
-	c.sessionClient = session.NewClient(ctx, c.createOutboundTLSConnection, &c.padding, config.IdleSessionCheckInterval, config.IdleSessionTimeout, config.MinIdleSession)
+	c.sessionClient = session.NewClient(ctx, c.createOutboundTLSConnection, &c.padding, config.IdleSessionCheckInterval, config.IdleSessionTimeout, config.MinIdleSession, config.DisableSessionReuse)
 	return c
 }
 

--- a/transport/anytls/session/client.go
+++ b/transport/anytls/session/client.go
@@ -31,17 +31,19 @@ type Client struct {
 
 	padding *atomic.Pointer[padding.PaddingFactory]
 
-	idleSessionTimeout time.Duration
-	minIdleSession     int
+	idleSessionTimeout  time.Duration
+	minIdleSession      int
+	disableSessionReuse bool
 }
 
-func NewClient(ctx context.Context, dialOut util.DialOutFunc, _padding *atomic.Pointer[padding.PaddingFactory], idleSessionCheckInterval, idleSessionTimeout time.Duration, minIdleSession int) *Client {
+func NewClient(ctx context.Context, dialOut util.DialOutFunc, _padding *atomic.Pointer[padding.PaddingFactory], idleSessionCheckInterval, idleSessionTimeout time.Duration, minIdleSession int, disableSessionReuse bool) *Client {
 	c := &Client{
-		sessions:           make(map[uint64]*Session),
-		dialOut:            dialOut,
-		padding:            _padding,
-		idleSessionTimeout: idleSessionTimeout,
-		minIdleSession:     minIdleSession,
+		sessions:            make(map[uint64]*Session),
+		dialOut:             dialOut,
+		padding:             _padding,
+		idleSessionTimeout:  idleSessionTimeout,
+		minIdleSession:      minIdleSession,
+		disableSessionReuse: disableSessionReuse,
 	}
 	if idleSessionCheckInterval <= time.Second*5 {
 		idleSessionCheckInterval = time.Second * 30
@@ -87,6 +89,10 @@ func (c *Client) CreateStream(ctx context.Context) (net.Conn, error) {
 				// Now client has been closed
 				go session.Close()
 			default:
+				if c.disableSessionReuse {
+					go session.Close()
+					return
+				}
 				c.idleSessionLock.Lock()
 				session.idleSince = time.Now()
 				c.idleSession.Insert(math.MaxUint64-session.seq, session)

--- a/transport/anytls/session/stream.go
+++ b/transport/anytls/session/stream.go
@@ -89,11 +89,12 @@ func (s *Stream) closeWithError(err error) error {
 		once = true
 	})
 	if once {
+		err = s.sess.streamClosed(s.id)
 		if s.dieHook != nil {
 			s.dieHook()
 			s.dieHook = nil
 		}
-		return s.sess.streamClosed(s.id)
+		return err
 	} else {
 		return s.dieErr
 	}


### PR DESCRIPTION
Anytls has a bug in session reuse (at the protocol level), this pr adds an option to disable it.

About the `transport/anytls/session/stream.go` change (this is requested by gpt-5.5):
When disable-session-reuse is enabled and a stream is closed, this goroutine can close the underlying TLS session before Stream.closeWithError reaches s.sess.streamClosed(s.id) because the die hook runs first. If the FIN write blocks or the goroutine is scheduled immediately, streamClosed can see a closed session/connection and return an error without sending the stream FIN, causing spurious Close errors and an abrupt server-side close for this option.The new option is wired through, but its close path introduces a race between stream FIN emission and closing the whole session when reuse is disabled. 