### PR TITLE
fix: apply TUIC v5 UDP relay size clamp when building server options

### DIFF
--- a/transport/tuic/server.go
+++ b/transport/tuic/server.go
@@ -237,7 +237,7 @@ func NewServer(option *ServerOption, pc net.PacketConn) (*Server, error) {
 			HandleTcpFn:           option.HandleTcpFn,
 			HandleUdpFn:           option.HandleUdpFn,
 			Users:                 option.Users,
-			MaxUdpRelayPacketSize: option.MaxUdpRelayPacketSize,
+			MaxUdpRelayPacketSize: maxUdpRelayPacketSize,
 		}
 	}
 	return server, nil


### PR DESCRIPTION
This code computes a clamped `maxUdpRelayPacketSize` for TUIC v5, but it never uses that value. The code still passes the original `option.MaxUdpRelayPacketSize` into `v5.ServerOption`, which means the intended safety limit is effectively ignored.