### PR TITLE
fix: leaked openStreams on failure in TUIC client

### DIFF
--- a/transport/tuic/v4/client.go
+++ b/transport/tuic/v4/client.go
@@ -275,10 +275,12 @@ func (t *clientImpl) DialContext(ctx context.Context, metadata *C.Metadata) (net
 		defer pool.PutBuffer(buf)
 		err = NewConnect(NewAddress(metadata)).WriteTo(buf)
 		if err != nil {
+			t.openStreams.Add(-1)
 			return nil, err
 		}
 		quicStream, err := quicConn.OpenStream()
 		if err != nil {
+			t.openStreams.Add(-1)
 			return nil, err
 		}
 		stream = types.NewQuicStreamConn(

--- a/transport/tuic/v5/client.go
+++ b/transport/tuic/v5/client.go
@@ -283,10 +283,12 @@ func (t *clientImpl) DialContext(ctx context.Context, metadata *C.Metadata) (net
 		defer pool.PutBuffer(buf)
 		err = NewConnect(NewAddress(metadata)).WriteTo(buf)
 		if err != nil {
+			t.openStreams.Add(-1)
 			return nil, err
 		}
 		quicStream, err := quicConn.OpenStream()
 		if err != nil {
+			t.openStreams.Add(-1)
 			return nil, err
 		}
 		stream = types.NewQuicStreamConn(


### PR DESCRIPTION
The only decrement is scheduled in the `NewQuicStreamConn` close callback (line 290/298), reached only after a stream is successfully created. If `OpenStream()` fails, `openStreams` is leaked forever. After enough failures every `DialContext` returns `TooManyOpenStreams` even with a healthy connection.