### PR TITLE
feat: support custom peer-info for openvpn outbound

### DIFF
--- a/adapter/outbound/openvpn.go
+++ b/adapter/outbound/openvpn.go
@@ -42,24 +42,25 @@ type OpenVPN struct {
 
 type OpenVPNOption struct {
 	BasicOption
-	Name        string `proxy:"name"`
-	Server      string `proxy:"server"`
-	Port        int    `proxy:"port"`
-	Proto       string `proxy:"proto,omitempty"`
-	Dev         string `proxy:"dev,omitempty"`
-	Cipher      string `proxy:"cipher,omitempty"`
-	Auth        string `proxy:"auth,omitempty"`
-	CompLZO     string `proxy:"comp-lzo,omitempty"`
-	CA          string `proxy:"ca"`
-	Cert        string `proxy:"cert,omitempty"`
-	Key         string `proxy:"key,omitempty"`
-	TLSCrypt    string `proxy:"tls-crypt,omitempty"`
-	Username    string `proxy:"username,omitempty"`
-	Password    string `proxy:"password,omitempty"`
-	Ping        int    `proxy:"ping,omitempty"`
-	PingRestart int    `proxy:"ping-restart,omitempty"`
-	MTU         int    `proxy:"mtu,omitempty"`
-	UDP         bool   `proxy:"udp,omitempty"`
+	Name        string            `proxy:"name"`
+	Server      string            `proxy:"server"`
+	Port        int               `proxy:"port"`
+	Proto       string            `proxy:"proto,omitempty"`
+	Dev         string            `proxy:"dev,omitempty"`
+	Cipher      string            `proxy:"cipher,omitempty"`
+	Auth        string            `proxy:"auth,omitempty"`
+	CompLZO     string            `proxy:"comp-lzo,omitempty"`
+	CA          string            `proxy:"ca"`
+	Cert        string            `proxy:"cert,omitempty"`
+	Key         string            `proxy:"key,omitempty"`
+	TLSCrypt    string            `proxy:"tls-crypt,omitempty"`
+	Username    string            `proxy:"username,omitempty"`
+	Password    string            `proxy:"password,omitempty"`
+	PeerInfo    map[string]string `proxy:"peer-info,omitempty"`
+	Ping        int               `proxy:"ping,omitempty"`
+	PingRestart int               `proxy:"ping-restart,omitempty"`
+	MTU         int               `proxy:"mtu,omitempty"`
+	UDP         bool              `proxy:"udp,omitempty"`
 
 	RemoteDnsResolve bool     `proxy:"remote-dns-resolve,omitempty"`
 	Dns              []string `proxy:"dns,omitempty"`
@@ -80,6 +81,7 @@ func NewOpenVPN(option OpenVPNOption) (*OpenVPN, error) {
 		TLSCrypt:     []byte(option.TLSCrypt),
 		Username:     option.Username,
 		Password:     option.Password,
+		PeerInfo:     option.PeerInfo,
 		PingInterval: time.Duration(option.Ping) * time.Second,
 		PingRestart:  time.Duration(option.PingRestart) * time.Second,
 	}

--- a/docs/config.yaml
+++ b/docs/config.yaml
@@ -1204,7 +1204,7 @@ proxies: # socks5
     #   00000000000000000000000000000000
     #   ...
     #   -----END OpenVPN Static key V1-----
-    # peer-info: # 透传给服务端的 peer-info 键值对，追加在内置 IV_VER/IV_PROTO/IV_CIPHERS 之后；用于服务端通过 --client-connect / PAM 基于 peer-info 做准入决策
+    # peer-info: # 透传给服务端的 peer-info 键值对，追加在内置 IV_VER/IV_PROTO/IV_CIPHERS 之后；用于服务端基于 peer-info 做准入决策
     #   IV_HWADDR: "52:54:00:ff:72:87"
     #   UV_DEVICE_ID: "laptop-001"
     # ping: 10 # 默认值为 0

--- a/docs/config.yaml
+++ b/docs/config.yaml
@@ -1204,6 +1204,9 @@ proxies: # socks5
     #   00000000000000000000000000000000
     #   ...
     #   -----END OpenVPN Static key V1-----
+    # peer-info: # 透传给服务端的 peer-info 键值对，追加在内置 IV_VER/IV_PROTO/IV_CIPHERS 之后；用于服务端通过 --client-connect / PAM 基于 peer-info 做准入决策
+    #   IV_HWADDR: "52:54:00:ff:72:87"
+    #   UV_DEVICE_ID: "laptop-001"
     # ping: 10 # 默认值为 0
     # ping-restart: 60 # 默认值为 0
     # mtu: 1500

--- a/transport/openvpn/client.go
+++ b/transport/openvpn/client.go
@@ -103,7 +103,7 @@ func (c *Client) Handshake(ctx context.Context) (*PushReply, error) {
 
 	clientRecord, err := NewClientKeyMethod2Record(
 		InstallScriptOptionsString(c.config.Proto, c.config.Cipher, c.config.Auth, c.config.CompLZO),
-		InstallScriptPeerInfo(c.config.Cipher, c.config.CompLZO),
+		InstallScriptPeerInfo(c.config.Cipher, c.config.CompLZO, c.config.PeerInfo),
 		strings.TrimSpace(c.config.Username),
 		c.config.Password,
 	)

--- a/transport/openvpn/config.go
+++ b/transport/openvpn/config.go
@@ -51,6 +51,8 @@ type ClientConfig struct {
 	Username string
 	Password string
 
+	PeerInfo map[string]string
+
 	PingInterval time.Duration
 	PingRestart  time.Duration
 

--- a/transport/openvpn/keymethod.go
+++ b/transport/openvpn/keymethod.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"hash"
+	"sort"
 )
 
 const (
@@ -171,12 +172,23 @@ func InstallScriptOptionsString(proto, cipher, auth string, compLZO string) stri
 	return fmt.Sprintf("V4,dev-type tun,link-mtu %s,tun-mtu 1500,proto %s,%scipher %s,auth %s,keysize %s,key-method 2,tls-client", mtu, protoName, comp, cipher, auth, keysize)
 }
 
-func InstallScriptPeerInfo(cipher string, compLZO string) string {
+func InstallScriptPeerInfo(cipher string, compLZO string, peerInfo map[string]string) string {
 	lzo := ""
 	if compLZO == CompLzoYes {
 		lzo = "IV_LZO=1\n"
 	}
-	return fmt.Sprintf("IV_VER=mihomo-openvpn\nIV_PROTO=6\n%sIV_CIPHERS=%s\n", lzo, cipher)
+	info := fmt.Sprintf("IV_VER=mihomo-openvpn\nIV_PROTO=6\n%sIV_CIPHERS=%s\n", lzo, cipher)
+	// Append user-defined peer-info entries (e.g. IV_HWADDR, UV_*) after the
+	// built-in fields. Keys are sorted so the output is deterministic.
+	keys := make([]string, 0, len(peerInfo))
+	for key := range peerInfo {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		info += fmt.Sprintf("%s=%s\n", key, peerInfo[key])
+	}
+	return info
 }
 
 func appendOpenVPNString(out []byte, s string) []byte {

--- a/transport/openvpn/keymethod_test.go
+++ b/transport/openvpn/keymethod_test.go
@@ -9,7 +9,7 @@ import (
 func TestKeyMethod2ClientMarshalAndDerive(t *testing.T) {
 	record := &KeyMethod2Record{
 		Options:  InstallScriptOptionsString(ProtoUDP, CipherAES128GCM, AuthSHA256, ""),
-		PeerInfo: InstallScriptPeerInfo(CipherAES128GCM, ""),
+		PeerInfo: InstallScriptPeerInfo(CipherAES128GCM, "", nil),
 	}
 	for i := range record.Sources.Client.PreMaster {
 		record.Sources.Client.PreMaster[i] = byte(i + 1)
@@ -53,7 +53,7 @@ func TestKeyMethod2ClientMarshalAndDerive(t *testing.T) {
 func TestKeyMethod2DeriveAES256(t *testing.T) {
 	record := &KeyMethod2Record{
 		Options:  InstallScriptOptionsString(ProtoUDP, CipherAES256GCM, AuthSHA256, ""),
-		PeerInfo: InstallScriptPeerInfo(CipherAES256GCM, ""),
+		PeerInfo: InstallScriptPeerInfo(CipherAES256GCM, "", nil),
 	}
 	for i := range record.Sources.Client.PreMaster {
 		record.Sources.Client.PreMaster[i] = byte(i + 1)
@@ -88,6 +88,24 @@ func TestInstallScriptOptionsCBCSHA1(t *testing.T) {
 		if !bytes.Contains([]byte(options), []byte(want)) {
 			t.Fatalf("options missing %q: %s", want, options)
 		}
+	}
+}
+
+func TestInstallScriptPeerInfo(t *testing.T) {
+	// Without user-defined peer-info the output is unchanged (backward compatible).
+	base := InstallScriptPeerInfo(CipherAES128GCM, "", nil)
+	if base != "IV_VER=mihomo-openvpn\nIV_PROTO=6\nIV_CIPHERS=AES-128-GCM\n" {
+		t.Fatalf("unexpected default peer-info: %q", base)
+	}
+
+	// User-defined entries are appended after the built-in fields, sorted by key.
+	info := InstallScriptPeerInfo(CipherAES128GCM, "", map[string]string{
+		"UV_DEVICE_ID": "laptop-001",
+		"IV_HWADDR":    "52:54:00:ff:72:87",
+	})
+	want := base + "IV_HWADDR=52:54:00:ff:72:87\nUV_DEVICE_ID=laptop-001\n"
+	if info != want {
+		t.Fatalf("unexpected peer-info:\n got %q\nwant %q", info, want)
 	}
 }
 


### PR DESCRIPTION
Closes #2919

Adds an optional `peer-info` map to the OpenVPN outbound, letting users declare custom peer-info entries (e.g. `IV_HWADDR`, `UV_*`) sent during the key-method-2 handshake. Entries are appended after the built-in `IV_VER`/`IV_PROTO`/`IV_CIPHERS` and sorted by key for deterministic output. Fully backward compatible — when `peer-info` is omitted the emitted bytes are identical to before.

```yaml
proxies:
  - name: "openvpn"
    type: openvpn
    server: vpn.example.com
    port: 1194
    ca: |
      -----BEGIN CERTIFICATE-----
      ...
      -----END CERTIFICATE-----
    peer-info:
      IV_HWADDR: "52:54:00:ff:72:87"
      UV_DEVICE_ID: "laptop-001"
```

### Why

Some OpenVPN deployments use `--client-connect` scripts or PAM plugins to read client-pushed peer-info (such as `IV_HWADDR` or custom `UV_*`) for access control — e.g. checking a device's hardware address against an allow-list. mihomo currently sends a hard-coded minimal peer-info, so such servers reject the connection and the OpenVPN outbound is unusable against them. This lets the client advertise the required peer-info.

> mihomo is a user-space client with no concept of OpenVPN's native default-gateway MAC, so the values are explicitly declared by the user, not auto-detected. The client *advertises* peer-info to satisfy server-side policy; it does not collect real hardware information.

### Related

Against servers that run slow access-control checks during the handshake, you may also need the standalone handshake-timeout fix in #2925 for the control channel to complete in time. That is submitted separately because it is an independent, pre-existing bug.

### Testing

`go test ./transport/openvpn/` passes. Verified against a real OpenVPN server that gates clients by `IV_HWADDR`.

---

### 这个 PR 做了什么

为 OpenVPN 出站新增一个可选的 `peer-info` map,允许用户声明在 key-method-2 握手时上送的自定义 peer-info 条目(如 `IV_HWADDR`、`UV_*`)。用户条目追加在内置 `IV_VER`/`IV_PROTO`/`IV_CIPHERS` 之后,并按 key 排序以保证确定性输出。完全向后兼容 —— 不填 `peer-info` 时,上送的字节与改动前逐字节一致。

### 为什么需要

部分 OpenVPN 部署会用 `--client-connect` 脚本或 PAM 插件读取客户端上送的 peer-info(如 `IV_HWADDR` 或自定义 `UV_*`)做准入控制(例如按设备硬件地址校验白名单)。mihomo 目前上送的是写死的最小 peer-info,这类服务端会拒绝连接,导致 OpenVPN 出站在这类环境下无法使用。本改动让客户端能上送所需的 peer-info。

> mihomo 是用户态客户端,没有 OpenVPN 原生「默认网关 MAC」的概念,因此值由用户显式声明,而非自动探测。客户端只是*上报* peer-info 以满足服务端策略,并不采集真实硬件信息。

### 关联

对在握手期间做慢速准入校验的服务端,可能还需要配合 #2925(独立的握手超时修复)才能让控制信道及时完成。那个修复是独立的、早已存在的 bug,因此单独成 PR。

### 测试

`go test ./transport/openvpn/` 通过。已针对真实按 `IV_HWADDR` 做准入的 OpenVPN 服务端验证连通。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
