### PR TITLE
fix: panic on full-width IP-SUFFIX rules

### DIFF
--- a/rules/common/ipsuffix.go
+++ b/rules/common/ipsuffix.go
@@ -47,7 +47,7 @@ func (is *IPSuffix) Match(metadata *C.Metadata, helper C.RuleMatchHelper) (bool,
 		}
 	}
 
-	if (is.ipBytes[size-bits/8-1] << (8 - bits%8)) != (mIPBytes[size-bits/8-1] << (8 - bits%8)) {
+	if bits%8 != 0 && (is.ipBytes[size-bits/8-1] << (8 - bits%8)) != (mIPBytes[size-bits/8-1] << (8 - bits%8)) {
 		return false, ""
 	}
 


### PR DESCRIPTION
`IPSuffix.Match` panics with index out of range [-1] when a rule uses a full-byte suffix such as `IP-Suffix,1.2.3.4/32` and a connection's address matches that suffix exactly.

When `bits%8 == 0`, the full-byte loop already validated the entire suffix, so the sub-byte check is unnecessary (and the `<< 8` shift would be a no-op anyway).

To reproduce the panic:
1. Add `- IP-SUFFIX,1.1.1.1/32,DIRECT` to your first rule.
2. Run `curl 1.1.1.1`.