### PR TITLE
fix: preserve shadow-tls in-user for snell listeners

### DIFF
--- a/listener/sing/context.go
+++ b/listener/sing/context.go
@@ -18,6 +18,8 @@ func WithAdditions(ctx context.Context, additions ...inbound.Addition) context.C
 	return context.WithValue(ctx, ctxKeyAdditions, additions)
 }
 
+func AdditionsFromContext(ctx context.Context) []inbound.Addition { return getAdditions(ctx) }
+
 func getAdditions(ctx context.Context) (additions []inbound.Addition) {
 	if v := ctx.Value(ctxKeyAdditions); v != nil {
 		if a, ok := v.([]inbound.Addition); ok {

--- a/listener/snell/server.go
+++ b/listener/snell/server.go
@@ -90,7 +90,7 @@ func New(config LC.SnellServer, lc C.InboundListenConfig, tunnel C.Tunnel, addit
 			WildcardSNI:            wildcardSNI,
 			Handler: sing.FnHandler{
 				NewConnectionFn: func(ctx context.Context, conn net.Conn, metadata M.Metadata) error {
-					l.handleConn(conn, tunnel, additions...)
+					l.handleConn(conn, tunnel, sing.AdditionsFromContext(ctx)...)
 					return nil
 				}},
 			Logger: log.SingLogger,


### PR DESCRIPTION
## Summary
Snell listeners using ShadowTLS v3 now preserve the authenticated user name in inbound metadata, so `IN-USER` rules can match the ShadowTLS user the same way they already do for Shadowsocks listeners.

The Snell ShadowTLS handler now reuses the existing sing context additions path instead of dropping the authenticated user before Snell request metadata is built.

## Test plan
- `go test ./listener/... -count=1`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
