### PR TITLE
fix: reconnect OpenVPN on server soft reset

### DIFF
--- a/adapter/outbound/openvpn.go
+++ b/adapter/outbound/openvpn.go
@@ -420,17 +420,6 @@ func (o *OpenVPN) startPacketLoops() {
 		}
 	}()
 
-	go func() {
-		defer stop()
-		if err := client.WaitForSoftReset(runCtx); err != nil {
-			if !errors.Is(err, context.Canceled) && !errors.Is(err, net.ErrClosed) && !errors.Is(err, os.ErrClosed) {
-				log.Warnln("[OpenVPN](%s) error waiting for server soft reset: %v", o.name, err)
-			}
-			return
-		}
-		log.Warnln("[OpenVPN](%s) server requested soft reset; closing session", o.name)
-	}()
-
 	if o.config.PingInterval > 0 {
 		go func() {
 			defer stop()

--- a/adapter/outbound/openvpn.go
+++ b/adapter/outbound/openvpn.go
@@ -420,6 +420,17 @@ func (o *OpenVPN) startPacketLoops() {
 		}
 	}()
 
+	go func() {
+		defer stop()
+		if err := client.WaitForSoftReset(runCtx); err != nil {
+			if !errors.Is(err, context.Canceled) && !errors.Is(err, net.ErrClosed) && !errors.Is(err, os.ErrClosed) {
+				log.Warnln("[OpenVPN](%s) error waiting for server soft reset: %v", o.name, err)
+			}
+			return
+		}
+		log.Warnln("[OpenVPN](%s) server requested soft reset; closing session", o.name)
+	}()
+
 	if o.config.PingInterval > 0 {
 		go func() {
 			defer stop()

--- a/transport/openvpn/client.go
+++ b/transport/openvpn/client.go
@@ -29,6 +29,7 @@ type Client struct {
 	data    *DataChannel
 	push    *PushReply
 
+	runCtx context.Context
 	cancel context.CancelFunc
 
 	writeSem *semaphore.Weighted
@@ -69,6 +70,7 @@ func NewClient(config *ClientConfig, io PacketIO) (*Client, error) {
 		config:   config,
 		mux:      mux,
 		control:  NewControlChannel(mux, crypt, local),
+		runCtx:   runCtx,
 		cancel:   cancel,
 		writeSem: semaphore.NewWeighted(1),
 	}
@@ -143,6 +145,8 @@ func (c *Client) Handshake(ctx context.Context) (*PushReply, error) {
 	}
 	c.markSend()
 	c.markReceive()
+	_ = c.tlsConn.SetDeadline(time.Time{})
+	go c.watchControl()
 	return push, nil
 }
 
@@ -205,33 +209,12 @@ func (c *Client) ReadIPPacket(ctx context.Context) ([]byte, error) {
 	}
 }
 
-// WaitForSoftReset watches raw control packets because a soft reset starts a new key epoch.
-func (c *Client) WaitForSoftReset(ctx context.Context) error {
-	for {
-		raw, err := c.mux.ReadPacket(ctx)
-		if err != nil {
-			return err
-		}
-		if c.isCurrentSoftReset(raw) {
-			return nil
-		}
-	}
-}
-
-func (c *Client) isCurrentSoftReset(raw []byte) bool {
-	if len(raw) == 0 {
-		return false
-	}
-	opcode, _ := parseOpcodeKeyID(raw[0])
-	if opcode != PControlSoftResetV1 {
-		return false
-	}
-	packet, _, _, err := DecodeControlPacket(c.control.crypt, raw)
-	if err != nil {
-		return false
-	}
-	remote := c.control.RemoteSessionID()
-	return remote != (SessionID{}) && packet.LocalSession == remote && packet.KeyID != 0
+// watchControl terminates the client when the established control channel
+// starts a new key epoch or otherwise stops.
+func (c *Client) watchControl() {
+	_ = c.control.waitForSoftReset(c.runCtx)
+	c.cancel()
+	_ = c.mux.Close()
 }
 
 func (c *Client) SinceSend() time.Duration {

--- a/transport/openvpn/client.go
+++ b/transport/openvpn/client.go
@@ -205,6 +205,35 @@ func (c *Client) ReadIPPacket(ctx context.Context) ([]byte, error) {
 	}
 }
 
+// WaitForSoftReset watches raw control packets because a soft reset starts a new key epoch.
+func (c *Client) WaitForSoftReset(ctx context.Context) error {
+	for {
+		raw, err := c.mux.ReadPacket(ctx)
+		if err != nil {
+			return err
+		}
+		if c.isCurrentSoftReset(raw) {
+			return nil
+		}
+	}
+}
+
+func (c *Client) isCurrentSoftReset(raw []byte) bool {
+	if len(raw) == 0 {
+		return false
+	}
+	opcode, _ := parseOpcodeKeyID(raw[0])
+	if opcode != PControlSoftResetV1 {
+		return false
+	}
+	packet, _, _, err := DecodeControlPacket(c.control.crypt, raw)
+	if err != nil {
+		return false
+	}
+	remote := c.control.RemoteSessionID()
+	return remote != (SessionID{}) && packet.LocalSession == remote && packet.KeyID != 0
+}
+
 func (c *Client) SinceSend() time.Duration {
 	return time.Duration(int64(time.Since(start)) - c.lastSendNano.Load())
 }

--- a/transport/openvpn/control.go
+++ b/transport/openvpn/control.go
@@ -117,9 +117,41 @@ func (c *ControlChannel) SendAck(ctx context.Context) error {
 }
 
 func (c *ControlChannel) Read(ctx context.Context) (*ControlPacket, error) {
+	return c.read(ctx, false)
+}
+
+func (c *ControlChannel) waitForSoftReset(ctx context.Context) error {
+	for {
+		packet, err := c.read(ctx, true)
+		if err != nil {
+			return err
+		}
+		if packet.Opcode == PControlSoftResetV1 {
+			return nil
+		}
+		if err := c.SendAck(ctx); err != nil {
+			return err
+		}
+	}
+}
+
+func (c *ControlChannel) read(ctx context.Context, watchSoftReset bool) (*ControlPacket, error) {
 	for {
 		c.mu.Lock()
 		if packet, ok := c.recvPending[c.recvMessage]; ok {
+			if watchSoftReset {
+				softReset, valid := c.classifyWatchPacketLocked(packet)
+				if !valid {
+					delete(c.recvPending, c.recvMessage)
+					c.mu.Unlock()
+					continue
+				}
+				if softReset {
+					delete(c.recvPending, c.recvMessage)
+					c.mu.Unlock()
+					return packet, nil
+				}
+			}
 			delete(c.recvPending, c.recvMessage)
 			c.recvMessage++
 			c.mu.Unlock()
@@ -127,9 +159,28 @@ func (c *ControlChannel) Read(ctx context.Context) (*ControlPacket, error) {
 		}
 		c.mu.Unlock()
 
-		packet, err := c.readControlPacket(ctx)
+		raw, err := c.readRawControlPacket(ctx)
 		if err != nil {
 			return nil, err
+		}
+		packet, _, _, err := DecodeControlPacket(c.crypt, raw)
+		if err != nil {
+			if watchSoftReset {
+				continue
+			}
+			return nil, err
+		}
+
+		if watchSoftReset {
+			c.mu.Lock()
+			softReset, valid := c.classifyWatchPacketLocked(packet)
+			c.mu.Unlock()
+			if !valid {
+				continue
+			}
+			if softReset {
+				return packet, nil
+			}
 		}
 
 		var deliver *ControlPacket
@@ -173,6 +224,18 @@ func (c *ControlChannel) Read(ctx context.Context) (*ControlPacket, error) {
 			}
 		}
 	}
+}
+
+// classifyWatchPacketLocked keeps packets from another session or key epoch
+// out of the established control channel. c.mu must be held by the caller.
+func (c *ControlChannel) classifyWatchPacketLocked(packet *ControlPacket) (softReset bool, valid bool) {
+	if c.remote == (SessionID{}) || packet.LocalSession != c.remote {
+		return false, false
+	}
+	if packet.Opcode == PControlSoftResetV1 {
+		return packet.KeyID != 0, packet.KeyID != 0
+	}
+	return false, packet.KeyID == c.keyID
 }
 
 func (c *ControlChannel) PendingMessages() int {
@@ -222,7 +285,7 @@ func (c *ControlChannel) writeControlPacket(ctx context.Context, packet *Control
 	return c.io.WritePacket(ctx, encoded)
 }
 
-func (c *ControlChannel) readControlPacket(ctx context.Context) (*ControlPacket, error) {
+func (c *ControlChannel) readRawControlPacket(ctx context.Context) ([]byte, error) {
 	c.mu.Lock()
 	deadline := c.readDeadline
 	c.mu.Unlock()
@@ -233,12 +296,7 @@ func (c *ControlChannel) readControlPacket(ctx context.Context) (*ControlPacket,
 		defer cancel()
 	}
 
-	raw, err := c.io.ReadPacket(ctx)
-	if err != nil {
-		return nil, err
-	}
-	packet, _, _, err := DecodeControlPacket(c.crypt, raw)
-	return packet, err
+	return c.io.ReadPacket(ctx)
 }
 
 func (c *ControlChannel) SetDeadline(t time.Time) error {

--- a/transport/openvpn/control_test.go
+++ b/transport/openvpn/control_test.go
@@ -267,6 +267,106 @@ func TestClientWaitServerResetRetransmitsUDP(t *testing.T) {
 	}
 }
 
+func TestClientWaitForSoftReset(t *testing.T) {
+	for _, name := range []string{"plain", "tls-auth", "tls-crypt"} {
+		t.Run(name, func(t *testing.T) {
+			var (
+				config      ClientConfig
+				serverCrypt ControlCryptor
+				err         error
+			)
+			switch name {
+			case "tls-auth":
+				config.TLSAuthKey = testStaticKey()
+				config.KeyDirection = "1"
+				serverCrypt, err = NewTLSAuth(testStaticKey(), "0")
+			case "tls-crypt":
+				config.TLSCryptKey = testStaticKey()
+				serverCrypt, err = NewTLSCrypt(testStaticKey(), false)
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			clientIO, serverIO := newMemoryPacketPair()
+			client, err := NewClient(&config, clientIO)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer client.Close()
+			var serverID SessionID
+			copy(serverID[:], []byte("server01"))
+			client.control.SetRemoteSessionID(serverID)
+			serverControl := NewControlChannel(serverIO, serverCrypt, serverID)
+			serverControl.SetRemoteSessionID(client.control.LocalSessionID())
+
+			ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+			defer cancel()
+			if _, err := serverControl.Send(ctx, PControlV1, nil); err != nil {
+				t.Fatal(err)
+			}
+			if err := serverIO.WritePacket(ctx, []byte{opcodeKeyID(PControlSoftResetV1, 1)}); err != nil {
+				t.Fatal(err)
+			}
+			softReset, err := (ControlPacket{
+				Opcode:       PControlSoftResetV1,
+				KeyID:        1,
+				LocalSession: serverID,
+				MessageID:    0,
+			}).Encode(serverCrypt, 1, 1714567890)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := serverIO.WritePacket(ctx, softReset); err != nil {
+				t.Fatal(err)
+			}
+			if err := client.WaitForSoftReset(ctx); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}
+
+func TestClientWaitForSoftResetIgnoresInvalidPackets(t *testing.T) {
+	var serverID SessionID
+	copy(serverID[:], []byte("server01"))
+	var otherID SessionID
+	copy(otherID[:], []byte("server02"))
+
+	encode := func(t *testing.T, keyID uint8, local SessionID) []byte {
+		t.Helper()
+		packet, err := (ControlPacket{
+			Opcode:       PControlSoftResetV1,
+			KeyID:        keyID,
+			LocalSession: local,
+			MessageID:    0,
+		}).Encode(nil, 0, 0)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return packet
+	}
+
+	tests := []struct {
+		name   string
+		packet []byte
+	}{
+		{"malformed", []byte{opcodeKeyID(PControlSoftResetV1, 1)}},
+		{"initial key id", encode(t, 0, serverID)},
+		{"wrong session", encode(t, 1, otherID)},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			control := NewControlChannel(nil, nil, SessionID{})
+			control.SetRemoteSessionID(serverID)
+			client := &Client{control: control}
+			if client.isCurrentSoftReset(test.packet) {
+				t.Fatal("expected packet to be ignored")
+			}
+		})
+	}
+}
+
 func TestTCPPacketIOFraming(t *testing.T) {
 	client, server := net.Pipe()
 	defer client.Close()

--- a/transport/openvpn/control_test.go
+++ b/transport/openvpn/control_test.go
@@ -267,7 +267,7 @@ func TestClientWaitServerResetRetransmitsUDP(t *testing.T) {
 	}
 }
 
-func TestClientWaitForSoftReset(t *testing.T) {
+func TestClientClosesOnSoftReset(t *testing.T) {
 	for _, name := range []string{"plain", "tls-auth", "tls-crypt"} {
 		t.Run(name, func(t *testing.T) {
 			var (
@@ -297,11 +297,25 @@ func TestClientWaitForSoftReset(t *testing.T) {
 			var serverID SessionID
 			copy(serverID[:], []byte("server01"))
 			client.control.SetRemoteSessionID(serverID)
+			go client.watchControl()
 			serverControl := NewControlChannel(serverIO, serverCrypt, serverID)
 			serverControl.SetRemoteSessionID(client.control.LocalSessionID())
 
 			ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 			defer cancel()
+			if _, err := client.control.Send(ctx, PControlV1, []byte("client control")); err != nil {
+				t.Fatal(err)
+			}
+			packet, err := serverControl.Read(ctx)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if string(packet.Payload) != "client control" {
+				t.Fatalf("unexpected client control payload: %q", packet.Payload)
+			}
+			if err := serverControl.SendAck(ctx); err != nil {
+				t.Fatal(err)
+			}
 			if _, err := serverControl.Send(ctx, PControlV1, nil); err != nil {
 				t.Fatal(err)
 			}
@@ -313,21 +327,39 @@ func TestClientWaitForSoftReset(t *testing.T) {
 				KeyID:        1,
 				LocalSession: serverID,
 				MessageID:    0,
-			}).Encode(serverCrypt, 1, 1714567890)
+			}).Encode(serverCrypt, 3, 1714567890)
 			if err != nil {
 				t.Fatal(err)
 			}
 			if err := serverIO.WritePacket(ctx, softReset); err != nil {
 				t.Fatal(err)
 			}
-			if err := client.WaitForSoftReset(ctx); err != nil {
-				t.Fatal(err)
+			select {
+			case <-client.mux.done:
+			case <-ctx.Done():
+				t.Fatal("client did not close after soft reset")
+			}
+			if client.control.recvMessage != 1 {
+				t.Fatalf("soft reset changed the old epoch receive sequence: %d", client.control.recvMessage)
+			}
+			if client.control.PendingMessages() != 0 {
+				t.Fatalf("expected server ack to clear client pending messages: %d", client.control.PendingMessages())
+			}
+
+			ackCtx, ackCancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+			defer ackCancel()
+			_, err = serverControl.Read(ackCtx)
+			if !errors.Is(err, context.DeadlineExceeded) {
+				t.Fatalf("expected deadline after consuming client ack, got %v", err)
+			}
+			if serverControl.PendingMessages() != 0 {
+				t.Fatalf("expected client to ack ordinary control message: %d", serverControl.PendingMessages())
 			}
 		})
 	}
 }
 
-func TestClientWaitForSoftResetIgnoresInvalidPackets(t *testing.T) {
+func TestClientControlWatcherIgnoresInvalidPackets(t *testing.T) {
 	var serverID SessionID
 	copy(serverID[:], []byte("server01"))
 	var otherID SessionID
@@ -357,11 +389,31 @@ func TestClientWaitForSoftResetIgnoresInvalidPackets(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			control := NewControlChannel(nil, nil, SessionID{})
-			control.SetRemoteSessionID(serverID)
-			client := &Client{control: control}
-			if client.isCurrentSoftReset(test.packet) {
-				t.Fatal("expected packet to be ignored")
+			clientIO, serverIO := newMemoryPacketPair()
+			client, err := NewClient(&ClientConfig{}, clientIO)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer client.Close()
+			client.control.SetRemoteSessionID(serverID)
+			go client.watchControl()
+
+			ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+			defer cancel()
+			if err := serverIO.WritePacket(ctx, test.packet); err != nil {
+				t.Fatal(err)
+			}
+			select {
+			case <-client.mux.done:
+				t.Fatal("invalid packet closed client")
+			case <-ctx.Done():
+			}
+			client.control.mu.Lock()
+			recvMessage := client.control.recvMessage
+			ackPending := len(client.control.ackPending)
+			client.control.mu.Unlock()
+			if recvMessage != 0 || ackPending != 0 {
+				t.Fatalf("invalid packet changed reliable state: recv=%d pending-acks=%d", recvMessage, ackPending)
 			}
 		})
 	}


### PR DESCRIPTION
OpenVPN servers can send `P_CONTROL_SOFT_RESET_V1` to begin data-channel key renegotiation. After the initial handshake, mihomo no longer reads the control stream, so the reset remains queued and the outbound can stop forwarding traffic until `ping-restart` tears down the session.

Keep a post-handshake watcher on the raw control stream. When it receives a valid soft-reset packet for the current server session and a nonzero key epoch, close the client and TUN device; the existing lazy startup path performs a fresh handshake on the next request. Reading the raw stream is intentional because a new key epoch can reset message IDs, which the existing ordered control channel may otherwise treat as an old or duplicate message.

This is intentionally a reconnect fallback, not in-session key renegotiation. It restores the outbound without waiting for the keepalive timeout while keeping the change scoped to the existing session lifecycle. Existing connections can still be interrupted during the reconnect.

Tests:

- `go test ./...`
- `go test ./transport/openvpn ./adapter/outbound`
- `go test -race ./transport/openvpn`
- `go vet ./transport/openvpn ./adapter/outbound`

Coverage includes plain, `tls-auth`, and `tls-crypt` control channels, plus malformed, initial-key, and wrong-session reset packets.
