### PR TITLE
feat: add embedded Tailscale host forwarding

### DIFF
--- a/adapter/outbound/base.go
+++ b/adapter/outbound/base.go
@@ -14,6 +14,7 @@ import (
 	"github.com/metacubex/mihomo/component/dialer"
 	"github.com/metacubex/mihomo/component/proxydialer"
 	"github.com/metacubex/mihomo/component/resolver"
+	"github.com/metacubex/mihomo/component/tailnet"
 	C "github.com/metacubex/mihomo/constant"
 	"github.com/metacubex/mihomo/log"
 
@@ -388,6 +389,14 @@ func (p *autoCloseProxyAdapter) Close() error {
 		p.closeErr = p.ProxyAdapter.Close()
 	})
 	return p.closeErr
+}
+
+func (p *autoCloseProxyAdapter) TailnetStatus(ctx context.Context) (tailnet.Status, error) {
+	provider, ok := p.ProxyAdapter.(tailnet.StatusProvider)
+	if !ok {
+		return tailnet.Status{Proxy: p.Name()}, tailnet.ErrStatusUnavailable
+	}
+	return provider.TailnetStatus(ctx)
 }
 
 func NewAutoCloseProxyAdapter(adapter ProxyAdapter) ProxyAdapter {

--- a/adapter/outbound/tailscale.go
+++ b/adapter/outbound/tailscale.go
@@ -541,16 +541,21 @@ func tailscaleStatusFromIPN(proxyName string, status *ipnstate.Status) tailnet.S
 
 func tailscalePeerStatusToNode(peer *ipnstate.PeerStatus, magicDNSSuffix string, self bool) tailnet.NodeStatus {
 	node := tailnet.NodeStatus{
-		HostName:     peer.HostName,
-		DNSName:      peer.DNSName,
-		OS:           peer.OS,
-		TailscaleIPs: tailscaleAddrsToStrings(peer.TailscaleIPs),
-		Online:       peer.Online,
-		Relay:        peer.Relay,
-		PeerRelay:    peer.PeerRelay,
-		TxBytes:      peer.TxBytes,
-		RxBytes:      peer.RxBytes,
-		Self:         self,
+		HostName:       peer.HostName,
+		DNSName:        peer.DNSName,
+		OS:             peer.OS,
+		TailscaleIPs:   tailscaleAddrsToStrings(peer.TailscaleIPs),
+		Online:         peer.Online,
+		Active:         peer.Active,
+		Relay:          peer.Relay,
+		Addrs:          append([]string{}, peer.Addrs...),
+		CurAddr:        peer.CurAddr,
+		PeerRelay:      peer.PeerRelay,
+		ExitNode:       peer.ExitNode,
+		ExitNodeOption: peer.ExitNodeOption,
+		TxBytes:        peer.TxBytes,
+		RxBytes:        peer.RxBytes,
+		Self:           self,
 	}
 	if !peer.LastSeen.IsZero() {
 		lastSeen := peer.LastSeen

--- a/adapter/outbound/tailscale.go
+++ b/adapter/outbound/tailscale.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"net"
 	"net/netip"
+	"os"
 	"runtime"
 	"strings"
 	"sync"
@@ -18,6 +19,7 @@ import (
 	"github.com/metacubex/mihomo/component/ca"
 	"github.com/metacubex/mihomo/component/dialer"
 	"github.com/metacubex/mihomo/component/iface/anet"
+	"github.com/metacubex/mihomo/component/keepalive"
 	"github.com/metacubex/mihomo/component/resolver"
 	"github.com/metacubex/mihomo/component/tailnet"
 	C "github.com/metacubex/mihomo/constant"
@@ -82,7 +84,13 @@ type TailscaleHostForwardOption struct {
 	UDP     *bool  `proxy:"udp,omitempty"`
 }
 
-const tailscaleHostForwardUDPIdleTimeout = 2 * time.Minute
+const (
+	tailscaleHostForwardUDPIdleTimeout               = 2 * time.Minute
+	tailscaleHostForwardNetstackKeepaliveIdleEnv     = "TS_NETSTACK_KEEPALIVE_IDLE"
+	tailscaleHostForwardNetstackKeepaliveIdle        = "60s"
+	tailscaleHostForwardNetstackKeepaliveIntervalEnv = "TS_NETSTACK_KEEPALIVE_INTERVAL"
+	tailscaleHostForwardNetstackKeepaliveInterval    = "15s"
+)
 
 var tailscaleHostForwardDefaultTarget = netip.MustParseAddr("127.0.0.1")
 
@@ -126,6 +134,7 @@ func newTailscaleHostForwarder(
 	}
 
 	dialer := &net.Dialer{}
+	keepalive.SetNetDialer(dialer)
 	return &tailscaleHostForwarder{
 		ctx:         ctx,
 		name:        name,
@@ -153,15 +162,29 @@ func (f *tailscaleHostForwarder) handleTCP(src, dst netip.AddrPort) (func(net.Co
 	}
 	target := f.targetAddress(dst)
 	return func(client net.Conn) {
+		keepalive.TCPKeepAlive(client)
 		backend, err := f.dialContext(f.ctx, "tcp", target)
 		if err != nil {
 			log.Debugln("[Tailscale](%s) host-forward TCP %s -> %s failed: %v", f.name, src, target, err)
 			_ = client.Close()
 			return
 		}
+		keepalive.TCPKeepAlive(backend)
 		log.Debugln("[Tailscale](%s) host-forward TCP %s -> %s", f.name, src, target)
 		N.Relay(client, backend)
 	}, true
+}
+
+func configureTailscaleHostForwardNetstackKeepalive() {
+	setTailscaleEnvDefault(tailscaleHostForwardNetstackKeepaliveIdleEnv, tailscaleHostForwardNetstackKeepaliveIdle)
+	setTailscaleEnvDefault(tailscaleHostForwardNetstackKeepaliveIntervalEnv, tailscaleHostForwardNetstackKeepaliveInterval)
+}
+
+func setTailscaleEnvDefault(name, value string) {
+	if os.Getenv(name) != "" {
+		return
+	}
+	envknob.Setenv(name, value)
 }
 
 func (f *tailscaleHostForwarder) handleUDP(src, dst netip.AddrPort) (func(nettype.ConnPacketConn), bool) {
@@ -361,6 +384,9 @@ func NewTailscale(option TailscaleOption) (*Tailscale, error) {
 		return nil, err
 	}
 	outbound.hostForward = hostForward
+	if hostForward != nil {
+		configureTailscaleHostForwardNetstackKeepalive()
+	}
 	dnsTransport := tailscaleDNSTransport{tailscale: outbound}
 	outbound.dnsResolver = dns.NewResolverFromClient(dnsTransport)
 	outbound.unregisterDNSResolver = dns.RegisterTailscaleDnsClient(option.Name, dnsTransport)
@@ -380,6 +406,7 @@ func NewTailscale(option TailscaleOption) (*Tailscale, error) {
 	}
 	if hostForward != nil {
 		log.Infoln("[Tailscale](%s) host-forward enabled: tcp=%v udp=%v target=%s", option.Name, hostForward.tcp, hostForward.udp, hostForward.target)
+		log.Infoln("[Tailscale](%s) host-forward netstack TCP keepalive: idle=%s interval=%s", option.Name, os.Getenv(tailscaleHostForwardNetstackKeepaliveIdleEnv), os.Getenv(tailscaleHostForwardNetstackKeepaliveIntervalEnv))
 	}
 	if option.MagicDNS {
 		log.Infoln("[Tailscale](%s) MagicDNS integration enabled", option.Name)

--- a/adapter/outbound/tailscale.go
+++ b/adapter/outbound/tailscale.go
@@ -6,12 +6,14 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"net"
 	"net/netip"
 	"runtime"
 	"sync"
 	"time"
 
+	N "github.com/metacubex/mihomo/common/net"
 	"github.com/metacubex/mihomo/component/ca"
 	"github.com/metacubex/mihomo/component/dialer"
 	"github.com/metacubex/mihomo/component/iface/anet"
@@ -26,6 +28,7 @@ import (
 	"github.com/metacubex/tailscale/net/netmon"
 	"github.com/metacubex/tailscale/tailcfg"
 	"github.com/metacubex/tailscale/tsnet"
+	"github.com/metacubex/tailscale/types/nettype"
 	D "github.com/miekg/dns"
 	"github.com/samber/lo"
 )
@@ -46,22 +49,195 @@ type Tailscale struct {
 
 	serverStarted bool
 
+	hostForward           *tailscaleHostForwarder
+	unregisterHostForward []func()
 	unregisterDNSResolver func()
 }
 
 type TailscaleOption struct {
 	BasicOption
-	Name       string `proxy:"name"`
-	Hostname   string `proxy:"hostname,omitempty"`
-	AuthKey    string `proxy:"auth-key,omitempty"`
-	ControlURL string `proxy:"control-url,omitempty"`
-	StateDir   string `proxy:"state-dir,omitempty"`
-	Ephemeral  bool   `proxy:"ephemeral,omitempty"`
-	UDP        bool   `proxy:"udp,omitempty"`
+	Name        string                     `proxy:"name"`
+	Hostname    string                     `proxy:"hostname,omitempty"`
+	AuthKey     string                     `proxy:"auth-key,omitempty"`
+	ControlURL  string                     `proxy:"control-url,omitempty"`
+	StateDir    string                     `proxy:"state-dir,omitempty"`
+	Ephemeral   bool                       `proxy:"ephemeral,omitempty"`
+	UDP         bool                       `proxy:"udp,omitempty"`
+	HostForward TailscaleHostForwardOption `proxy:"host-forward,omitempty"`
 
 	AcceptRoutes           *bool  `proxy:"accept-routes,omitempty"`
 	ExitNode               string `proxy:"exit-node,omitempty"`
 	ExitNodeAllowLANAccess *bool  `proxy:"exit-node-allow-lan-access,omitempty"`
+}
+
+type TailscaleHostForwardOption struct {
+	Enabled bool   `proxy:"enabled,omitempty"`
+	Target  string `proxy:"target,omitempty"`
+	TCP     *bool  `proxy:"tcp,omitempty"`
+	UDP     *bool  `proxy:"udp,omitempty"`
+}
+
+const tailscaleHostForwardUDPIdleTimeout = 2 * time.Minute
+
+var tailscaleHostForwardDefaultTarget = netip.MustParseAddr("127.0.0.1")
+
+type tailscaleHostForwarder struct {
+	ctx         context.Context
+	name        string
+	target      netip.Addr
+	tcp         bool
+	udp         bool
+	tailscaleIP func() (netip.Addr, netip.Addr)
+	dialContext func(context.Context, string, string) (net.Conn, error)
+}
+
+func newTailscaleHostForwarder(
+	ctx context.Context,
+	name string,
+	option TailscaleHostForwardOption,
+	tailscaleIP func() (netip.Addr, netip.Addr),
+) (*tailscaleHostForwarder, error) {
+	if !option.Enabled {
+		return nil, nil
+	}
+
+	target := option.Target
+	if target == "" {
+		target = tailscaleHostForwardDefaultTarget.String()
+	}
+	targetIP, err := netip.ParseAddr(target)
+	if err != nil {
+		return nil, fmt.Errorf("invalid tailscale host-forward target %q: %w", target, err)
+	}
+	targetIP = targetIP.Unmap()
+	if !targetIP.IsLoopback() {
+		return nil, fmt.Errorf("tailscale host-forward target must be a loopback address: %s", targetIP)
+	}
+
+	tcpEnabled := option.TCP == nil || *option.TCP
+	udpEnabled := option.UDP == nil || *option.UDP
+	if !tcpEnabled && !udpEnabled {
+		return nil, errors.New("tailscale host-forward requires tcp or udp")
+	}
+
+	dialer := &net.Dialer{}
+	return &tailscaleHostForwarder{
+		ctx:         ctx,
+		name:        name,
+		target:      targetIP,
+		tcp:         tcpEnabled,
+		udp:         udpEnabled,
+		tailscaleIP: tailscaleIP,
+		dialContext: dialer.DialContext,
+	}, nil
+}
+
+func (f *tailscaleHostForwarder) accepts(dst netip.AddrPort) bool {
+	dstAddr := dst.Addr().Unmap()
+	v4, v6 := f.tailscaleIP()
+	return (v4.IsValid() && dstAddr == v4.Unmap()) || (v6.IsValid() && dstAddr == v6.Unmap())
+}
+
+func (f *tailscaleHostForwarder) targetAddress(dst netip.AddrPort) string {
+	return netip.AddrPortFrom(f.target, dst.Port()).String()
+}
+
+func (f *tailscaleHostForwarder) handleTCP(src, dst netip.AddrPort) (func(net.Conn), bool) {
+	if !f.tcp || !f.accepts(dst) {
+		return nil, false
+	}
+	target := f.targetAddress(dst)
+	return func(client net.Conn) {
+		backend, err := f.dialContext(f.ctx, "tcp", target)
+		if err != nil {
+			log.Debugln("[Tailscale](%s) host-forward TCP %s -> %s failed: %v", f.name, src, target, err)
+			_ = client.Close()
+			return
+		}
+		log.Debugln("[Tailscale](%s) host-forward TCP %s -> %s", f.name, src, target)
+		N.Relay(client, backend)
+	}, true
+}
+
+func (f *tailscaleHostForwarder) handleUDP(src, dst netip.AddrPort) (func(nettype.ConnPacketConn), bool) {
+	if !f.udp || !f.accepts(dst) {
+		return nil, false
+	}
+	target := f.targetAddress(dst)
+	return func(client nettype.ConnPacketConn) {
+		backend, err := f.dialContext(f.ctx, "udp", target)
+		if err != nil {
+			log.Debugln("[Tailscale](%s) host-forward UDP %s -> %s failed: %v", f.name, src, target, err)
+			_ = client.Close()
+			return
+		}
+		log.Debugln("[Tailscale](%s) host-forward UDP %s -> %s", f.name, src, target)
+		_ = relayTailscaleHostUDP(f.ctx, client, backend, tailscaleHostForwardUDPIdleTimeout)
+	}, true
+}
+
+func relayTailscaleHostUDP(ctx context.Context, client nettype.ConnPacketConn, backend net.Conn, idleTimeout time.Duration) error {
+	refreshDeadline := func() {
+		deadline := time.Now().Add(idleTimeout)
+		_ = client.SetDeadline(deadline)
+		_ = backend.SetDeadline(deadline)
+	}
+	refreshDeadline()
+
+	copyClientToBackend := func() error {
+		buffer := make([]byte, 64*1024)
+		for {
+			n, _, err := client.ReadFrom(buffer)
+			if err != nil {
+				return err
+			}
+			written, err := backend.Write(buffer[:n])
+			if err != nil {
+				return err
+			}
+			if written != n {
+				return io.ErrShortWrite
+			}
+			refreshDeadline()
+		}
+	}
+	copyBackendToClient := func() error {
+		buffer := make([]byte, 64*1024)
+		for {
+			n, err := backend.Read(buffer)
+			if err != nil {
+				return err
+			}
+			written, err := client.Write(buffer[:n])
+			if err != nil {
+				return err
+			}
+			if written != n {
+				return io.ErrShortWrite
+			}
+			refreshDeadline()
+		}
+	}
+
+	errCh := make(chan error, 2)
+	go func() { errCh <- copyClientToBackend() }()
+	go func() { errCh <- copyBackendToClient() }()
+
+	completed := 0
+	var firstErr error
+	select {
+	case firstErr = <-errCh:
+		completed = 1
+	case <-ctx.Done():
+		firstErr = ctx.Err()
+	}
+	_ = client.Close()
+	_ = backend.Close()
+	for completed < 2 {
+		<-errCh
+		completed++
+	}
+	return firstErr
 }
 
 func init() {
@@ -174,9 +350,28 @@ func NewTailscale(option TailscaleOption) (*Tailscale, error) {
 			log.Debugln("[Tailscale](%s) %s", option.Name, fmt.Sprintf(format, args...))
 		},
 	}
+	hostForward, err := newTailscaleHostForwarder(ctx, option.Name, option.HostForward, outbound.server.TailscaleIPs)
+	if err != nil {
+		cancel()
+		return nil, err
+	}
+	outbound.hostForward = hostForward
 	dnsTransport := tailscaleDNSTransport{tailscale: outbound}
 	outbound.dnsResolver = dns.NewResolverFromClient(dnsTransport)
 	outbound.unregisterDNSResolver = dns.RegisterTailscaleDnsClient(option.Name, dnsTransport)
+	if hostForward != nil {
+		if hostForward.tcp {
+			outbound.unregisterHostForward = append(outbound.unregisterHostForward, outbound.server.RegisterFallbackTCPHandler(hostForward.handleTCP))
+		}
+		if hostForward.udp {
+			outbound.unregisterHostForward = append(outbound.unregisterHostForward, outbound.server.RegisterFallbackUDPHandler(hostForward.handleUDP))
+		}
+		if err := outbound.start(); err != nil {
+			_ = outbound.Close()
+			return nil, fmt.Errorf("start tailscale host-forward: %w", err)
+		}
+		log.Infoln("[Tailscale](%s) host-forward enabled: tcp=%v udp=%v target=%s", option.Name, hostForward.tcp, hostForward.udp, hostForward.target)
+	}
 	return outbound, nil
 }
 
@@ -463,6 +658,10 @@ func (t *Tailscale) IsL3Protocol(metadata *C.Metadata) bool {
 
 func (t *Tailscale) Close() error {
 	t.cancel()
+	for _, unregister := range t.unregisterHostForward {
+		unregister()
+	}
+	t.unregisterHostForward = nil
 	if t.unregisterDNSResolver != nil {
 		t.unregisterDNSResolver()
 	}

--- a/adapter/outbound/tailscale.go
+++ b/adapter/outbound/tailscale.go
@@ -10,6 +10,7 @@ import (
 	"net"
 	"net/netip"
 	"runtime"
+	"strings"
 	"sync"
 	"time"
 
@@ -26,6 +27,7 @@ import (
 	"github.com/metacubex/tailscale/envknob"
 	"github.com/metacubex/tailscale/hostinfo"
 	"github.com/metacubex/tailscale/ipn"
+	"github.com/metacubex/tailscale/ipn/ipnstate"
 	"github.com/metacubex/tailscale/net/netmon"
 	"github.com/metacubex/tailscale/tailcfg"
 	"github.com/metacubex/tailscale/tsnet"
@@ -484,6 +486,111 @@ func tailscaleMagicDNSSearchDomains(nm *netmap.NetworkMap) []string {
 		domains = append(domains, nm.MagicDNSSuffix())
 	}
 	return tailnet.NormalizeSearchDomains(domains)
+}
+
+func (t *Tailscale) TailnetStatus(ctx context.Context) (tailnet.Status, error) {
+	if err := t.ensureStarted(ctx); err != nil {
+		return tailnet.Status{Proxy: t.Name()}, err
+	}
+	lc, err := t.server.LocalClient()
+	if err != nil {
+		return tailnet.Status{Proxy: t.Name()}, err
+	}
+	status, err := lc.Status(ctx)
+	if err != nil {
+		return tailnet.Status{Proxy: t.Name()}, err
+	}
+	return tailscaleStatusFromIPN(t.Name(), status), nil
+}
+
+func tailscaleStatusFromIPN(proxyName string, status *ipnstate.Status) tailnet.Status {
+	result := tailnet.Status{
+		Proxy: proxyName,
+		Peers: []tailnet.NodeStatus{},
+	}
+	if status == nil {
+		return result
+	}
+
+	result.BackendState = status.BackendState
+	result.TailscaleIPs = tailscaleAddrsToStrings(status.TailscaleIPs)
+	if status.CurrentTailnet != nil {
+		result.MagicDNSSuffix = status.CurrentTailnet.MagicDNSSuffix
+		result.MagicDNSEnabled = status.CurrentTailnet.MagicDNSEnabled
+	} else {
+		result.MagicDNSSuffix = status.MagicDNSSuffix
+	}
+
+	if status.Self != nil {
+		self := tailscalePeerStatusToNode(status.Self, result.MagicDNSSuffix, true)
+		if !self.Online && status.BackendState == ipn.Running.String() {
+			self.Online = true
+		}
+		result.Self = &self
+	}
+
+	for _, key := range status.Peers() {
+		peer := status.Peer[key]
+		if peer == nil {
+			continue
+		}
+		result.Peers = append(result.Peers, tailscalePeerStatusToNode(peer, result.MagicDNSSuffix, false))
+	}
+	return result
+}
+
+func tailscalePeerStatusToNode(peer *ipnstate.PeerStatus, magicDNSSuffix string, self bool) tailnet.NodeStatus {
+	node := tailnet.NodeStatus{
+		HostName:     peer.HostName,
+		DNSName:      peer.DNSName,
+		OS:           peer.OS,
+		TailscaleIPs: tailscaleAddrsToStrings(peer.TailscaleIPs),
+		Online:       peer.Online,
+		Relay:        peer.Relay,
+		PeerRelay:    peer.PeerRelay,
+		TxBytes:      peer.TxBytes,
+		RxBytes:      peer.RxBytes,
+		Self:         self,
+	}
+	if !peer.LastSeen.IsZero() {
+		lastSeen := peer.LastSeen
+		node.LastSeen = &lastSeen
+	}
+	node.Name = tailscalePeerDisplayName(node, magicDNSSuffix)
+	return node
+}
+
+func tailscalePeerDisplayName(node tailnet.NodeStatus, magicDNSSuffix string) string {
+	dnsName := strings.TrimRight(node.DNSName, ".")
+	suffix := strings.TrimRight(magicDNSSuffix, ".")
+	if dnsName != "" && suffix != "" {
+		if dnsName == suffix {
+			return dnsName
+		}
+		if name, ok := strings.CutSuffix(dnsName, "."+suffix); ok && name != "" {
+			return name
+		}
+	}
+	if node.HostName != "" {
+		return node.HostName
+	}
+	if dnsName != "" {
+		return dnsName
+	}
+	if len(node.TailscaleIPs) > 0 {
+		return node.TailscaleIPs[0]
+	}
+	return ""
+}
+
+func tailscaleAddrsToStrings(addrs []netip.Addr) []string {
+	result := make([]string, 0, len(addrs))
+	for _, addr := range addrs {
+		if addr.IsValid() {
+			result = append(result, addr.String())
+		}
+	}
+	return result
 }
 
 func (t *Tailscale) setBackendInitialized(err error) {

--- a/adapter/outbound/tailscale.go
+++ b/adapter/outbound/tailscale.go
@@ -56,6 +56,7 @@ type Tailscale struct {
 	serverStarted bool
 
 	hostForward           *tailscaleHostForwarder
+	kernelHostForward     *tailscaleKernelHostForwarder
 	unregisterHostForward []func()
 	unregisterDNSResolver func()
 }
@@ -79,12 +80,18 @@ type TailscaleOption struct {
 
 type TailscaleHostForwardOption struct {
 	Enabled bool   `proxy:"enabled,omitempty"`
+	Mode    string `proxy:"mode,omitempty"`
 	Target  string `proxy:"target,omitempty"`
 	TCP     *bool  `proxy:"tcp,omitempty"`
 	UDP     *bool  `proxy:"udp,omitempty"`
+	Device  string `proxy:"device,omitempty"`
+	MTU     uint32 `proxy:"mtu,omitempty"`
 }
 
 const (
+	tailscaleHostForwardModeUserspace = "userspace"
+	tailscaleHostForwardModeKernel    = "kernel"
+
 	tailscaleHostForwardUDPIdleTimeout               = 2 * time.Minute
 	tailscaleHostForwardNetstackKeepaliveIdleEnv     = "TS_NETSTACK_KEEPALIVE_IDLE"
 	tailscaleHostForwardNetstackKeepaliveIdle        = "60s"
@@ -93,6 +100,19 @@ const (
 )
 
 var tailscaleHostForwardDefaultTarget = netip.MustParseAddr("127.0.0.1")
+
+func tailscaleHostForwardMode(option TailscaleHostForwardOption) (string, error) {
+	mode := strings.ToLower(strings.TrimSpace(option.Mode))
+	if mode == "" {
+		return tailscaleHostForwardModeUserspace, nil
+	}
+	switch mode {
+	case tailscaleHostForwardModeUserspace, tailscaleHostForwardModeKernel:
+		return mode, nil
+	default:
+		return "", fmt.Errorf("unsupported tailscale host-forward mode %q", option.Mode)
+	}
+}
 
 type tailscaleHostForwarder struct {
 	ctx         context.Context
@@ -316,6 +336,14 @@ func NewTailscale(option TailscaleOption) (*Tailscale, error) {
 	if _, err := buildTailscaleMaskedPrefs(option); err != nil {
 		return nil, err
 	}
+	hostForwardMode := tailscaleHostForwardModeUserspace
+	if option.HostForward.Enabled {
+		var err error
+		hostForwardMode, err = tailscaleHostForwardMode(option.HostForward)
+		if err != nil {
+			return nil, err
+		}
+	}
 	if option.StateDir == "" {
 		option.StateDir = "tailscale"
 	}
@@ -346,6 +374,14 @@ func NewTailscale(option TailscaleOption) (*Tailscale, error) {
 		backendInitCh: make(chan struct{}),
 	}
 	outbound.dialer = option.NewDialer(outbound.DialOptions())
+	if option.HostForward.Enabled && hostForwardMode == tailscaleHostForwardModeKernel {
+		kernelHostForward, err := newTailscaleKernelHostForwarder(option.Name, option.HostForward)
+		if err != nil {
+			cancel()
+			return nil, err
+		}
+		outbound.kernelHostForward = kernelHostForward
+	}
 	outbound.server = &tsnet.Server{
 		Dir:        option.StateDir,
 		Hostname:   option.Hostname,
@@ -378,10 +414,17 @@ func NewTailscale(option TailscaleOption) (*Tailscale, error) {
 			log.Debugln("[Tailscale](%s) %s", option.Name, fmt.Sprintf(format, args...))
 		},
 	}
-	hostForward, err := newTailscaleHostForwarder(ctx, option.Name, option.HostForward, outbound.server.TailscaleIPs)
-	if err != nil {
-		cancel()
-		return nil, err
+	if outbound.kernelHostForward != nil {
+		outbound.server.Tun = outbound.kernelHostForward.Device()
+	}
+	var hostForward *tailscaleHostForwarder
+	var err error
+	if option.HostForward.Enabled && hostForwardMode == tailscaleHostForwardModeUserspace {
+		hostForward, err = newTailscaleHostForwarder(ctx, option.Name, option.HostForward, outbound.server.TailscaleIPs)
+		if err != nil {
+			cancel()
+			return nil, err
+		}
 	}
 	outbound.hostForward = hostForward
 	if hostForward != nil {
@@ -390,7 +433,7 @@ func NewTailscale(option TailscaleOption) (*Tailscale, error) {
 	dnsTransport := tailscaleDNSTransport{tailscale: outbound}
 	outbound.dnsResolver = dns.NewResolverFromClient(dnsTransport)
 	outbound.unregisterDNSResolver = dns.RegisterTailscaleDnsClient(option.Name, dnsTransport)
-	if hostForward != nil || option.MagicDNS {
+	if hostForward != nil || outbound.kernelHostForward != nil || option.MagicDNS {
 		if hostForward != nil {
 			if hostForward.tcp {
 				outbound.unregisterHostForward = append(outbound.unregisterHostForward, outbound.server.RegisterFallbackTCPHandler(hostForward.handleTCP))
@@ -407,6 +450,9 @@ func NewTailscale(option TailscaleOption) (*Tailscale, error) {
 	if hostForward != nil {
 		log.Infoln("[Tailscale](%s) host-forward enabled: tcp=%v udp=%v target=%s", option.Name, hostForward.tcp, hostForward.udp, hostForward.target)
 		log.Infoln("[Tailscale](%s) host-forward netstack TCP keepalive: idle=%s interval=%s", option.Name, os.Getenv(tailscaleHostForwardNetstackKeepaliveIdleEnv), os.Getenv(tailscaleHostForwardNetstackKeepaliveIntervalEnv))
+	}
+	if outbound.kernelHostForward != nil {
+		log.Infoln("[Tailscale](%s) host-forward kernel mode enabled: device=%s mtu=%d routes=%v", option.Name, outbound.kernelHostForward.Name(), outbound.kernelHostForward.MTU(), outbound.kernelHostForward.Routes())
 	}
 	if option.MagicDNS {
 		log.Infoln("[Tailscale](%s) MagicDNS integration enabled", option.Name)
@@ -459,6 +505,7 @@ func (t *Tailscale) watchBackendState() {
 	defer watcher.Close()
 
 	backendInitialized := false
+	kernelHostForwardConfigured := t.kernelHostForward == nil
 	exitNodeNeedsStatus := tailscaleExitNodeNeedsStatus(t.option)
 	for {
 		n, err := watcher.Next()
@@ -476,12 +523,22 @@ func (t *Tailscale) watchBackendState() {
 			t.publishMagicDNSSearchDomains(n.NetMap)
 		}
 
+		if !kernelHostForwardConfigured && *n.State == ipn.Running {
+			v4, v6 := t.server.TailscaleIPs()
+			if err := t.kernelHostForward.Configure(v4, v6); err != nil {
+				t.setBackendInitialized(err)
+				log.Warnln("[Tailscale](%s) configure kernel host-forward failed: %v", t.Name(), err)
+				return
+			}
+			kernelHostForwardConfigured = true
+			log.Infoln("[Tailscale](%s) host-forward kernel interface configured: device=%s ips=%v routes=%v", t.Name(), t.kernelHostForward.Name(), t.kernelHostForward.Addresses(), t.kernelHostForward.Routes())
+		}
 		if *n.State != ipn.NoState && !backendInitialized {
 			t.setBackendInitialized(nil)
 			backendInitialized = true
-			if !exitNodeNeedsStatus && !t.option.MagicDNS {
-				return
-			}
+		}
+		if backendInitialized && !exitNodeNeedsStatus && !t.option.MagicDNS && kernelHostForwardConfigured {
+			return
 		}
 		if exitNodeNeedsStatus && *n.State == ipn.Running {
 			if err := t.applyExitNodePrefs(t.ctx); err != nil {
@@ -853,8 +910,12 @@ func (t *Tailscale) Close() error {
 	t.startOnce.Do(func() {
 		t.startErr = errors.New("tailscale outbound closed")
 	})
+	var err error
 	if t.server != nil && t.serverStarted { // tsnet.Server.Close() must not be called before or concurrently with Start.
-		return t.server.Close()
+		err = t.server.Close()
 	}
-	return nil
+	if t.kernelHostForward != nil {
+		err = errors.Join(err, t.kernelHostForward.Close())
+	}
+	return err
 }

--- a/adapter/outbound/tailscale.go
+++ b/adapter/outbound/tailscale.go
@@ -18,6 +18,7 @@ import (
 	"github.com/metacubex/mihomo/component/dialer"
 	"github.com/metacubex/mihomo/component/iface/anet"
 	"github.com/metacubex/mihomo/component/resolver"
+	"github.com/metacubex/mihomo/component/tailnet"
 	C "github.com/metacubex/mihomo/constant"
 	"github.com/metacubex/mihomo/dns"
 	"github.com/metacubex/mihomo/log"
@@ -28,6 +29,7 @@ import (
 	"github.com/metacubex/tailscale/net/netmon"
 	"github.com/metacubex/tailscale/tailcfg"
 	"github.com/metacubex/tailscale/tsnet"
+	"github.com/metacubex/tailscale/types/netmap"
 	"github.com/metacubex/tailscale/types/nettype"
 	D "github.com/miekg/dns"
 	"github.com/samber/lo"
@@ -63,6 +65,7 @@ type TailscaleOption struct {
 	StateDir    string                     `proxy:"state-dir,omitempty"`
 	Ephemeral   bool                       `proxy:"ephemeral,omitempty"`
 	UDP         bool                       `proxy:"udp,omitempty"`
+	MagicDNS    bool                       `proxy:"magic-dns,omitempty"`
 	HostForward TailscaleHostForwardOption `proxy:"host-forward,omitempty"`
 
 	AcceptRoutes           *bool  `proxy:"accept-routes,omitempty"`
@@ -359,18 +362,25 @@ func NewTailscale(option TailscaleOption) (*Tailscale, error) {
 	dnsTransport := tailscaleDNSTransport{tailscale: outbound}
 	outbound.dnsResolver = dns.NewResolverFromClient(dnsTransport)
 	outbound.unregisterDNSResolver = dns.RegisterTailscaleDnsClient(option.Name, dnsTransport)
-	if hostForward != nil {
-		if hostForward.tcp {
-			outbound.unregisterHostForward = append(outbound.unregisterHostForward, outbound.server.RegisterFallbackTCPHandler(hostForward.handleTCP))
-		}
-		if hostForward.udp {
-			outbound.unregisterHostForward = append(outbound.unregisterHostForward, outbound.server.RegisterFallbackUDPHandler(hostForward.handleUDP))
+	if hostForward != nil || option.MagicDNS {
+		if hostForward != nil {
+			if hostForward.tcp {
+				outbound.unregisterHostForward = append(outbound.unregisterHostForward, outbound.server.RegisterFallbackTCPHandler(hostForward.handleTCP))
+			}
+			if hostForward.udp {
+				outbound.unregisterHostForward = append(outbound.unregisterHostForward, outbound.server.RegisterFallbackUDPHandler(hostForward.handleUDP))
+			}
 		}
 		if err := outbound.start(); err != nil {
 			_ = outbound.Close()
-			return nil, fmt.Errorf("start tailscale host-forward: %w", err)
+			return nil, fmt.Errorf("start tailscale proxy: %w", err)
 		}
+	}
+	if hostForward != nil {
 		log.Infoln("[Tailscale](%s) host-forward enabled: tcp=%v udp=%v target=%s", option.Name, hostForward.tcp, hostForward.udp, hostForward.target)
+	}
+	if option.MagicDNS {
+		log.Infoln("[Tailscale](%s) MagicDNS integration enabled", option.Name)
 	}
 	return outbound, nil
 }
@@ -408,7 +418,11 @@ func (t *Tailscale) watchBackendState() {
 		t.setBackendInitialized(err)
 		return
 	}
-	watcher, err := lc.WatchIPNBus(t.ctx, ipn.NotifyInitialState)
+	watchMask := ipn.NotifyInitialState
+	if t.option.MagicDNS {
+		watchMask |= ipn.NotifyInitialNetMap
+	}
+	watcher, err := lc.WatchIPNBus(t.ctx, watchMask)
 	if err != nil {
 		t.setBackendInitialized(err)
 		return
@@ -424,13 +438,19 @@ func (t *Tailscale) watchBackendState() {
 			return
 		}
 		if n.State == nil {
+			if t.option.MagicDNS && n.NetMap != nil {
+				t.publishMagicDNSSearchDomains(n.NetMap)
+			}
 			continue
+		}
+		if t.option.MagicDNS && n.NetMap != nil {
+			t.publishMagicDNSSearchDomains(n.NetMap)
 		}
 
 		if *n.State != ipn.NoState && !backendInitialized {
 			t.setBackendInitialized(nil)
 			backendInitialized = true
-			if !exitNodeNeedsStatus {
+			if !exitNodeNeedsStatus && !t.option.MagicDNS {
 				return
 			}
 		}
@@ -438,9 +458,32 @@ func (t *Tailscale) watchBackendState() {
 			if err := t.applyExitNodePrefs(t.ctx); err != nil {
 				log.Warnln("[Tailscale](%s) set exit node failed: %v", t.Name(), err)
 			}
-			return
+			if !t.option.MagicDNS {
+				return
+			}
+			exitNodeNeedsStatus = false
 		}
 	}
+}
+
+func (t *Tailscale) publishMagicDNSSearchDomains(nm *netmap.NetworkMap) {
+	domains := tailscaleMagicDNSSearchDomains(nm)
+	if len(domains) == 0 {
+		return
+	}
+	tailnet.SetSearchDomains(t.Name(), domains)
+	log.Debugln("[Tailscale](%s) MagicDNS search domains: %v", t.Name(), domains)
+}
+
+func tailscaleMagicDNSSearchDomains(nm *netmap.NetworkMap) []string {
+	if nm == nil {
+		return nil
+	}
+	domains := append([]string{}, nm.DNS.Domains...)
+	if nm.DNS.Proxied {
+		domains = append(domains, nm.MagicDNSSuffix())
+	}
+	return tailnet.NormalizeSearchDomains(domains)
 }
 
 func (t *Tailscale) setBackendInitialized(err error) {
@@ -658,6 +701,9 @@ func (t *Tailscale) IsL3Protocol(metadata *C.Metadata) bool {
 
 func (t *Tailscale) Close() error {
 	t.cancel()
+	if t.option.MagicDNS {
+		tailnet.RemoveSearchDomains(t.Name())
+	}
 	for _, unregister := range t.unregisterHostForward {
 		unregister()
 	}

--- a/adapter/outbound/tailscale_host_forward_e2e_test.go
+++ b/adapter/outbound/tailscale_host_forward_e2e_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/metacubex/mihomo/adapter/outbound"
 	C "github.com/metacubex/mihomo/constant"
 	mlog "github.com/metacubex/mihomo/log"
+	"github.com/metacubex/tailscale/envknob"
 	"github.com/metacubex/tailscale/net/netns"
 	"github.com/metacubex/tailscale/net/stun/stuntest"
 	"github.com/metacubex/tailscale/tailcfg"
@@ -36,6 +37,7 @@ func TestTailscaleHostForwardE2E(t *testing.T) {
 	oldHome := C.Path.HomeDir()
 	C.SetHomeDir(t.TempDir())
 	t.Cleanup(func() { C.SetHomeDir(oldHome) })
+	setShortNetstackKeepalive(t)
 
 	controlURL := startControl(t)
 	serverHost := "hf-server.tail-scale.ts.net"
@@ -106,6 +108,14 @@ func TestTailscaleHostForwardE2E(t *testing.T) {
 	})
 	t.Log("SSH handshake over host-forward reached authentication")
 
+	idleDuration := hostForwardE2EIdleDuration(t, 6*time.Second)
+	idleEchoPort := startEchoService(t)
+	idleEchoForward := startTCPForwarder(t, client, serverHost, idleEchoPort, 0)
+	if err := checkIdleTCPFlow(idleEchoForward, idleDuration); err != nil {
+		t.Fatal(err)
+	}
+	t.Log("idle TCP flow over host-forward survived quiet period")
+
 	iperfTCPPort := startIperfServer(t)
 	iperfTCPForward := startTCPForwarder(t, client, serverHost, iperfTCPPort, 0)
 	out, err := runCommand(25*time.Second, "iperf3", "-c", "127.0.0.1", "-p", portString(iperfTCPForward), "-t", "1", "-J")
@@ -134,6 +144,39 @@ func TestTailscaleHostForwardE2E(t *testing.T) {
 		t.Fatalf("closed-port check emitted %d host-forward warnings", got-beforeWarnings)
 	}
 	t.Log("closed TCP port failed cleanly without host-forward warnings")
+}
+
+func setShortNetstackKeepalive(t *testing.T) {
+	t.Helper()
+	const (
+		idleEnv     = "TS_NETSTACK_KEEPALIVE_IDLE"
+		intervalEnv = "TS_NETSTACK_KEEPALIVE_INTERVAL"
+	)
+	oldIdle := os.Getenv(idleEnv)
+	oldInterval := os.Getenv(intervalEnv)
+	if oldIdle == "" {
+		envknob.Setenv(idleEnv, "2s")
+	}
+	if oldInterval == "" {
+		envknob.Setenv(intervalEnv, "1s")
+	}
+	t.Cleanup(func() {
+		envknob.Setenv(idleEnv, oldIdle)
+		envknob.Setenv(intervalEnv, oldInterval)
+	})
+}
+
+func hostForwardE2EIdleDuration(t *testing.T, fallback time.Duration) time.Duration {
+	t.Helper()
+	raw := os.Getenv("MIHOMO_TAILSCALE_HOST_FORWARD_E2E_IDLE")
+	if raw == "" {
+		return fallback
+	}
+	d, err := time.ParseDuration(raw)
+	if err != nil {
+		t.Fatalf("invalid MIHOMO_TAILSCALE_HOST_FORWARD_E2E_IDLE %q: %v", raw, err)
+	}
+	return d
 }
 
 func startControl(t *testing.T) string {
@@ -208,6 +251,35 @@ func startHTTPService(t *testing.T) int {
 		defer cancel()
 		_ = srv.Shutdown(ctx)
 	})
+	return ln.Addr().(*net.TCPAddr).Port
+}
+
+func startEchoService(t *testing.T) int {
+	t.Helper()
+	ln, err := net.Listen("tcp4", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(func() {
+		cancel()
+		_ = ln.Close()
+	})
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				if ctx.Err() == nil {
+					t.Logf("echo service accept failed: %v", err)
+				}
+				return
+			}
+			go func(conn net.Conn) {
+				defer conn.Close()
+				_, _ = io.Copy(conn, conn)
+			}(conn)
+		}
+	}()
 	return ln.Addr().(*net.TCPAddr).Port
 }
 
@@ -428,6 +500,37 @@ func checkSSHHandshake(addr string) error {
 	}
 	if !strings.Contains(err.Error(), "unable to authenticate") {
 		return err
+	}
+	return nil
+}
+
+func checkIdleTCPFlow(addr string, idle time.Duration) error {
+	conn, err := net.DialTimeout("tcp4", addr, 15*time.Second)
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+
+	if err := writeAndReadEcho(conn, "before-idle"); err != nil {
+		return err
+	}
+	time.Sleep(idle)
+	return writeAndReadEcho(conn, "after-idle")
+}
+
+func writeAndReadEcho(conn net.Conn, payload string) error {
+	if err := conn.SetDeadline(time.Now().Add(15 * time.Second)); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(conn, payload); err != nil {
+		return err
+	}
+	got := make([]byte, len(payload))
+	if _, err := io.ReadFull(conn, got); err != nil {
+		return err
+	}
+	if string(got) != payload {
+		return fmt.Errorf("echo response = %q, want %q", got, payload)
 	}
 	return nil
 }

--- a/adapter/outbound/tailscale_host_forward_e2e_test.go
+++ b/adapter/outbound/tailscale_host_forward_e2e_test.go
@@ -1,0 +1,520 @@
+//go:build with_gvisor && !no_tailscale && tailscale_host_forward_e2e
+
+package outbound_test
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/netip"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/metacubex/mihomo/adapter/outbound"
+	C "github.com/metacubex/mihomo/constant"
+	mlog "github.com/metacubex/mihomo/log"
+	"github.com/metacubex/tailscale/net/netns"
+	"github.com/metacubex/tailscale/net/stun/stuntest"
+	"github.com/metacubex/tailscale/tailcfg"
+	"github.com/metacubex/tailscale/tstest/integration/testcontrol"
+	"github.com/metacubex/tailscale/types/nettype"
+	"golang.org/x/crypto/ssh"
+)
+
+func TestTailscaleHostForwardE2E(t *testing.T) {
+	oldHome := C.Path.HomeDir()
+	C.SetHomeDir(t.TempDir())
+	t.Cleanup(func() { C.SetHomeDir(oldHome) })
+
+	controlURL := startControl(t)
+	serverHost := "hf-server.tail-scale.ts.net"
+
+	server, err := outbound.NewTailscale(outbound.TailscaleOption{
+		Name:       "hf-server",
+		Hostname:   "hf-server",
+		ControlURL: controlURL,
+		StateDir:   filepath.Join("tailscale-e2e", "server"),
+		Ephemeral:  true,
+		HostForward: outbound.TailscaleHostForwardOption{
+			Enabled: true,
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = server.Close() })
+
+	client, err := outbound.NewTailscale(outbound.TailscaleOption{
+		Name:       "hf-client",
+		Hostname:   "hf-client",
+		ControlURL: controlURL,
+		StateDir:   filepath.Join("tailscale-e2e", "client"),
+		Ephemeral:  true,
+		UDP:        true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = client.Close() })
+
+	var hostForwardWarnings atomic.Int32
+	sub := mlog.Subscribe()
+	doneLogs := make(chan struct{})
+	go func() {
+		defer close(doneLogs)
+		for ev := range sub {
+			if ev.LogLevel >= mlog.WARNING && strings.Contains(ev.Payload, "host-forward") {
+				hostForwardWarnings.Add(1)
+				t.Logf("host-forward warning: %s", ev.Payload)
+			}
+		}
+	}()
+	t.Cleanup(func() {
+		mlog.UnSubscribe(sub)
+		<-doneLogs
+	})
+
+	httpPort := startHTTPService(t)
+	httpForward := startTCPForwarder(t, client, serverHost, httpPort, 0)
+	eventually(t, 75*time.Second, 2*time.Second, func() error {
+		out, err := runCommand(15*time.Second, "curl", "-fsS", "http://"+httpForward)
+		if err != nil {
+			return fmt.Errorf("curl failed: %w: %s", err, out)
+		}
+		if !strings.Contains(out, "mihomo-host-forward-ok") {
+			return fmt.Errorf("unexpected HTTP response %q", out)
+		}
+		return nil
+	})
+	t.Log("HTTP over host-forward succeeded")
+
+	sshdPort := startSSHD(t)
+	sshForward := startTCPForwarder(t, client, serverHost, sshdPort, 0)
+	eventually(t, 45*time.Second, time.Second, func() error {
+		return checkSSHHandshake(sshForward)
+	})
+	t.Log("SSH handshake over host-forward reached authentication")
+
+	iperfTCPPort := startIperfServer(t)
+	iperfTCPForward := startTCPForwarder(t, client, serverHost, iperfTCPPort, 0)
+	out, err := runCommand(25*time.Second, "iperf3", "-c", "127.0.0.1", "-p", portString(iperfTCPForward), "-t", "1", "-J")
+	if err != nil {
+		t.Fatalf("iperf3 TCP failed: %v: %s", err, out)
+	}
+	t.Log("iperf3 TCP over host-forward succeeded")
+
+	iperfUDPPort := startIperfServer(t)
+	iperfUDPForward := startTCPForwarder(t, client, serverHost, iperfUDPPort, 0)
+	startUDPForwarder(t, client, serverHost, iperfUDPPort, portNumber(iperfUDPForward))
+	out, err = runCommand(30*time.Second, "iperf3", "-u", "-c", "127.0.0.1", "-p", portString(iperfUDPForward), "-t", "1", "-b", "256K", "-J")
+	if err != nil {
+		t.Fatalf("iperf3 UDP failed: %v: %s", err, out)
+	}
+	t.Log("iperf3 UDP over host-forward succeeded")
+
+	closedTargetPort := freeTCPPort(t)
+	closedForward := startTCPForwarder(t, client, serverHost, closedTargetPort, 0)
+	beforeWarnings := hostForwardWarnings.Load()
+	if err := checkClosedPort(closedForward); err != nil {
+		t.Fatal(err)
+	}
+	time.Sleep(200 * time.Millisecond)
+	if got := hostForwardWarnings.Load(); got != beforeWarnings {
+		t.Fatalf("closed-port check emitted %d host-forward warnings", got-beforeWarnings)
+	}
+	t.Log("closed TCP port failed cleanly without host-forward warnings")
+}
+
+func startControl(t *testing.T) string {
+	t.Helper()
+	netns.SetEnabled(false)
+	t.Cleanup(func() { netns.SetEnabled(true) })
+
+	derpMap := runLocalSTUNDERPMap(t, "127.0.0.1")
+	control := &testcontrol.Server{
+		DERPMap: derpMap,
+		DNSConfig: &tailcfg.DNSConfig{
+			Proxied: true,
+		},
+		MagicDNSDomain: "tail-scale.ts.net",
+		Logf:           t.Logf,
+		AllOnline:      true,
+	}
+	control.HTTPTestServer = httptest.NewUnstartedServer(control)
+	control.HTTPTestServer.Start()
+	t.Cleanup(control.HTTPTestServer.Close)
+	return control.HTTPTestServer.URL
+}
+
+func runLocalSTUNDERPMap(t *testing.T, ipAddress string) *tailcfg.DERPMap {
+	t.Helper()
+
+	stunAddr, stunCleanup := stuntest.ServeWithPacketListener(t, nettype.Std{})
+	t.Cleanup(func() {
+		stunCleanup()
+	})
+
+	// These local nodes can connect directly once STUN publishes endpoints.
+	return &tailcfg.DERPMap{
+		Regions: map[int]*tailcfg.DERPRegion{
+			1: {
+				RegionID:   1,
+				RegionCode: "test",
+				Nodes: []*tailcfg.DERPNode{
+					{
+						Name:             "t1",
+						RegionID:         1,
+						HostName:         ipAddress,
+						IPv4:             ipAddress,
+						IPv6:             "none",
+						STUNPort:         stunAddr.Port,
+						DERPPort:         9,
+						InsecureForTests: true,
+						STUNTestIP:       ipAddress,
+					},
+				},
+			},
+		},
+	}
+}
+
+func startHTTPService(t *testing.T) int {
+	t.Helper()
+	ln, err := net.Listen("tcp4", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	srv := &http.Server{Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, "mihomo-host-forward-ok\n")
+	})}
+	go func() {
+		if err := srv.Serve(ln); err != nil && err != http.ErrServerClosed {
+			t.Errorf("HTTP service failed: %v", err)
+		}
+	}()
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		_ = srv.Shutdown(ctx)
+	})
+	return ln.Addr().(*net.TCPAddr).Port
+}
+
+func startSSHD(t *testing.T) int {
+	t.Helper()
+	if err := os.MkdirAll("/run/sshd", 0o755); err != nil {
+		t.Fatal(err)
+	}
+	port := freeTCPPort(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	var out bytes.Buffer
+	cmd := exec.CommandContext(ctx, "/usr/sbin/sshd",
+		"-D",
+		"-e",
+		"-p", strconv.Itoa(port),
+		"-o", "ListenAddress=127.0.0.1",
+		"-o", "PasswordAuthentication=no",
+		"-o", "KbdInteractiveAuthentication=no",
+		"-o", "ChallengeResponseAuthentication=no",
+		"-o", "PermitRootLogin=yes",
+		"-o", "UsePAM=no",
+		"-o", "LogLevel=ERROR",
+	)
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Start(); err != nil {
+		cancel()
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		cancel()
+		_ = cmd.Wait()
+	})
+	waitTCPPortInUse(t, port, 5*time.Second, &out)
+	return port
+}
+
+func startIperfServer(t *testing.T) int {
+	t.Helper()
+	port := freeTCPPort(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	var out bytes.Buffer
+	cmd := exec.CommandContext(ctx, "iperf3", "-s", "-1", "-B", "127.0.0.1", "-p", strconv.Itoa(port))
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Start(); err != nil {
+		cancel()
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		cancel()
+		_ = cmd.Wait()
+	})
+	waitTCPPortInUse(t, port, 5*time.Second, &out)
+	return port
+}
+
+func startTCPForwarder(t *testing.T, proxy *outbound.Tailscale, host string, targetPort, listenPort int) string {
+	t.Helper()
+	ln, err := net.Listen("tcp4", fmt.Sprintf("127.0.0.1:%d", listenPort))
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(func() {
+		cancel()
+		_ = ln.Close()
+	})
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				if ctx.Err() == nil {
+					t.Logf("TCP forward accept failed: %v", err)
+				}
+				return
+			}
+			go func() {
+				dialCtx, dialCancel := context.WithTimeout(ctx, 45*time.Second)
+				remote, err := proxy.DialContext(dialCtx, targetMetadata(C.TCP, host, targetPort))
+				dialCancel()
+				if err != nil {
+					_ = conn.Close()
+					t.Logf("TCP forward dial %s:%d failed: %v", host, targetPort, err)
+					return
+				}
+				relayTCP(conn, remote)
+			}()
+		}
+	}()
+	return ln.Addr().String()
+}
+
+func startUDPForwarder(t *testing.T, proxy *outbound.Tailscale, host string, targetPort, listenPort int) string {
+	t.Helper()
+	local, err := net.ListenPacket("udp4", fmt.Sprintf("127.0.0.1:%d", listenPort))
+	if err != nil {
+		t.Fatal(err)
+	}
+	md := targetMetadata(C.UDP, host, targetPort)
+	dialCtx, dialCancel := context.WithTimeout(context.Background(), 45*time.Second)
+	remote, err := proxy.ListenPacketContext(dialCtx, md)
+	dialCancel()
+	if err != nil {
+		_ = local.Close()
+		t.Fatal(err)
+	}
+	if !md.DstIP.IsValid() {
+		_ = local.Close()
+		_ = remote.Close()
+		t.Fatalf("resolved UDP target %s:%d has no IP", host, targetPort)
+	}
+	target := net.UDPAddrFromAddrPort(netip.AddrPortFrom(md.DstIP, uint16(targetPort)))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(func() {
+		cancel()
+		_ = local.Close()
+		_ = remote.Close()
+	})
+
+	var peerMu sync.RWMutex
+	var localPeer net.Addr
+	go func() {
+		buffer := make([]byte, 64*1024)
+		for {
+			n, peer, err := local.ReadFrom(buffer)
+			if err != nil {
+				if ctx.Err() == nil {
+					t.Logf("UDP local read failed: %v", err)
+				}
+				return
+			}
+			peerMu.Lock()
+			localPeer = peer
+			peerMu.Unlock()
+			if _, err := remote.WriteTo(buffer[:n], target); err != nil {
+				t.Logf("UDP remote write failed: %v", err)
+				return
+			}
+		}
+	}()
+	go func() {
+		buffer := make([]byte, 64*1024)
+		for {
+			n, _, err := remote.ReadFrom(buffer)
+			if err != nil {
+				if ctx.Err() == nil {
+					t.Logf("UDP remote read failed: %v", err)
+				}
+				return
+			}
+			peerMu.RLock()
+			peer := localPeer
+			peerMu.RUnlock()
+			if peer == nil {
+				continue
+			}
+			if _, err := local.WriteTo(buffer[:n], peer); err != nil {
+				t.Logf("UDP local write failed: %v", err)
+				return
+			}
+		}
+	}()
+	return local.LocalAddr().String()
+}
+
+func targetMetadata(network C.NetWork, host string, port int) *C.Metadata {
+	return &C.Metadata{
+		NetWork: network,
+		Type:    C.INNER,
+		Host:    host,
+		DstPort: uint16(port),
+	}
+}
+
+func relayTCP(left, right net.Conn) {
+	defer left.Close()
+	defer right.Close()
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		copyAndCloseWrite(left, right)
+	}()
+	go func() {
+		defer wg.Done()
+		copyAndCloseWrite(right, left)
+	}()
+	wg.Wait()
+}
+
+func copyAndCloseWrite(dst, src net.Conn) {
+	if _, err := io.Copy(dst, src); err == nil {
+		if cw, ok := dst.(interface{ CloseWrite() error }); ok {
+			_ = cw.CloseWrite()
+			return
+		}
+	}
+	_ = dst.Close()
+}
+
+func checkSSHHandshake(addr string) error {
+	conn, err := net.DialTimeout("tcp4", addr, 15*time.Second)
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+	_, _, _, err = ssh.NewClientConn(conn, addr, &ssh.ClientConfig{
+		User:            "root",
+		Auth:            []ssh.AuthMethod{ssh.Password("not-a-real-password")},
+		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+		Timeout:         15 * time.Second,
+	})
+	if err == nil {
+		return fmt.Errorf("unexpected SSH authentication success")
+	}
+	if !strings.Contains(err.Error(), "unable to authenticate") {
+		return err
+	}
+	return nil
+}
+
+func checkClosedPort(addr string) error {
+	conn, err := net.DialTimeout("tcp4", addr, 10*time.Second)
+	if err != nil {
+		return nil
+	}
+	defer conn.Close()
+	_ = conn.SetDeadline(time.Now().Add(10 * time.Second))
+	if _, err := conn.Write([]byte("closed-port-probe")); err != nil {
+		return nil
+	}
+	var one [1]byte
+	if _, err := conn.Read(one[:]); err != nil {
+		return nil
+	}
+	return fmt.Errorf("closed port unexpectedly accepted data")
+}
+
+func eventually(t *testing.T, timeout, interval time.Duration, fn func() error) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	var lastErr error
+	for time.Now().Before(deadline) {
+		if err := fn(); err != nil {
+			lastErr = err
+			time.Sleep(interval)
+			continue
+		}
+		return
+	}
+	t.Fatalf("condition not met within %s: %v", timeout, lastErr)
+}
+
+func runCommand(timeout time.Duration, name string, args ...string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, name, args...)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	if ctx.Err() != nil {
+		err = ctx.Err()
+	}
+	return out.String(), err
+}
+
+func freeTCPPort(t *testing.T) int {
+	t.Helper()
+	ln, err := net.Listen("tcp4", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ln.Close()
+	return ln.Addr().(*net.TCPAddr).Port
+}
+
+func waitTCPPortInUse(t *testing.T, port int, timeout time.Duration, output *bytes.Buffer) {
+	t.Helper()
+	addr := fmt.Sprintf("127.0.0.1:%d", port)
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		ln, err := net.Listen("tcp4", addr)
+		if err != nil {
+			return
+		}
+		_ = ln.Close()
+		time.Sleep(50 * time.Millisecond)
+	}
+	t.Fatalf("port %d was not opened: %s", port, output.String())
+}
+
+func portString(addr string) string {
+	return strconv.Itoa(portNumber(addr))
+}
+
+func portNumber(addr string) int {
+	_, port, err := net.SplitHostPort(addr)
+	if err != nil {
+		panic(err)
+	}
+	n, err := strconv.Atoi(port)
+	if err != nil {
+		panic(err)
+	}
+	return n
+}

--- a/adapter/outbound/tailscale_host_forward_test.go
+++ b/adapter/outbound/tailscale_host_forward_test.go
@@ -73,6 +73,10 @@ func TestTailscaleStatusFromIPN(t *testing.T) {
 				OS:           "linux",
 				TailscaleIPs: []netip.Addr{netip.MustParseAddr("100.90.103.91")},
 				Online:       true,
+				Active:       true,
+				Addrs:        []string{"10.10.10.1:41641"},
+				CurAddr:      "10.10.10.1:41641",
+				Relay:        "cnhome",
 				LastSeen:     lastSeen,
 				TxBytes:      42,
 				RxBytes:      24,
@@ -94,8 +98,17 @@ func TestTailscaleStatusFromIPN(t *testing.T) {
 	if peer.Name != "newvbox" || len(peer.TailscaleIPs) != 1 || peer.TailscaleIPs[0] != "100.90.103.91" {
 		t.Fatalf("peer status: %+v", peer)
 	}
-	if text := got.Text(); !strings.Contains(text, "newvbox") || !strings.Contains(text, "100.90.103.91") {
-		t.Fatalf("status text missing peer: %s", text)
+	if !peer.Active || peer.CurAddr != "10.10.10.1:41641" || peer.Relay != "cnhome" {
+		t.Fatalf("peer connection fields: %+v", peer)
+	}
+	text := got.Text()
+	for _, want := range []string{"newvbox", "100.90.103.91", "direct 10.10.10.1:41641"} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("status text missing %q: %s", want, text)
+		}
+	}
+	if strings.Contains(text, `relay "cnhome"`) {
+		t.Fatalf("status text used DERP relay despite CurAddr: %s", text)
 	}
 }
 

--- a/adapter/outbound/tailscale_host_forward_test.go
+++ b/adapter/outbound/tailscale_host_forward_test.go
@@ -23,7 +23,8 @@ func TestTailscaleHostForwardOptionDecode(t *testing.T) {
 		WeaklyTypedInput: true,
 		KeyReplacer:      structure.DefaultKeyReplacer,
 	}).Decode(map[string]any{
-		"name": "test",
+		"name":      "test",
+		"magic-dns": true,
 		"host-forward": map[string]any{
 			"enabled": true,
 			"target":  "127.0.0.2",
@@ -33,6 +34,9 @@ func TestTailscaleHostForwardOptionDecode(t *testing.T) {
 	}, &option)
 	if err != nil {
 		t.Fatal(err)
+	}
+	if !option.MagicDNS {
+		t.Fatal("magic-dns was not decoded")
 	}
 	if !option.HostForward.Enabled || option.HostForward.Target != "127.0.0.2" {
 		t.Fatalf("decoded host-forward: %+v", option.HostForward)

--- a/adapter/outbound/tailscale_host_forward_test.go
+++ b/adapter/outbound/tailscale_host_forward_test.go
@@ -1,0 +1,433 @@
+//go:build with_gvisor && !no_tailscale
+
+package outbound
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net"
+	"net/netip"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/metacubex/mihomo/common/structure"
+	C "github.com/metacubex/mihomo/constant"
+)
+
+func TestTailscaleHostForwardOptionDecode(t *testing.T) {
+	var option TailscaleOption
+	err := structure.NewDecoder(structure.Option{
+		TagName:          "proxy",
+		WeaklyTypedInput: true,
+		KeyReplacer:      structure.DefaultKeyReplacer,
+	}).Decode(map[string]any{
+		"name": "test",
+		"host-forward": map[string]any{
+			"enabled": true,
+			"target":  "127.0.0.2",
+			"tcp":     false,
+			"udp":     true,
+		},
+	}, &option)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !option.HostForward.Enabled || option.HostForward.Target != "127.0.0.2" {
+		t.Fatalf("decoded host-forward: %+v", option.HostForward)
+	}
+	if option.HostForward.TCP == nil || *option.HostForward.TCP {
+		t.Fatalf("decoded tcp: %v", option.HostForward.TCP)
+	}
+	if option.HostForward.UDP == nil || !*option.HostForward.UDP {
+		t.Fatalf("decoded udp: %v", option.HostForward.UDP)
+	}
+}
+
+func TestTailscaleHostForwardOptions(t *testing.T) {
+	localIP := netip.MustParseAddr("100.64.0.1")
+	localIPs := func() (netip.Addr, netip.Addr) { return localIP, netip.Addr{} }
+
+	forwarder, err := newTailscaleHostForwarder(context.Background(), "test", TailscaleHostForwardOption{Enabled: true}, localIPs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !forwarder.tcp || !forwarder.udp {
+		t.Fatalf("default protocols: tcp=%v udp=%v", forwarder.tcp, forwarder.udp)
+	}
+	if forwarder.target != tailscaleHostForwardDefaultTarget {
+		t.Fatalf("default target: %s", forwarder.target)
+	}
+
+	if _, err := newTailscaleHostForwarder(context.Background(), "test", TailscaleHostForwardOption{
+		Enabled: true,
+		Target:  "192.0.2.1",
+	}, localIPs); err == nil {
+		t.Fatal("expected non-loopback target to fail")
+	}
+
+	disabled := false
+	if _, err := newTailscaleHostForwarder(context.Background(), "test", TailscaleHostForwardOption{
+		Enabled: true,
+		TCP:     &disabled,
+		UDP:     &disabled,
+	}, localIPs); err == nil {
+		t.Fatal("expected disabled TCP and UDP to fail")
+	}
+}
+
+func TestTailscaleHostForwardDisabledKeepsLazyStartup(t *testing.T) {
+	oldHome := C.Path.HomeDir()
+	C.SetHomeDir(t.TempDir())
+	t.Cleanup(func() { C.SetHomeDir(oldHome) })
+
+	outbound, err := NewTailscale(TailscaleOption{
+		Name:     "lazy-test",
+		StateDir: "tailscale",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = outbound.Close() })
+
+	if outbound.serverStarted {
+		t.Fatal("host-forward disabled started tsnet eagerly")
+	}
+}
+
+func TestTailscaleHostForwardDestinationFilter(t *testing.T) {
+	localV4 := netip.MustParseAddr("100.64.0.1")
+	localV6 := netip.MustParseAddr("fd7a:115c:a1e0::1")
+	forwarder, err := newTailscaleHostForwarder(context.Background(), "test", TailscaleHostForwardOption{Enabled: true}, func() (netip.Addr, netip.Addr) {
+		return localV4, localV6
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	src := netip.MustParseAddrPort("100.64.0.2:12345")
+	if _, intercept := forwarder.handleTCP(src, netip.AddrPortFrom(localV4, 22)); !intercept {
+		t.Fatal("local IPv4 TCP flow was not intercepted")
+	}
+	if _, intercept := forwarder.handleUDP(src, netip.AddrPortFrom(localV6, 53)); !intercept {
+		t.Fatal("local IPv6 UDP flow was not intercepted")
+	}
+	if handler, intercept := forwarder.handleTCP(src, netip.MustParseAddrPort("192.0.2.1:22")); intercept || handler != nil {
+		t.Fatal("subnet-routed TCP flow was intercepted")
+	}
+	if handler, intercept := forwarder.handleUDP(src, netip.MustParseAddrPort("100.64.0.3:53")); intercept || handler != nil {
+		t.Fatal("foreign-node UDP flow was intercepted")
+	}
+}
+
+func TestTailscaleHostForwardDialFailureClosesClient(t *testing.T) {
+	localIP := netip.MustParseAddr("100.64.0.1")
+	forwarder, err := newTailscaleHostForwarder(context.Background(), "test", TailscaleHostForwardOption{Enabled: true}, func() (netip.Addr, netip.Addr) {
+		return localIP, netip.Addr{}
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	forwarder.dialContext = func(context.Context, string, string) (net.Conn, error) {
+		return nil, errors.New("connection refused")
+	}
+
+	tcpHandler, intercept := forwarder.handleTCP(netip.MustParseAddrPort("100.64.0.2:12345"), netip.AddrPortFrom(localIP, 22))
+	if !intercept || tcpHandler == nil {
+		t.Fatal("TCP handler was not installed")
+	}
+	tcpClient, tcpAccepted := net.Pipe()
+	t.Cleanup(func() { _ = tcpClient.Close() })
+	tcpHandler(tcpAccepted)
+	if _, err := tcpClient.Write([]byte("x")); err == nil {
+		t.Fatal("TCP client was not closed after dial failure")
+	}
+
+	udpHandler, intercept := forwarder.handleUDP(netip.MustParseAddrPort("100.64.0.2:12345"), netip.AddrPortFrom(localIP, 53))
+	if !intercept || udpHandler == nil {
+		t.Fatal("UDP handler was not installed")
+	}
+	udpClient := newTestPacketConn()
+	udpHandler(udpClient)
+	select {
+	case <-udpClient.closed:
+	case <-time.After(time.Second):
+		t.Fatal("UDP client was not closed after dial failure")
+	}
+}
+
+func TestTailscaleHostForwardTCP(t *testing.T) {
+	listener, err := net.Listen("tcp4", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = listener.Close() })
+	go func() {
+		conn, err := listener.Accept()
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		_, _ = io.Copy(conn, conn)
+	}()
+
+	localIP := netip.MustParseAddr("100.64.0.1")
+	forwarder, err := newTailscaleHostForwarder(context.Background(), "test", TailscaleHostForwardOption{Enabled: true}, func() (netip.Addr, netip.Addr) {
+		return localIP, netip.Addr{}
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	port := uint16(listener.Addr().(*net.TCPAddr).Port)
+	handler, intercept := forwarder.handleTCP(netip.MustParseAddrPort("100.64.0.2:12345"), netip.AddrPortFrom(localIP, port))
+	if !intercept || handler == nil {
+		t.Fatal("local Tailscale TCP flow was not intercepted")
+	}
+	if handler, intercept := forwarder.handleTCP(netip.MustParseAddrPort("100.64.0.2:12345"), netip.AddrPortFrom(netip.MustParseAddr("100.64.0.3"), port)); intercept || handler != nil {
+		t.Fatal("non-local Tailscale TCP flow was intercepted")
+	}
+
+	client, accepted := net.Pipe()
+	t.Cleanup(func() { _ = client.Close() })
+	go handler(accepted)
+	if err := client.SetDeadline(time.Now().Add(3 * time.Second)); err != nil {
+		t.Fatal(err)
+	}
+	payload := []byte("tailscale host-forward tcp")
+	if _, err := client.Write(payload); err != nil {
+		t.Fatal(err)
+	}
+	reply := make([]byte, len(payload))
+	if _, err := io.ReadFull(client, reply); err != nil {
+		t.Fatal(err)
+	}
+	if string(reply) != string(payload) {
+		t.Fatalf("reply %q, want %q", reply, payload)
+	}
+}
+
+func TestTailscaleHostForwardUDP(t *testing.T) {
+	backend, err := net.ListenUDP("udp4", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = backend.Close() })
+	go func() {
+		buffer := make([]byte, 64*1024)
+		n, peer, err := backend.ReadFromUDP(buffer)
+		if err != nil {
+			return
+		}
+		_, _ = backend.WriteToUDP(buffer[:n], peer)
+	}()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	localIP := netip.MustParseAddr("100.64.0.1")
+	forwarder, err := newTailscaleHostForwarder(ctx, "test", TailscaleHostForwardOption{Enabled: true}, func() (netip.Addr, netip.Addr) {
+		return localIP, netip.Addr{}
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	port := uint16(backend.LocalAddr().(*net.UDPAddr).Port)
+	handler, intercept := forwarder.handleUDP(netip.MustParseAddrPort("100.64.0.2:12345"), netip.AddrPortFrom(localIP, port))
+	if !intercept || handler == nil {
+		t.Fatal("local Tailscale UDP flow was not intercepted")
+	}
+
+	client, accepted := net.Pipe()
+	t.Cleanup(func() { _ = client.Close() })
+	go handler(testConnPacketConn{Conn: accepted})
+	if err := client.SetDeadline(time.Now().Add(3 * time.Second)); err != nil {
+		t.Fatal(err)
+	}
+	payload := []byte("tailscale host-forward udp")
+	if _, err := client.Write(payload); err != nil {
+		t.Fatal(err)
+	}
+	reply := make([]byte, len(payload))
+	if _, err := io.ReadFull(client, reply); err != nil {
+		t.Fatal(err)
+	}
+	if string(reply) != string(payload) {
+		t.Fatalf("reply %q, want %q", reply, payload)
+	}
+}
+
+func TestRelayTailscaleHostUDPDatagramBoundaries(t *testing.T) {
+	backend, err := net.ListenUDP("udp4", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = backend.Close() })
+	go func() {
+		buffer := make([]byte, 64*1024)
+		for i := 0; i < 2; i++ {
+			n, peer, err := backend.ReadFromUDP(buffer)
+			if err != nil {
+				return
+			}
+			response := append([]byte("echo:"), buffer[:n]...)
+			_, _ = backend.WriteToUDP(response, peer)
+		}
+	}()
+
+	backendConn, err := net.Dial("udp4", backend.LocalAddr().String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = backendConn.Close() })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	client := newTestPacketConn()
+	done := make(chan error, 1)
+	go func() {
+		done <- relayTailscaleHostUDP(ctx, client, backendConn, time.Minute)
+	}()
+
+	client.queueRead([]byte("one"))
+	client.queueRead([]byte("two-two"))
+	if got := client.readWritten(t); string(got) != "echo:one" {
+		t.Fatalf("first datagram = %q", got)
+	}
+	if got := client.readWritten(t); string(got) != "echo:two-two" {
+		t.Fatalf("second datagram = %q", got)
+	}
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("UDP relay did not stop after context cancellation")
+	}
+}
+
+func TestRelayTailscaleHostUDPIdleCleanup(t *testing.T) {
+	client, accepted := net.Pipe()
+	t.Cleanup(func() { _ = client.Close() })
+	backend, backendPeer := net.Pipe()
+	t.Cleanup(func() { _ = backendPeer.Close() })
+
+	done := make(chan error, 1)
+	go func() {
+		done <- relayTailscaleHostUDP(context.Background(), testConnPacketConn{Conn: accepted}, backend, 20*time.Millisecond)
+	}()
+
+	select {
+	case err := <-done:
+		if netErr, ok := err.(net.Error); !ok || !netErr.Timeout() {
+			t.Fatalf("relay error = %v, want timeout", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("UDP relay did not stop after idle deadline")
+	}
+}
+
+type testConnPacketConn struct {
+	net.Conn
+}
+
+func (c testConnPacketConn) ReadFrom(buffer []byte) (int, net.Addr, error) {
+	n, err := c.Read(buffer)
+	return n, c.RemoteAddr(), err
+}
+
+func (c testConnPacketConn) WriteTo(buffer []byte, _ net.Addr) (int, error) {
+	return c.Write(buffer)
+}
+
+type testPacketConn struct {
+	incoming chan []byte
+	outgoing chan []byte
+	closed   chan struct{}
+	once     sync.Once
+	local    net.Addr
+	remote   net.Addr
+}
+
+func newTestPacketConn() *testPacketConn {
+	return &testPacketConn{
+		incoming: make(chan []byte, 8),
+		outgoing: make(chan []byte, 8),
+		closed:   make(chan struct{}),
+		local:    &net.UDPAddr{IP: net.IPv4(100, 64, 0, 1), Port: 53},
+		remote:   &net.UDPAddr{IP: net.IPv4(100, 64, 0, 2), Port: 12345},
+	}
+}
+
+func (c *testPacketConn) queueRead(packet []byte) {
+	packet = append([]byte(nil), packet...)
+	select {
+	case c.incoming <- packet:
+	case <-c.closed:
+	}
+}
+
+func (c *testPacketConn) readWritten(t *testing.T) []byte {
+	t.Helper()
+	select {
+	case packet := <-c.outgoing:
+		return packet
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for written packet")
+		return nil
+	}
+}
+
+func (c *testPacketConn) Read(buffer []byte) (int, error) {
+	n, _, err := c.ReadFrom(buffer)
+	return n, err
+}
+
+func (c *testPacketConn) ReadFrom(buffer []byte) (int, net.Addr, error) {
+	select {
+	case packet := <-c.incoming:
+		return copy(buffer, packet), c.remote, nil
+	case <-c.closed:
+		return 0, nil, net.ErrClosed
+	}
+}
+
+func (c *testPacketConn) Write(buffer []byte) (int, error) {
+	packet := append([]byte(nil), buffer...)
+	select {
+	case c.outgoing <- packet:
+		return len(buffer), nil
+	case <-c.closed:
+		return 0, net.ErrClosed
+	}
+}
+
+func (c *testPacketConn) WriteTo(buffer []byte, _ net.Addr) (int, error) {
+	return c.Write(buffer)
+}
+
+func (c *testPacketConn) Close() error {
+	c.once.Do(func() {
+		close(c.closed)
+	})
+	return nil
+}
+
+func (c *testPacketConn) LocalAddr() net.Addr {
+	return c.local
+}
+
+func (c *testPacketConn) RemoteAddr() net.Addr {
+	return c.remote
+}
+
+func (c *testPacketConn) SetDeadline(time.Time) error {
+	return nil
+}
+
+func (c *testPacketConn) SetReadDeadline(time.Time) error {
+	return nil
+}
+
+func (c *testPacketConn) SetWriteDeadline(time.Time) error {
+	return nil
+}

--- a/adapter/outbound/tailscale_host_forward_test.go
+++ b/adapter/outbound/tailscale_host_forward_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net"
 	"net/netip"
+	"os"
 	"strings"
 	"sync"
 	"testing"
@@ -16,6 +17,7 @@ import (
 	"github.com/metacubex/mihomo/common/structure"
 	C "github.com/metacubex/mihomo/constant"
 
+	"github.com/metacubex/tailscale/envknob"
 	"github.com/metacubex/tailscale/ipn"
 	"github.com/metacubex/tailscale/ipn/ipnstate"
 	"github.com/metacubex/tailscale/types/key"
@@ -141,6 +143,35 @@ func TestTailscaleHostForwardOptions(t *testing.T) {
 		UDP:     &disabled,
 	}, localIPs); err == nil {
 		t.Fatal("expected disabled TCP and UDP to fail")
+	}
+}
+
+func TestTailscaleHostForwardConfiguresNetstackKeepalive(t *testing.T) {
+	oldIdle := os.Getenv(tailscaleHostForwardNetstackKeepaliveIdleEnv)
+	oldInterval := os.Getenv(tailscaleHostForwardNetstackKeepaliveIntervalEnv)
+	t.Cleanup(func() {
+		envknob.Setenv(tailscaleHostForwardNetstackKeepaliveIdleEnv, oldIdle)
+		envknob.Setenv(tailscaleHostForwardNetstackKeepaliveIntervalEnv, oldInterval)
+	})
+
+	envknob.Setenv(tailscaleHostForwardNetstackKeepaliveIdleEnv, "")
+	envknob.Setenv(tailscaleHostForwardNetstackKeepaliveIntervalEnv, "")
+	configureTailscaleHostForwardNetstackKeepalive()
+	if got := os.Getenv(tailscaleHostForwardNetstackKeepaliveIdleEnv); got != tailscaleHostForwardNetstackKeepaliveIdle {
+		t.Fatalf("%s = %q, want %q", tailscaleHostForwardNetstackKeepaliveIdleEnv, got, tailscaleHostForwardNetstackKeepaliveIdle)
+	}
+	if got := os.Getenv(tailscaleHostForwardNetstackKeepaliveIntervalEnv); got != tailscaleHostForwardNetstackKeepaliveInterval {
+		t.Fatalf("%s = %q, want %q", tailscaleHostForwardNetstackKeepaliveIntervalEnv, got, tailscaleHostForwardNetstackKeepaliveInterval)
+	}
+
+	envknob.Setenv(tailscaleHostForwardNetstackKeepaliveIdleEnv, "2m")
+	envknob.Setenv(tailscaleHostForwardNetstackKeepaliveIntervalEnv, "30s")
+	configureTailscaleHostForwardNetstackKeepalive()
+	if got := os.Getenv(tailscaleHostForwardNetstackKeepaliveIdleEnv); got != "2m" {
+		t.Fatalf("%s override = %q, want 2m", tailscaleHostForwardNetstackKeepaliveIdleEnv, got)
+	}
+	if got := os.Getenv(tailscaleHostForwardNetstackKeepaliveIntervalEnv); got != "30s" {
+		t.Fatalf("%s override = %q, want 30s", tailscaleHostForwardNetstackKeepaliveIntervalEnv, got)
 	}
 }
 

--- a/adapter/outbound/tailscale_host_forward_test.go
+++ b/adapter/outbound/tailscale_host_forward_test.go
@@ -8,12 +8,17 @@ import (
 	"io"
 	"net"
 	"net/netip"
+	"strings"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/metacubex/mihomo/common/structure"
 	C "github.com/metacubex/mihomo/constant"
+
+	"github.com/metacubex/tailscale/ipn"
+	"github.com/metacubex/tailscale/ipn/ipnstate"
+	"github.com/metacubex/tailscale/types/key"
 )
 
 func TestTailscaleHostForwardOptionDecode(t *testing.T) {
@@ -46,6 +51,51 @@ func TestTailscaleHostForwardOptionDecode(t *testing.T) {
 	}
 	if option.HostForward.UDP == nil || !*option.HostForward.UDP {
 		t.Fatalf("decoded udp: %v", option.HostForward.UDP)
+	}
+}
+
+func TestTailscaleStatusFromIPN(t *testing.T) {
+	lastSeen := time.Date(2026, 7, 10, 4, 0, 0, 0, time.UTC)
+	status := &ipnstate.Status{
+		BackendState:   ipn.Running.String(),
+		MagicDNSSuffix: "tailnet.test",
+		TailscaleIPs:   []netip.Addr{netip.MustParseAddr("100.64.0.1")},
+		Self: &ipnstate.PeerStatus{
+			HostName:     "mihomo-tailnet-staging",
+			DNSName:      "mihomo-tailnet-staging.tailnet.test.",
+			OS:           "linux",
+			TailscaleIPs: []netip.Addr{netip.MustParseAddr("100.64.0.1")},
+		},
+		Peer: map[key.NodePublic]*ipnstate.PeerStatus{
+			{}: {
+				HostName:     "newvbox",
+				DNSName:      "newvbox.tailnet.test.",
+				OS:           "linux",
+				TailscaleIPs: []netip.Addr{netip.MustParseAddr("100.90.103.91")},
+				Online:       true,
+				LastSeen:     lastSeen,
+				TxBytes:      42,
+				RxBytes:      24,
+			},
+		},
+	}
+
+	got := tailscaleStatusFromIPN("ts", status)
+	if got.Proxy != "ts" || got.BackendState != ipn.Running.String() {
+		t.Fatalf("status metadata: %+v", got)
+	}
+	if got.Self == nil || got.Self.Name != "mihomo-tailnet-staging" || !got.Self.Online {
+		t.Fatalf("self status: %+v", got.Self)
+	}
+	if len(got.Peers) != 1 {
+		t.Fatalf("peers length: %d", len(got.Peers))
+	}
+	peer := got.Peers[0]
+	if peer.Name != "newvbox" || len(peer.TailscaleIPs) != 1 || peer.TailscaleIPs[0] != "100.90.103.91" {
+		t.Fatalf("peer status: %+v", peer)
+	}
+	if text := got.Text(); !strings.Contains(text, "newvbox") || !strings.Contains(text, "100.90.103.91") {
+		t.Fatalf("status text missing peer: %s", text)
 	}
 }
 

--- a/adapter/outbound/tailscale_host_forward_test.go
+++ b/adapter/outbound/tailscale_host_forward_test.go
@@ -34,9 +34,12 @@ func TestTailscaleHostForwardOptionDecode(t *testing.T) {
 		"magic-dns": true,
 		"host-forward": map[string]any{
 			"enabled": true,
+			"mode":    "kernel",
 			"target":  "127.0.0.2",
 			"tcp":     false,
 			"udp":     true,
+			"device":  "mts-test",
+			"mtu":     1280,
 		},
 	}, &option)
 	if err != nil {
@@ -48,11 +51,41 @@ func TestTailscaleHostForwardOptionDecode(t *testing.T) {
 	if !option.HostForward.Enabled || option.HostForward.Target != "127.0.0.2" {
 		t.Fatalf("decoded host-forward: %+v", option.HostForward)
 	}
+	if option.HostForward.Mode != "kernel" || option.HostForward.Device != "mts-test" || option.HostForward.MTU != 1280 {
+		t.Fatalf("decoded kernel host-forward fields: %+v", option.HostForward)
+	}
 	if option.HostForward.TCP == nil || *option.HostForward.TCP {
 		t.Fatalf("decoded tcp: %v", option.HostForward.TCP)
 	}
 	if option.HostForward.UDP == nil || !*option.HostForward.UDP {
 		t.Fatalf("decoded udp: %v", option.HostForward.UDP)
+	}
+}
+
+func TestTailscaleHostForwardMode(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		mode string
+		want string
+	}{
+		{name: "default", want: tailscaleHostForwardModeUserspace},
+		{name: "userspace", mode: "userspace", want: tailscaleHostForwardModeUserspace},
+		{name: "kernel", mode: "kernel", want: tailscaleHostForwardModeKernel},
+		{name: "case and space", mode: " Kernel ", want: tailscaleHostForwardModeKernel},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := tailscaleHostForwardMode(TailscaleHostForwardOption{Mode: tc.mode})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got != tc.want {
+				t.Fatalf("mode = %q, want %q", got, tc.want)
+			}
+		})
+	}
+
+	if _, err := tailscaleHostForwardMode(TailscaleHostForwardOption{Mode: "netstack"}); err == nil {
+		t.Fatal("expected invalid mode to fail")
 	}
 }
 

--- a/adapter/outbound/tailscale_kernel_tun_e2e_test.go
+++ b/adapter/outbound/tailscale_kernel_tun_e2e_test.go
@@ -1,0 +1,129 @@
+//go:build with_gvisor && !no_tailscale && linux && tailscale_kernel_host_forward_e2e
+
+package outbound
+
+import (
+	"fmt"
+	"net"
+	"net/netip"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestTailscaleKernelHostForwardTUNConfigureE2E(t *testing.T) {
+	if os.Geteuid() != 0 {
+		t.Skip("kernel host-forward TUN e2e requires root or CAP_NET_ADMIN")
+	}
+
+	deviceName := fmt.Sprintf("mtse%06d", os.Getpid()%1000000)
+	for _, route := range []struct {
+		family string
+		prefix string
+	}{
+		{family: "4", prefix: "100.64.0.0/10"},
+		{family: "6", prefix: "fd7a:115c:a1e0::/48"},
+	} {
+		if out, err := ipRouteShow(route.family, route.prefix, deviceName); err == nil && strings.TrimSpace(out) != "" {
+			t.Fatalf("test device route already exists for %s: %s", route.prefix, out)
+		}
+	}
+
+	forwarder, err := newTailscaleKernelHostForwarder("kernel-e2e", TailscaleHostForwardOption{
+		Enabled: true,
+		Mode:    tailscaleHostForwardModeKernel,
+		Device:  deviceName,
+		MTU:     1280,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = forwarder.Close() })
+
+	if _, err := net.InterfaceByName(deviceName); err != nil {
+		t.Fatalf("kernel host-forward interface was not created: %v", err)
+	}
+
+	v4 := netip.MustParseAddr("100.100.100.100")
+	v6 := netip.MustParseAddr("fd7a:115c:a1e0::1234")
+	if err := forwarder.Configure(v4, v6); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, want := range []string{"100.100.100.100/32", "fd7a:115c:a1e0::1234/128"} {
+		if err := interfaceHasAddress(deviceName, want); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for _, route := range []struct {
+		family string
+		prefix string
+	}{
+		{family: "4", prefix: "100.64.0.0/10"},
+		{family: "6", prefix: "fd7a:115c:a1e0::/48"},
+	} {
+		out, err := ipRouteShow(route.family, route.prefix, deviceName)
+		if err != nil {
+			t.Fatalf("route lookup failed for %s: %v: %s", route.prefix, err, out)
+		}
+		if strings.TrimSpace(out) == "" {
+			t.Fatalf("route for %s via %s was not installed", route.prefix, deviceName)
+		}
+	}
+
+	if err := forwarder.Close(); err != nil {
+		t.Fatal(err)
+	}
+	eventuallyKernelTUN(t, 5*time.Second, 100*time.Millisecond, func() error {
+		iface, err := net.InterfaceByName(deviceName)
+		if err == nil {
+			return fmt.Errorf("kernel host-forward interface still exists: %+v", iface)
+		}
+		return nil
+	})
+}
+
+func interfaceHasAddress(deviceName, want string) error {
+	iface, err := net.InterfaceByName(deviceName)
+	if err != nil {
+		return err
+	}
+	addrs, err := iface.Addrs()
+	if err != nil {
+		return err
+	}
+	for _, addr := range addrs {
+		if addr.String() == want {
+			return nil
+		}
+	}
+	return fmt.Errorf("%s is missing address %s; got %v", deviceName, want, addrs)
+}
+
+func ipRouteShow(family, prefix, deviceName string) (string, error) {
+	args := []string{"route", "show", prefix, "dev", deviceName}
+	if family == "6" {
+		args = append([]string{"-6"}, args...)
+	}
+	out, err := exec.Command("ip", args...).CombinedOutput()
+	return string(out), err
+}
+
+func eventuallyKernelTUN(t *testing.T, timeout, interval time.Duration, fn func() error) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	var lastErr error
+	for time.Now().Before(deadline) {
+		if err := fn(); err != nil {
+			lastErr = err
+			time.Sleep(interval)
+			continue
+		}
+		return
+	}
+	if lastErr != nil {
+		t.Fatal(lastErr)
+	}
+}

--- a/adapter/outbound/tailscale_kernel_tun_linux.go
+++ b/adapter/outbound/tailscale_kernel_tun_linux.go
@@ -1,0 +1,380 @@
+//go:build with_gvisor && !no_tailscale && linux
+
+package outbound
+
+import (
+	"errors"
+	"fmt"
+	"hash/fnv"
+	"net"
+	"net/netip"
+	"os"
+	"strings"
+	"sync"
+
+	"github.com/metacubex/mihomo/log"
+
+	singtun "github.com/metacubex/sing-tun"
+	tstun "github.com/metacubex/tailscale-wireguard-go/tun"
+	"github.com/sagernet/netlink"
+	"golang.org/x/sys/unix"
+)
+
+const (
+	tailscaleKernelHostForwardDefaultMTU       = 1280
+	tailscaleKernelHostForwardMaxDeviceNameLen = 15
+)
+
+var tailscaleKernelHostForwardDefaultRoutes = []netip.Prefix{
+	netip.MustParsePrefix("100.64.0.0/10"),
+	netip.MustParsePrefix("fd7a:115c:a1e0::/48"),
+}
+
+type tailscaleKernelHostForwarder struct {
+	deviceName string
+	mtu        uint32
+	tun        *tailscaleKernelTUN
+	routes     []netip.Prefix
+
+	mu             sync.Mutex
+	configured     bool
+	addresses      []netip.Prefix
+	ownedAddresses []netip.Prefix
+	ownedRoutes    []netip.Prefix
+}
+
+func newTailscaleKernelHostForwarder(name string, option TailscaleHostForwardOption) (*tailscaleKernelHostForwarder, error) {
+	deviceName, err := tailscaleKernelHostForwardDeviceName(name, option.Device)
+	if err != nil {
+		return nil, err
+	}
+	mtu := option.MTU
+	if mtu == 0 {
+		mtu = tailscaleKernelHostForwardDefaultMTU
+	}
+	if mtu < 1280 {
+		return nil, fmt.Errorf("tailscale kernel host-forward mtu must be at least 1280: %d", mtu)
+	}
+
+	k := &tailscaleKernelHostForwarder{
+		deviceName: deviceName,
+		mtu:        mtu,
+		routes:     append([]netip.Prefix{}, tailscaleKernelHostForwardDefaultRoutes...),
+	}
+	tun, err := newTailscaleKernelTUN(deviceName, mtu, k.cleanup)
+	if err != nil {
+		return nil, fmt.Errorf("create tailscale kernel host-forward tun %s: %w", deviceName, err)
+	}
+	k.tun = tun
+	return k, nil
+}
+
+func tailscaleKernelHostForwardDeviceName(proxyName, configured string) (string, error) {
+	deviceName := strings.TrimSpace(configured)
+	if deviceName == "" {
+		h := fnv.New32a()
+		_, _ = h.Write([]byte(proxyName))
+		deviceName = fmt.Sprintf("mts%08x", h.Sum32())
+	}
+	if len([]byte(deviceName)) > tailscaleKernelHostForwardMaxDeviceNameLen {
+		return "", fmt.Errorf("tailscale kernel host-forward device name %q exceeds %d bytes", deviceName, tailscaleKernelHostForwardMaxDeviceNameLen)
+	}
+	if strings.ContainsAny(deviceName, " \t\r\n/") {
+		return "", fmt.Errorf("tailscale kernel host-forward device name %q contains whitespace or slash", deviceName)
+	}
+	return deviceName, nil
+}
+
+func (k *tailscaleKernelHostForwarder) Device() tstun.Device {
+	return k.tun
+}
+
+func (k *tailscaleKernelHostForwarder) Name() string {
+	return k.deviceName
+}
+
+func (k *tailscaleKernelHostForwarder) MTU() uint32 {
+	return k.mtu
+}
+
+func (k *tailscaleKernelHostForwarder) Routes() []netip.Prefix {
+	return append([]netip.Prefix{}, k.routes...)
+}
+
+func (k *tailscaleKernelHostForwarder) Addresses() []netip.Prefix {
+	k.mu.Lock()
+	defer k.mu.Unlock()
+	return append([]netip.Prefix{}, k.addresses...)
+}
+
+func (k *tailscaleKernelHostForwarder) Configure(v4, v6 netip.Addr) error {
+	addresses := tailscaleKernelHostForwardAddressPrefixes(v4, v6)
+	if len(addresses) == 0 {
+		return errors.New("tailscale kernel host-forward has no Tailscale IPs")
+	}
+
+	k.mu.Lock()
+	defer k.mu.Unlock()
+	if k.configured && tailscaleKernelHostForwardSamePrefixes(k.addresses, addresses) {
+		return nil
+	}
+
+	link, err := netlink.LinkByName(k.deviceName)
+	if err != nil {
+		return err
+	}
+	if err := netlink.LinkSetUp(link); err != nil && !errors.Is(err, unix.EPERM) {
+		return err
+	}
+
+	for _, address := range addresses {
+		added, err := tailscaleKernelHostForwardAddAddress(link, address)
+		if err != nil {
+			return err
+		}
+		if added {
+			k.ownedAddresses = append(k.ownedAddresses, address)
+		}
+	}
+	for _, route := range k.routes {
+		if route.Addr().Is4() && !v4.IsValid() {
+			continue
+		}
+		if route.Addr().Is6() && !v6.IsValid() {
+			continue
+		}
+		added, err := tailscaleKernelHostForwardAddRoute(link, route)
+		if err != nil {
+			return err
+		}
+		if added {
+			k.ownedRoutes = append(k.ownedRoutes, route)
+		}
+	}
+
+	k.addresses = addresses
+	k.configured = true
+	return nil
+}
+
+func (k *tailscaleKernelHostForwarder) Close() error {
+	if k.tun == nil {
+		return nil
+	}
+	return k.tun.Close()
+}
+
+func (k *tailscaleKernelHostForwarder) cleanup() error {
+	k.mu.Lock()
+	defer k.mu.Unlock()
+
+	link, err := netlink.LinkByName(k.deviceName)
+	if err != nil {
+		k.ownedAddresses = nil
+		k.ownedRoutes = nil
+		return nil
+	}
+
+	var errs error
+	for i := len(k.ownedRoutes) - 1; i >= 0; i-- {
+		errs = errors.Join(errs, tailscaleKernelHostForwardDeleteRoute(link, k.ownedRoutes[i]))
+	}
+	for i := len(k.ownedAddresses) - 1; i >= 0; i-- {
+		errs = errors.Join(errs, tailscaleKernelHostForwardDeleteAddress(link, k.ownedAddresses[i]))
+	}
+	k.ownedAddresses = nil
+	k.ownedRoutes = nil
+	k.addresses = nil
+	k.configured = false
+	return errs
+}
+
+func tailscaleKernelHostForwardAddressPrefixes(v4, v6 netip.Addr) []netip.Prefix {
+	var prefixes []netip.Prefix
+	if v4.IsValid() {
+		prefixes = append(prefixes, netip.PrefixFrom(v4.Unmap(), 32))
+	}
+	if v6.IsValid() {
+		prefixes = append(prefixes, netip.PrefixFrom(v6.Unmap(), 128))
+	}
+	return prefixes
+}
+
+func tailscaleKernelHostForwardSamePrefixes(a, b []netip.Prefix) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func tailscaleKernelHostForwardAddAddress(link netlink.Link, prefix netip.Prefix) (bool, error) {
+	addr, err := netlink.ParseAddr(prefix.String())
+	if err != nil {
+		return false, err
+	}
+	err = netlink.AddrAdd(link, addr)
+	if err == nil {
+		return true, nil
+	}
+	if errors.Is(err, unix.EEXIST) {
+		return false, nil
+	}
+	return false, err
+}
+
+func tailscaleKernelHostForwardDeleteAddress(link netlink.Link, prefix netip.Prefix) error {
+	addr, err := netlink.ParseAddr(prefix.String())
+	if err != nil {
+		return err
+	}
+	err = netlink.AddrDel(link, addr)
+	if errors.Is(err, unix.EADDRNOTAVAIL) || errors.Is(err, unix.ENODEV) {
+		return nil
+	}
+	return err
+}
+
+func tailscaleKernelHostForwardAddRoute(link netlink.Link, prefix netip.Prefix) (bool, error) {
+	route, err := tailscaleKernelHostForwardRoute(link, prefix)
+	if err != nil {
+		return false, err
+	}
+	err = netlink.RouteAdd(route)
+	if err == nil {
+		return true, nil
+	}
+	if errors.Is(err, unix.EEXIST) {
+		return false, nil
+	}
+	return false, err
+}
+
+func tailscaleKernelHostForwardDeleteRoute(link netlink.Link, prefix netip.Prefix) error {
+	route, err := tailscaleKernelHostForwardRoute(link, prefix)
+	if err != nil {
+		return err
+	}
+	err = netlink.RouteDel(route)
+	if errors.Is(err, unix.ENOENT) || errors.Is(err, unix.ENODEV) || errors.Is(err, unix.ESRCH) {
+		return nil
+	}
+	return err
+}
+
+func tailscaleKernelHostForwardRoute(link netlink.Link, prefix netip.Prefix) (*netlink.Route, error) {
+	ipNet, err := tailscaleKernelHostForwardIPNet(prefix)
+	if err != nil {
+		return nil, err
+	}
+	return &netlink.Route{
+		LinkIndex: link.Attrs().Index,
+		Scope:     netlink.SCOPE_LINK,
+		Dst:       ipNet,
+	}, nil
+}
+
+func tailscaleKernelHostForwardIPNet(prefix netip.Prefix) (*net.IPNet, error) {
+	_, ipNet, err := net.ParseCIDR(prefix.Masked().String())
+	return ipNet, err
+}
+
+type tailscaleKernelTUN struct {
+	tun       singtun.Tun
+	name      string
+	mtu       int
+	events    chan tstun.Event
+	closeHook func() error
+	closeOnce sync.Once
+	closeErr  error
+}
+
+func newTailscaleKernelTUN(name string, mtu uint32, closeHook func() error) (*tailscaleKernelTUN, error) {
+	tunIf, err := singtun.New(singtun.Options{
+		Name:   name,
+		MTU:    mtu,
+		Logger: log.SingLogger,
+	})
+	if err != nil {
+		return nil, err
+	}
+	tun := &tailscaleKernelTUN{
+		tun:       tunIf,
+		name:      name,
+		mtu:       int(mtu),
+		events:    make(chan tstun.Event, 1),
+		closeHook: closeHook,
+	}
+	tun.events <- tstun.EventUp
+	return tun, nil
+}
+
+func (t *tailscaleKernelTUN) File() *os.File {
+	return nil
+}
+
+func (t *tailscaleKernelTUN) Read(bufs [][]byte, sizes []int, offset int) (int, error) {
+	if len(bufs) == 0 {
+		return 0, nil
+	}
+	if linuxTun, ok := t.tun.(singtun.LinuxTUN); ok {
+		return linuxTun.BatchRead(bufs, offset, sizes)
+	}
+	n, err := t.tun.Read(bufs[0][offset:])
+	if err != nil {
+		return 0, err
+	}
+	sizes[0] = n
+	return 1, nil
+}
+
+func (t *tailscaleKernelTUN) Write(bufs [][]byte, offset int) (int, error) {
+	if linuxTun, ok := t.tun.(singtun.LinuxTUN); ok {
+		if _, err := linuxTun.BatchWrite(bufs, offset); err != nil {
+			return 0, err
+		}
+		return len(bufs), nil
+	}
+	for i, buf := range bufs {
+		if _, err := t.tun.Write(buf[offset:]); err != nil {
+			return i, err
+		}
+	}
+	return len(bufs), nil
+}
+
+func (t *tailscaleKernelTUN) MTU() (int, error) {
+	return t.mtu, nil
+}
+
+func (t *tailscaleKernelTUN) Name() (string, error) {
+	return t.name, nil
+}
+
+func (t *tailscaleKernelTUN) Events() <-chan tstun.Event {
+	return t.events
+}
+
+func (t *tailscaleKernelTUN) Close() error {
+	t.closeOnce.Do(func() {
+		var err error
+		if t.closeHook != nil {
+			err = errors.Join(err, t.closeHook())
+		}
+		err = errors.Join(err, t.tun.Close())
+		close(t.events)
+		t.closeErr = err
+	})
+	return t.closeErr
+}
+
+func (t *tailscaleKernelTUN) BatchSize() int {
+	if linuxTun, ok := t.tun.(singtun.LinuxTUN); ok {
+		return linuxTun.BatchSize()
+	}
+	return 1
+}

--- a/adapter/outbound/tailscale_kernel_tun_stub.go
+++ b/adapter/outbound/tailscale_kernel_tun_stub.go
@@ -1,0 +1,44 @@
+//go:build with_gvisor && !no_tailscale && !linux
+
+package outbound
+
+import (
+	"errors"
+	"net/netip"
+
+	tstun "github.com/metacubex/tailscale-wireguard-go/tun"
+)
+
+type tailscaleKernelHostForwarder struct{}
+
+func newTailscaleKernelHostForwarder(name string, option TailscaleHostForwardOption) (*tailscaleKernelHostForwarder, error) {
+	return nil, errors.New("tailscale kernel host-forward mode is only supported on Linux")
+}
+
+func (k *tailscaleKernelHostForwarder) Device() tstun.Device {
+	return nil
+}
+
+func (k *tailscaleKernelHostForwarder) Name() string {
+	return ""
+}
+
+func (k *tailscaleKernelHostForwarder) MTU() uint32 {
+	return 0
+}
+
+func (k *tailscaleKernelHostForwarder) Routes() []netip.Prefix {
+	return nil
+}
+
+func (k *tailscaleKernelHostForwarder) Addresses() []netip.Prefix {
+	return nil
+}
+
+func (k *tailscaleKernelHostForwarder) Configure(v4, v6 netip.Addr) error {
+	return nil
+}
+
+func (k *tailscaleKernelHostForwarder) Close() error {
+	return nil
+}

--- a/adapter/outbound/tailscale_stub.go
+++ b/adapter/outbound/tailscale_stub.go
@@ -10,9 +10,12 @@ type Tailscale struct {
 
 type TailscaleHostForwardOption struct {
 	Enabled bool   `proxy:"enabled,omitempty"`
+	Mode    string `proxy:"mode,omitempty"`
 	Target  string `proxy:"target,omitempty"`
 	TCP     *bool  `proxy:"tcp,omitempty"`
 	UDP     *bool  `proxy:"udp,omitempty"`
+	Device  string `proxy:"device,omitempty"`
+	MTU     uint32 `proxy:"mtu,omitempty"`
 }
 
 type TailscaleOption struct {

--- a/adapter/outbound/tailscale_stub.go
+++ b/adapter/outbound/tailscale_stub.go
@@ -24,6 +24,7 @@ type TailscaleOption struct {
 	StateDir    string                     `proxy:"state-dir,omitempty"`
 	Ephemeral   bool                       `proxy:"ephemeral,omitempty"`
 	UDP         bool                       `proxy:"udp,omitempty"`
+	MagicDNS    bool                       `proxy:"magic-dns,omitempty"`
 	HostForward TailscaleHostForwardOption `proxy:"host-forward,omitempty"`
 
 	AcceptRoutes           *bool  `proxy:"accept-routes,omitempty"`

--- a/adapter/outbound/tailscale_stub.go
+++ b/adapter/outbound/tailscale_stub.go
@@ -8,15 +8,23 @@ type Tailscale struct {
 	*Base
 }
 
+type TailscaleHostForwardOption struct {
+	Enabled bool   `proxy:"enabled,omitempty"`
+	Target  string `proxy:"target,omitempty"`
+	TCP     *bool  `proxy:"tcp,omitempty"`
+	UDP     *bool  `proxy:"udp,omitempty"`
+}
+
 type TailscaleOption struct {
 	BasicOption
-	Name       string `proxy:"name"`
-	Hostname   string `proxy:"hostname,omitempty"`
-	AuthKey    string `proxy:"auth-key,omitempty"`
-	ControlURL string `proxy:"control-url,omitempty"`
-	StateDir   string `proxy:"state-dir,omitempty"`
-	Ephemeral  bool   `proxy:"ephemeral,omitempty"`
-	UDP        bool   `proxy:"udp,omitempty"`
+	Name        string                     `proxy:"name"`
+	Hostname    string                     `proxy:"hostname,omitempty"`
+	AuthKey     string                     `proxy:"auth-key,omitempty"`
+	ControlURL  string                     `proxy:"control-url,omitempty"`
+	StateDir    string                     `proxy:"state-dir,omitempty"`
+	Ephemeral   bool                       `proxy:"ephemeral,omitempty"`
+	UDP         bool                       `proxy:"udp,omitempty"`
+	HostForward TailscaleHostForwardOption `proxy:"host-forward,omitempty"`
 
 	AcceptRoutes           *bool  `proxy:"accept-routes,omitempty"`
 	ExitNode               string `proxy:"exit-node,omitempty"`

--- a/component/tailnet/magicdns.go
+++ b/component/tailnet/magicdns.go
@@ -1,0 +1,106 @@
+package tailnet
+
+import (
+	"io"
+	"strings"
+	"sync"
+
+	"github.com/metacubex/mihomo/common/utils"
+
+	"golang.org/x/exp/maps"
+	"golang.org/x/exp/slices"
+)
+
+var magicDNS = struct {
+	sync.RWMutex
+	domains   map[string][]string
+	callbacks *utils.Callback[[]string]
+}{
+	domains:   map[string][]string{},
+	callbacks: utils.NewCallback[[]string](),
+}
+
+func NormalizeSearchDomains(domains []string) []string {
+	normalized := make([]string, 0, len(domains))
+	for _, domain := range domains {
+		domain = strings.ToLower(strings.TrimSpace(domain))
+		domain = strings.TrimRight(domain, ".")
+		if domain == "" || domain == "~" {
+			continue
+		}
+		normalized = append(normalized, domain)
+	}
+	slices.Sort(normalized)
+	return slices.Compact(normalized)
+}
+
+func SetSearchDomains(proxyName string, domains []string) {
+	domains = NormalizeSearchDomains(domains)
+
+	magicDNS.Lock()
+	if len(domains) == 0 {
+		delete(magicDNS.domains, proxyName)
+	} else if slices.Equal(magicDNS.domains[proxyName], domains) {
+		magicDNS.Unlock()
+		return
+	} else {
+		magicDNS.domains[proxyName] = domains
+	}
+	aggregate := searchDomainsLocked()
+	magicDNS.Unlock()
+
+	magicDNS.callbacks.Emit(aggregate)
+}
+
+func RemoveSearchDomains(proxyName string) {
+	SetSearchDomains(proxyName, nil)
+}
+
+func SearchDomains() []string {
+	magicDNS.RLock()
+	defer magicDNS.RUnlock()
+	return searchDomainsLocked()
+}
+
+func RegisterSearchDomainCallback(callback func([]string)) io.Closer {
+	closer := magicDNS.callbacks.Register(callback)
+	callback(SearchDomains())
+	return closer
+}
+
+func ProxyNameForDomain(domain string) (string, bool) {
+	domain = strings.ToLower(strings.TrimSpace(domain))
+	domain = strings.TrimRight(domain, ".")
+	if domain == "" {
+		return "", false
+	}
+
+	magicDNS.RLock()
+	defer magicDNS.RUnlock()
+
+	var (
+		bestProxy  string
+		bestSuffix string
+	)
+	for proxyName, domains := range magicDNS.domains {
+		for _, suffix := range domains {
+			if domain != suffix && !strings.HasSuffix(domain, "."+suffix) {
+				continue
+			}
+			if len(suffix) > len(bestSuffix) {
+				bestProxy = proxyName
+				bestSuffix = suffix
+			}
+		}
+	}
+	return bestProxy, bestProxy != ""
+}
+
+func searchDomainsLocked() []string {
+	var domains []string
+	for _, proxyDomains := range maps.Values(magicDNS.domains) {
+		domains = append(domains, proxyDomains...)
+	}
+	slices.Sort(domains)
+	return slices.Compact(domains)
+}

--- a/component/tailnet/magicdns_test.go
+++ b/component/tailnet/magicdns_test.go
@@ -1,0 +1,45 @@
+package tailnet
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestNormalizeSearchDomains(t *testing.T) {
+	got := NormalizeSearchDomains([]string{
+		" TailB2B774.TS.NET. ",
+		"tailb2b774.ts.net",
+		"",
+		"~.",
+	})
+	want := []string{"tailb2b774.ts.net"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("NormalizeSearchDomains() = %v, want %v", got, want)
+	}
+}
+
+func TestMagicDNSSearchDomainRegistry(t *testing.T) {
+	const (
+		proxyA = "magicdns-test-a"
+		proxyB = "magicdns-test-b"
+	)
+	RemoveSearchDomains(proxyA)
+	RemoveSearchDomains(proxyB)
+	t.Cleanup(func() {
+		RemoveSearchDomains(proxyA)
+		RemoveSearchDomains(proxyB)
+	})
+
+	SetSearchDomains(proxyA, []string{"tailnet.test."})
+	SetSearchDomains(proxyB, []string{"dept.tailnet.test"})
+
+	if got, ok := ProxyNameForDomain("newvbox.tailnet.test."); !ok || got != proxyA {
+		t.Fatalf("ProxyNameForDomain tailnet = %q, %v", got, ok)
+	}
+	if got, ok := ProxyNameForDomain("newvbox.dept.tailnet.test."); !ok || got != proxyB {
+		t.Fatalf("ProxyNameForDomain longest suffix = %q, %v", got, ok)
+	}
+	if got, ok := ProxyNameForDomain("example.invalid."); ok || got != "" {
+		t.Fatalf("ProxyNameForDomain unrelated = %q, %v", got, ok)
+	}
+}

--- a/component/tailnet/status.go
+++ b/component/tailnet/status.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"strconv"
 	"strings"
 	"text/tabwriter"
 	"time"
@@ -26,18 +27,23 @@ type Status struct {
 }
 
 type NodeStatus struct {
-	Name         string     `json:"name"`
-	HostName     string     `json:"hostName,omitempty"`
-	DNSName      string     `json:"dnsName,omitempty"`
-	OS           string     `json:"os,omitempty"`
-	TailscaleIPs []string   `json:"tailscaleIPs,omitempty"`
-	Online       bool       `json:"online"`
-	LastSeen     *time.Time `json:"lastSeen,omitempty"`
-	Relay        string     `json:"relay,omitempty"`
-	PeerRelay    string     `json:"peerRelay,omitempty"`
-	TxBytes      int64      `json:"txBytes,omitempty"`
-	RxBytes      int64      `json:"rxBytes,omitempty"`
-	Self         bool       `json:"self,omitempty"`
+	Name           string     `json:"name"`
+	HostName       string     `json:"hostName,omitempty"`
+	DNSName        string     `json:"dnsName,omitempty"`
+	OS             string     `json:"os,omitempty"`
+	TailscaleIPs   []string   `json:"tailscaleIPs,omitempty"`
+	Online         bool       `json:"online"`
+	Active         bool       `json:"active"`
+	LastSeen       *time.Time `json:"lastSeen,omitempty"`
+	Addrs          []string   `json:"addrs,omitempty"`
+	CurAddr        string     `json:"curAddr,omitempty"`
+	Relay          string     `json:"relay,omitempty"`
+	PeerRelay      string     `json:"peerRelay,omitempty"`
+	ExitNode       bool       `json:"exitNode,omitempty"`
+	ExitNodeOption bool       `json:"exitNodeOption,omitempty"`
+	TxBytes        int64      `json:"txBytes,omitempty"`
+	RxBytes        int64      `json:"rxBytes,omitempty"`
+	Self           bool       `json:"self,omitempty"`
 }
 
 func (s Status) Text() string {
@@ -67,17 +73,7 @@ func writeNodeStatus(tw *tabwriter.Writer, node NodeStatus) {
 		name = node.TailscaleIPs[0]
 	}
 
-	status := "-"
-	if node.Online {
-		status = "online"
-	} else if node.LastSeen != nil {
-		status = "offline, last seen " + node.LastSeen.Format(time.RFC3339)
-	} else if !node.Self {
-		status = "offline"
-	}
-	if node.Relay != "" {
-		status += `; relay "` + node.Relay + `"`
-	}
+	status := nodeStatusText(node)
 
 	_, _ = tw.Write([]byte(strings.Join([]string{
 		strings.Join(node.TailscaleIPs, ","),
@@ -85,4 +81,60 @@ func writeNodeStatus(tw *tabwriter.Writer, node NodeStatus) {
 		node.OS,
 		status,
 	}, "\t") + "\n"))
+}
+
+func nodeStatusText(node NodeStatus) string {
+	anyTraffic := node.TxBytes != 0 || node.RxBytes != 0
+	offline := ""
+	if !node.Online {
+		offline = "; offline" + lastSeenText(node.LastSeen)
+	}
+
+	var parts []string
+	if !node.Active {
+		switch {
+		case node.ExitNode:
+			parts = append(parts, "idle", "exit node"+offline)
+		case node.ExitNodeOption:
+			parts = append(parts, "idle", "offers exit node"+offline)
+		case anyTraffic:
+			parts = append(parts, "idle"+offline)
+		case !node.Online:
+			parts = append(parts, "offline"+lastSeenText(node.LastSeen))
+		default:
+			parts = append(parts, "-")
+		}
+	} else {
+		parts = append(parts, "active")
+		switch {
+		case node.ExitNode:
+			parts = append(parts, "exit node")
+		case node.ExitNodeOption:
+			parts = append(parts, "offers exit node")
+		}
+		switch {
+		case node.CurAddr != "":
+			parts = append(parts, "direct "+node.CurAddr)
+		case node.PeerRelay != "":
+			parts = append(parts, "peer-relay "+node.PeerRelay)
+		case node.Relay != "":
+			parts = append(parts, `relay "`+node.Relay+`"`)
+		}
+		if !node.Online {
+			parts = append(parts, strings.TrimPrefix(offline, "; "))
+		}
+	}
+
+	status := strings.Join(parts, "; ")
+	if anyTraffic {
+		status += ", tx " + strconv.FormatInt(node.TxBytes, 10) + " rx " + strconv.FormatInt(node.RxBytes, 10)
+	}
+	return status
+}
+
+func lastSeenText(lastSeen *time.Time) string {
+	if lastSeen == nil {
+		return ""
+	}
+	return ", last seen " + lastSeen.Format(time.RFC3339)
 }

--- a/component/tailnet/status.go
+++ b/component/tailnet/status.go
@@ -1,0 +1,88 @@
+package tailnet
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"strings"
+	"text/tabwriter"
+	"time"
+)
+
+var ErrStatusUnavailable = errors.New("proxy does not provide Tailnet status")
+
+type StatusProvider interface {
+	TailnetStatus(ctx context.Context) (Status, error)
+}
+
+type Status struct {
+	Proxy           string       `json:"proxy"`
+	BackendState    string       `json:"backendState"`
+	MagicDNSSuffix  string       `json:"magicDNSSuffix,omitempty"`
+	MagicDNSEnabled bool         `json:"magicDNSEnabled,omitempty"`
+	TailscaleIPs    []string     `json:"tailscaleIPs,omitempty"`
+	Self            *NodeStatus  `json:"self,omitempty"`
+	Peers           []NodeStatus `json:"peers"`
+}
+
+type NodeStatus struct {
+	Name         string     `json:"name"`
+	HostName     string     `json:"hostName,omitempty"`
+	DNSName      string     `json:"dnsName,omitempty"`
+	OS           string     `json:"os,omitempty"`
+	TailscaleIPs []string   `json:"tailscaleIPs,omitempty"`
+	Online       bool       `json:"online"`
+	LastSeen     *time.Time `json:"lastSeen,omitempty"`
+	Relay        string     `json:"relay,omitempty"`
+	PeerRelay    string     `json:"peerRelay,omitempty"`
+	TxBytes      int64      `json:"txBytes,omitempty"`
+	RxBytes      int64      `json:"rxBytes,omitempty"`
+	Self         bool       `json:"self,omitempty"`
+}
+
+func (s Status) Text() string {
+	var buf bytes.Buffer
+	tw := tabwriter.NewWriter(&buf, 0, 0, 2, ' ', 0)
+
+	if s.Self != nil {
+		writeNodeStatus(tw, *s.Self)
+	}
+	for _, peer := range s.Peers {
+		writeNodeStatus(tw, peer)
+	}
+
+	_ = tw.Flush()
+	return buf.String()
+}
+
+func writeNodeStatus(tw *tabwriter.Writer, node NodeStatus) {
+	name := node.Name
+	if name == "" {
+		name = node.HostName
+	}
+	if name == "" {
+		name = strings.TrimRight(node.DNSName, ".")
+	}
+	if name == "" && len(node.TailscaleIPs) > 0 {
+		name = node.TailscaleIPs[0]
+	}
+
+	status := "-"
+	if node.Online {
+		status = "online"
+	} else if node.LastSeen != nil {
+		status = "offline, last seen " + node.LastSeen.Format(time.RFC3339)
+	} else if !node.Self {
+		status = "offline"
+	}
+	if node.Relay != "" {
+		status += `; relay "` + node.Relay + `"`
+	}
+
+	_, _ = tw.Write([]byte(strings.Join([]string{
+		strings.Join(node.TailscaleIPs, ","),
+		name,
+		node.OS,
+		status,
+	}, "\t") + "\n"))
+}

--- a/component/tailnet/status_test.go
+++ b/component/tailnet/status_test.go
@@ -1,0 +1,47 @@
+package tailnet
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestStatusText(t *testing.T) {
+	lastSeen := time.Date(2026, 7, 10, 4, 0, 0, 0, time.UTC)
+	status := Status{
+		Self: &NodeStatus{
+			Name:         "mihomo-tailnet-staging",
+			OS:           "linux",
+			TailscaleIPs: []string{"100.104.140.27"},
+			Online:       true,
+			Self:         true,
+		},
+		Peers: []NodeStatus{
+			{
+				Name:         "newvbox",
+				OS:           "linux",
+				TailscaleIPs: []string{"100.90.103.91"},
+				Online:       true,
+			},
+			{
+				Name:         "offline-node",
+				OS:           "linux",
+				TailscaleIPs: []string{"100.64.0.2"},
+				LastSeen:     &lastSeen,
+			},
+		},
+	}
+
+	text := status.Text()
+	for _, want := range []string{
+		"100.104.140.27",
+		"mihomo-tailnet-staging",
+		"100.90.103.91",
+		"newvbox",
+		"offline, last seen 2026-07-10T04:00:00Z",
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("Text() missing %q in:\n%s", want, text)
+		}
+	}
+}

--- a/config/config.go
+++ b/config/config.go
@@ -275,6 +275,7 @@ type RawTun struct {
 	Device              string     `yaml:"device" json:"device"`
 	Stack               C.TUNStack `yaml:"stack" json:"stack"`
 	DNSHijack           []string   `yaml:"dns-hijack" json:"dns-hijack"`
+	DNSSearchDomains    []string   `yaml:"dns-search-domains" json:"dns-search-domains"`
 	AutoRoute           bool       `yaml:"auto-route" json:"auto-route"`
 	AutoDetectInterface bool       `yaml:"auto-detect-interface" json:"auto-detect-interface"`
 
@@ -1680,6 +1681,7 @@ func parseTun(rawTun RawTun, dns *DNS, general *General) error {
 		Device:              rawTun.Device,
 		Stack:               rawTun.Stack,
 		DNSHijack:           rawTun.DNSHijack,
+		DNSSearchDomains:    rawTun.DNSSearchDomains,
 		AutoRoute:           rawTun.AutoRoute,
 		AutoDetectInterface: rawTun.AutoDetectInterface,
 

--- a/config/tun_test.go
+++ b/config/tun_test.go
@@ -1,0 +1,23 @@
+package config
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestParseTunDNSSearchDomains(t *testing.T) {
+	var general General
+	err := parseTun(RawTun{
+		Enable:           true,
+		DNSHijack:        []string{"0.0.0.0:53"},
+		DNSSearchDomains: []string{"tailb2b774.ts.net"},
+	}, &DNS{}, &general)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := []string{"tailb2b774.ts.net"}
+	if !reflect.DeepEqual(general.Tun.DNSSearchDomains, want) {
+		t.Fatalf("DNSSearchDomains = %v, want %v", general.Tun.DNSSearchDomains, want)
+	}
+}

--- a/dns/resolver.go
+++ b/dns/resolver.go
@@ -10,6 +10,7 @@ import (
 	"github.com/metacubex/mihomo/common/lru"
 	"github.com/metacubex/mihomo/common/singleflight"
 	"github.com/metacubex/mihomo/component/resolver"
+	"github.com/metacubex/mihomo/component/tailnet"
 	"github.com/metacubex/mihomo/component/trie"
 	C "github.com/metacubex/mihomo/constant"
 	"github.com/metacubex/mihomo/log"
@@ -259,19 +260,20 @@ func (r *Resolver) exchangeWithoutCache(ctx context.Context, m *D.Msg) (msg *D.M
 }
 
 func (r *Resolver) matchPolicy(m *D.Msg) []dnsClient {
-	if r.policy == nil {
-		return nil
-	}
-
 	domain := msgToDomain(m)
 	if domain == "" {
 		return nil
 	}
 
-	for _, policy := range r.policy {
-		if dnsClients := policy.Match(domain); len(dnsClients) > 0 {
-			return dnsClients
+	if r.policy != nil {
+		for _, policy := range r.policy {
+			if dnsClients := policy.Match(domain); len(dnsClients) > 0 {
+				return dnsClients
+			}
 		}
+	}
+	if proxyName, ok := tailnet.ProxyNameForDomain(domain); ok {
+		return []dnsClient{newTailscaleClient(proxyName)}
 	}
 	return nil
 }

--- a/dns/tailscale_test.go
+++ b/dns/tailscale_test.go
@@ -1,0 +1,26 @@
+package dns
+
+import (
+	"testing"
+
+	"github.com/metacubex/mihomo/component/tailnet"
+
+	D "github.com/miekg/dns"
+)
+
+func TestResolverMatchesTailnetMagicDNSPolicy(t *testing.T) {
+	const proxyName = "magicdns-policy-test"
+	tailnet.SetSearchDomains(proxyName, []string{"tailnet.test"})
+	t.Cleanup(func() { tailnet.RemoveSearchDomains(proxyName) })
+
+	query := new(D.Msg)
+	query.SetQuestion(D.Fqdn("newvbox.tailnet.test"), D.TypeA)
+
+	matched := (&Resolver{}).matchPolicy(query)
+	if len(matched) != 1 {
+		t.Fatalf("matched %d clients, want 1", len(matched))
+	}
+	if got, want := matched[0].Address(), "tailscale://"+proxyName; got != want {
+		t.Fatalf("matched client = %q, want %q", got, want)
+	}
+}

--- a/docs/config.yaml
+++ b/docs/config.yaml
@@ -1255,6 +1255,7 @@ proxies: # socks5
     #   target: 127.0.0.1 # 仅允许回环地址，默认 127.0.0.1
     #   tcp: true # enabled 时默认 true
     #   udp: true # enabled 时默认 true；与上层出站 udp 开关无关
+    # 启用 host-forward 时会将 Tailscale userspace netstack TCP keepalive 默认设为 60s/15s，避免 SSH 等空闲长连接在 WireGuard session 过期后断开；可用 TS_NETSTACK_KEEPALIVE_IDLE/INTERVAL 覆盖
     # accept-routes: true # 是否接受 Tailnet 中发布的 subnet routes
     # exit-node: 100.64.0.1 # 使用指定 exit node，可填写节点 IP；也支持 auto:any
     # exit-node-allow-lan-access: true # 使用 exit node 时是否允许访问本地 LAN

--- a/docs/config.yaml
+++ b/docs/config.yaml
@@ -136,6 +136,8 @@ tun:
   stack: system # gvisor/mixed
   dns-hijack:
     - 0.0.0.0:53 # 需要劫持的 DNS
+  # dns-search-domains: # 追加到系统 TUN DNS 链路的搜索域；Linux/systemd-resolved 上可用于 MagicDNS 单标签解析，如 ssh newvbox
+  #   - tailnet.ts.net
   # auto-detect-interface: true # 自动识别出口网卡
   # auto-route: true # 配置路由表
   # mtu: 9000 # 最大传输单元
@@ -155,6 +157,8 @@ tun:
     - 128.0.0.0/1
     - "::/1"
     - "8000::/1"
+    # - 100.64.0.0/10 # Tailnet IPv4；配合 type: tailscale / magic-dns 可透明访问 Tailnet
+    # - "fd7a:115c:a1e0::/48" # Tailnet IPv6
   # inet4-route-address: # 启用 auto-route 时使用自定义路由而不是默认路由（旧写法）
   #   - 0.0.0.0/1
   #   - 128.0.0.0/1
@@ -1244,6 +1248,7 @@ proxies: # socks5
     # state-dir: ./tailscale # tsnet 状态目录，默认 tailscale
     # ephemeral: false # 是否作为 ephemeral node 登录，默认 false
     udp: true # 是否启用 UDP，默认 false
+    # magic-dns: true # 启用 MagicDNS 集成；会启动 tsnet、自动发布 Tailnet 搜索域，并将匹配域名交给此出站的 Tailscale DNS
     # host-forward: # 可选；将发往此节点 Tailscale IP 任意端口的流量转发到同端口的本机回环服务
     #   enabled: true
     #   target: 127.0.0.1 # 仅允许回环地址，默认 127.0.0.1
@@ -2336,6 +2341,8 @@ listeners:
     stack: system # gvisor / mixed
     dns-hijack:
     - 0.0.0.0:53 # 需要劫持的 DNS
+    # dns-search-domains: # 追加到系统 TUN DNS 链路的搜索域；Linux/systemd-resolved 上可用于 MagicDNS 单标签解析
+    # - tailnet.ts.net
     # auto-detect-interface: false # 自动识别出口网卡
     # auto-route: false # 配置路由表
     # mtu: 9000 # 最大传输单元

--- a/docs/config.yaml
+++ b/docs/config.yaml
@@ -1249,6 +1249,7 @@ proxies: # socks5
     # ephemeral: false # 是否作为 ephemeral node 登录，默认 false
     udp: true # 是否启用 UDP，默认 false
     # magic-dns: true # 启用 MagicDNS 集成；会启动 tsnet、自动发布 Tailnet 搜索域，并将匹配域名交给此出站的 Tailscale DNS
+    # 可通过 RESTful API `GET /proxies/{name}/tailscale/status?format=text` 查看 Tailnet 节点 IP、名称和在线状态
     # host-forward: # 可选；将发往此节点 Tailscale IP 任意端口的流量转发到同端口的本机回环服务
     #   enabled: true
     #   target: 127.0.0.1 # 仅允许回环地址，默认 127.0.0.1

--- a/docs/config.yaml
+++ b/docs/config.yaml
@@ -1252,9 +1252,12 @@ proxies: # socks5
     # 可通过 RESTful API `GET /proxies/{name}/tailscale/status?format=text` 查看 Tailnet 节点 IP、名称和在线状态
     # host-forward: # 可选；将发往此节点 Tailscale IP 任意端口的流量转发到同端口的本机回环服务
     #   enabled: true
+    #   mode: userspace # userspace: 回环同端口转发；kernel: Linux TUN 接入主机网络栈
     #   target: 127.0.0.1 # 仅允许回环地址，默认 127.0.0.1
     #   tcp: true # enabled 时默认 true
     #   udp: true # enabled 时默认 true；与上层出站 udp 开关无关
+    #   device: mts0 # kernel 模式可选；默认按代理名生成
+    #   mtu: 1280 # kernel 模式可选；默认 1280
     # 启用 host-forward 时会将 Tailscale userspace netstack TCP keepalive 默认设为 60s/15s，避免 SSH 等空闲长连接在 WireGuard session 过期后断开；可用 TS_NETSTACK_KEEPALIVE_IDLE/INTERVAL 覆盖
     # accept-routes: true # 是否接受 Tailnet 中发布的 subnet routes
     # exit-node: 100.64.0.1 # 使用指定 exit node，可填写节点 IP；也支持 auto:any

--- a/docs/config.yaml
+++ b/docs/config.yaml
@@ -1244,6 +1244,11 @@ proxies: # socks5
     # state-dir: ./tailscale # tsnet 状态目录，默认 tailscale
     # ephemeral: false # 是否作为 ephemeral node 登录，默认 false
     udp: true # 是否启用 UDP，默认 false
+    # host-forward: # 可选；将发往此节点 Tailscale IP 任意端口的流量转发到同端口的本机回环服务
+    #   enabled: true
+    #   target: 127.0.0.1 # 仅允许回环地址，默认 127.0.0.1
+    #   tcp: true # enabled 时默认 true
+    #   udp: true # enabled 时默认 true；与上层出站 udp 开关无关
     # accept-routes: true # 是否接受 Tailnet 中发布的 subnet routes
     # exit-node: 100.64.0.1 # 使用指定 exit node，可填写节点 IP；也支持 auto:any
     # exit-node-allow-lan-access: true # 使用 exit node 时是否允许访问本地 LAN

--- a/go.mod
+++ b/go.mod
@@ -42,6 +42,7 @@ require (
 	github.com/metacubex/smux v0.0.0-20260105030934-d0c8756d3141
 	github.com/metacubex/ssh v0.1.0
 	github.com/metacubex/tailscale v0.0.0-20260623094802-1ab893d4162c
+	github.com/metacubex/tailscale-wireguard-go v0.0.0-20260623093519-06ea214022e4
 	github.com/metacubex/tfo-go v0.0.0-20260623020846-376a77860b8c
 	github.com/metacubex/tls v0.1.7
 	github.com/metacubex/utls v1.8.7
@@ -50,6 +51,7 @@ require (
 	github.com/openacid/low v0.1.21
 	github.com/rasky/go-lzo v0.0.0-20200203143853-96a758eda86e
 	github.com/samber/lo v1.53.0
+	github.com/sagernet/netlink v0.0.0-20240612041022-b9a21c07ac6a
 	github.com/sirupsen/logrus v1.9.4
 	github.com/stretchr/testify v1.11.1
 	github.com/vmihailenco/msgpack/v5 v5.4.1
@@ -117,7 +119,6 @@ require (
 	github.com/metacubex/jsonv2 v0.0.0-20260518173308-f4597c22f1df // indirect
 	github.com/metacubex/nftables v0.0.0-20260426003805-208c2c1ba2cb // indirect
 	github.com/metacubex/qpack v0.6.0 // indirect
-	github.com/metacubex/tailscale-wireguard-go v0.0.0-20260623093519-06ea214022e4 // indirect
 	github.com/metacubex/yamux v0.0.0-20250918083631-dd5f17c0be49 // indirect
 	github.com/mitchellh/go-ps v1.0.0 // indirect
 	github.com/oasisprotocol/deoxysii v0.0.0-20220228165953-2091330c22b7 // indirect
@@ -125,7 +126,6 @@ require (
 	github.com/pires/go-proxyproto v0.8.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/safchain/ethtool v0.3.0 // indirect
-	github.com/sagernet/netlink v0.0.0-20240612041022-b9a21c07ac6a // indirect
 	github.com/sina-ghaderi/poly1305 v0.0.0-20220724002748-c5926b03988b // indirect
 	github.com/sina-ghaderi/rabaead v0.0.0-20220730151906-ab6e06b96e8c // indirect
 	github.com/sina-ghaderi/rabbitio v0.0.0-20220730151941-9ce26f4f872e // indirect

--- a/hub/route/proxies.go
+++ b/hub/route/proxies.go
@@ -2,6 +2,7 @@ package route
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strconv"
 	"time"
@@ -9,6 +10,7 @@ import (
 	"github.com/metacubex/mihomo/adapter/outboundgroup"
 	"github.com/metacubex/mihomo/common/utils"
 	"github.com/metacubex/mihomo/component/profile/cachefile"
+	"github.com/metacubex/mihomo/component/tailnet"
 	C "github.com/metacubex/mihomo/constant"
 	"github.com/metacubex/mihomo/tunnel"
 
@@ -29,6 +31,7 @@ func proxyRouter() http.Handler {
 		r.Use(parseProxyName, findProxyByName)
 		r.Get("/", getProxy)
 		r.Get("/delay", getProxyDelay)
+		r.Get("/tailscale/status", getProxyTailnetStatus)
 		r.Put("/", updateProxy)
 		r.Delete("/", unfixedProxy)
 	})
@@ -145,6 +148,43 @@ func getProxyDelay(w http.ResponseWriter, r *http.Request) {
 	render.JSON(w, r, render.M{
 		"delay": delay,
 	})
+}
+
+func getProxyTailnetStatus(w http.ResponseWriter, r *http.Request) {
+	proxy := r.Context().Value(CtxKeyProxy).(C.Proxy)
+	statusProvider, ok := proxy.Adapter().(tailnet.StatusProvider)
+	if !ok {
+		render.Status(r, http.StatusBadRequest)
+		render.JSON(w, r, newError("proxy does not provide Tailnet status"))
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
+	defer cancel()
+
+	status, err := statusProvider.TailnetStatus(ctx)
+	if ctx.Err() != nil {
+		render.Status(r, http.StatusGatewayTimeout)
+		render.JSON(w, r, ErrRequestTimeout)
+		return
+	}
+	if err != nil {
+		if errors.Is(err, tailnet.ErrStatusUnavailable) {
+			render.Status(r, http.StatusBadRequest)
+			render.JSON(w, r, newError(err.Error()))
+			return
+		}
+		render.Status(r, http.StatusServiceUnavailable)
+		render.JSON(w, r, newError(err.Error()))
+		return
+	}
+
+	if r.URL.Query().Get("format") == "text" {
+		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+		_, _ = w.Write([]byte(status.Text()))
+		return
+	}
+	render.JSON(w, r, status)
 }
 
 func unfixedProxy(w http.ResponseWriter, r *http.Request) {

--- a/listener/config/tun.go
+++ b/listener/config/tun.go
@@ -14,6 +14,7 @@ type Tun struct {
 	Device              string     `yaml:"device" json:"device"`
 	Stack               C.TUNStack `yaml:"stack" json:"stack"`
 	DNSHijack           []string   `yaml:"dns-hijack" json:"dns-hijack"`
+	DNSSearchDomains    []string   `yaml:"dns-search-domains" json:"dns-search-domains"`
 	AutoRoute           bool       `yaml:"auto-route" json:"auto-route"`
 	AutoDetectInterface bool       `yaml:"auto-detect-interface" json:"auto-detect-interface"`
 
@@ -67,6 +68,7 @@ type Tun struct {
 
 func (t *Tun) Sort() {
 	slices.Sort(t.DNSHijack)
+	slices.Sort(t.DNSSearchDomains)
 
 	slices.SortFunc(t.Inet4Address, netipx.ComparePrefix)
 	slices.SortFunc(t.Inet6Address, netipx.ComparePrefix)
@@ -103,6 +105,9 @@ func (t *Tun) Equal(other Tun) bool {
 		return false
 	}
 	if !slices.Equal(t.DNSHijack, other.DNSHijack) {
+		return false
+	}
+	if !slices.Equal(t.DNSSearchDomains, other.DNSSearchDomains) {
 		return false
 	}
 	if t.AutoRoute != other.AutoRoute {

--- a/listener/inbound/tun.go
+++ b/listener/inbound/tun.go
@@ -15,6 +15,7 @@ type TunOption struct {
 	Device              string     `inbound:"device,omitempty"`
 	Stack               C.TUNStack `inbound:"stack,omitempty"`
 	DNSHijack           []string   `inbound:"dns-hijack,omitempty"`
+	DNSSearchDomains    []string   `inbound:"dns-search-domains,omitempty"`
 	AutoRoute           bool       `inbound:"auto-route,omitempty"`
 	AutoDetectInterface bool       `inbound:"auto-detect-interface,omitempty"`
 
@@ -94,6 +95,7 @@ func NewTun(options *TunOption) (*Tun, error) {
 			Device:                                options.Device,
 			Stack:                                 options.Stack,
 			DNSHijack:                             options.DNSHijack,
+			DNSSearchDomains:                      options.DNSSearchDomains,
 			AutoRoute:                             options.AutoRoute,
 			AutoDetectInterface:                   options.AutoDetectInterface,
 			MTU:                                   options.MTU,

--- a/listener/sing_tun/server.go
+++ b/listener/sing_tun/server.go
@@ -17,6 +17,7 @@ import (
 	"github.com/metacubex/mihomo/component/dialer"
 	"github.com/metacubex/mihomo/component/iface"
 	"github.com/metacubex/mihomo/component/resolver"
+	"github.com/metacubex/mihomo/component/tailnet"
 	C "github.com/metacubex/mihomo/constant"
 	P "github.com/metacubex/mihomo/constant/provider"
 	LC "github.com/metacubex/mihomo/listener/config"
@@ -65,6 +66,9 @@ type Listener struct {
 	routeExcludeAddressSet   []*netipx.IPSet
 
 	dnsServerIp []string
+
+	systemDNSCancel          context.CancelFunc
+	tailnetSearchDomainClose io.Closer
 }
 
 type ListenerHandler struct {
@@ -510,6 +514,11 @@ func New(options LC.Tun, tunnel C.Tunnel, additions ...inbound.Addition) (l *Lis
 		return
 	}
 	l.tunStack = tunStack
+	systemDNSCtx, systemDNSCancel := context.WithCancel(ctx)
+	l.systemDNSCancel = systemDNSCancel
+	l.tailnetSearchDomainClose = tailnet.RegisterSearchDomainCallback(func(domains []string) {
+		l.updateSystemDNSSearchDomains(systemDNSCtx, domains)
+	})
 
 	if l.autoRedirect != nil {
 		if len(l.options.RouteAddressSet) > 0 && len(l.routeAddressSet) == 0 {
@@ -544,6 +553,16 @@ func New(options LC.Tun, tunnel C.Tunnel, additions ...inbound.Addition) (l *Lis
 	l.addrStr = fmt.Sprintf("%s(%s,%s), mtu: %d, auto route: %v, auto redir: %v, ip stack: %s",
 		tunName, tunOptions.Inet4Address, tunOptions.Inet6Address, tunMTU, options.AutoRoute, options.AutoRedirect, options.Stack)
 	return
+}
+
+func (l *Listener) updateSystemDNSSearchDomains(ctx context.Context, tailnetDomains []string) {
+	domains := make([]string, 0, len(l.options.DNSSearchDomains)+len(tailnetDomains))
+	domains = append(domains, l.options.DNSSearchDomains...)
+	domains = append(domains, tailnetDomains...)
+	if len(tailnet.NormalizeSearchDomains(domains)) == 0 {
+		return
+	}
+	configureSystemDNSSearchDomains(ctx, l.tunName, domains)
 }
 
 func (l *Listener) ruleUpdateCallback(ruleProvider P.RuleProvider) {
@@ -667,6 +686,9 @@ func parseRange[T constraints.Integer](uidRanges []ranges.Range[T], rangeList []
 
 func (l *Listener) Close() error {
 	l.closed = true
+	if l.systemDNSCancel != nil {
+		l.systemDNSCancel()
+	}
 	resolver.RemoveSystemDnsBlacklist(l.dnsServerIp...)
 	if l.autoRedirectOutputMark != 0 {
 		dialer.DefaultRoutingMark.CompareAndSwap(l.autoRedirectOutputMark, 0)
@@ -675,6 +697,7 @@ func (l *Listener) Close() error {
 		dialer.DefaultInterfaceFinder.CompareAndSwap(l.cDialerInterfaceFinder, nil)
 	}
 	return common.Close(
+		l.tailnetSearchDomainClose,
 		l.ruleUpdateCallbackCloser,
 		l.tunStack,
 		l.tunIf,

--- a/listener/sing_tun/system_dns.go
+++ b/listener/sing_tun/system_dns.go
@@ -1,0 +1,8 @@
+package sing_tun
+
+import "github.com/metacubex/mihomo/component/tailnet"
+
+func systemDNSSearchDomainArgs(tunName string, searchDomains []string) []string {
+	args := []string{"domain", tunName, "~."}
+	return append(args, tailnet.NormalizeSearchDomains(searchDomains)...)
+}

--- a/listener/sing_tun/system_dns_linux.go
+++ b/listener/sing_tun/system_dns_linux.go
@@ -1,0 +1,42 @@
+//go:build linux
+
+package sing_tun
+
+import (
+	"context"
+	"os/exec"
+	"time"
+
+	"github.com/metacubex/mihomo/log"
+)
+
+func configureSystemDNSSearchDomains(ctx context.Context, tunName string, searchDomains []string) {
+	args := systemDNSSearchDomainArgs(tunName, searchDomains)
+	ctlPath, err := exec.LookPath("resolvectl")
+	if err != nil {
+		log.Debugln("[TUN] skip dns-search-domains for %s: resolvectl not found", tunName)
+		return
+	}
+
+	go func() {
+		var success bool
+		var lastErr error
+		for _, delay := range []time.Duration{0, 200 * time.Millisecond, time.Second} {
+			if delay > 0 {
+				select {
+				case <-ctx.Done():
+					return
+				case <-time.After(delay):
+				}
+			}
+			if err := exec.CommandContext(ctx, ctlPath, args...).Run(); err != nil {
+				lastErr = err
+				continue
+			}
+			success = true
+		}
+		if !success && lastErr != nil && ctx.Err() == nil {
+			log.Warnln("[TUN] set dns-search-domains for %s failed: %v", tunName, lastErr)
+		}
+	}()
+}

--- a/listener/sing_tun/system_dns_other.go
+++ b/listener/sing_tun/system_dns_other.go
@@ -1,0 +1,7 @@
+//go:build !linux
+
+package sing_tun
+
+import "context"
+
+func configureSystemDNSSearchDomains(ctx context.Context, tunName string, searchDomains []string) {}

--- a/listener/sing_tun/system_dns_test.go
+++ b/listener/sing_tun/system_dns_test.go
@@ -1,0 +1,18 @@
+package sing_tun
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestSystemDNSSearchDomainArgs(t *testing.T) {
+	got := systemDNSSearchDomainArgs("Meta", []string{
+		" TailB2B774.TS.NET. ",
+		"tailb2b774.ts.net",
+		"",
+	})
+	want := []string{"domain", "Meta", "~.", "tailb2b774.ts.net"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("systemDNSSearchDomainArgs() = %v, want %v", got, want)
+	}
+}


### PR DESCRIPTION
## Summary

- add opt-in embedded Tailscale host forwarding for TCP/UDP services
- add MagicDNS/Tailnet status surfaces so users can use Mihomo without the tailscale CLI for common workflows
- add Linux-only `host-forward.mode: kernel`, which connects tsnet to a real TUN device and installs Tailnet address/routes

## Modes

- `host-forward.mode: userspace` remains the default and dynamically forwards inbound flows for this node Tailnet IP to the same port on a loopback target.
- `host-forward.mode: kernel` creates a Linux TUN, assigns it to `tsnet.Server.Tun`, then configures the node Tailnet IPv4/IPv6 plus Tailnet routes once tsnet is running.

## Verification

All build and network checks were run inside the Incus VM `mihomo-tailnet-vm` from `/workspace/mihomo`.

- `GOMAXPROCS=2 go test -p 2 -tags with_gvisor ./component/tailnet ./adapter/outbound ./hub/route`
- `GOMAXPROCS=2 go test -p 2 -tags no_tailscale ./component/tailnet ./adapter/outbound ./hub/route`
- `GOMAXPROCS=2 go test -p 2 -tags with_gvisor ./adapter/...`
- `GOMAXPROCS=2 go test -p 2 -tags no_tailscale ./adapter/...`
- `GOMAXPROCS=2 go test -p 1 -count=1 -vet=off -gcflags=all=-lang=go1.26 -run TestTailscaleHostForwardE2E -tags "with_gvisor tailscale_host_forward_e2e" ./adapter/outbound -v`
- `TS_NETSTACK_KEEPALIVE_IDLE=60s TS_NETSTACK_KEEPALIVE_INTERVAL=15s MIHOMO_TAILSCALE_HOST_FORWARD_E2E_IDLE=210s GOMAXPROCS=2 go test -timeout=7m -p 1 -count=1 -vet=off -gcflags=all=-lang=go1.26 -run TestTailscaleHostForwardE2E -tags "with_gvisor tailscale_host_forward_e2e" ./adapter/outbound -v`
- `GOMAXPROCS=2 go test -p 1 -count=1 -tags "with_gvisor tailscale_kernel_host_forward_e2e" ./adapter/outbound -run TestTailscaleKernelHostForwardTUNConfigureE2E -v`
- `GOMAXPROCS=2 go build -p 2 -tags with_gvisor -trimpath -o /tmp/mihomo-host-forward-kernel ./main.go`

## Notes

- Kernel mode requires Linux with root/CAP_NET_ADMIN and `/dev/net/tun`.
- Kernel mode delivers packets to the host network stack. Services listening on `0.0.0.0`, `::`, or the Tailnet IP can accept them; loopback-only services should use userspace mode or a future explicit redirect/NAT layer.
- The two-node userspace host-forward e2e uses Tailscale test control. For kernel mode, this branch keeps a privileged Linux TUN ownership e2e because the current test-control custom-TUN path panics inside peer-relay setup before traffic starts, which is separate from Mihomo runtime code.
