### PR TITLE
fix: TUIC v5 fragmented UDP reads in quicStreamPacketConn.ReadFrom

### DIFF
--- a/transport/tuic/v5/packet.go
+++ b/transport/tuic/v5/packet.go
@@ -104,7 +104,7 @@ func (q *quicStreamPacketConn) ReadFrom(p []byte) (n int, addr net.Addr, err err
 				return
 			}
 			if packetPtr := q.deFragger.Feed(&packet); packetPtr != nil {
-				n = copy(p, packet.DATA)
+				n = copy(p, packetPtr.DATA)
 				addr = packetPtr.ADDR.UDPAddr()
 				return
 			}


### PR DESCRIPTION
`quicStreamPacketConn.ReadFrom` in TUIC v5 reassembles fragmented UDP packets via `deFragger.Feed`, but it copies from the last fragment’s `packet.DATA` instead of the fully assembled `packetPtr.DATA`. That makes the standard  `net.PacketConn` read path return truncated or wrong payloads whenever a UDP datagram is fragmented.