### PR TITLE
fix: wireguard per-peer reserved ignored

### DIFF
--- a/adapter/outbound/wireguard.go
+++ b/adapter/outbound/wireguard.go
@@ -482,7 +482,7 @@ func (w *WireGuard) genIpcConf(ctx context.Context, updateOnly bool) (string, er
 			ipcConf += "endpoint=" + destination.String() + "\n"
 			if len(peer.Reserved) > 0 {
 				var reserved [3]uint8
-				copy(reserved[:], w.option.Reserved)
+				copy(reserved[:], peer.Reserved)
 				w.bind.SetReservedForEndpoint(destination, reserved)
 			}
 			if updateOnly {


### PR DESCRIPTION
Fix a bug in wireguard where per‑peer Reserved bytes were ignored.