### PR TITLE
fix: wrong realm resolver when only IPv6 is requested

### DIFF
--- a/adapter/outbound/hysteria2.go
+++ b/adapter/outbound/hysteria2.go
@@ -297,7 +297,7 @@ func NewHysteria2(option Hysteria2Option) (*Hysteria2, error) {
 				if ipv4 && !ipv6 {
 					return resolver.LookupIPv4WithResolver(ctx, host, resolver.ProxyServerHostResolver)
 				} else if ipv6 && !ipv4 {
-					return resolver.LookupIPv4WithResolver(ctx, host, resolver.ProxyServerHostResolver)
+					return resolver.LookupIPv6WithResolver(ctx, host, resolver.ProxyServerHostResolver)
 				}
 				return resolver.LookupIPWithResolver(ctx, host, resolver.ProxyServerHostResolver)
 			},

--- a/listener/sing_hysteria2/server.go
+++ b/listener/sing_hysteria2/server.go
@@ -191,7 +191,7 @@ func New(config LC.Hysteria2Server, tunnel C.Tunnel, additions ...inbound.Additi
 				if ipv4 && !ipv6 {
 					return resolver.LookupIPv4WithResolver(ctx, host, resolver.ProxyServerHostResolver)
 				} else if ipv6 && !ipv4 {
-					return resolver.LookupIPv4WithResolver(ctx, host, resolver.ProxyServerHostResolver)
+					return resolver.LookupIPv6WithResolver(ctx, host, resolver.ProxyServerHostResolver)
 				}
 				return resolver.LookupIPWithResolver(ctx, host, resolver.ProxyServerHostResolver)
 			},


### PR DESCRIPTION
Fix a copy-paste error in Hysteria2 Realm resolver where it calls LookupIPv4WithResolver instead of LookupIPv6WithResolver when only IPv6 is requested.