### PR TITLE
fix: CNAME query matching a hosts domain-entry returns an empty answer

### DIFF
--- a/dns/middleware.go
+++ b/dns/middleware.go
@@ -82,7 +82,7 @@ func withHosts(mapping *lru.LruCache[netip.Addr, string]) middleware {
 			case D.TypeAAAA:
 				handleIPs()
 			case D.TypeCNAME:
-				handleCName(r, record.Domain)
+				handleCName(msg, record.Domain)
 			default:
 				return next(ctx, r)
 			}


### PR DESCRIPTION
`handleCName` prepends the CNAME record to its first argument's Answer. For A/AAAA it correctly uses `msg`. For the NAME case it wrongly passes `r` (the original request). The function returns `msg`, which keeps an empty Answer, so a CNAME query that matches a hosts entry whose value is a domain rewrite is answered with RCODE Success but zero records, instead of a CNAME pointing at record.Domain.