### PR TITLE
feat: synchronize REALITY with Xray ML-KEM

### DIFF
--- a/adapter/outbound/reality.go
+++ b/adapter/outbound/reality.go
@@ -14,13 +14,14 @@ type RealityOptions struct {
 	PublicKey string `proxy:"public-key"`
 	ShortID   string `proxy:"short-id,omitempty"`
 
+	// Deprecated: REALITY always preserves the selected browser fingerprint.
+	// Use an explicit legacy fingerprint such as chrome120 for legacy servers.
 	SupportX25519MLKEM768 bool `proxy:"support-x25519mlkem768,omitempty"`
 }
 
 func (o RealityOptions) Parse() (*tlsC.RealityConfig, error) {
 	if o.PublicKey != "" {
 		config := new(tlsC.RealityConfig)
-		config.SupportX25519MLKEM768 = o.SupportX25519MLKEM768
 
 		const x25519ScalarSize = 32
 		publicKey, err := base64.RawURLEncoding.DecodeString(o.PublicKey)

--- a/adapter/outbound/reality.go
+++ b/adapter/outbound/reality.go
@@ -6,13 +6,22 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"net/url"
+	"os"
+	"strconv"
+	"strings"
 
 	tlsC "github.com/metacubex/mihomo/component/tls"
 )
 
 type RealityOptions struct {
-	PublicKey string `proxy:"public-key"`
-	ShortID   string `proxy:"short-id,omitempty"`
+	PublicKey     string `proxy:"public-key"`
+	Password      string `proxy:"password,omitempty"`
+	ShortID       string `proxy:"short-id,omitempty"`
+	Mldsa65Verify string `proxy:"mldsa65-verify,omitempty"`
+	SpiderX       string `proxy:"spider-x,omitempty"`
+	Show          bool   `proxy:"show,omitempty"`
+	MasterKeyLog  string `proxy:"master-key-log,omitempty"`
 
 	// Deprecated: REALITY always preserves the selected browser fingerprint.
 	// Use an explicit legacy fingerprint such as chrome120 for legacy servers.
@@ -20,11 +29,15 @@ type RealityOptions struct {
 }
 
 func (o RealityOptions) Parse() (*tlsC.RealityConfig, error) {
-	if o.PublicKey != "" {
+	publicKeyValue := o.PublicKey
+	if o.Password != "" {
+		publicKeyValue = o.Password
+	}
+	if publicKeyValue != "" {
 		config := new(tlsC.RealityConfig)
 
 		const x25519ScalarSize = 32
-		publicKey, err := base64.RawURLEncoding.DecodeString(o.PublicKey)
+		publicKey, err := base64.RawURLEncoding.DecodeString(publicKeyValue)
 		if err != nil || len(publicKey) != x25519ScalarSize {
 			return nil, errors.New("invalid REALITY public key")
 		}
@@ -42,7 +55,60 @@ func (o RealityOptions) Parse() (*tlsC.RealityConfig, error) {
 			return nil, errors.New("invalid REALITY short ID")
 		}
 
+		if o.Mldsa65Verify != "" {
+			config.Mldsa65Verify, err = base64.RawURLEncoding.DecodeString(o.Mldsa65Verify)
+			if err != nil || len(config.Mldsa65Verify) != 1952 {
+				return nil, errors.New("invalid REALITY ML-DSA-65 verification key")
+			}
+		}
+		config.SpiderX, config.SpiderY, err = parseRealitySpider(o.SpiderX)
+		if err != nil {
+			return nil, err
+		}
+		config.Show = o.Show
+		if o.MasterKeyLog != "" && o.MasterKeyLog != "none" {
+			config.KeyLogWriter, err = os.OpenFile(o.MasterKeyLog, os.O_CREATE|os.O_RDWR|os.O_APPEND, 0o644)
+			if err != nil {
+				return nil, fmt.Errorf("open REALITY master key log: %w", err)
+			}
+		}
+
 		return config, nil
 	}
 	return nil, nil
+}
+
+func parseRealitySpider(value string) (string, [10]int64, error) {
+	if value == "" {
+		value = "/"
+	}
+	if value[0] != '/' {
+		return "", [10]int64{}, errors.New("invalid REALITY spider-x")
+	}
+	parsed, err := url.Parse(value)
+	if err != nil {
+		return "", [10]int64{}, fmt.Errorf("parse REALITY spider-x: %w", err)
+	}
+	query := parsed.Query()
+	var ranges [10]int64
+	parseRange := func(name string, index int) {
+		value := query.Get(name)
+		if value == "" {
+			return
+		}
+		parts := strings.Split(value, "-")
+		ranges[index], _ = strconv.ParseInt(parts[0], 10, 64)
+		ranges[index+1] = ranges[index]
+		if len(parts) > 1 {
+			ranges[index+1], _ = strconv.ParseInt(parts[1], 10, 64)
+		}
+		query.Del(name)
+	}
+	parseRange("p", 0)
+	parseRange("c", 2)
+	parseRange("t", 4)
+	parseRange("i", 6)
+	parseRange("r", 8)
+	parsed.RawQuery = query.Encode()
+	return parsed.String(), ranges, nil
 }

--- a/adapter/outbound/reality_test.go
+++ b/adapter/outbound/reality_test.go
@@ -1,0 +1,106 @@
+package outbound
+
+import (
+	"encoding/base64"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestRealityOptionsParseXrayAliasesAndSpider(t *testing.T) {
+	publicKey := make([]byte, 32)
+	publicKey[0] = 1
+	verifyKey := make([]byte, 1952)
+	verifyKey[0] = 2
+
+	config, err := (RealityOptions{
+		PublicKey:     "invalid-but-overridden",
+		Password:      base64.RawURLEncoding.EncodeToString(publicKey),
+		ShortID:       "0123456789abcdef",
+		Mldsa65Verify: base64.RawURLEncoding.EncodeToString(verifyKey),
+		SpiderX:       "/start?keep=yes&p=10-20&c=2&t=3-4&i=5&r=6-7",
+		Show:          true,
+	}).Parse()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := config.PublicKey.Bytes(); !equalBytes(got, publicKey) {
+		t.Fatalf("public key = %v, want %v", got, publicKey)
+	}
+	if got := config.Mldsa65Verify; !equalBytes(got, verifyKey) {
+		t.Fatalf("ML-DSA-65 verify key length = %d, want %d", len(got), len(verifyKey))
+	}
+	if got, want := config.SpiderX, "/start?keep=yes"; got != want {
+		t.Fatalf("SpiderX = %q, want %q", got, want)
+	}
+	if got, want := config.SpiderY, [10]int64{10, 20, 2, 2, 3, 4, 5, 5, 6, 7}; got != want {
+		t.Fatalf("SpiderY = %v, want %v", got, want)
+	}
+	if !config.Show {
+		t.Fatal("Show = false, want true")
+	}
+}
+
+func TestRealityOptionsParseDefaultsSpider(t *testing.T) {
+	config, err := (RealityOptions{
+		PublicKey: base64.RawURLEncoding.EncodeToString(make([]byte, 32)),
+	}).Parse()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := config.SpiderX, "/"; got != want {
+		t.Fatalf("SpiderX = %q, want %q", got, want)
+	}
+}
+
+func TestRealityOptionsParseRejectsInvalidMldsa65Verify(t *testing.T) {
+	_, err := (RealityOptions{
+		PublicKey:     base64.RawURLEncoding.EncodeToString(make([]byte, 32)),
+		Mldsa65Verify: base64.RawURLEncoding.EncodeToString(make([]byte, 1951)),
+	}).Parse()
+	if err == nil {
+		t.Fatal("Parse() error = nil")
+	}
+}
+
+func TestRealityOptionsParseOpensMasterKeyLog(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "reality.keys")
+	config, err := (RealityOptions{
+		PublicKey:    base64.RawURLEncoding.EncodeToString(make([]byte, 32)),
+		MasterKeyLog: path,
+	}).Parse()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if config.KeyLogWriter == nil {
+		t.Fatal("KeyLogWriter = nil")
+	}
+	if _, err := io.WriteString(config.KeyLogWriter, "CLIENT_RANDOM test\n"); err != nil {
+		t.Fatal(err)
+	}
+	if closer, ok := config.KeyLogWriter.(io.Closer); ok {
+		if err := closer.Close(); err != nil {
+			t.Fatal(err)
+		}
+	}
+	contents, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := string(contents), "CLIENT_RANDOM test\n"; got != want {
+		t.Fatalf("key log = %q, want %q", got, want)
+	}
+}
+
+func equalBytes(a, b []byte) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/component/tls/reality.go
+++ b/component/tls/reality.go
@@ -13,8 +13,11 @@ import (
 	"crypto/x509"
 	"encoding/binary"
 	"errors"
+	"io"
 	"net"
+	"regexp"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/metacubex/mihomo/log"
@@ -33,19 +36,26 @@ const (
 	// gate. These bytes represent Mihomo's tested REALITY compatibility, not
 	// Mihomo's application version.
 	realityClientVersionMajor byte = 26
-	realityClientVersionMinor byte = 3
-	realityClientVersionPatch byte = 27
+	realityClientVersionMinor byte = 7
+	realityClientVersionPatch byte = 11
 )
 
 type RealityConfig struct {
-	PublicKey *ecdh.PublicKey
-	ShortID   [RealityMaxShortIDLen]byte
+	PublicKey     *ecdh.PublicKey
+	ShortID       [RealityMaxShortIDLen]byte
+	Mldsa65Verify []byte
+	SpiderX       string
+	SpiderY       [10]int64
+	Show          bool
+	KeyLogWriter  io.Writer
 }
 
 func GetRealityConn(ctx context.Context, conn net.Conn, fingerprint UClientHelloID, serverName string, realityConfig *RealityConfig) (net.Conn, error) {
 	for retry := 0; ; retry++ {
 		verifier := &realityVerifier{
-			serverName: serverName,
+			serverName:    serverName,
+			mldsa65Verify: realityConfig.Mldsa65Verify,
+			show:          realityConfig.Show,
 		}
 		uConfig := &utls.Config{
 			Time:                   ntp.Now,
@@ -53,6 +63,7 @@ func GetRealityConn(ctx context.Context, conn net.Conn, fingerprint UClientHello
 			InsecureSkipVerify:     true,
 			SessionTicketsDisabled: true,
 			VerifyConnection:       verifier.VerifyConnection,
+			KeyLogWriter:           realityConfig.KeyLogWriter,
 		}
 
 		uConn := utls.UClient(conn, uConfig, fingerprint)
@@ -123,7 +134,8 @@ func GetRealityConn(ctx context.Context, conn net.Conn, fingerprint UClientHello
 		log.Debugln("REALITY Authentication: %v, AEAD: %T", verifier.verified, aeadCipher)
 
 		if !verifier.verified {
-			go realityClientFallback(uConn, uConfig.ServerName, fingerprint)
+			go realityClientFallback(uConn, uConfig.ServerName, fingerprint, realityConfig.SpiderX, realityConfig.SpiderY)
+			time.Sleep(realityRandomDuration(realityConfig.SpiderY[8], realityConfig.SpiderY[9]))
 			return nil, errors.New("REALITY authentication failed")
 		}
 
@@ -131,8 +143,7 @@ func GetRealityConn(ctx context.Context, conn net.Conn, fingerprint UClientHello
 	}
 }
 
-func realityClientFallback(uConn net.Conn, serverName string, fingerprint utls.ClientHelloID) {
-	defer uConn.Close()
+func realityClientFallback(uConn net.Conn, serverName string, fingerprint utls.ClientHelloID, spiderX string, spiderY [10]int64) {
 	// use h2c mode to disallow the net/http fallback to http1.1
 	//
 	// Note that this usage is only applicable to our own net/http fork.
@@ -148,38 +159,168 @@ func realityClientFallback(uConn net.Conn, serverName string, fingerprint utls.C
 			Protocols: protocols,
 		},
 	}
-	request, err := http.NewRequest("GET", "https://"+serverName, nil)
-	if err != nil {
-		return
+	prefix := "https://" + serverName
+	realitySpiderPaths.Lock()
+	if realitySpiderPaths.paths == nil {
+		realitySpiderPaths.paths = make(map[string]map[string]struct{})
 	}
-	request.Header.Set("User-Agent", fingerprint.Client)
-	request.AddCookie(&http.Cookie{Name: "padding", Value: strings.Repeat("0", randv2.IntN(32)+30)})
-	response, err := client.Do(request)
-	if err != nil {
-		return
+	paths := realitySpiderPaths.paths[serverName]
+	if paths == nil {
+		paths = map[string]struct{}{spiderX: {}}
+		realitySpiderPaths.paths[serverName] = paths
 	}
-	//_, _ = io.Copy(io.Discard, response.Body)
-	time.Sleep(time.Duration(5+randv2.IntN(10)) * time.Second)
-	response.Body.Close()
-	client.CloseIdleConnections()
+	firstURL := prefix + realitySpiderPathLocked(paths)
+	realitySpiderPaths.Unlock()
+
+	get := func(first bool) {
+		requestURL := firstURL
+		if !first {
+			realitySpiderPaths.Lock()
+			requestURL = prefix + realitySpiderPathLocked(paths)
+			realitySpiderPaths.Unlock()
+		}
+		request, err := http.NewRequest("GET", requestURL, nil)
+		if err != nil {
+			return
+		}
+		realitySetNavigationHeaders(request, fingerprint)
+		times := int64(1)
+		if !first {
+			times = realityRandBetween(spiderY[4], spiderY[5])
+		}
+		for i := int64(0); i < times; i++ {
+			if !first && i == 0 {
+				request.Header.Set("Referer", firstURL)
+			}
+			request.AddCookie(&http.Cookie{Name: "padding", Value: strings.Repeat("0", int(realityRandBetween(spiderY[0], spiderY[1])))})
+			response, err := client.Do(request)
+			if err != nil {
+				return
+			}
+			body, readErr := io.ReadAll(response.Body)
+			_ = response.Body.Close()
+			if readErr != nil {
+				return
+			}
+			request.Header.Set("Referer", request.URL.String())
+			realitySpiderPaths.Lock()
+			realityDiscoverPaths(paths, prefix, body)
+			request.URL.Path = realitySpiderPathLocked(paths)
+			realitySpiderPaths.Unlock()
+			if !first {
+				time.Sleep(realityRandomDuration(spiderY[6], spiderY[7]))
+			}
+		}
+	}
+
+	get(true)
+	for i := int64(0); i < realityRandBetween(spiderY[2], spiderY[3]); i++ {
+		go get(false)
+	}
+}
+
+var realityHref = regexp.MustCompile(`href="([/h].*?)"`)
+
+var realitySpiderPaths struct {
+	sync.Mutex
+	paths map[string]map[string]struct{}
+}
+
+func realityDiscoverPaths(paths map[string]struct{}, prefix string, body []byte) {
+	for _, match := range realityHref.FindAllSubmatch(body, -1) {
+		path := strings.TrimPrefix(string(match[1]), prefix)
+		if !strings.Contains(path, ".") {
+			paths[path] = struct{}{}
+		}
+	}
+}
+
+func realitySpiderPathLocked(paths map[string]struct{}) string {
+	stopAt := randv2.IntN(len(paths))
+	index := 0
+	for path := range paths {
+		if index == stopAt {
+			return path
+		}
+		index++
+	}
+	return "/"
+}
+
+func realityRandBetween(from, to int64) int64 {
+	if from == to {
+		return from
+	}
+	if from > to {
+		from, to = to, from
+	}
+	return from + randv2.Int64N(to-from)
+}
+
+func realityRandomDuration(from, to int64) time.Duration {
+	return time.Duration(realityRandBetween(from, to)) * time.Millisecond
+}
+
+func realitySetNavigationHeaders(request *http.Request, _ utls.ClientHelloID) {
+	// Xray's default navigation profile is a coherent desktop Chrome request,
+	// independently of the uTLS fingerprint selected for the failed handshake.
+	const chromeMajor = "148"
+	request.Header.Set("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/"+chromeMajor+".0.0.0 Safari/537.36")
+	request.Header.Set("Sec-CH-UA", `"Not_A Brand";v="99", "Chromium";v="`+chromeMajor+`", "Google Chrome";v="`+chromeMajor+`"`)
+	request.Header.Set("Sec-CH-UA-Mobile", "?0")
+	request.Header.Set("Sec-CH-UA-Platform", `"Windows"`)
+	request.Header.Set("DNT", "1")
+	request.Header.Set("Cache-Control", "max-age=0")
+	request.Header.Set("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,image/jxl,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7")
+	request.Header.Set("Accept-Language", "en-US,en;q=0.9")
+	request.Header.Set("Sec-Fetch-Dest", "document")
+	request.Header.Set("Sec-Fetch-Mode", "navigate")
+	request.Header.Set("Sec-Fetch-Site", "none")
+	request.Header.Set("Sec-Fetch-User", "?1")
+	request.Header.Set("Upgrade-Insecure-Requests", "1")
+	request.Header.Set("Priority", "u=0, i")
 }
 
 type realityVerifier struct {
 	*utls.UConn
-	serverName string
-	authKey    []byte
-	verified   bool
+	serverName    string
+	authKey       []byte
+	mldsa65Verify []byte
+	verified      bool
+	show          bool
 }
 
 func (c *realityVerifier) VerifyConnection(state utls.ConnectionState) error {
-	log.Debugln("REALITY localAddr: %v is using X25519MLKEM768 for TLS' communication: %v", c.RemoteAddr(), c.HandshakeState.ServerHello.ServerShare.Group == utls.X25519MLKEM768)
+	if c.show {
+		log.Infoln("REALITY localAddr: %v is using X25519MLKEM768 for TLS' communication: %v", c.RemoteAddr(), c.HandshakeState.ServerHello.ServerShare.Group == utls.X25519MLKEM768)
+	}
 	certs := state.PeerCertificates
+	if len(certs) == 0 {
+		return errors.New("REALITY server sent no certificate")
+	}
 	if pub, ok := certs[0].PublicKey.(ed25519.PublicKey); ok {
 		h := hmac.New(sha512.New, c.authKey)
 		h.Write(pub)
 		if bytes.Equal(h.Sum(nil), certs[0].Signature) {
-			c.verified = true
-			return nil
+			if c.show {
+				log.Infoln("REALITY Ed25519 HMAC certificate authentication: valid")
+			}
+			if len(c.mldsa65Verify) == 0 {
+				c.verified = true
+				return nil
+			}
+			if len(certs[0].Extensions) > 0 {
+				h.Write(c.HandshakeState.Hello.Raw)
+				h.Write(c.HandshakeState.ServerHello.Raw)
+				mldsaValid := utls.RealityMldsa65Verify(c.mldsa65Verify, h.Sum(nil), certs[0].Extensions[0].Value)
+				if c.show {
+					log.Infoln("REALITY ML-DSA-65 certificate authentication: %v (signature length %d)", mldsaValid, len(certs[0].Extensions[0].Value))
+				}
+				if mldsaValid {
+					c.verified = true
+					return nil
+				}
+			}
 		}
 	}
 	opts := x509.VerifyOptions{

--- a/component/tls/reality.go
+++ b/component/tls/reality.go
@@ -26,13 +26,20 @@ import (
 	"golang.org/x/crypto/hkdf"
 )
 
-const RealityMaxShortIDLen = 8
+const (
+	RealityMaxShortIDLen = 8
+
+	// The REALITY protocol uses Xray-style release bytes as a compatibility
+	// gate. These bytes represent Mihomo's tested REALITY compatibility, not
+	// Mihomo's application version.
+	realityClientVersionMajor byte = 26
+	realityClientVersionMinor byte = 3
+	realityClientVersionPatch byte = 27
+)
 
 type RealityConfig struct {
 	PublicKey *ecdh.PublicKey
 	ShortID   [RealityMaxShortIDLen]byte
-
-	SupportX25519MLKEM768 bool
 }
 
 func GetRealityConn(ctx context.Context, conn net.Conn, fingerprint UClientHelloID, serverName string, realityConfig *RealityConfig) (net.Conn, error) {
@@ -55,13 +62,6 @@ func GetRealityConn(ctx context.Context, conn net.Conn, fingerprint UClientHello
 			return nil, err
 		}
 
-		if !realityConfig.SupportX25519MLKEM768 { // for X25519MLKEM768 does not work properly with the old reality server
-			err = BuildRemovedX25519MLKEM768HandshakeState(uConn)
-			if err != nil {
-				return nil, err
-			}
-		}
-
 		hello := uConn.HandshakeState.Hello
 		rawSessionID := hello.Raw[39 : 39+32] // the location of session ID
 		for i := range rawSessionID {         // https://github.com/golang/go/issues/5373
@@ -71,9 +71,9 @@ func GetRealityConn(ctx context.Context, conn net.Conn, fingerprint UClientHello
 		binary.BigEndian.PutUint64(hello.SessionId, uint64(ntp.Now().Unix()))
 
 		copy(hello.SessionId[8:], realityConfig.ShortID[:])
-		hello.SessionId[0] = 1
-		hello.SessionId[1] = 8
-		hello.SessionId[2] = 2
+		hello.SessionId[0] = realityClientVersionMajor
+		hello.SessionId[1] = realityClientVersionMinor
+		hello.SessionId[2] = realityClientVersionPatch
 
 		//log.Debugln("REALITY hello.sessionId[:16]: %v", hello.SessionId[:16])
 

--- a/component/tls/reality_test.go
+++ b/component/tls/reality_test.go
@@ -1,0 +1,253 @@
+package tls
+
+import (
+	"context"
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/ecdh"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/binary"
+	"io"
+	"net"
+	"reflect"
+	"slices"
+	"testing"
+	"time"
+
+	utls "github.com/metacubex/utls"
+	"golang.org/x/crypto/hkdf"
+)
+
+func TestRealityChromeClientHelloPreservesFingerprint(t *testing.T) {
+	hello, privateKey := captureRealityClientHello(t, utls.HelloChrome_Auto)
+	baseline := buildClientHello(t, utls.HelloChrome_Auto)
+
+	assertClientHelloShape(t, baseline, hello)
+
+	plainSessionID := decryptRealitySessionID(t, hello, privateKey)
+	if got, want := [3]byte(plainSessionID[:3]), [3]byte{26, 3, 27}; got != want {
+		t.Fatalf("REALITY compatibility version = %v, want %v", got, want)
+	}
+	if plainSessionID[3] != 0 {
+		t.Fatalf("REALITY reserved version byte = %d, want 0", plainSessionID[3])
+	}
+}
+
+func TestRealityChrome120ClientHelloPreservesLegacyFingerprint(t *testing.T) {
+	hello, _ := captureRealityClientHello(t, utls.HelloChrome_120)
+	baseline := buildClientHello(t, utls.HelloChrome_120)
+
+	assertClientHelloShape(t, baseline, hello)
+	if slices.Contains(hello.SupportedCurves, utls.X25519MLKEM768) {
+		t.Fatal("Chrome 120 unexpectedly contains X25519MLKEM768")
+	}
+}
+
+func assertClientHelloShape(t *testing.T, baseline, hello *utls.PubClientHelloMsg) {
+	t.Helper()
+	assertUint16Shape(t, "cipher suites", baseline.CipherSuites, hello.CipherSuites)
+	assertCurveShape(t, "supported curves", baseline.SupportedCurves, hello.SupportedCurves)
+	assertKeyShareShape(t, baseline.KeyShares, hello.KeyShares)
+	assertUint16Shape(t, "supported versions", baseline.SupportedVersions, hello.SupportedVersions)
+	if !slices.Equal(baseline.SupportedSignatureAlgorithms, hello.SupportedSignatureAlgorithms) {
+		t.Fatalf("signature algorithms changed:\nwant %v\n got %v", baseline.SupportedSignatureAlgorithms, hello.SupportedSignatureAlgorithms)
+	}
+	if !slices.Equal(baseline.AlpnProtocols, hello.AlpnProtocols) {
+		t.Fatalf("ALPN changed:\nwant %v\n got %v", baseline.AlpnProtocols, hello.AlpnProtocols)
+	}
+	if !reflect.DeepEqual(sortedExtensionIDs(t, baseline.Raw), sortedExtensionIDs(t, hello.Raw)) {
+		t.Fatalf("extension set changed:\nwant %v\n got %v", sortedExtensionIDs(t, baseline.Raw), sortedExtensionIDs(t, hello.Raw))
+	}
+}
+
+func captureRealityClientHello(t *testing.T, fingerprint utls.ClientHelloID) (*utls.PubClientHelloMsg, *ecdh.PrivateKey) {
+	t.Helper()
+	privateKey, err := ecdh.X25519().GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	client, server := net.Pipe()
+	t.Cleanup(func() {
+		client.Close()
+		server.Close()
+	})
+	deadline := time.Now().Add(5 * time.Second)
+	_ = client.SetDeadline(deadline)
+	_ = server.SetDeadline(deadline)
+
+	result := make(chan error, 1)
+	go func() {
+		_, err := GetRealityConn(context.Background(), client, fingerprint, "example.com", &RealityConfig{
+			PublicKey: privateKey.PublicKey(),
+		})
+		result <- err
+	}()
+
+	hello, err := readClientHello(server)
+	if err != nil {
+		select {
+		case handshakeErr := <-result:
+			t.Fatalf("capture ClientHello: %v (handshake: %v)", err, handshakeErr)
+		default:
+			t.Fatalf("capture ClientHello: %v", err)
+		}
+	}
+	if hello == nil {
+		t.Fatal("captured TLS record does not contain a valid ClientHello")
+	}
+	_ = server.Close()
+	select {
+	case <-result:
+	case <-time.After(time.Second):
+		t.Fatal("REALITY client did not stop after capture connection closed")
+	}
+	return hello, privateKey
+}
+
+func buildClientHello(t *testing.T, fingerprint utls.ClientHelloID) *utls.PubClientHelloMsg {
+	t.Helper()
+	client, server := net.Pipe()
+	defer client.Close()
+	defer server.Close()
+	uConn := utls.UClient(client, &utls.Config{
+		ServerName:             "example.com",
+		InsecureSkipVerify:     true,
+		SessionTicketsDisabled: true,
+	}, fingerprint)
+	if err := uConn.BuildHandshakeState(); err != nil {
+		t.Fatal(err)
+	}
+	hello := utls.UnmarshalClientHello(uConn.HandshakeState.Hello.Raw)
+	if hello == nil {
+		t.Fatal("failed to parse baseline ClientHello")
+	}
+	return hello
+}
+
+func readClientHello(conn net.Conn) (*utls.PubClientHelloMsg, error) {
+	header := make([]byte, 5)
+	if _, err := io.ReadFull(conn, header); err != nil {
+		return nil, err
+	}
+	length := int(binary.BigEndian.Uint16(header[3:5]))
+	payload := make([]byte, length)
+	if _, err := io.ReadFull(conn, payload); err != nil {
+		return nil, err
+	}
+	return utls.UnmarshalClientHello(payload), nil
+}
+
+func decryptRealitySessionID(t *testing.T, hello *utls.PubClientHelloMsg, privateKey *ecdh.PrivateKey) [16]byte {
+	t.Helper()
+	var peerPublicKey []byte
+	for _, share := range hello.KeyShares {
+		if share.Group == utls.X25519 {
+			peerPublicKey = share.Data
+			break
+		}
+	}
+	if peerPublicKey == nil {
+		t.Fatal("captured ClientHello has no X25519 key share")
+	}
+	peerKey, err := ecdh.X25519().NewPublicKey(peerPublicKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	authKey, err := privateKey.ECDH(peerKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	derivedKey := make([]byte, len(authKey))
+	if _, err := io.ReadFull(hkdf.New(sha256.New, authKey, hello.Random[:20], []byte("REALITY")), derivedKey); err != nil {
+		t.Fatal(err)
+	}
+	block, err := aes.NewCipher(derivedKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	aead, err := cipher.NewGCM(block)
+	if err != nil {
+		t.Fatal(err)
+	}
+	additionalData := slices.Clone(hello.Raw)
+	for i := 39; i < 39+32; i++ {
+		additionalData[i] = 0
+	}
+	plain, err := aead.Open(nil, hello.Random[20:], hello.SessionId, additionalData)
+	if err != nil {
+		t.Fatalf("decrypt REALITY session ID: %v", err)
+	}
+	return [16]byte(plain)
+}
+
+func assertUint16Shape(t *testing.T, name string, want, got []uint16) {
+	t.Helper()
+	want = normalizeGREASE(want)
+	got = normalizeGREASE(got)
+	if !slices.Equal(want, got) {
+		t.Fatalf("%s changed:\nwant %v\n got %v", name, want, got)
+	}
+}
+
+func assertCurveShape(t *testing.T, name string, want, got []utls.CurveID) {
+	t.Helper()
+	w := make([]uint16, len(want))
+	g := make([]uint16, len(got))
+	for i := range want {
+		w[i] = uint16(want[i])
+	}
+	for i := range got {
+		g[i] = uint16(got[i])
+	}
+	assertUint16Shape(t, name, w, g)
+}
+
+func assertKeyShareShape(t *testing.T, want, got []utls.KeyShare) {
+	t.Helper()
+	w := make([]uint16, len(want))
+	g := make([]uint16, len(got))
+	for i := range want {
+		w[i] = uint16(want[i].Group)
+	}
+	for i := range got {
+		g[i] = uint16(got[i].Group)
+	}
+	assertUint16Shape(t, "key share groups", w, g)
+}
+
+func normalizeGREASE(values []uint16) []uint16 {
+	result := slices.Clone(values)
+	for i, value := range result {
+		if value&0x0f0f == 0x0a0a && byte(value>>8) == byte(value) {
+			result[i] = 0x0a0a
+		}
+	}
+	return result
+}
+
+func sortedExtensionIDs(t *testing.T, raw []byte) []uint16 {
+	t.Helper()
+	offset := 4 + 2 + 32
+	offset += 1 + int(raw[offset])
+	cipherSuitesLen := int(binary.BigEndian.Uint16(raw[offset : offset+2]))
+	offset += 2 + cipherSuitesLen
+	offset += 1 + int(raw[offset])
+	extensionsLen := int(binary.BigEndian.Uint16(raw[offset : offset+2]))
+	offset += 2
+	end := offset + extensionsLen
+	var ids []uint16
+	for offset < end {
+		id := binary.BigEndian.Uint16(raw[offset : offset+2])
+		length := int(binary.BigEndian.Uint16(raw[offset+2 : offset+4]))
+		// Chrome's padding extension is calculated from the final randomized
+		// ClientHello length and can legitimately be omitted when no padding is
+		// required. It is not a stable part of the fingerprint comparison.
+		if id != 21 {
+			ids = append(ids, normalizeGREASE([]uint16{id})[0])
+		}
+		offset += 4 + length
+	}
+	slices.Sort(ids)
+	return ids
+}

--- a/component/tls/reality_test.go
+++ b/component/tls/reality_test.go
@@ -5,16 +5,22 @@ import (
 	"crypto/aes"
 	"crypto/cipher"
 	"crypto/ecdh"
+	"crypto/ed25519"
+	"crypto/hmac"
 	"crypto/rand"
 	"crypto/sha256"
+	"crypto/sha512"
+	"crypto/x509"
 	"encoding/binary"
 	"io"
 	"net"
 	"reflect"
-	"slices"
+	"sort"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/metacubex/http"
 	utls "github.com/metacubex/utls"
 	"golang.org/x/crypto/hkdf"
 )
@@ -24,9 +30,22 @@ func TestRealityChromeClientHelloPreservesFingerprint(t *testing.T) {
 	baseline := buildClientHello(t, utls.HelloChrome_Auto)
 
 	assertClientHelloShape(t, baseline, hello)
+	if !containsCurve(hello.SupportedCurves, utls.X25519MLKEM768) {
+		t.Fatal("Chrome Auto REALITY ClientHello does not contain X25519MLKEM768")
+	}
+	containsHybridShare := false
+	for _, share := range hello.KeyShares {
+		if share.Group == utls.X25519MLKEM768 {
+			containsHybridShare = true
+			break
+		}
+	}
+	if !containsHybridShare {
+		t.Fatal("Chrome Auto REALITY ClientHello does not contain an X25519MLKEM768 key share")
+	}
 
 	plainSessionID := decryptRealitySessionID(t, hello, privateKey)
-	if got, want := [3]byte(plainSessionID[:3]), [3]byte{26, 3, 27}; got != want {
+	if got, want := [3]byte(plainSessionID[:3]), [3]byte{26, 7, 11}; got != want {
 		t.Fatalf("REALITY compatibility version = %v, want %v", got, want)
 	}
 	if plainSessionID[3] != 0 {
@@ -39,8 +58,81 @@ func TestRealityChrome120ClientHelloPreservesLegacyFingerprint(t *testing.T) {
 	baseline := buildClientHello(t, utls.HelloChrome_120)
 
 	assertClientHelloShape(t, baseline, hello)
-	if slices.Contains(hello.SupportedCurves, utls.X25519MLKEM768) {
+	if containsCurve(hello.SupportedCurves, utls.X25519MLKEM768) {
 		t.Fatal("Chrome 120 unexpectedly contains X25519MLKEM768")
+	}
+}
+
+func TestRealityDiscoverPathsMatchesXraySpider(t *testing.T) {
+	paths := map[string]struct{}{"/start": {}}
+	body := []byte("<a href=\"/next\">next</a>" +
+		"<a href=\"https://example.com/absolute\">absolute</a>" +
+		"<a href=\"/asset.js\">asset</a>" +
+		"<a href=\"https://other.example/page\">other host</a>")
+	realityDiscoverPaths(paths, "https://example.com", body)
+	for _, want := range []string{"/start", "/next", "/absolute"} {
+		if _, ok := paths[want]; !ok {
+			t.Fatalf("discovered paths missing %q: %v", want, paths)
+		}
+	}
+	for _, rejected := range []string{"/asset.js", "https://other.example/page"} {
+		if _, ok := paths[rejected]; ok {
+			t.Fatalf("discovered paths unexpectedly contains %q: %v", rejected, paths)
+		}
+	}
+}
+
+func TestRealityRandBetweenMatchesXrayBounds(t *testing.T) {
+	if got := realityRandBetween(7, 7); got != 7 {
+		t.Fatalf("equal bounds result = %d, want 7", got)
+	}
+	for i := 0; i < 100; i++ {
+		if got := realityRandBetween(9, 3); got < 3 || got >= 9 {
+			t.Fatalf("reversed bounds result = %d, want [3,9)", got)
+		}
+	}
+}
+
+func TestRealityNavigationHeadersMatchXrayChromeProfile(t *testing.T) {
+	request, err := http.NewRequest("GET", "https://example.com/", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	realitySetNavigationHeaders(request, utls.HelloFirefox_Auto)
+	if got := request.Header.Get("User-Agent"); !strings.Contains(got, "Mozilla/5.0") || !strings.Contains(got, "Chrome/") {
+		t.Fatalf("User-Agent = %q", got)
+	}
+	for _, name := range []string{"Sec-CH-UA", "Sec-Fetch-Mode", "Priority", "Upgrade-Insecure-Requests"} {
+		if request.Header.Get(name) == "" {
+			t.Fatalf("navigation header %q is empty", name)
+		}
+	}
+}
+
+func TestRealityVerifierRequiresConfiguredMldsa65Extension(t *testing.T) {
+	publicKey, _, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	authKey := []byte("reality auth key")
+	h := hmac.New(sha512.New, authKey)
+	_, _ = h.Write(publicKey)
+	certificate := &x509.Certificate{PublicKey: publicKey, Signature: h.Sum(nil)}
+
+	withoutMldsa := &realityVerifier{authKey: authKey}
+	if err := withoutMldsa.VerifyConnection(utls.ConnectionState{PeerCertificates: []*x509.Certificate{certificate}}); err != nil {
+		t.Fatalf("Ed25519-only verification failed: %v", err)
+	}
+	if !withoutMldsa.verified {
+		t.Fatal("Ed25519-only certificate was not authenticated")
+	}
+
+	withMldsa := &realityVerifier{authKey: authKey, mldsa65Verify: make([]byte, 1952)}
+	if err := withMldsa.VerifyConnection(utls.ConnectionState{PeerCertificates: []*x509.Certificate{certificate}}); err == nil {
+		t.Fatal("verification accepted a missing ML-DSA-65 extension")
+	}
+	if withMldsa.verified {
+		t.Fatal("missing ML-DSA-65 extension authenticated the certificate")
 	}
 }
 
@@ -50,10 +142,10 @@ func assertClientHelloShape(t *testing.T, baseline, hello *utls.PubClientHelloMs
 	assertCurveShape(t, "supported curves", baseline.SupportedCurves, hello.SupportedCurves)
 	assertKeyShareShape(t, baseline.KeyShares, hello.KeyShares)
 	assertUint16Shape(t, "supported versions", baseline.SupportedVersions, hello.SupportedVersions)
-	if !slices.Equal(baseline.SupportedSignatureAlgorithms, hello.SupportedSignatureAlgorithms) {
+	if !reflect.DeepEqual(baseline.SupportedSignatureAlgorithms, hello.SupportedSignatureAlgorithms) {
 		t.Fatalf("signature algorithms changed:\nwant %v\n got %v", baseline.SupportedSignatureAlgorithms, hello.SupportedSignatureAlgorithms)
 	}
-	if !slices.Equal(baseline.AlpnProtocols, hello.AlpnProtocols) {
+	if !reflect.DeepEqual(baseline.AlpnProtocols, hello.AlpnProtocols) {
 		t.Fatalf("ALPN changed:\nwant %v\n got %v", baseline.AlpnProtocols, hello.AlpnProtocols)
 	}
 	if !reflect.DeepEqual(sortedExtensionIDs(t, baseline.Raw), sortedExtensionIDs(t, hello.Raw)) {
@@ -170,7 +262,7 @@ func decryptRealitySessionID(t *testing.T, hello *utls.PubClientHelloMsg, privat
 	if err != nil {
 		t.Fatal(err)
 	}
-	additionalData := slices.Clone(hello.Raw)
+	additionalData := append([]byte(nil), hello.Raw...)
 	for i := 39; i < 39+32; i++ {
 		additionalData[i] = 0
 	}
@@ -185,7 +277,7 @@ func assertUint16Shape(t *testing.T, name string, want, got []uint16) {
 	t.Helper()
 	want = normalizeGREASE(want)
 	got = normalizeGREASE(got)
-	if !slices.Equal(want, got) {
+	if !reflect.DeepEqual(want, got) {
 		t.Fatalf("%s changed:\nwant %v\n got %v", name, want, got)
 	}
 }
@@ -217,7 +309,7 @@ func assertKeyShareShape(t *testing.T, want, got []utls.KeyShare) {
 }
 
 func normalizeGREASE(values []uint16) []uint16 {
-	result := slices.Clone(values)
+	result := append([]uint16(nil), values...)
 	for i, value := range result {
 		if value&0x0f0f == 0x0a0a && byte(value>>8) == byte(value) {
 			result[i] = 0x0a0a
@@ -248,6 +340,15 @@ func sortedExtensionIDs(t *testing.T, raw []byte) []uint16 {
 		}
 		offset += 4 + length
 	}
-	slices.Sort(ids)
+	sort.Slice(ids, func(i, j int) bool { return ids[i] < ids[j] })
 	return ids
+}
+
+func containsCurve(curves []utls.CurveID, target utls.CurveID) bool {
+	for _, curve := range curves {
+		if curve == target {
+			return true
+		}
+	}
+	return false
 }

--- a/docs/config.yaml
+++ b/docs/config.yaml
@@ -966,8 +966,8 @@ proxies: # socks5
     reality-opts:
       public-key: xxx
       short-id: xxx # optional
-      support-x25519mlkem768: false # 如果服务端支持可手动设置为true
-    client-fingerprint: chrome # cannot be empty
+    # REALITY 默认为 chrome；旧服务端如不支持 X25519MLKEM768，请显式使用 chrome120
+    client-fingerprint: chrome
 
   - name: "vless-reality-grpc"
     type: vless
@@ -993,7 +993,7 @@ proxies: # socks5
     reality-opts:
       public-key: CrrQSjAG_YkHLwvM2M-7XkKJilgL5upBKCp0od0tLhE
       short-id: 10f897e26c4b9478
-      support-x25519mlkem768: false # 如果服务端支持可手动设置为true
+    # 旧服务端如不支持 X25519MLKEM768，请设置 client-fingerprint: chrome120
 
   - name: "vless-ws"
     type: vless
@@ -2193,6 +2193,7 @@ listeners:
     #     - 0123456789abcdef
     #   server-names:
     #     - test.com
+    #   max-time-difference: 0 # 客户端时间最大允许偏差，单位毫秒；0 表示不限制
     #   #下列两个 limit 为选填，可对未通过验证的回落连接限速，bytesPerSec 默认为 0 即不启用
     #   #回落限速是一种特征，不建议启用，如果您是面板/一键脚本开发者，务必让这些参数随机化
     #   limit-fallback-upload:
@@ -2373,6 +2374,7 @@ listeners:
         - 0123456789abcdef
       server-names:
         - test.com
+      max-time-difference: 0 # 客户端时间最大允许偏差，单位毫秒；0 表示不限制
       #下列两个 limit 为选填，可对未通过验证的回落连接限速，bytesPerSec 默认为 0 即不启用
       #回落限速是一种特征，不建议启用，如果您是面板/一键脚本开发者，务必让这些参数随机化
       limit-fallback-upload:
@@ -2553,6 +2555,7 @@ listeners:
     #     - 0123456789abcdef
     #   server-names:
     #     - test.com
+    #   max-time-difference: 0 # 客户端时间最大允许偏差，单位毫秒；0 表示不限制
     #   #下列两个 limit 为选填，可对未通过验证的回落连接限速，bytesPerSec 默认为 0 即不启用
     #   #回落限速是一种特征，不建议启用，如果您是面板/一键脚本开发者，务必让这些参数随机化
     #   limit-fallback-upload:

--- a/docs/config.yaml
+++ b/docs/config.yaml
@@ -964,8 +964,12 @@ proxies: # socks5
     flow: xtls-rprx-vision
     servername: www.microsoft.com # REALITY servername
     reality-opts:
-      public-key: xxx
+      public-key: xxx # X25519 public key；亦可使用 Xray 别名 password，二者同时存在时 password 优先
       short-id: xxx # optional
+      # mldsa65-verify: xxx # 可选，Xray ML-DSA-65 验证公钥（1952 字节，raw URL-safe base64）
+      # spider-x: "/?p=30-60&c=1-2&t=1-3&i=0-100&r=0-100" # 未认证回落爬虫；p/c/t/i/r 分别为 padding/concurrency/times/interval/return 的范围
+      # show: false # 输出 REALITY 协商信息，包括是否使用 X25519MLKEM768 和 ML-DSA-65
+      # master-key-log: none # TLS key log 文件；none 或空值表示禁用
     # REALITY 默认为 chrome；旧服务端如不支持 X25519MLKEM768，请显式使用 chrome120
     client-fingerprint: chrome
 
@@ -2368,13 +2372,20 @@ listeners:
     #   # rate-limit: 0 # fallback 转发限速，单位 bit/s；0 表示不限速
     # 如果填写reality-config则开启reality（注意不可与certificate和private-key同时填写）
     reality-config:
-      dest: test.com:443
+      dest: test.com:443 # 回落目标；Xray 别名 target 优先于 dest
+      # type: tcp # 可选 tcp/unix；省略时根据 target/dest 推断，纯端口会转换为 localhost:<port>
+      # xver: 0 # 发往回落目标的 PROXY protocol：0=关闭、1=v1、2=v2
       private-key: jNXHt1yRo0vDuchQlIP6Z0ZvjT3KtzVI-T4E7RoLJS0 # 可由 mihomo generate reality-keypair 命令生成
       short-id:
         - 0123456789abcdef
       server-names:
         - test.com
+      # min-client-ver: 26.3.27 # 默认且最低允许值；必须为三个 0..255 的数字段
+      # max-client-ver: 26.7.11 # 可选，必须为三个 0..255 的数字段
       max-time-difference: 0 # 客户端时间最大允许偏差，单位毫秒；0 表示不限制
+      # mldsa65-seed: xxx # 可选，32 字节 ML-DSA-65 seed（raw URL-safe base64），不得与 private-key 相同
+      # show: false # 输出 REALITY 协商信息，包括 X25519MLKEM768
+      # master-key-log: none # TLS key log 文件；none 或空值表示禁用
       #下列两个 limit 为选填，可对未通过验证的回落连接限速，bytesPerSec 默认为 0 即不启用
       #回落限速是一种特征，不建议启用，如果您是面板/一键脚本开发者，务必让这些参数随机化
       limit-fallback-upload:

--- a/docs/research/xray-core-pr-6507.md
+++ b/docs/research/xray-core-pr-6507.md
@@ -1,0 +1,56 @@
+# Xray-core PR #6507: minimum REALITY client version
+
+Date reviewed: 2026-07-16
+
+## What the PR changes
+
+[XTLS/Xray-core#6507](https://github.com/XTLS/Xray-core/pull/6507) is an open, one-file change to `infra/conf/transport_security.go`. It does not change the REALITY wire format or handshake implementation. Its patch:
+
+- defines the minimum accepted version as the three bytes `{26, 3, 27}`;
+- keeps `26.3.27` as the default when `minClientVer` is omitted;
+- requires an explicit `minClientVer` to contain exactly three decimal components, each fitting in one byte;
+- rejects an explicit value lower than `26.3.27`.
+
+The default itself predates the PR. It was introduced by Xray-core commit [`af7eb680`](https://github.com/XTLS/Xray-core/commit/af7eb68028732a8ee3c0e5d6ab2b8a657bb2e770). PR #6507 commit [`2f86dd39`](https://github.com/XTLS/Xray-core/commit/2f86dd3909a28ce514de195004c7da622e799e24) mainly prevents operators from lowering that default.
+
+The three version bytes are compared as a big-endian integer by the REALITY server. Xray clients fill them from `core.Version_x`, `core.Version_y`, and `core.Version_z`, so this is an implementation release marker rather than a newly negotiated protocol version.
+
+## Motivation and current upstream position
+
+The linked maintainer discussion ties the `26.3.27` floor to TLS fingerprint risk, not to a cryptographic or wire-compatibility break. The discussion explicitly calls out Mihomo's use of an old Chrome 120 fingerprint and the distinguishability created by modifying a current fingerprint to remove `X25519MLKEM768`: [Xray-core#6181 comment](https://github.com/XTLS/Xray-core/pull/6181#issuecomment-4567373533).
+
+PR #6507 is not merged. In its discussion, RPRX suggests warnings may be more appropriate than making the lower bound impossible to override: warn that the default accepts only Xray-core `v26.3.27+`, and warn about fingerprint risk when a non-default value is used. Therefore the enforcement behavior should not yet be treated as settled upstream policy.
+
+The current patch also cannot compile as posted: it declares `minClientVer := [...]byte{26, 3, 27}` at package scope, where Go requires a `var` declaration. This is another reason not to copy the diff literally.
+
+## Impact on Mihomo
+
+At the review baseline, Mihomo had two independent differences from Xray-core:
+
+1. The REALITY client writes the hard-coded version `1.8.2` into the first three bytes of the encrypted Session ID in `component/tls/reality.go`. An Xray server using the current default minimum `26.3.27` will reject that value before short-ID acceptance.
+2. The Mihomo REALITY inbound builds `utls.RealityConfig` without setting `MinClientVer`, so its server accepts every client version. The configuration structs do not currently expose minimum or maximum client version fields.
+
+The pinned `github.com/metacubex/utls v1.8.7` dependency already supports `RealityConfig.MinClientVer` and `MaxClientVer`, so no dependency upgrade is required just to add the server-side bound.
+
+There was also a fingerprint concern separate from the numeric version. Unless `support-x25519mlkem768` was enabled, `component/tls/reality.go` called `BuildRemovedX25519MLKEM768HandshakeState`, which removed the post-quantum group from an otherwise current uTLS ClientHello. This is the distinguishability pattern discussed upstream. Merely changing `1.8.2` to `26.3.27` would have restored numeric compatibility without resolving that fingerprint risk.
+
+## Suggested implementation split
+
+Keep the work in separate commits so compatibility and policy remain reviewable:
+
+1. **Client compatibility:** replace the stale `1.8.2` literal with a named REALITY compatibility version and test the three emitted bytes. Using `26.3.27` will pass the Xray default, but the commit message should state clearly that this is compatibility metadata, not Mihomo's own release version.
+2. **Server policy (optional):** decide whether Mihomo should default `MinClientVer` to `26.3.27`, expose a configurable minimum, only warn, or preserve its current permissive behavior. Copying PR #6507 exactly would be a breaking policy change for older and third-party clients.
+3. **Fingerprint safety:** separately decide whether an unmodified current Chrome fingerprint with `X25519MLKEM768` should become the default, while retaining an explicit legacy compatibility mode for old REALITY servers.
+
+Minimum tests for a future fix:
+
+- assert the client writes the intended version bytes into the REALITY Session ID before encryption;
+- verify server boundary behavior for `26.3.26`, `26.3.27`, and a greater version if a minimum is added;
+- validate exactly three components in the range `0..255` if the setting is exposed;
+- add an Xray process interoperability test against a server using its default `minClientVer`.
+
+## Implemented resolution
+
+The `fix/reality-min-client-version` branch resolves the client-side findings together: it preserves the selected uTLS fingerprint, defaults an omitted REALITY fingerprint to Chrome Auto, advertises the tested `26.3.27` compatibility version, and interprets inbound `max-time-difference` in Xray-compatible milliseconds. The legacy `support-x25519mlkem768` field remains accepted as a deprecated no-op; old servers must use an explicit intact legacy preset such as `chrome120`.
+
+The end-to-end gate launches Xray-core 26.7.11 from commit `50231eaff98ccc31b5cbd247a721c16e97fe5ec1` with its default `minClientVer` and verifies both plain VLESS TCP with an empty fingerprint and VLESS Vision with Chrome Auto.

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/metacubex/mihomo
 
 go 1.20
 
+replace github.com/metacubex/utls => github.com/Jolymmiles/utls v1.8.8-0.20260716213119-e541740a06a2
+
 require (
 	github.com/bahlo/generic-list-go v0.2.0
 	github.com/coreos/go-iptables v0.8.0

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/Jolymmiles/utls v1.8.8-0.20260716213119-e541740a06a2 h1:4BwrdMNAUg48r6jsu/VhT48Nf/sbeYKuDArrhH2k0aA=
+github.com/Jolymmiles/utls v1.8.8-0.20260716213119-e541740a06a2/go.mod h1:y3iNNBPOBgMnmrRXcVJTfYFwOyh+CPF9TXZa/kGI3hM=
 github.com/RyuaNerin/go-krypto v1.3.0 h1:smavTzSMAx8iuVlGb4pEwl9MD2qicqMzuXR2QWp2/Pg=
 github.com/RyuaNerin/go-krypto v1.3.0/go.mod h1:9R9TU936laAIqAmjcHo/LsaXYOZlymudOAxjaBf62UM=
 github.com/RyuaNerin/testingutil v0.1.0 h1:IYT6JL57RV3U2ml3dLHZsVtPOP6yNK7WUVdzzlpNrss=
@@ -185,8 +187,6 @@ github.com/metacubex/tfo-go v0.0.0-20260623020846-376a77860b8c h1:+2C1UshSLzaogL
 github.com/metacubex/tfo-go v0.0.0-20260623020846-376a77860b8c/go.mod h1:l9oLnLoEXyGZ5RVLsh7QCC5XsouTUyKk4F2nLm2DHLw=
 github.com/metacubex/tls v0.1.7 h1:7YW+7z2xGH1bozSg04q3gKNd7GBSiTSXIrQY2SMnfoE=
 github.com/metacubex/tls v0.1.7/go.mod h1:0XeVdL0cBw+8i5Hqy3lVeP9IyD/LFTq02ExvHM6rzEM=
-github.com/metacubex/utls v1.8.7 h1:Cp+yWkNTFkSihETgGWq34hlVFds5HpYWVOR1xovUVTs=
-github.com/metacubex/utls v1.8.7/go.mod h1:kncGGVhFaoGn5M3pFe3SXhZCzsbCJayNOH4UEqTKTko=
 github.com/metacubex/wireguard-go v0.0.0-20250820062549-a6cecdd7f57f h1:FGBPRb1zUabhPhDrlKEjQ9lgIwQ6cHL4x8M9lrERhbk=
 github.com/metacubex/wireguard-go v0.0.0-20250820062549-a6cecdd7f57f/go.mod h1:oPGcV994OGJedmmxrcK9+ni7jUEMGhR+uVQAdaduIP4=
 github.com/metacubex/yamux v0.0.0-20250918083631-dd5f17c0be49 h1:lhlqpYHopuTLx9xQt22kSA9HtnyTDmk5XjjQVCGHe2E=

--- a/listener/inbound/common_test.go
+++ b/listener/inbound/common_test.go
@@ -42,6 +42,7 @@ var tlsCertificate, tlsPrivateKey, tlsFingerprint, _ = ca.NewRandomTLSKeyPair(ca
 var tlsAuthCertificate, tlsAuthPrivateKey, _, _ = ca.NewRandomTLSKeyPair(ca.KeyPairTypeP256)
 var tlsConfigCert, _ = tls.X509KeyPair([]byte(tlsCertificate), []byte(tlsPrivateKey))
 var tlsConfig = &tls.Config{Certificates: []tls.Certificate{tlsConfigCert}, NextProtos: []string{"h2", "http/1.1"}}
+var realityTLSConfig = newRealityCarrierTLSConfig()
 var tlsClientConfig, _ = ca.GetTLSConfig(ca.Option{Fingerprint: tlsFingerprint})
 var realityPrivateKey, realityPublickey string
 var realityDest = "itunes.apple.com"
@@ -59,6 +60,15 @@ func init() {
 	}
 	realityPrivateKey = base64.RawURLEncoding.EncodeToString(privateKey.Bytes())
 	realityPublickey = base64.RawURLEncoding.EncodeToString(privateKey.PublicKey().Bytes())
+}
+
+func newRealityCarrierTLSConfig() *tls.Config {
+	certificate := tlsConfigCert
+	leaf := append([]byte(nil), certificate.Certificate[0]...)
+	for chainBytes := len(leaf); chainBytes < 6*1024; chainBytes += len(leaf) {
+		certificate.Certificate = append(certificate.Certificate, append([]byte(nil), leaf...))
+	}
+	return &tls.Config{Certificates: []tls.Certificate{certificate}, NextProtos: []string{"h2", "http/1.1"}}
 }
 
 type TestDialer struct {
@@ -330,7 +340,11 @@ func NewHttpTestTunnel() *TestTunnel {
 				ch:   make(chan struct{}),
 			}
 			if metadata.DstPort == 443 {
-				tlsConn := tls.Server(c, tlsConfig)
+				serverTLSConfig := tlsConfig
+				if metadata.Host == realityDest {
+					serverTLSConfig = realityTLSConfig
+				}
+				tlsConn := tls.Server(c, serverTLSConfig)
 				if metadata.Host == realityDest { // ignore the tls handshake error for realityDest
 					if realityRealDial {
 						rconn, err := dialer.DialContext(ctx, "tcp", metadata.RemoteAddress())

--- a/listener/inbound/reality.go
+++ b/listener/inbound/reality.go
@@ -3,11 +3,19 @@ package inbound
 import "github.com/metacubex/mihomo/listener/reality"
 
 type RealityConfig struct {
+	Target            string   `inbound:"target,omitempty"`
 	Dest              string   `inbound:"dest"`
+	Type              string   `inbound:"type,omitempty"`
+	Xver              uint64   `inbound:"xver,omitempty"`
 	PrivateKey        string   `inbound:"private-key"`
 	ShortID           []string `inbound:"short-id"`
 	ServerNames       []string `inbound:"server-names"`
+	MinClientVersion  string   `inbound:"min-client-ver,omitempty"`
+	MaxClientVersion  string   `inbound:"max-client-ver,omitempty"`
 	MaxTimeDifference int      `inbound:"max-time-difference,omitempty"`
+	Mldsa65Seed       string   `inbound:"mldsa65-seed,omitempty"`
+	Show              bool     `inbound:"show,omitempty"`
+	MasterKeyLog      string   `inbound:"master-key-log,omitempty"`
 	Proxy             string   `inbound:"proxy,omitempty"`
 
 	LimitFallbackUpload   RealityLimitFallback `inbound:"limit-fallback-upload,omitempty"`
@@ -22,11 +30,19 @@ type RealityLimitFallback struct {
 
 func (c RealityConfig) Build() reality.Config {
 	return reality.Config{
+		Target:            c.Target,
 		Dest:              c.Dest,
+		Type:              c.Type,
+		Xver:              c.Xver,
 		PrivateKey:        c.PrivateKey,
 		ShortID:           c.ShortID,
 		ServerNames:       c.ServerNames,
+		MinClientVersion:  c.MinClientVersion,
+		MaxClientVersion:  c.MaxClientVersion,
 		MaxTimeDifference: c.MaxTimeDifference,
+		Mldsa65Seed:       c.Mldsa65Seed,
+		Show:              c.Show,
+		MasterKeyLog:      c.MasterKeyLog,
 		Proxy:             c.Proxy,
 
 		LimitFallbackUpload: reality.LimitFallback{

--- a/listener/inbound/vless_test.go
+++ b/listener/inbound/vless_test.go
@@ -1,6 +1,7 @@
 package inbound_test
 
 import (
+	"encoding/base64"
 	"net"
 	"net/netip"
 	"testing"
@@ -8,6 +9,7 @@ import (
 	"github.com/metacubex/mihomo/adapter/outbound"
 	"github.com/metacubex/mihomo/listener/inbound"
 	"github.com/metacubex/mihomo/transport/vless/encryption"
+	utls "github.com/metacubex/utls"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -380,6 +382,21 @@ func TestInboundVless_Reality(t *testing.T) {
 			outboundOptions.Flow = "xtls-rprx-vision"
 			testInboundVless(t, inboundOptions, outboundOptions)
 		})
+	})
+	t.Run("X25519MLKEM768 and ML-DSA-65", func(t *testing.T) {
+		seed := make([]byte, 32)
+		seed[0] = 1
+		_, verifyKey, err := utls.RealityMldsa65KeyFromSeed(seed)
+		if !assert.NoError(t, err) {
+			return
+		}
+		inboundOptions := inboundOptions
+		inboundOptions.RealityConfig.Mldsa65Seed = base64.RawURLEncoding.EncodeToString(seed)
+		inboundOptions.RealityConfig.Show = true
+		outboundOptions := outboundOptions
+		outboundOptions.RealityOpts.Mldsa65Verify = base64.RawURLEncoding.EncodeToString(verifyKey)
+		outboundOptions.RealityOpts.Show = true
+		testInboundVless(t, inboundOptions, outboundOptions)
 	})
 }
 

--- a/listener/inbound/vless_xray_reality_interop_test.go
+++ b/listener/inbound/vless_xray_reality_interop_test.go
@@ -1,0 +1,179 @@
+package inbound_test
+
+import (
+	"bytes"
+	"context"
+	"crypto/ecdh"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/metacubex/mihomo/adapter/outbound"
+
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	xrayRealityPlainUUID  = "73c1a1d8-6f4b-4b64-94f7-87a15fcdfe93"
+	xrayRealityVisionUUID = "a4c6475a-c27d-43d9-b9b5-21ec8e5f67bc"
+	xrayRealityShortID    = "0123456789abcdef"
+)
+
+func TestVLESSRealityXrayInterop(t *testing.T) {
+	xrayBinary := os.Getenv("XRAY_BINARY")
+	if xrayBinary == "" {
+		t.Skip("XRAY_BINARY is not set; point it at a current Xray-core executable")
+	}
+	versionOutput, err := exec.Command(xrayBinary, "version").CombinedOutput()
+	require.NoError(t, err, "xray version: %s", versionOutput)
+	t.Logf("Xray executable: %s\n%s", xrayBinary, versionOutput)
+
+	origin := startTLSMirrorInteropCarrierTLS(t)
+	echoAddr := startVMessInteropEcho(t)
+	xrayPort := vmessInteropReserveTCPPort(t)
+	privateKey, err := ecdh.X25519().GenerateKey(rand.Reader)
+	require.NoError(t, err)
+
+	config := xrayRealityServerConfig(t, xrayPort.Port(), origin.addr, privateKey)
+	startXrayRealityServer(t, xrayBinary, config, xrayPort)
+
+	testCases := []struct {
+		name              string
+		uuid              string
+		flow              string
+		clientFingerprint string
+	}{
+		{
+			name: "tcp empty fingerprint",
+			uuid: xrayRealityPlainUUID,
+		},
+		{
+			name:              "vision chrome auto",
+			uuid:              xrayRealityVisionUUID,
+			flow:              "xtls-rprx-vision",
+			clientFingerprint: "chrome",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			out, err := outbound.NewVless(outbound.VlessOption{
+				Name:              "vless_reality_xray",
+				Server:            "127.0.0.1",
+				Port:              xrayPort.Port(),
+				UUID:              testCase.uuid,
+				Flow:              testCase.flow,
+				TLS:               true,
+				ServerName:        "localhost",
+				ClientFingerprint: testCase.clientFingerprint,
+				RealityOpts: outbound.RealityOptions{
+					PublicKey: base64.RawURLEncoding.EncodeToString(privateKey.PublicKey().Bytes()),
+					ShortID:   xrayRealityShortID,
+				},
+			})
+			require.NoError(t, err)
+			t.Cleanup(func() { _ = out.Close() })
+
+			vmessInteropRoundTripWithRetry(t, func() (net.Conn, error) {
+				return out.DialContext(context.Background(), vmessInteropMetadata(t, echoAddr))
+			}, 128*1024)
+		})
+	}
+}
+
+func xrayRealityServerConfig(t *testing.T, port int, originAddr string, privateKey *ecdh.PrivateKey) []byte {
+	t.Helper()
+	config := map[string]any{
+		"log": map[string]any{
+			"loglevel": "debug",
+		},
+		"inbounds": []any{map[string]any{
+			"listen":   "127.0.0.1",
+			"port":     port,
+			"protocol": "vless",
+			"settings": map[string]any{
+				"clients": []any{
+					map[string]any{"id": xrayRealityPlainUUID},
+					map[string]any{"id": xrayRealityVisionUUID, "flow": "xtls-rprx-vision"},
+				},
+				"decryption": "none",
+			},
+			"streamSettings": map[string]any{
+				"network":  "tcp",
+				"security": "reality",
+				"realitySettings": map[string]any{
+					"target":      originAddr,
+					"serverNames": []string{"localhost"},
+					"privateKey":  base64.RawURLEncoding.EncodeToString(privateKey.Bytes()),
+					"shortIds":    []string{xrayRealityShortID},
+					// Deliberately omit minClientVer. The JSON builder must apply
+					// Xray-core's default minimum (currently 26.3.27).
+				},
+			},
+		}},
+		"outbounds": []any{map[string]any{
+			"protocol": "freedom",
+			"tag":      "direct",
+			"settings": map[string]any{
+				// Current Xray blocks private destinations by default for VLESS.
+				// The interop echo server is intentionally loopback-only.
+				"finalRules": []any{map[string]any{"action": "allow"}},
+			},
+		}},
+	}
+	data, err := json.MarshalIndent(config, "", "  ")
+	require.NoError(t, err)
+	return append(data, '\n')
+}
+
+func startXrayRealityServer(t *testing.T, xrayBinary string, config []byte, port *vmessInteropReservedTCPPort) {
+	t.Helper()
+	configPath := filepath.Join(t.TempDir(), "xray-reality.json")
+	require.NoError(t, os.WriteFile(configPath, config, 0o600))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cmd := exec.CommandContext(ctx, xrayBinary, "run", "-c", configPath)
+	var output bytes.Buffer
+	cmd.Stdout = &output
+	cmd.Stderr = &output
+	port.Release()
+	require.NoError(t, cmd.Start())
+	done := make(chan error, 1)
+	go func() { done <- cmd.Wait() }()
+	waited := false
+	t.Cleanup(func() {
+		cancel()
+		if !waited {
+			<-done
+		}
+		if t.Failed() {
+			t.Log(output.String())
+		}
+	})
+
+	address := net.JoinHostPort("127.0.0.1", fmt.Sprint(port.Port()))
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		select {
+		case err := <-done:
+			waited = true
+			require.NoError(t, err, output.String())
+			t.Fatalf("Xray exited before listening on %s\n%s", address, output.String())
+		default:
+		}
+		conn, err := net.DialTimeout("tcp", address, 100*time.Millisecond)
+		if err == nil {
+			_ = conn.Close()
+			return
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	t.Fatalf("Xray did not listen on %s\n%s", address, output.String())
+}

--- a/listener/inbound/vless_xray_reality_interop_test.go
+++ b/listener/inbound/vless_xray_reality_interop_test.go
@@ -16,6 +16,9 @@ import (
 	"time"
 
 	"github.com/metacubex/mihomo/adapter/outbound"
+	"github.com/metacubex/mihomo/listener/inbound"
+	"github.com/metacubex/tls"
+	utls "github.com/metacubex/utls"
 
 	"github.com/stretchr/testify/require"
 )
@@ -35,13 +38,17 @@ func TestVLESSRealityXrayInterop(t *testing.T) {
 	require.NoError(t, err, "xray version: %s", versionOutput)
 	t.Logf("Xray executable: %s\n%s", xrayBinary, versionOutput)
 
-	origin := startTLSMirrorInteropCarrierTLS(t)
+	origin := startTLSMirrorInteropCarrierTLS(t, padRealityCarrierCertificate)
 	echoAddr := startVMessInteropEcho(t)
 	xrayPort := vmessInteropReserveTCPPort(t)
 	privateKey, err := ecdh.X25519().GenerateKey(rand.Reader)
 	require.NoError(t, err)
+	mldsa65Seed := make([]byte, 32)
+	mldsa65Seed[0] = 1
+	_, mldsa65Verify, err := utls.RealityMldsa65KeyFromSeed(mldsa65Seed)
+	require.NoError(t, err)
 
-	config := xrayRealityServerConfig(t, xrayPort.Port(), origin.addr, privateKey)
+	config := xrayRealityServerConfig(t, xrayPort.Port(), origin.addr, privateKey, mldsa65Seed)
 	startXrayRealityServer(t, xrayBinary, config, xrayPort)
 
 	testCases := []struct {
@@ -49,6 +56,7 @@ func TestVLESSRealityXrayInterop(t *testing.T) {
 		uuid              string
 		flow              string
 		clientFingerprint string
+		mldsa65Verify     []byte
 	}{
 		{
 			name: "tcp empty fingerprint",
@@ -59,6 +67,12 @@ func TestVLESSRealityXrayInterop(t *testing.T) {
 			uuid:              xrayRealityVisionUUID,
 			flow:              "xtls-rprx-vision",
 			clientFingerprint: "chrome",
+		},
+		{
+			name:              "chrome auto X25519MLKEM768 and ML-DSA-65",
+			uuid:              xrayRealityPlainUUID,
+			clientFingerprint: "chrome",
+			mldsa65Verify:     mldsa65Verify,
 		},
 	}
 
@@ -74,8 +88,10 @@ func TestVLESSRealityXrayInterop(t *testing.T) {
 				ServerName:        "localhost",
 				ClientFingerprint: testCase.clientFingerprint,
 				RealityOpts: outbound.RealityOptions{
-					PublicKey: base64.RawURLEncoding.EncodeToString(privateKey.PublicKey().Bytes()),
-					ShortID:   xrayRealityShortID,
+					PublicKey:     base64.RawURLEncoding.EncodeToString(privateKey.PublicKey().Bytes()),
+					ShortID:       xrayRealityShortID,
+					Mldsa65Verify: base64.RawURLEncoding.EncodeToString(testCase.mldsa65Verify),
+					Show:          testCase.mldsa65Verify != nil,
 				},
 			})
 			require.NoError(t, err)
@@ -88,7 +104,87 @@ func TestVLESSRealityXrayInterop(t *testing.T) {
 	}
 }
 
-func xrayRealityServerConfig(t *testing.T, port int, originAddr string, privateKey *ecdh.PrivateKey) []byte {
+func TestVLESSRealityXrayClientToMihomoServer(t *testing.T) {
+	xrayBinary := os.Getenv("XRAY_BINARY")
+	if xrayBinary == "" {
+		t.Skip("XRAY_BINARY is not set; point it at a current Xray-core executable")
+	}
+	origin := startTLSMirrorInteropCarrierTLS(t, padRealityCarrierCertificate)
+	echoAddr := startVMessInteropEcho(t)
+	privateKey, err := ecdh.X25519().GenerateKey(rand.Reader)
+	require.NoError(t, err)
+	mldsa65Seed := make([]byte, 32)
+	mldsa65Seed[0] = 2
+	_, mldsa65Verify, err := utls.RealityMldsa65KeyFromSeed(mldsa65Seed)
+	require.NoError(t, err)
+
+	in, err := inbound.NewVless(&inbound.VlessOption{
+		BaseOption: inbound.BaseOption{NameStr: "vless_reality_xray_client", Listen: "127.0.0.1", Port: "0"},
+		Users:      []inbound.VlessUser{{Username: "xray", UUID: xrayRealityPlainUUID}},
+		RealityConfig: inbound.RealityConfig{
+			Dest:        origin.addr,
+			PrivateKey:  base64.RawURLEncoding.EncodeToString(privateKey.Bytes()),
+			ShortID:     []string{xrayRealityShortID},
+			ServerNames: []string{"localhost"},
+			Mldsa65Seed: base64.RawURLEncoding.EncodeToString(mldsa65Seed),
+			Show:        true,
+		},
+	})
+	require.NoError(t, err)
+	require.NoError(t, in.Listen(vmessInteropDirectTunnel(t)))
+	t.Cleanup(func() { _ = in.Close() })
+	mihomoPort := vmessInteropParsePort(t, vmessInteropPort(in.Address()))
+
+	xrayPort := vmessInteropReserveTCPPort(t)
+	config := xrayRealityClientConfig(t, xrayPort.Port(), mihomoPort, echoAddr, privateKey.PublicKey().Bytes(), mldsa65Verify)
+	startXrayRealityServer(t, xrayBinary, config, xrayPort)
+
+	vmessInteropRoundTripWithRetry(t, func() (net.Conn, error) {
+		return net.Dial("tcp", net.JoinHostPort("127.0.0.1", fmt.Sprint(xrayPort.Port())))
+	}, 128*1024)
+}
+
+func xrayRealityClientConfig(t *testing.T, listenPort, serverPort int, targetAddr string, publicKey, mldsa65Verify []byte) []byte {
+	t.Helper()
+	targetHost, targetPort, err := net.SplitHostPort(targetAddr)
+	require.NoError(t, err)
+	targetPortNumber, err := net.LookupPort("tcp", targetPort)
+	require.NoError(t, err)
+	config := map[string]any{
+		"log": map[string]any{"loglevel": "debug"},
+		"inbounds": []any{map[string]any{
+			"listen":   "127.0.0.1",
+			"port":     listenPort,
+			"protocol": "dokodemo-door",
+			"settings": map[string]any{"address": targetHost, "port": targetPortNumber, "network": "tcp"},
+		}},
+		"outbounds": []any{map[string]any{
+			"protocol": "vless",
+			"settings": map[string]any{"vnext": []any{map[string]any{
+				"address": "127.0.0.1",
+				"port":    serverPort,
+				"users":   []any{map[string]any{"id": xrayRealityPlainUUID, "encryption": "none"}},
+			}}},
+			"streamSettings": map[string]any{
+				"network":  "tcp",
+				"security": "reality",
+				"realitySettings": map[string]any{
+					"show":          true,
+					"fingerprint":   "chrome",
+					"serverName":    "localhost",
+					"publicKey":     base64.RawURLEncoding.EncodeToString(publicKey),
+					"shortId":       xrayRealityShortID,
+					"mldsa65Verify": base64.RawURLEncoding.EncodeToString(mldsa65Verify),
+				},
+			},
+		}},
+	}
+	data, err := json.MarshalIndent(config, "", "  ")
+	require.NoError(t, err)
+	return append(data, '\n')
+}
+
+func xrayRealityServerConfig(t *testing.T, port int, originAddr string, privateKey *ecdh.PrivateKey, mldsa65Seed []byte) []byte {
 	t.Helper()
 	config := map[string]any{
 		"log": map[string]any{
@@ -109,10 +205,12 @@ func xrayRealityServerConfig(t *testing.T, port int, originAddr string, privateK
 				"network":  "tcp",
 				"security": "reality",
 				"realitySettings": map[string]any{
+					"show":        true,
 					"target":      originAddr,
 					"serverNames": []string{"localhost"},
 					"privateKey":  base64.RawURLEncoding.EncodeToString(privateKey.Bytes()),
 					"shortIds":    []string{xrayRealityShortID},
+					"mldsa65Seed": base64.RawURLEncoding.EncodeToString(mldsa65Seed),
 					// Deliberately omit minClientVer. The JSON builder must apply
 					// Xray-core's default minimum (currently 26.3.27).
 				},
@@ -131,6 +229,15 @@ func xrayRealityServerConfig(t *testing.T, port int, originAddr string, privateK
 	data, err := json.MarshalIndent(config, "", "  ")
 	require.NoError(t, err)
 	return append(data, '\n')
+}
+
+func padRealityCarrierCertificate(config *tls.Config) {
+	certificate := config.Certificates[0]
+	leaf := append([]byte(nil), certificate.Certificate[0]...)
+	for chainBytes := len(leaf); chainBytes < 6*1024; chainBytes += len(leaf) {
+		certificate.Certificate = append(certificate.Certificate, append([]byte(nil), leaf...))
+	}
+	config.Certificates[0] = certificate
 }
 
 func startXrayRealityServer(t *testing.T, xrayBinary string, config []byte, port *vmessInteropReservedTCPPort) {

--- a/listener/reality/reality.go
+++ b/listener/reality/reality.go
@@ -7,7 +7,12 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"os"
+	"runtime"
 	"runtime/debug"
+	"strconv"
+	"strings"
+	"syscall"
 	"time"
 
 	N "github.com/metacubex/mihomo/common/net"
@@ -23,11 +28,19 @@ type Conn = utls.Conn
 type LimitFallback = utls.RealityLimitFallback
 
 type Config struct {
+	Target            string
 	Dest              string
+	Type              string
+	Xver              uint64
 	PrivateKey        string
 	ShortID           []string
 	ServerNames       []string
+	MinClientVersion  string
+	MaxClientVersion  string
 	MaxTimeDifference int
+	Mldsa65Seed       string
+	Show              bool
+	MasterKeyLog      string
 	Proxy             string
 
 	LimitFallbackUpload   LimitFallback
@@ -37,11 +50,29 @@ type Config struct {
 func (c Config) Build(tunnel C.Tunnel) (*Builder, error) {
 	realityConfig := &utls.RealityConfig{}
 	realityConfig.SessionTicketsDisabled = true
-	realityConfig.Type = "tcp"
-	realityConfig.Dest = c.Dest
+	target := c.Dest
+	if c.Target != "" {
+		target = c.Target
+	}
+	typeName, target, err := normalizeTarget(c.Type, target)
+	if err != nil {
+		return nil, err
+	}
+	if c.Xver > 2 {
+		return nil, fmt.Errorf("invalid PROXY protocol version %d: xver only accepts 0, 1, 2", c.Xver)
+	}
+	realityConfig.Type = typeName
+	realityConfig.Dest = target
+	realityConfig.Xver = byte(c.Xver)
 	realityConfig.Time = ntp.Now
 	realityConfig.ServerNames = make(map[string]bool)
-	realityConfig.Log = log.Debugln
+	if len(c.ServerNames) == 0 {
+		return nil, errors.New("empty server-names")
+	}
+	realityConfig.Log = log.Infoln
+	if !c.Show {
+		realityConfig.Log = nil
+	}
 	for _, it := range c.ServerNames {
 		realityConfig.ServerNames[it] = true
 	}
@@ -54,9 +85,23 @@ func (c Config) Build(tunnel C.Tunnel) (*Builder, error) {
 	}
 	realityConfig.PrivateKey = privateKey
 
+	realityConfig.MinClientVer, err = parseClientVersion(c.MinClientVersion, []byte{26, 3, 27}, true)
+	if err != nil {
+		return nil, fmt.Errorf("invalid min-client-ver: %w", err)
+	}
+	if c.MaxClientVersion != "" {
+		realityConfig.MaxClientVer, err = parseClientVersion(c.MaxClientVersion, nil, false)
+		if err != nil {
+			return nil, fmt.Errorf("invalid max-client-ver: %w", err)
+		}
+	}
+
 	realityConfig.MaxTimeDiff = time.Duration(c.MaxTimeDifference) * time.Millisecond
 
 	realityConfig.ShortIds = make(map[[8]byte]bool)
+	if len(c.ShortID) == 0 {
+		return nil, errors.New("empty short-id")
+	}
 	for i, shortIDString := range c.ShortID {
 		var shortID [8]byte
 		decodedLen := hex.DecodedLen(len(shortIDString))
@@ -74,23 +119,113 @@ func (c Config) Build(tunnel C.Tunnel) (*Builder, error) {
 	}
 
 	realityConfig.DialContext = func(ctx context.Context, network, address string) (net.Conn, error) {
+		if network == "unix" {
+			return (&net.Dialer{}).DialContext(ctx, network, address)
+		}
 		return inner.HandleTcp(tunnel, address, c.Proxy)
 	}
 
 	realityConfig.LimitFallbackUpload = c.LimitFallbackUpload
 	realityConfig.LimitFallbackDownload = c.LimitFallbackDownload
 
-	return &Builder{realityConfig}, nil
+	var mldsa65Seed []byte
+	if c.Mldsa65Seed != "" {
+		if c.Mldsa65Seed == c.PrivateKey {
+			return nil, errors.New("mldsa65-seed and private-key cannot be the same value")
+		}
+		mldsa65Seed, err = base64.RawURLEncoding.DecodeString(c.Mldsa65Seed)
+		if err != nil || len(mldsa65Seed) != 32 {
+			return nil, errors.New("invalid mldsa65-seed")
+		}
+		realityConfig.Mldsa65Key, _, err = utls.RealityMldsa65KeyFromSeed(mldsa65Seed)
+		if err != nil {
+			return nil, fmt.Errorf("derive ML-DSA-65 key: %w", err)
+		}
+	}
+	if c.MasterKeyLog != "" && c.MasterKeyLog != "none" {
+		realityConfig.KeyLogWriter, err = os.OpenFile(c.MasterKeyLog, os.O_CREATE|os.O_RDWR|os.O_APPEND, 0o644)
+		if err != nil {
+			return nil, fmt.Errorf("open REALITY master key log: %w", err)
+		}
+	}
+
+	return &Builder{realityConfig: realityConfig, mldsa65Seed: mldsa65Seed}, nil
 }
 
 type Builder struct {
 	realityConfig *utls.RealityConfig
+	mldsa65Seed   []byte
+}
+
+func normalizeTarget(typeName, target string) (string, string, error) {
+	if target == "" {
+		return "", "", errors.New("empty target")
+	}
+	if typeName == "" {
+		switch target[0] {
+		case '@', '/':
+			typeName = "unix"
+			if target[0] == '@' && len(target) > 1 && target[1] == '@' && (runtime.GOOS == "linux" || runtime.GOOS == "android") {
+				fullAddress := make([]byte, len(syscall.RawSockaddrUnix{}.Path))
+				copy(fullAddress, target[1:])
+				target = string(fullAddress)
+			}
+		default:
+			if _, err := strconv.Atoi(target); err == nil {
+				target = net.JoinHostPort("localhost", target)
+			}
+			if _, _, err := net.SplitHostPort(target); err == nil {
+				typeName = "tcp"
+			}
+		}
+	}
+	if typeName != "tcp" && typeName != "unix" {
+		return "", "", fmt.Errorf("invalid target %q with type %q", target, typeName)
+	}
+	return typeName, target, nil
+}
+
+func parseClientVersion(value string, defaultValue []byte, enforceFloor bool) ([]byte, error) {
+	if value == "" {
+		return append([]byte(nil), defaultValue...), nil
+	}
+	parts := strings.Split(value, ".")
+	if len(parts) != 3 {
+		return nil, errors.New("version must have exactly three components")
+	}
+	version := make([]byte, 3)
+	for i, part := range parts {
+		component, err := strconv.ParseUint(part, 10, 8)
+		if err != nil {
+			return nil, fmt.Errorf("component %d %q must be between 0 and 255", i, part)
+		}
+		version[i] = byte(component)
+	}
+	if enforceFloor && compareVersion(version, []byte{26, 3, 27}) < 0 {
+		return nil, errors.New("version must be at least 26.3.27")
+	}
+	return version, nil
+}
+
+func compareVersion(left, right []byte) int {
+	for i := 0; i < len(left) && i < len(right); i++ {
+		if left[i] < right[i] {
+			return -1
+		}
+		if left[i] > right[i] {
+			return 1
+		}
+	}
+	return len(left) - len(right)
 }
 
 func (b Builder) NewListener(l net.Listener) net.Listener {
 	return N.NewHandleContextListener(context.Background(), l, func(ctx context.Context, conn net.Conn) (net.Conn, error) {
 		c, err := utls.RealityServer(ctx, conn, b.realityConfig)
 		if err != nil {
+			if b.realityConfig.Log != nil {
+				b.realityConfig.Log("REALITY server handshake failed: %v", err)
+			}
 			return nil, err
 		}
 		// Due to low implementation quality, the reality server intercepted half-close and caused memory leaks.
@@ -111,7 +246,7 @@ func (c realityConnWrapper) Upstream() any {
 }
 
 func (c realityConnWrapper) CloseWrite() error {
-	return c.Close()
+	return c.Conn.CloseWrite()
 }
 
 func (c realityConnWrapper) ReaderReplaceable() bool {

--- a/listener/reality/reality.go
+++ b/listener/reality/reality.go
@@ -54,7 +54,7 @@ func (c Config) Build(tunnel C.Tunnel) (*Builder, error) {
 	}
 	realityConfig.PrivateKey = privateKey
 
-	realityConfig.MaxTimeDiff = time.Duration(c.MaxTimeDifference) * time.Microsecond
+	realityConfig.MaxTimeDiff = time.Duration(c.MaxTimeDifference) * time.Millisecond
 
 	realityConfig.ShortIds = make(map[[8]byte]bool)
 	for i, shortIDString := range c.ShortID {

--- a/listener/reality/reality_test.go
+++ b/listener/reality/reality_test.go
@@ -1,0 +1,22 @@
+package reality
+
+import (
+	"encoding/base64"
+	"testing"
+	"time"
+)
+
+func TestConfigBuildUsesMillisecondsForMaxTimeDifference(t *testing.T) {
+	builder, err := (Config{
+		Dest:              "127.0.0.1:443",
+		PrivateKey:        base64.RawURLEncoding.EncodeToString(make([]byte, 32)),
+		ServerNames:       []string{"example.com"},
+		MaxTimeDifference: 1500,
+	}).Build(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := builder.realityConfig.MaxTimeDiff, 1500*time.Millisecond; got != want {
+		t.Fatalf("MaxTimeDiff = %v, want %v", got, want)
+	}
+}

--- a/listener/reality/reality_test.go
+++ b/listener/reality/reality_test.go
@@ -1,22 +1,237 @@
 package reality
 
 import (
+	"context"
 	"encoding/base64"
+	"io"
+	"net"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strconv"
 	"testing"
 	"time"
 )
 
 func TestConfigBuildUsesMillisecondsForMaxTimeDifference(t *testing.T) {
-	builder, err := (Config{
-		Dest:              "127.0.0.1:443",
-		PrivateKey:        base64.RawURLEncoding.EncodeToString(make([]byte, 32)),
-		ServerNames:       []string{"example.com"},
-		MaxTimeDifference: 1500,
-	}).Build(nil)
+	builder, err := validConfig(func(c *Config) { c.MaxTimeDifference = 1500 }).Build(nil)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if got, want := builder.realityConfig.MaxTimeDiff, 1500*time.Millisecond; got != want {
 		t.Fatalf("MaxTimeDiff = %v, want %v", got, want)
 	}
+}
+
+func TestConfigBuildAppliesXrayVersionPolicy(t *testing.T) {
+	tests := []struct {
+		name    string
+		min     string
+		max     string
+		wantMin []byte
+		wantMax []byte
+		wantErr bool
+	}{
+		{name: "default minimum", wantMin: []byte{26, 3, 27}},
+		{name: "explicit bounds", min: "26.7.11", max: "27.0.0", wantMin: []byte{26, 7, 11}, wantMax: []byte{27, 0, 0}},
+		{name: "minimum below safety floor", min: "26.3.26", wantErr: true},
+		{name: "minimum missing component", min: "26.3", wantErr: true},
+		{name: "maximum missing component", max: "26.7", wantErr: true},
+		{name: "component overflow", min: "26.300.1", wantErr: true},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			builder, err := validConfig(func(c *Config) {
+				c.MinClientVersion = test.min
+				c.MaxClientVersion = test.max
+			}).Build(nil)
+			if test.wantErr {
+				if err == nil {
+					t.Fatal("Build() error = nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got := builder.realityConfig.MinClientVer; !bytesEqual(got, test.wantMin) {
+				t.Fatalf("MinClientVer = %v, want %v", got, test.wantMin)
+			}
+			if got := builder.realityConfig.MaxClientVer; !bytesEqual(got, test.wantMax) {
+				t.Fatalf("MaxClientVer = %v, want %v", got, test.wantMax)
+			}
+		})
+	}
+}
+
+func TestConfigBuildInfersXrayTargetTypeAndValidatesXver(t *testing.T) {
+	tests := []struct {
+		name     string
+		target   string
+		typeName string
+		xver     uint64
+		wantType string
+		wantDest string
+		wantErr  bool
+	}{
+		{name: "tcp address", target: "example.com:443", wantType: "tcp", wantDest: "example.com:443"},
+		{name: "tcp port", target: "443", wantType: "tcp", wantDest: "localhost:443"},
+		{name: "explicit tcp", target: "example.com:443", typeName: "tcp", xver: 2, wantType: "tcp", wantDest: "example.com:443"},
+		{name: "unix path", target: "/tmp/reality.sock", wantType: "unix", wantDest: "/tmp/reality.sock"},
+		{name: "invalid xver", target: "example.com:443", xver: 3, wantErr: true},
+		{name: "invalid target", target: "not-an-address", wantErr: true},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			builder, err := validConfig(func(c *Config) {
+				c.Dest = ""
+				c.Target = test.target
+				c.Type = test.typeName
+				c.Xver = test.xver
+			}).Build(nil)
+			if test.wantErr {
+				if err == nil {
+					t.Fatal("Build() error = nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got := builder.realityConfig.Type; got != test.wantType {
+				t.Fatalf("Type = %q, want %q", got, test.wantType)
+			}
+			if got := builder.realityConfig.Dest; got != test.wantDest {
+				t.Fatalf("Dest = %q, want %q", got, test.wantDest)
+			}
+			if got := builder.realityConfig.Xver; got != byte(test.xver) {
+				t.Fatalf("Xver = %d, want %d", got, test.xver)
+			}
+		})
+	}
+	_ = runtime.GOOS // unix address normalization has OS-specific follow-up coverage
+}
+
+func TestConfigBuildDialsUnixTarget(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("unix sockets are not available on Windows")
+	}
+	path := filepath.Join(os.TempDir(), "mihomo-reality-"+strconv.FormatInt(time.Now().UnixNano(), 10)+".sock")
+	defer os.Remove(path)
+	listener, err := net.Listen("unix", path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer listener.Close()
+
+	builder, err := validConfig(func(c *Config) {
+		c.Dest = ""
+		c.Target = path
+	}).Build(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	accepted := make(chan net.Conn, 1)
+	go func() {
+		conn, _ := listener.Accept()
+		accepted <- conn
+	}()
+	client, err := builder.realityConfig.DialContext(context.Background(), "unix", path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer client.Close()
+	server := <-accepted
+	if server == nil {
+		t.Fatal("unix target did not accept the REALITY dial")
+	}
+	defer server.Close()
+}
+
+func TestConfigBuildValidatesMldsa65Seed(t *testing.T) {
+	privateKey := base64.RawURLEncoding.EncodeToString(make([]byte, 32))
+	validSeedBytes := make([]byte, 32)
+	validSeedBytes[0] = 1
+	validSeed := base64.RawURLEncoding.EncodeToString(validSeedBytes)
+
+	tests := []struct {
+		name    string
+		seed    string
+		wantErr bool
+	}{
+		{name: "omitted"},
+		{name: "valid", seed: validSeed},
+		{name: "same as private key", seed: privateKey, wantErr: true},
+		{name: "wrong length", seed: base64.RawURLEncoding.EncodeToString(make([]byte, 31)), wantErr: true},
+		{name: "invalid base64", seed: "***", wantErr: true},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			builder, err := validConfig(func(c *Config) { c.Mldsa65Seed = test.seed }).Build(nil)
+			if test.wantErr {
+				if err == nil {
+					t.Fatal("Build() error = nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			if test.seed != "" && len(builder.mldsa65Seed) != 32 {
+				t.Fatalf("mldsa65 seed length = %d, want 32", len(builder.mldsa65Seed))
+			}
+		})
+	}
+}
+
+func TestConfigBuildOpensMasterKeyLog(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "reality.keys")
+	builder, err := validConfig(func(c *Config) { c.MasterKeyLog = path }).Build(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	writer := builder.realityConfig.KeyLogWriter
+	if writer == nil {
+		t.Fatal("KeyLogWriter = nil")
+	}
+	if _, err := io.WriteString(writer, "SERVER_HANDSHAKE_TRAFFIC_SECRET test\n"); err != nil {
+		t.Fatal(err)
+	}
+	if closer, ok := writer.(io.Closer); ok {
+		if err := closer.Close(); err != nil {
+			t.Fatal(err)
+		}
+	}
+	contents, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := string(contents), "SERVER_HANDSHAKE_TRAFFIC_SECRET test\n"; got != want {
+		t.Fatalf("key log = %q, want %q", got, want)
+	}
+}
+
+func validConfig(modify func(*Config)) Config {
+	c := Config{
+		Dest:        "127.0.0.1:443",
+		PrivateKey:  base64.RawURLEncoding.EncodeToString(make([]byte, 32)),
+		ShortID:     []string{"0123456789abcdef"},
+		ServerNames: []string{"example.com"},
+	}
+	if modify != nil {
+		modify(&c)
+	}
+	return c
+}
+
+func bytesEqual(a, b []byte) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
 }

--- a/openspec/changes/fix-reality-client-compatibility/.openspec.yaml
+++ b/openspec/changes/fix-reality-client-compatibility/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-16

--- a/openspec/changes/fix-reality-client-compatibility/design.md
+++ b/openspec/changes/fix-reality-client-compatibility/design.md
@@ -1,0 +1,72 @@
+## Context
+
+Mihomo currently starts from a valid uTLS browser preset and conditionally removes X25519MLKEM768 after `BuildHandshakeState`. That creates a ClientHello no released browser sends. REALITY authentication also embeds `1.8.2`, while Xray-core's JSON server configuration defaults `minClientVer` to `26.3.27`. Empty fingerprint selection fails before REALITY is invoked, and Mihomo's inbound `max-time-difference` conversion is 1000 times smaller than Xray's documented millisecond unit.
+
+The existing Mihomo-to-Mihomo tests cannot detect the version problem because Mihomo's embedded REALITY server does not set a minimum client version. End-to-end evidence must therefore include the local Xray-core checkout at `/Users/jesus/GolandProjects/Xray-core`.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Preserve genuine uTLS browser ClientHellos through the REALITY authentication transformation.
+- Match Xray-core's empty-fingerprint, minimum-version, and time-unit semantics.
+- Prove VLESS TCP and Vision interoperability against a launched Xray-core process.
+- Keep ordinary non-REALITY TLS fingerprint selection unchanged.
+
+**Non-Goals:**
+
+- Reimplement Xray's VLESS framing or Vision flow.
+- Add Xray's optional ML-DSA-65 configuration in this change.
+- Claim that Mihomo is the same product version as Xray-core; the three authentication bytes describe REALITY compatibility only.
+
+## Decisions
+
+### Preserve presets instead of editing ClientHello
+
+`GetRealityConn` will no longer call `BuildRemovedX25519MLKEM768HandshakeState`. The selected uTLS ID is authoritative. Users needing a pre-ML-KEM browser shape select an existing intact preset such as `chrome120`.
+
+The legacy `support-x25519mlkem768` field remains accepted for configuration compatibility but becomes a deprecated no-op. Removing the field immediately would turn existing YAML into an unknown-field failure in strict parsers; mapping `false` to Chrome 120 would still make `client-fingerprint: chrome` dishonest.
+
+### Default only REALITY's empty fingerprint
+
+`StreamTLSConn` will substitute Chrome Auto only when `cfg.Reality != nil` and `cfg.ClientFingerprint == ""`. The shared `GetFingerprint` function remains unchanged so other TLS transports keep their existing standard-library fallback. Explicit `none` remains an error for REALITY.
+
+### Advertise a protocol compatibility constant
+
+REALITY authentication will use a named `[3]byte{26, 3, 27}` compatibility constant and retain the reserved fourth byte as zero. Using Mihomo's release version would remain below Xray's version namespace, while copying Xray's latest release on every update would falsely imply unrelated feature parity. The minimum accepted version is the narrow honest compatibility contract exercised by the end-to-end test.
+
+### Correct time units at the inbound boundary
+
+`listener/reality.Config.Build` will convert the integer `max-time-difference` using `time.Millisecond`. The YAML name stays unchanged and documentation will explicitly state milliseconds.
+
+### Use layered TDD evidence
+
+Fast tests will capture the actual ClientHello emitted by `GetRealityConn`, verify empty-fingerprint routing at `StreamTLSConn`, inspect the public `Config.Build` conversion boundary, and authenticate against a REALITY server with `MinClientVer: []byte{26,3,27}`. A separately invokable integration test will launch the local Xray executable and transfer application data through VLESS TCP and Vision. This keeps ordinary CI deterministic while retaining a reproducible upstream interoperability gate.
+
+### Keep the current uTLS dependency unless evidence requires a fork change
+
+`github.com/metacubex/utls v1.8.7` already defines `HelloChrome_Auto` as Chrome 133, includes X25519MLKEM768 in its supported groups and key shares, and implements the hybrid exchange on both client and server paths. Updating or patching the dependency without a failing dependency-level test would add risk without addressing the Mihomo-side mutation.
+
+## Risks / Trade-offs
+
+- [Old REALITY servers may not support ML-KEM] → Require an explicit intact legacy fingerprint such as `chrome120` rather than emitting a synthetic current-Chrome fingerprint.
+- [Correcting milliseconds changes existing effective tolerances] → Document the unit and migration prominently; the old behavior contradicted Xray compatibility.
+- [Xray raises its default minimum in the future] → The external integration gate will fail and require an explicit compatibility review rather than silently spoofing a newer version.
+- [External integration depends on a local binary/path] → Gate it with an explicit executable environment variable and record the exact Xray commit used for verification.
+
+## Migration Plan
+
+1. Replace reliance on `support-x25519mlkem768: false` with `client-fingerprint: chrome120` only for servers that require a legacy profile.
+2. Treat all inbound `max-time-difference` values as milliseconds and adjust values that were chosen around the accidental microsecond conversion.
+3. Roll back by reverting the behavior commit; no persisted data migration is involved.
+
+## Open Questions
+
+None. Dependency changes remain conditional on a demonstrated failing uTLS test.
+
+## Verification Evidence
+
+- Xray-core source: `/Users/jesus/GolandProjects/Xray-core` at commit `50231eaff98ccc31b5cbd247a721c16e97fe5ec1` (the executable reports `50231ea-dirty` because that checkout contains unrelated untracked files).
+- Xray build: `go build -o /tmp/xray-core-reality ./main` from the Xray-core checkout.
+- End-to-end command: `XRAY_BINARY=/tmp/xray-core-reality go test ./listener/inbound -run '^TestVLESSRealityXrayInterop$' -v -count=1`.
+- Result: VLESS TCP with an empty fingerprint and VLESS Vision with Chrome Auto both transferred application data successfully through Xray 26.7.11. The JSON server configuration deliberately omitted `minClientVer`, exercising Xray's `26.3.27` default.

--- a/openspec/changes/fix-reality-client-compatibility/proposal.md
+++ b/openspec/changes/fix-reality-client-compatibility/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+Mihomo's REALITY client currently advertises a synthetic Chrome ClientHello, rejects an empty browser fingerprint, and reports an obsolete client version, so current Xray-core servers can reject or uniquely identify it. Mihomo's REALITY server also interprets `max-time-difference` in microseconds while Xray-core defines the setting in milliseconds.
+
+## What Changes
+
+- Make REALITY use an intact selected uTLS browser fingerprint; `chrome` must remain the exact `HelloChrome_Auto` profile including X25519MLKEM768.
+- Default an empty REALITY `client-fingerprint` to Chrome Auto, matching Xray-core.
+- Advertise an explicit REALITY compatibility version accepted by Xray-core's default `minClientVer` policy.
+- **BREAKING**: stop using `support-x25519mlkem768: false` to mutate a selected browser profile. Legacy servers must use an explicit intact legacy fingerprint such as `chrome120`.
+- **BREAKING**: interpret inbound `max-time-difference` as milliseconds, matching Xray-core rather than the current accidental microseconds.
+- Add public-behavior and end-to-end tests against a launched local Xray-core server, including VLESS TCP and Vision.
+- Update uTLS or its fork only if the tests demonstrate a dependency-level incompatibility.
+
+## Capabilities
+
+### New Capabilities
+
+- `reality-compatibility`: Defines Xray-compatible REALITY client fingerprint selection, version authentication, server time tolerance, and end-to-end VLESS interoperability.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+Affected areas include REALITY handshake construction in `component/tls`, REALITY fingerprint selection in outbound TLS setup, inbound REALITY configuration, VLESS integration tests, and configuration documentation. Existing configurations that rely on the legacy `support-x25519mlkem768: false` mutation or microsecond `max-time-difference` values must migrate to an explicit legacy fingerprint or millisecond value respectively.

--- a/openspec/changes/fix-reality-client-compatibility/specs/reality-compatibility/spec.md
+++ b/openspec/changes/fix-reality-client-compatibility/specs/reality-compatibility/spec.md
@@ -1,0 +1,52 @@
+## ADDED Requirements
+
+### Requirement: REALITY preserves the selected browser fingerprint
+The REALITY client SHALL send the intact uTLS ClientHello selected by `client-fingerprint` and MUST NOT add, remove, or reorder fingerprint extensions, supported groups, or key shares after uTLS builds it.
+
+#### Scenario: Current Chrome fingerprint
+- **WHEN** a REALITY connection uses `client-fingerprint: chrome`
+- **THEN** its ClientHello matches `HelloChrome_Auto`, including X25519MLKEM768 in both supported groups and key shares
+
+#### Scenario: Explicit legacy Chrome fingerprint
+- **WHEN** a REALITY connection uses `client-fingerprint: chrome120`
+- **THEN** it sends the intact Chrome 120 profile without synthesizing a modified current-Chrome profile
+
+#### Scenario: Deprecated ML-KEM support flag
+- **WHEN** a configuration contains the legacy `support-x25519mlkem768` option
+- **THEN** the option does not mutate the selected browser fingerprint
+
+### Requirement: REALITY defaults an empty browser fingerprint
+The TLS transport SHALL select `HelloChrome_Auto` when REALITY is enabled and `client-fingerprint` is empty, while preserving the existing empty-fingerprint behavior for non-REALITY TLS.
+
+#### Scenario: Empty REALITY fingerprint
+- **WHEN** REALITY is enabled and `client-fingerprint` is omitted or empty
+- **THEN** the connection uses `HelloChrome_Auto` and proceeds with the REALITY handshake
+
+#### Scenario: Explicit none remains invalid for REALITY
+- **WHEN** REALITY is enabled and `client-fingerprint` is explicitly `none`
+- **THEN** configuration or connection setup fails instead of silently selecting a browser fingerprint
+
+### Requirement: REALITY advertises an accepted compatibility version
+The REALITY authentication payload SHALL advertise a named compatibility version that is at least `26.3.27`, with the fourth version byte reserved as zero.
+
+#### Scenario: Xray default minimum client version
+- **WHEN** an Xray-core REALITY server uses its default `minClientVer` policy
+- **THEN** the server accepts Mihomo's authenticated client version
+
+### Requirement: REALITY server time tolerance uses Xray units
+The inbound `max-time-difference` setting SHALL be interpreted as milliseconds, matching Xray-core's JSON configuration.
+
+#### Scenario: Convert configured time tolerance
+- **WHEN** inbound REALITY is configured with `max-time-difference: 1500`
+- **THEN** the server permits an absolute client clock difference of up to 1500 milliseconds
+
+### Requirement: Mihomo interoperates with a current Xray-core server
+The project SHALL provide an end-to-end test that launches a current local Xray-core executable with a real JSON configuration and exercises Mihomo as a VLESS-over-REALITY client.
+
+#### Scenario: VLESS TCP over REALITY
+- **WHEN** Mihomo connects to the launched Xray-core server using VLESS TCP, an empty fingerprint, and the server's default REALITY minimum version
+- **THEN** application data traverses the connection successfully
+
+#### Scenario: VLESS Vision over REALITY
+- **WHEN** Mihomo connects to the launched Xray-core server using `xtls-rprx-vision`, Chrome Auto, and the server's default REALITY minimum version
+- **THEN** application data traverses the connection successfully

--- a/openspec/changes/fix-reality-client-compatibility/tasks.md
+++ b/openspec/changes/fix-reality-client-compatibility/tasks.md
@@ -1,0 +1,27 @@
+## 1. RED: Compatibility Tests
+
+- [x] 1.1 Add a failing test that captures REALITY's emitted Chrome ClientHello and requires intact X25519MLKEM768 groups and key shares
+- [x] 1.2 Add failing transport tests for empty REALITY fingerprint defaulting and explicit `none` rejection
+- [x] 1.3 Add a failing handshake test requiring the authenticated REALITY client version to satisfy `26.3.27`
+- [x] 1.4 Add a failing inbound configuration test requiring `max-time-difference` milliseconds
+
+## 2. GREEN: Client and Server Behavior
+
+- [x] 2.1 Remove post-build ClientHello mutation and make the legacy ML-KEM support option a compatibility no-op
+- [x] 2.2 Default empty REALITY fingerprint selection to Chrome Auto without changing non-REALITY TLS
+- [x] 2.3 Replace the obsolete REALITY version bytes with a named `26.3.27` compatibility constant
+- [x] 2.4 Convert inbound `max-time-difference` using milliseconds
+- [x] 2.5 Update configuration documentation and migration guidance
+
+## 3. Upstream End-to-End Verification
+
+- [x] 3.1 Add a reproducible integration test that launches a supplied Xray-core executable with default `minClientVer`
+- [x] 3.2 Prove VLESS TCP over REALITY transfers application data with an empty fingerprint
+- [x] 3.3 Prove VLESS Vision over REALITY transfers application data with Chrome Auto
+- [x] 3.4 Record the exact Xray-core commit and integration command used for verification
+
+## 4. Completion Audit
+
+- [x] 4.1 Run focused REALITY, VLESS, VMess, and Trojan test packages
+- [x] 4.2 Run formatting, static checks, and the project-wide feasible Go test suite
+- [x] 4.3 Validate OpenSpec artifacts and confirm every requirement has authoritative evidence

--- a/openspec/changes/synchronize-reality-with-xray/.openspec.yaml
+++ b/openspec/changes/synchronize-reality-with-xray/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-16

--- a/transport/vmess/tls.go
+++ b/transport/vmess/tls.go
@@ -111,7 +111,11 @@ func StreamTLSConn(ctx context.Context, conn net.Conn, cfg *TLSConfig) (net.Conn
 		return nil, err
 	}
 
-	if clientFingerprint, ok := tlsC.GetFingerprint(cfg.ClientFingerprint); ok {
+	clientFingerprintName := cfg.ClientFingerprint
+	if cfg.Reality != nil && clientFingerprintName == "" {
+		clientFingerprintName = "chrome"
+	}
+	if clientFingerprint, ok := tlsC.GetFingerprint(clientFingerprintName); ok {
 		if cfg.Reality != nil {
 			return tlsC.GetRealityConn(ctx, conn, clientFingerprint, tlsConfig.ServerName, cfg.Reality)
 		}

--- a/transport/vmess/tls_test.go
+++ b/transport/vmess/tls_test.go
@@ -1,0 +1,74 @@
+package vmess
+
+import (
+	"context"
+	"crypto/ecdh"
+	"crypto/rand"
+	"net"
+	"strings"
+	"testing"
+	"time"
+
+	tlsC "github.com/metacubex/mihomo/component/tls"
+)
+
+func TestStreamTLSConnDefaultsEmptyRealityFingerprint(t *testing.T) {
+	privateKey, err := ecdh.X25519().GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	client, server := net.Pipe()
+	defer client.Close()
+	defer server.Close()
+	_ = client.SetDeadline(time.Now().Add(3 * time.Second))
+	_ = server.SetDeadline(time.Now().Add(3 * time.Second))
+
+	result := make(chan error, 1)
+	go func() {
+		_, err := StreamTLSConn(context.Background(), client, &TLSConfig{
+			Host: "example.com",
+			Reality: &tlsC.RealityConfig{
+				PublicKey: privateKey.PublicKey(),
+			},
+		})
+		result <- err
+	}()
+
+	header := make([]byte, 1)
+	readResult := make(chan error, 1)
+	go func() {
+		_, err := server.Read(header)
+		readResult <- err
+	}()
+	select {
+	case err := <-result:
+		t.Fatalf("empty REALITY fingerprint failed before ClientHello: %v", err)
+	case err := <-readResult:
+		if err != nil {
+			t.Fatalf("read ClientHello: %v", err)
+		}
+		if header[0] != 22 {
+			t.Fatalf("first TLS record type = %d, want handshake (22)", header[0])
+		}
+	}
+}
+
+func TestStreamTLSConnRejectsExplicitNoneRealityFingerprint(t *testing.T) {
+	privateKey, err := ecdh.X25519().GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	client, server := net.Pipe()
+	defer client.Close()
+	defer server.Close()
+	_, err = StreamTLSConn(context.Background(), client, &TLSConfig{
+		Host:              "example.com",
+		ClientFingerprint: "none",
+		Reality: &tlsC.RealityConfig{
+			PublicKey: privateKey.PublicKey(),
+		},
+	})
+	if err == nil || !strings.Contains(err.Error(), "client-fingerprint") {
+		t.Fatalf("explicit none error = %v, want client-fingerprint error", err)
+	}
+}


### PR DESCRIPTION
Synchronizes Mihomo REALITY client and server behavior with Xray-core 26.7.11 and the minimum-version validation intent of Xray-core PR #6507.

Highlights:
- preserves the configured ClientHello fingerprint and X25519MLKEM768
- adds optional ML-DSA-65 verification and server signing
- adds target/type/xver, version bounds, unix targets, key logging, and Xray-compatible spider fallback
- backports the Go 1.20-compatible server runtime through MetaCubeX/utls PR #4
- adds bidirectional Mihomo/Xray interop coverage

Validation:
- `go test ./...`
- `go test ./... -tags with_gvisor -count=1`
- focused race-enabled ML-KEM/ML-DSA interop
- Go 1.20.14 compile checks
- strict OpenSpec validation

This branch contains no mux.cool commits.
