### PR TITLE
fix: stop reaper goroutine busy-looping after context cancel

### DIFF
--- a/listener/hysteria2_realm/session.go
+++ b/listener/hysteria2_realm/session.go
@@ -191,7 +191,7 @@ func (s *server) reaper(ctx context.Context) {
 	for {
 		select {
 		case <-ctx.Done():
-			break
+			return
 		case <-t.C:
 			s.mu.Lock()
 			now := time.Now()


### PR DESCRIPTION
The `ctx.Done()` case used `break`, which only exits the select statement, not the enclosing for loop.