### PR TITLE
fix: openvpn handshake must not inherit the per-dial timeout

### DIFF
--- a/adapter/outbound/openvpn.go
+++ b/adapter/outbound/openvpn.go
@@ -121,6 +121,8 @@ func (o *OpenVPN) DialContext(ctx context.Context, metadata *C.Metadata) (_ C.Co
 	if err != nil {
 		return nil, err
 	}
+	ctx, cancel := o.afterRunContext(ctx)
+	defer cancel()
 	var conn net.Conn
 	if !metadata.Resolved() || r != nil {
 		if r == nil {
@@ -148,6 +150,8 @@ func (o *OpenVPN) ListenPacketContext(ctx context.Context, metadata *C.Metadata)
 	if err != nil {
 		return nil, err
 	}
+	ctx, cancel := o.afterRunContext(ctx)
+	defer cancel()
 	if err = o.resolveUDP(ctx, metadata, r); err != nil {
 		return nil, err
 	}
@@ -166,6 +170,8 @@ func (o *OpenVPN) ResolveUDP(ctx context.Context, metadata *C.Metadata) error {
 	if err != nil {
 		return err
 	}
+	ctx, cancel := o.afterRunContext(ctx)
+	defer cancel()
 	return o.resolveUDP(ctx, metadata, r)
 }
 
@@ -302,12 +308,25 @@ func (o *OpenVPN) lockRun(ctx context.Context) error {
 }
 
 func (o *OpenVPN) handshakeContext(ctx context.Context) (context.Context, context.CancelFunc) {
-	handshakeCtx, handshakeCancel := context.WithTimeout(ctx, ovpn.DefaultHandshakeTimeout)
-	stop := contextutils.AfterFunc(o.runCtx, handshakeCancel)
-	return handshakeCtx, func() {
-		stop()
-		handshakeCancel()
+	// The OpenVPN tunnel is a shared, long-lived resource established once and
+	// reused by every connection. Its handshake must not be bound by the short
+	// per-dial timeout of whichever connection happens to trigger it (which is
+	// far shorter than the handshake of a server that performs push-peer-info /
+	// PAM checks), so use the outbound's run context with the full handshake
+	// timeout instead.
+	return context.WithTimeout(o.runCtx, ovpn.DefaultHandshakeTimeout)
+}
+
+// afterRunContext refreshes the dial deadline once the tunnel is established.
+// The first request that triggers the one-time handshake would otherwise have
+// spent most of its (short) dial budget building the tunnel, leaving too little
+// for the actual dial and failing the triggering request. Since the tunnel is
+// shared infrastructure, give the subsequent dial a fresh budget instead.
+func (o *OpenVPN) afterRunContext(ctx context.Context) (context.Context, context.CancelFunc) {
+	if deadline, ok := ctx.Deadline(); ok && time.Until(deadline) < C.DefaultTCPTimeout {
+		return context.WithTimeout(context.WithoutCancel(ctx), C.DefaultTCPTimeout)
 	}
+	return ctx, func() {}
 }
 
 func (o *OpenVPN) contextErr(ctx context.Context) error {


### PR DESCRIPTION
### Problem

The OpenVPN outbound establishes its control-channel tunnel lazily — on the first connection that needs it. The handshake context, however, was derived from that triggering dial's context:

```go
handshakeCtx, handshakeCancel := context.WithTimeout(ctx, ovpn.DefaultHandshakeTimeout)
```

Because `ctx` already carries the per-dial deadline (`C.DefaultTCPTimeout`, 5s), the effective handshake timeout was `min(5s, 30s) = 5s` — the 30s `DefaultHandshakeTimeout` never actually applied. Any OpenVPN server whose control-channel handshake takes longer than ~5s (TLS-auth, PAM / `--client-connect` scripts, a large `PUSH_REPLY`, slow links) fails the handshake before it can finish, even with correct credentials.

### Fix

- Run the handshake under the outbound's own run context (`o.runCtx`) with the full `DefaultHandshakeTimeout`, instead of inheriting the triggering dial's short deadline. The tunnel is shared, long-lived infrastructure reused by every connection — its one-time handshake should not be bounded by whichever single dial happens to trigger it.
- After the tunnel is established, refresh the dial deadline (`afterRunContext`) so the first request — which paid for the one-time handshake — is not failed for having spent its own short budget building shared infrastructure.

### Notes

This is an independent, pre-existing bug, not tied to any specific feature. It was discovered while implementing custom peer-info support (#2926), but it affects **any** slow OpenVPN handshake. Submitted as its own PR per the one-change-per-PR guideline.

`go build ./adapter/outbound/` passes.

---

### 问题

OpenVPN 出站的控制信道隧道是惰性建立的 —— 由第一条需要它的连接触发。但握手 context 继承自那条触发拨号的 context:

```go
handshakeCtx, handshakeCancel := context.WithTimeout(ctx, ovpn.DefaultHandshakeTimeout)
```

由于 `ctx` 已经带着单次拨号的 deadline(`C.DefaultTCPTimeout`,5s),实际握手超时是 `min(5s, 30s) = 5s` —— 30s 的 `DefaultHandshakeTimeout` 从未真正生效。任何控制信道握手耗时超过 ~5s 的服务端(TLS-auth、PAM / `--client-connect` 脚本、较大的 `PUSH_REPLY`、慢链路)都会在握手完成前超时,即使账密完全正确。

### 修复

- 握手改用 outbound 自己的 run context(`o.runCtx`)跑满完整的 `DefaultHandshakeTimeout`,不再继承触发拨号的短 deadline。隧道是被所有连接复用的、长生命周期的共享资源,它的一次性握手不应被「恰好触发它的那条拨号」的超时所限制。
- 隧道建立后刷新拨号 deadline(`afterRunContext`),使「为一次性握手买单」的首个请求,不因把自己的短预算花在建设共享设施上而失败。

### 说明

这是一个独立的、早已存在的 bug,与任何具体功能无关。它是在实现自定义 peer-info(#2926)时发现的,但影响**任何**慢速 OpenVPN 握手。按「一个 PR 只做一件事」的规范,单独成 PR 提交。

`go build ./adapter/outbound/` 通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
