### PR TITLE
fix: listener duplicate-name check

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -997,11 +997,11 @@ func parseListeners(cfg *RawConfig) (listeners map[string]C.InboundListener, err
 	for index, mapping := range cfg.Listeners {
 		inboundListener, err := listener.ParseListener(mapping)
 		if err != nil {
-			return nil, fmt.Errorf("proxy %d: %w", index, err)
+			return nil, fmt.Errorf("listener %d: %w", index, err)
 		}
 
 		name := inboundListener.Name()
-		if _, exist := mapping[name]; exist {
+		if _, exist := listeners[name]; exist {
 			return nil, fmt.Errorf("listener %s is the duplicate name", name)
 		}
 


### PR DESCRIPTION
The code checks duplicate listener names against the local mapping variable instead of the listeners map, so it misses duplicate listener names across the config and never detects them.