### PR TITLE
fix: DOMAIN-WILDCARD ignores sniffed hostname

### DIFF
--- a/rules/common/domain_wildcard.go
+++ b/rules/common/domain_wildcard.go
@@ -18,7 +18,7 @@ func (dw *DomainWildcard) RuleType() C.RuleType {
 }
 
 func (dw *DomainWildcard) Match(metadata *C.Metadata, _ C.RuleMatchHelper) (bool, string) {
-	return wildcard.Match(dw.pattern, metadata.Host), dw.adapter
+	return wildcard.Match(dw.pattern, metadata.RuleHost()), dw.adapter
 }
 
 func (dw *DomainWildcard) Adapter() string {


### PR DESCRIPTION
The code uses `metadata.Host` instead of `metadata.RuleHost()`. Every other domain rule (DOMAIN, DOMAIN-SUFFIX, DOMAIN-KEYWORD, DOMAIN-REGEX) uses `RuleHost()`, so a wildcard rule won't match a host discovered via sniffing, unlike its siblings.