### PR TITLE
feat(openvpn): TLS rekey fix, data-ciphers negotiation, tls-crypt-v2

### DIFF
--- a/adapter/outbound/openvpn.go
+++ b/adapter/outbound/openvpn.go
@@ -46,8 +46,10 @@ type OpenVPNOption struct {
 	Port             int               `proxy:"port"`
 	Proto            string            `proxy:"proto,omitempty"`
 	Dev              string            `proxy:"dev,omitempty"`
-	Cipher           string            `proxy:"cipher,omitempty"`
-	Auth             string            `proxy:"auth,omitempty"`
+	Cipher             string            `proxy:"cipher,omitempty"`
+	DataCiphers        []string          `proxy:"data-ciphers,omitempty"`
+	DataCipherFallback string            `proxy:"data-ciphers-fallback,omitempty"`
+	Auth               string            `proxy:"auth,omitempty"`
 	CompLZO          string            `proxy:"comp-lzo,omitempty"`
 	CA               string            `proxy:"ca"`
 	Cert             string            `proxy:"cert,omitempty"`
@@ -55,6 +57,7 @@ type OpenVPNOption struct {
 	TLSAuth          string            `proxy:"tls-auth,omitempty"`
 	KeyDirection     string            `proxy:"key-direction,omitempty"`
 	TLSCrypt         string            `proxy:"tls-crypt,omitempty"`
+	TLSCryptV2       string            `proxy:"tls-crypt-v2,omitempty"`
 	Username         string            `proxy:"username,omitempty"`
 	Password         string            `proxy:"password,omitempty"`
 	PeerInfo         map[string]string `proxy:"peer-info,omitempty"`
@@ -77,7 +80,9 @@ func NewOpenVPN(option OpenVPNOption) (*OpenVPN, error) {
 		RemotePort:   uint16(option.Port),
 		Proto:        option.Proto,
 		Dev:          option.Dev,
-		Cipher:       option.Cipher,
+		Cipher:         option.Cipher,
+		DataCiphers:    option.DataCiphers,
+		FallbackCipher: option.DataCipherFallback,
 		Auth:         option.Auth,
 		CompLZO:      option.CompLZO,
 		CA:           []byte(option.CA),
@@ -86,6 +91,7 @@ func NewOpenVPN(option OpenVPNOption) (*OpenVPN, error) {
 		TLSAuth:      []byte(option.TLSAuth),
 		KeyDirection: option.KeyDirection,
 		TLSCrypt:     []byte(option.TLSCrypt),
+		TLSCryptV2:   []byte(option.TLSCryptV2),
 		Username:     option.Username,
 		Password:     option.Password,
 		PeerInfo:     option.PeerInfo,

--- a/adapter/outbound/openvpn.go
+++ b/adapter/outbound/openvpn.go
@@ -41,31 +41,31 @@ type OpenVPN struct {
 
 type OpenVPNOption struct {
 	BasicOption
-	Name             string            `proxy:"name"`
-	Server           string            `proxy:"server"`
-	Port             int               `proxy:"port"`
-	Proto            string            `proxy:"proto,omitempty"`
-	Dev              string            `proxy:"dev,omitempty"`
+	Name               string            `proxy:"name"`
+	Server             string            `proxy:"server"`
+	Port               int               `proxy:"port"`
+	Proto              string            `proxy:"proto,omitempty"`
+	Dev                string            `proxy:"dev,omitempty"`
 	Cipher             string            `proxy:"cipher,omitempty"`
 	DataCiphers        []string          `proxy:"data-ciphers,omitempty"`
 	DataCipherFallback string            `proxy:"data-ciphers-fallback,omitempty"`
 	Auth               string            `proxy:"auth,omitempty"`
-	CompLZO          string            `proxy:"comp-lzo,omitempty"`
-	CA               string            `proxy:"ca"`
-	Cert             string            `proxy:"cert,omitempty"`
-	Key              string            `proxy:"key,omitempty"`
-	TLSAuth          string            `proxy:"tls-auth,omitempty"`
-	KeyDirection     string            `proxy:"key-direction,omitempty"`
-	TLSCrypt         string            `proxy:"tls-crypt,omitempty"`
-	TLSCryptV2       string            `proxy:"tls-crypt-v2,omitempty"`
-	Username         string            `proxy:"username,omitempty"`
-	Password         string            `proxy:"password,omitempty"`
-	PeerInfo         map[string]string `proxy:"peer-info,omitempty"`
-	Ping             int               `proxy:"ping,omitempty"`
-	PingRestart      int               `proxy:"ping-restart,omitempty"`
-	HandshakeTimeout int               `proxy:"handshake-timeout,omitempty"`
-	MTU              int               `proxy:"mtu,omitempty"`
-	UDP              bool              `proxy:"udp,omitempty"`
+	CompLZO            string            `proxy:"comp-lzo,omitempty"`
+	CA                 string            `proxy:"ca"`
+	Cert               string            `proxy:"cert,omitempty"`
+	Key                string            `proxy:"key,omitempty"`
+	TLSAuth            string            `proxy:"tls-auth,omitempty"`
+	KeyDirection       string            `proxy:"key-direction,omitempty"`
+	TLSCrypt           string            `proxy:"tls-crypt,omitempty"`
+	TLSCryptV2         string            `proxy:"tls-crypt-v2,omitempty"`
+	Username           string            `proxy:"username,omitempty"`
+	Password           string            `proxy:"password,omitempty"`
+	PeerInfo           map[string]string `proxy:"peer-info,omitempty"`
+	Ping               int               `proxy:"ping,omitempty"`
+	PingRestart        int               `proxy:"ping-restart,omitempty"`
+	HandshakeTimeout   int               `proxy:"handshake-timeout,omitempty"`
+	MTU                int               `proxy:"mtu,omitempty"`
+	UDP                bool              `proxy:"udp,omitempty"`
 
 	RemoteDnsResolve bool     `proxy:"remote-dns-resolve,omitempty"`
 	Dns              []string `proxy:"dns,omitempty"`
@@ -76,27 +76,27 @@ func NewOpenVPN(option OpenVPNOption) (*OpenVPN, error) {
 		return nil, errors.New("openvpn handshake timeout must be non-negative")
 	}
 	cfg := &ovpn.ClientConfig{
-		RemoteHost:   option.Server,
-		RemotePort:   uint16(option.Port),
-		Proto:        option.Proto,
-		Dev:          option.Dev,
+		RemoteHost:     option.Server,
+		RemotePort:     uint16(option.Port),
+		Proto:          option.Proto,
+		Dev:            option.Dev,
 		Cipher:         option.Cipher,
 		DataCiphers:    option.DataCiphers,
 		FallbackCipher: option.DataCipherFallback,
-		Auth:         option.Auth,
-		CompLZO:      option.CompLZO,
-		CA:           []byte(option.CA),
-		Cert:         []byte(option.Cert),
-		Key:          []byte(option.Key),
-		TLSAuth:      []byte(option.TLSAuth),
-		KeyDirection: option.KeyDirection,
-		TLSCrypt:     []byte(option.TLSCrypt),
-		TLSCryptV2:   []byte(option.TLSCryptV2),
-		Username:     option.Username,
-		Password:     option.Password,
-		PeerInfo:     option.PeerInfo,
-		PingInterval: time.Duration(option.Ping) * time.Second,
-		PingRestart:  time.Duration(option.PingRestart) * time.Second,
+		Auth:           option.Auth,
+		CompLZO:        option.CompLZO,
+		CA:             []byte(option.CA),
+		Cert:           []byte(option.Cert),
+		Key:            []byte(option.Key),
+		TLSAuth:        []byte(option.TLSAuth),
+		KeyDirection:   option.KeyDirection,
+		TLSCrypt:       []byte(option.TLSCrypt),
+		TLSCryptV2:     []byte(option.TLSCryptV2),
+		Username:       option.Username,
+		Password:       option.Password,
+		PeerInfo:       option.PeerInfo,
+		PingInterval:   time.Duration(option.Ping) * time.Second,
+		PingRestart:    time.Duration(option.PingRestart) * time.Second,
 	}
 	if err := cfg.Prepare(); err != nil {
 		return nil, err

--- a/docs/config.yaml
+++ b/docs/config.yaml
@@ -1359,6 +1359,8 @@ proxies: # socks5
     proto: udp # udp/tcp，默认 udp
     # dev: tun # 目前仅支持 tun，默认 tun
     # cipher: AES-128-GCM # 支持 AES-128-GCM / AES-192-GCM / AES-256-GCM / AES-128-CBC / AES-192-CBC / AES-256-CBC / CHACHA20-POLY1305，默认 AES-128-GCM；AES-CBC 会按 AES-128-CBC 处理
+    # data-ciphers: [AES-256-GCM, AES-128-GCM] # 数据通道 cipher 协商列表，发送 IV_CIPHERS 给服务端；服务端 push 的 cipher 列表与本地列表取交集，取第一个匹配项
+    # data-ciphers-fallback: AES-128-CBC # 协商失败时的回退 cipher（对应 --data-ciphers-fallback）
     # auth: SHA256 # 支持 MD5 / SHA1 / SHA256 / SHA384 / SHA512，默认 SHA256；AEAD cipher 会忽略 auth
     # comp-lzo: "no" # 可选值："yes", "no", "adaptive"
     # username / password: auth-user-pass 模式（与下方 cert+key 二选一，不能都不填）
@@ -1386,12 +1388,17 @@ proxies: # socks5
     #   ...
     #   -----END OpenVPN Static key V1-----
     # key-direction: "1" # tls-auth 使用，支持 "1" 或 "0"；如果不填或为空字符串，则为双向模式（bidirectional）
-    # 从 .ovpn 中复制 <tls-crypt></tls-crypt> 内的内容，不需要保留 <tls-crypt> 标签；没有 tls-crypt 的配置可省略
+    # 从 .ovpn 中复制 <tls-crypt></tls-crypt> 内的内容，不需要保留 <tls-crypt> 标签；没有 tls-crypt 的配置可省略；与 tls-auth / tls-crypt-v2 互斥
     # tls-crypt: |
     #   -----BEGIN OpenVPN Static key V1-----
     #   00000000000000000000000000000000
     #   ...
     #   -----END OpenVPN Static key V1-----
+    # 从 .ovpn 中复制 <tls-crypt-v2></tls-crypt-v2> 内的内容；tls-crypt-v2 使用独立客户端密钥（PEM 内含 256 字节密钥 + wrapped key）；与 tls-auth / tls-crypt 互斥
+    # tls-crypt-v2: |
+    #   -----BEGIN OpenVPN tls-crypt-v2 client key-----
+    #   AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8...
+    #   -----END OpenVPN tls-crypt-v2 client key-----
     # peer-info: # 透传给服务端的 peer-info 键值对，追加在内置 IV_VER/IV_PROTO/IV_CIPHERS 之后；用于服务端基于 peer-info 做准入决策
     #   IV_HWADDR: "52:54:00:ff:72:87"
     #   UV_DEVICE_ID: "laptop-001"

--- a/transport/openvpn/client.go
+++ b/transport/openvpn/client.go
@@ -248,15 +248,17 @@ func (c *Client) writeDataPacket(ctx context.Context, packet []byte, compress bo
 
 func (c *Client) ReadIPPacket(ctx context.Context) ([]byte, error) {
 	for {
+		packet, err := c.mux.ReadDataPacket(ctx)
+		if err != nil {
+			return nil, err
+		}
+		// Re-acquire the data channel after reading, since a rekey may have
+		// swapped c.data while ReadDataPacket was blocked.
 		c.dataLock.RLock()
 		data := c.data
 		c.dataLock.RUnlock()
 		if data == nil {
 			return nil, errors.New("openvpn data channel is not ready")
-		}
-		packet, err := c.mux.ReadDataPacket(ctx)
-		if err != nil {
-			return nil, err
 		}
 		plain, err := data.Decrypt(packet)
 		if err != nil {

--- a/transport/openvpn/client.go
+++ b/transport/openvpn/client.go
@@ -217,16 +217,18 @@ func (c *Client) WritePing(ctx context.Context) error {
 }
 
 func (c *Client) writeDataPacket(ctx context.Context, packet []byte, compress bool) error {
+	if err := c.writeSem.Acquire(ctx, 1); err != nil {
+		return err
+	}
+	defer c.writeSem.Release(1)
+	// Acquire the data channel after securing the write semaphore, since a
+	// rekey may swap c.data while Acquire is blocked.
 	c.dataLock.RLock()
 	data := c.data
 	c.dataLock.RUnlock()
 	if data == nil {
 		return errors.New("openvpn data channel is not ready")
 	}
-	if err := c.writeSem.Acquire(ctx, 1); err != nil {
-		return err
-	}
-	defer c.writeSem.Release(1)
 	if compress && c.config.CompLZO == CompLzoYes {
 		compressed, err := lzo1xCompressSafe(packet)
 		if err != nil {

--- a/transport/openvpn/client.go
+++ b/transport/openvpn/client.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"net"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -18,6 +19,11 @@ import (
 
 const (
 	ControlRetransmitDelay = time.Second
+
+	// renegotiateTimeout is the maximum time allowed for a TLS renegotiation
+	// (rekey) cycle. OpenVPN servers typically rekey every hour; the
+	// renegotiation itself should complete in seconds.
+	renegotiateTimeout = 30 * time.Second
 )
 
 type Client struct {
@@ -28,6 +34,14 @@ type Client struct {
 	tlsConn *tls.Conn
 	data    *DataChannel
 	push    *PushReply
+
+	// negotiatedCipher is the data channel cipher selected during the most
+	// recent key exchange.
+	negotiatedCipher string
+
+	// dataLock protects c.data during TLS renegotiation (rekey), where the
+	// DataChannel is atomically replaced.
+	dataLock sync.RWMutex
 
 	runCtx context.Context
 	cancel context.CancelFunc
@@ -46,7 +60,13 @@ func NewClient(config *ClientConfig, io PacketIO) (*Client, error) {
 		return nil, errors.New("nil openvpn packet io")
 	}
 	var crypt ControlCryptor
-	if len(config.TLSCryptKey) > 0 {
+	if len(config.TLSCryptV2Key) > 0 || len(config.TLSCryptV2WrappedKey) > 0 {
+		var err error
+		crypt, err = NewTLSCryptV2(config.TLSCryptV2Key, config.TLSCryptV2WrappedKey)
+		if err != nil {
+			return nil, err
+		}
+	} else if len(config.TLSCryptKey) > 0 {
 		var err error
 		crypt, err = NewTLSCrypt(config.TLSCryptKey, true)
 		if err != nil {
@@ -103,9 +123,28 @@ func (c *Client) Handshake(ctx context.Context) (*PushReply, error) {
 		return nil, fmt.Errorf("openvpn tls handshake: %w", err)
 	}
 
+	push, err := c.doKeyExchange(ctx)
+	if err != nil {
+		return nil, err
+	}
+	_ = c.tlsConn.SetDeadline(time.Time{})
+	go c.watchControl()
+	return push, nil
+}
+
+// doKeyExchange performs the OpenVPN key method 2 exchange over the TLS
+// control channel and creates a fresh data channel. It is used both for the
+// initial handshake and for subsequent TLS renegotiations (rekeys).
+// On success, c.data is atomically replaced with the new DataChannel.
+func (c *Client) doKeyExchange(ctx context.Context) (*PushReply, error) {
+	primaryCipher := c.config.Cipher
+	if len(c.config.DataCiphers) > 0 {
+		primaryCipher = normalizeCipher(c.config.DataCiphers[0])
+	}
+
 	clientRecord, err := NewClientKeyMethod2Record(
-		InstallScriptOptionsString(c.config.Proto, c.config.Cipher, c.config.Auth, c.config.CompLZO),
-		InstallScriptPeerInfo(c.config.Cipher, c.config.CompLZO, c.config.PeerInfo),
+		InstallScriptOptionsString(c.config.Proto, primaryCipher, c.config.Auth, c.config.CompLZO),
+		InstallScriptPeerInfo(primaryCipher, c.config.DataCiphers, c.config.CompLZO, c.config.PeerInfo),
 		strings.TrimSpace(c.config.Username),
 		c.config.Password,
 	)
@@ -124,9 +163,12 @@ func (c *Client) Handshake(ctx context.Context) (*PushReply, error) {
 		return nil, err
 	}
 
+	// Derive keys using the maximum cipher key length (32 bytes). The actual
+	// cipher is determined after the push reply, and keys are sliced to the
+	// correct length at that point.
 	sources := clientRecord.Sources
 	sources.Server = serverRecord.Sources.Server
-	keys, err := DeriveClientKeyMaterial(sources, c.control.LocalSessionID(), c.control.RemoteSessionID(), c.config.DataCipherKeyLength())
+	keys, err := DeriveClientKeyMaterial(sources, c.control.LocalSessionID(), c.control.RemoteSessionID(), 32)
 	if err != nil {
 		return nil, fmt.Errorf("derive data channel keys: %w", err)
 	}
@@ -139,14 +181,30 @@ func (c *Client) Handshake(ctx context.Context) (*PushReply, error) {
 		return nil, err
 	}
 	c.push = push
-	c.data, err = NewDataChannel(keys, c.config.Cipher, c.config.Auth, push.PeerID)
+
+	// Negotiate the data channel cipher based on the push reply.
+	negotiatedCipher, err := c.config.NegotiateCipher(push.DataCiphers, push.Cipher)
+	if err != nil {
+		return nil, fmt.Errorf("negotiate data cipher: %w", err)
+	}
+	c.negotiatedCipher = negotiatedCipher
+
+	// Slice the derived keys to the negotiated cipher's key length.
+	cipherKeyLen := CipherKeyLength(negotiatedCipher)
+	keys.SendCipherKey = keys.SendCipherKey[:cipherKeyLen]
+	keys.RecvCipherKey = keys.RecvCipherKey[:cipherKeyLen]
+
+	newData, err := NewDataChannel(keys, negotiatedCipher, c.config.Auth, push.PeerID)
 	if err != nil {
 		return nil, err
 	}
+	c.dataLock.Lock()
+	oldData := c.data
+	c.data = newData
+	c.dataLock.Unlock()
+	_ = oldData
 	c.markSend()
 	c.markReceive()
-	_ = c.tlsConn.SetDeadline(time.Time{})
-	go c.watchControl()
 	return push, nil
 }
 
@@ -159,7 +217,10 @@ func (c *Client) WritePing(ctx context.Context) error {
 }
 
 func (c *Client) writeDataPacket(ctx context.Context, packet []byte, compress bool) error {
-	if c.data == nil {
+	c.dataLock.RLock()
+	data := c.data
+	c.dataLock.RUnlock()
+	if data == nil {
 		return errors.New("openvpn data channel is not ready")
 	}
 	if err := c.writeSem.Acquire(ctx, 1); err != nil {
@@ -173,7 +234,7 @@ func (c *Client) writeDataPacket(ctx context.Context, packet []byte, compress bo
 		}
 		packet = compressed
 	}
-	encrypted, err := c.data.Encrypt(packet)
+	encrypted, err := data.Encrypt(packet)
 	if err != nil {
 		return err
 	}
@@ -186,15 +247,18 @@ func (c *Client) writeDataPacket(ctx context.Context, packet []byte, compress bo
 }
 
 func (c *Client) ReadIPPacket(ctx context.Context) ([]byte, error) {
-	if c.data == nil {
-		return nil, errors.New("openvpn data channel is not ready")
-	}
 	for {
+		c.dataLock.RLock()
+		data := c.data
+		c.dataLock.RUnlock()
+		if data == nil {
+			return nil, errors.New("openvpn data channel is not ready")
+		}
 		packet, err := c.mux.ReadDataPacket(ctx)
 		if err != nil {
 			return nil, err
 		}
-		plain, err := c.data.Decrypt(packet)
+		plain, err := data.Decrypt(packet)
 		if err != nil {
 			continue
 		}
@@ -209,12 +273,55 @@ func (c *Client) ReadIPPacket(ctx context.Context) ([]byte, error) {
 	}
 }
 
-// watchControl terminates the client when the established control channel
-// starts a new key epoch or otherwise stops.
+// watchControl monitors the control channel for TLS renegotiation requests
+// (soft resets / rekeys). When the server initiates a rekey, the client
+// performs a full TLS renegotiation followed by a new key method 2 exchange,
+// then atomically swaps in a fresh DataChannel. If renegotiation fails or
+// the control channel stops, the client is terminated.
 func (c *Client) watchControl() {
-	_ = c.control.waitForSoftReset(c.runCtx)
-	c.cancel()
-	_ = c.mux.Close()
+	for {
+		err := c.control.waitForSoftReset(c.runCtx)
+		if err != nil {
+			c.cancel()
+			_ = c.mux.Close()
+			return
+		}
+		if err := c.renegotiate(); err != nil {
+			c.cancel()
+			_ = c.mux.Close()
+			return
+		}
+	}
+}
+
+// errRenegotiateNoTLS is returned when renegotiate() is called before a TLS
+// connection has been established.
+var errRenegotiateNoTLS = errors.New("cannot renegotiate: tls connection not established")
+
+// renegotiate performs a single TLS renegotiation cycle:
+// 1. Send our own soft reset to acknowledge the server's rekey request
+// 2. Renegotiate the TLS session on the existing tlsConn
+// 3. Exchange fresh key method 2 records and derive new data channel keys
+// 4. Atomically replace c.data with the new DataChannel
+func (c *Client) renegotiate() error {
+	if c.tlsConn == nil {
+		return errRenegotiateNoTLS
+	}
+	renegCtx, cancel := context.WithTimeout(c.runCtx, renegotiateTimeout)
+	defer cancel()
+
+	if err := c.control.SendSoftReset(renegCtx); err != nil {
+		return fmt.Errorf("send soft reset: %w", err)
+	}
+
+	if err := c.tlsConn.HandshakeContext(renegCtx); err != nil {
+		return fmt.Errorf("tls renegotiation: %w", err)
+	}
+
+	if _, err := c.doKeyExchange(renegCtx); err != nil {
+		return fmt.Errorf("rekey exchange: %w", err)
+	}
+	return nil
 }
 
 func (c *Client) SinceSend() time.Duration {
@@ -353,6 +460,9 @@ func (c *Client) tlsConfig() (*tls.Config, error) {
 	cfg := &tls.Config{
 		InsecureSkipVerify: true,
 		VerifyConnection:   verify,
+		// Allow the server to initiate TLS renegotiation (rekey). OpenVPN
+		// servers rekey the control channel at regular intervals (default 1h).
+		Renegotiation: tls.RenegotiateFreelyAsClient,
 	}
 	certPEM := bytes.TrimSpace(c.config.Cert)
 	keyPEM := bytes.TrimSpace(c.config.Key)

--- a/transport/openvpn/config.go
+++ b/transport/openvpn/config.go
@@ -61,17 +61,116 @@ type ClientConfig struct {
 
 	TLSCryptKey []byte
 	TLSAuthKey  []byte
+
+	// TLSCryptV2Key is the first 256 bytes of tls-crypt-v2 client key material.
+	TLSCryptV2Key []byte
+	// TLSCryptV2WrappedKey is appended to the initial V3 hard-reset packet.
+	TLSCryptV2WrappedKey []byte
+	// TLSCryptV2 is the raw PEM-encoded OpenVPN tls-crypt-v2 client key.
+	TLSCryptV2 []byte
+
+	// DataCiphers is the list of data channel ciphers the client offers to
+	// the server for negotiation (OpenVPN --data-ciphers). If non-empty, the
+	// negotiated cipher is the first entry in the server's pushed cipher list
+	// that also appears here. If empty, the single Cipher field is used.
+	DataCiphers []string
+
+	// FallbackCipher is used when the server does not support cipher
+	// negotiation (OpenVPN --data-ciphers-fallback).
+	FallbackCipher string
 }
 
 // DataCipherKeyLength returns the key size for the negotiated data cipher.
 func (c ClientConfig) DataCipherKeyLength() int {
-	switch c.Cipher {
+	return CipherKeyLength(c.Cipher)
+}
+
+// CipherKeyLength returns the key size for a given cipher name.
+func CipherKeyLength(cipher string) int {
+	switch cipher {
 	case CipherAES256GCM, CipherAES256CBC, CipherChaCha20Poly1305:
 		return 32
 	case CipherAES192GCM, CipherAES192CBC:
 		return 24
 	default:
 		return 16
+	}
+}
+
+// NegotiateCipher selects the data channel cipher based on the server-pushed
+// cipher list and the locally configured DataCiphers list.
+//
+// If the server pushed a cipher list (via "data-ciphers" or "cipher" push
+// options), the result is the first cipher in the server's list that also
+// appears in the local DataCiphers list. If no intersection exists and a
+// FallbackCipher is configured, it is used. If no fallback is configured but
+// the server pushed a single cipher that matches the local Cipher, that is
+// used.
+//
+// If the server did not push any cipher options, the local Cipher is used
+// as-is (legacy behavior for servers without cipher negotiation).
+func (c ClientConfig) NegotiateCipher(pushedCiphers []string, pushedCipher string) (string, error) {
+	if len(pushedCiphers) == 0 && pushedCipher == "" {
+		return c.Cipher, nil
+	}
+
+	if len(c.DataCiphers) > 0 {
+		serverList := pushedCiphers
+		if len(serverList) == 0 && pushedCipher != "" {
+			serverList = []string{pushedCipher}
+		}
+		for _, serverCipher := range serverList {
+			normalized := normalizeCipher(serverCipher)
+			for _, localCipher := range c.DataCiphers {
+				if normalizeCipher(localCipher) == normalized {
+					return normalized, nil
+				}
+			}
+		}
+		if c.FallbackCipher != "" {
+			return normalizeCipher(c.FallbackCipher), nil
+		}
+		return "", fmt.Errorf("no common data cipher between client %v and server %v", c.DataCiphers, serverList)
+	}
+
+	if pushedCipher != "" {
+		normalized := normalizeCipher(pushedCipher)
+		if normalized == c.Cipher {
+			return normalized, nil
+		}
+		if c.FallbackCipher != "" {
+			return normalizeCipher(c.FallbackCipher), nil
+		}
+		if isSupportedCipher(normalized) {
+			return normalized, nil
+		}
+		return "", fmt.Errorf("server pushed unsupported cipher %q", pushedCipher)
+	}
+
+	if len(pushedCiphers) > 0 {
+		for _, sc := range pushedCiphers {
+			normalized := normalizeCipher(sc)
+			if isSupportedCipher(normalized) {
+				if c.FallbackCipher != "" {
+					return normalizeCipher(c.FallbackCipher), nil
+				}
+				return normalized, nil
+			}
+		}
+	}
+
+	return c.Cipher, nil
+}
+
+// isSupportedCipher returns true if the cipher name is recognized.
+func isSupportedCipher(cipher string) bool {
+	switch cipher {
+	case CipherAES128GCM, CipherAES192GCM, CipherAES256GCM,
+		CipherAES128CBC, CipherAES192CBC, CipherAES256CBC,
+		CipherChaCha20Poly1305:
+		return true
+	default:
+		return false
 	}
 }
 
@@ -154,6 +253,14 @@ func (c *ClientConfig) Prepare() error {
 		}
 		c.TLSCryptKey = key
 	}
+	if len(bytes.TrimSpace(c.TLSCryptV2)) > 0 {
+		keyMaterial, wrappedKey, err := DecodeTLSCryptV2ClientKey(c.TLSCryptV2)
+		if err != nil {
+			return fmt.Errorf("parse tls-crypt-v2 client key: %w", err)
+		}
+		c.TLSCryptV2Key = keyMaterial
+		c.TLSCryptV2WrappedKey = wrappedKey
+	}
 	return nil
 }
 
@@ -181,6 +288,11 @@ func (c *ClientConfig) ValidateInstallScriptSubset() error {
 	}
 	if len(bytes.TrimSpace(c.TLSAuth)) > 0 && len(bytes.TrimSpace(c.TLSCrypt)) > 0 {
 		return errors.New("openvpn tls-auth and tls-crypt are mutually exclusive")
+	}
+	if len(bytes.TrimSpace(c.TLSCryptV2)) > 0 {
+		if len(bytes.TrimSpace(c.TLSAuth)) > 0 || len(bytes.TrimSpace(c.TLSCrypt)) > 0 {
+			return errors.New("openvpn tls-crypt-v2 is mutually exclusive with tls-auth and tls-crypt")
+		}
 	}
 	for name, value := range map[string][]byte{
 		"ca": c.CA,

--- a/transport/openvpn/control.go
+++ b/transport/openvpn/control.go
@@ -67,7 +67,29 @@ func (c *ControlChannel) SetRemoteSessionID(id SessionID) {
 }
 
 func (c *ControlChannel) SendReset(ctx context.Context) error {
-	_, err := c.Send(ctx, PControlHardResetClientV2, nil)
+	opcode := PControlHardResetClientV2
+	if _, isTLSCryptV2 := c.crypt.(*TLSCryptV2); isTLSCryptV2 {
+		opcode = PControlHardResetClientV3
+	}
+	_, err := c.Send(ctx, opcode, nil)
+	return err
+}
+
+// SendSoftReset sends a P_CONTROL_SOFT_RESET_V1 and rotates the key ID.
+// Called during TLS renegotiation (rekey) to transition to a new key epoch.
+// The old pending/recvPending maps are cleared because they belong to the
+// previous key epoch; the message counters are reset for the new epoch.
+func (c *ControlChannel) SendSoftReset(ctx context.Context) error {
+	c.mu.Lock()
+	newKeyID := c.keyID ^ 1 // toggle 0<->1
+	c.keyID = newKeyID
+	c.sendMessage = 0
+	c.recvMessage = 0
+	c.ackPending = nil
+	c.pending = make(map[uint32]*ControlPacket)
+	c.recvPending = make(map[uint32]*ControlPacket)
+	c.mu.Unlock()
+	_, err := c.Send(ctx, PControlSoftResetV1, nil)
 	return err
 }
 
@@ -233,7 +255,10 @@ func (c *ControlChannel) classifyWatchPacketLocked(packet *ControlPacket) (softR
 		return false, false
 	}
 	if packet.Opcode == PControlSoftResetV1 {
-		return packet.KeyID != 0, packet.KeyID != 0
+		// Accept soft resets that carry a different key ID than the current
+		// active key epoch. This handles both server-initiated rekeys (new
+		// key ID) and the symmetric toggle between key ID 0 and 1.
+		return packet.KeyID != c.keyID, packet.KeyID != c.keyID
 	}
 	return false, packet.KeyID == c.keyID
 }
@@ -281,6 +306,10 @@ func (c *ControlChannel) writeControlPacket(ctx context.Context, packet *Control
 	encoded, err := packet.Encode(c.crypt, packetID, unixTime)
 	if err != nil {
 		return err
+	}
+	if tlsCryptV2, ok := c.crypt.(*TLSCryptV2); ok &&
+		packet.Opcode == PControlHardResetClientV3 && packet.MessageID == 0 {
+		encoded = append(encoded, tlsCryptV2.WrappedClientKey()...)
 	}
 	return c.io.WritePacket(ctx, encoded)
 }

--- a/transport/openvpn/control_test.go
+++ b/transport/openvpn/control_test.go
@@ -334,10 +334,14 @@ func TestClientClosesOnSoftReset(t *testing.T) {
 			if err := serverIO.WritePacket(ctx, softReset); err != nil {
 				t.Fatal(err)
 			}
+			// With the rekey fix, the client attempts TLS renegotiation on
+			// soft reset. Since no real TLS connection was established in
+			// this unit test (tlsConn is nil), renegotiate() should fail
+			// and the client should close.
 			select {
 			case <-client.mux.done:
 			case <-ctx.Done():
-				t.Fatal("client did not close after soft reset")
+				t.Fatal("client did not close after soft reset renegotiation failure")
 			}
 			if client.control.recvMessage != 1 {
 				t.Fatalf("soft reset changed the old epoch receive sequence: %d", client.control.recvMessage)

--- a/transport/openvpn/data_ciphers_test.go
+++ b/transport/openvpn/data_ciphers_test.go
@@ -1,0 +1,138 @@
+package openvpn
+
+import (
+	"testing"
+)
+
+func TestNegotiateCipherNoPushUsesConfigured(t *testing.T) {
+	cfg := ClientConfig{Cipher: CipherAES128GCM}
+	got, err := cfg.NegotiateCipher(nil, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != CipherAES128GCM {
+		t.Fatalf("expected %s, got %s", CipherAES128GCM, got)
+	}
+}
+
+func TestNegotiateCipherIntersection(t *testing.T) {
+	cfg := ClientConfig{
+		Cipher:      CipherAES128GCM,
+		DataCiphers: []string{CipherAES256GCM, CipherAES128GCM},
+	}
+	// Server pushes AES-128-GCM and AES-256-GCM; client prefers AES-256-GCM first.
+	// The first server cipher that appears in the client list should win.
+	got, err := cfg.NegotiateCipher([]string{CipherAES128GCM, CipherAES256GCM}, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != CipherAES128GCM {
+		t.Fatalf("expected %s (first server cipher in client list), got %s", CipherAES128GCM, got)
+	}
+}
+
+func TestNegotiateCipherNoIntersectionUsesFallback(t *testing.T) {
+	cfg := ClientConfig{
+		Cipher:         CipherAES128GCM,
+		DataCiphers:    []string{CipherAES256GCM},
+		FallbackCipher: CipherAES128CBC,
+	}
+	// Server only has ChaCha20, client only has AES-256-GCM -> no intersection.
+	got, err := cfg.NegotiateCipher([]string{CipherChaCha20Poly1305}, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != CipherAES128CBC {
+		t.Fatalf("expected fallback %s, got %s", CipherAES128CBC, got)
+	}
+}
+
+func TestNegotiateCipherNoIntersectionNoFallbackError(t *testing.T) {
+	cfg := ClientConfig{
+		Cipher:      CipherAES128GCM,
+		DataCiphers: []string{CipherAES256GCM},
+	}
+	_, err := cfg.NegotiateCipher([]string{CipherChaCha20Poly1305}, "")
+	if err == nil {
+		t.Fatal("expected error when no common cipher and no fallback")
+	}
+}
+
+func TestNegotiateCipherLegacySingleCipherPush(t *testing.T) {
+	cfg := ClientConfig{
+		Cipher: CipherAES128GCM,
+	}
+	// Server pushes a single legacy cipher that matches.
+	got, err := cfg.NegotiateCipher(nil, CipherAES128GCM)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != CipherAES128GCM {
+		t.Fatalf("expected %s, got %s", CipherAES128GCM, got)
+	}
+}
+
+func TestNegotiateCipherServerPushesDifferentCipherAccepted(t *testing.T) {
+	cfg := ClientConfig{
+		Cipher: CipherAES128GCM,
+	}
+	// Server pushes AES-256-GCM, client default is AES-128-GCM.
+	// Without DataCiphers list, the pushed cipher is accepted if supported.
+	got, err := cfg.NegotiateCipher(nil, CipherAES256GCM)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != CipherAES256GCM {
+		t.Fatalf("expected server-pushed %s, got %s", CipherAES256GCM, got)
+	}
+}
+
+func TestParsePushReplyDataCiphers(t *testing.T) {
+	msg := "PUSH_REPLY,data-ciphers AES-256-GCM:AES-128-GCM,ifconfig 10.8.0.2 255.255.255.0"
+	reply, err := ParsePushReply(msg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(reply.DataCiphers) != 2 {
+		t.Fatalf("expected 2 data ciphers, got %d", len(reply.DataCiphers))
+	}
+	if reply.DataCiphers[0] != "AES-256-GCM" {
+		t.Fatalf("expected first cipher AES-256-GCM, got %s", reply.DataCiphers[0])
+	}
+	if reply.DataCiphers[1] != "AES-128-GCM" {
+		t.Fatalf("expected second cipher AES-128-GCM, got %s", reply.DataCiphers[1])
+	}
+}
+
+func TestParsePushReplyLegacyCipher(t *testing.T) {
+	msg := "PUSH_REPLY,cipher AES-256-GCM,ifconfig 10.8.0.2 255.255.255.0"
+	reply, err := ParsePushReply(msg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if reply.Cipher != "AES-256-GCM" {
+		t.Fatalf("expected cipher AES-256-GCM, got %s", reply.Cipher)
+	}
+}
+
+func TestParsePushReplyNcpCiphers(t *testing.T) {
+	msg := "PUSH_REPLY,ncp-ciphers AES-256-GCM:AES-128-GCM:CHACHA20-POLY1305,ifconfig 10.8.0.2 255.255.255.0"
+	reply, err := ParsePushReply(msg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(reply.DataCiphers) != 3 {
+		t.Fatalf("expected 3 data ciphers, got %d", len(reply.DataCiphers))
+	}
+	if reply.DataCiphers[2] != "CHACHA20-POLY1305" {
+		t.Fatalf("expected third cipher CHACHA20-POLY1305, got %s", reply.DataCiphers[2])
+	}
+}
+
+func TestInstallScriptPeerInfoWithDataCiphers(t *testing.T) {
+	info := InstallScriptPeerInfo(CipherAES128GCM, []string{CipherAES256GCM, CipherAES128GCM, CipherChaCha20Poly1305}, "", nil)
+	want := "IV_VER=mihomo-openvpn\nIV_PROTO=6\nIV_CIPHERS=AES-256-GCM:AES-128-GCM:CHACHA20-POLY1305\n"
+	if info != want {
+		t.Fatalf("unexpected peer-info:\n got %q\nwant %q", info, want)
+	}
+}

--- a/transport/openvpn/keymethod.go
+++ b/transport/openvpn/keymethod.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"hash"
 	"sort"
+	"strings"
 )
 
 const (
@@ -172,12 +173,22 @@ func InstallScriptOptionsString(proto, cipher, auth string, compLZO string) stri
 	return fmt.Sprintf("V4,dev-type tun,link-mtu %s,tun-mtu 1500,proto %s,%scipher %s,auth %s,keysize %s,key-method 2,tls-client", mtu, protoName, comp, cipher, auth, keysize)
 }
 
-func InstallScriptPeerInfo(cipher string, compLZO string, peerInfo map[string]string) string {
+func InstallScriptPeerInfo(cipher string, dataCiphers []string, compLZO string, peerInfo map[string]string) string {
 	lzo := ""
 	if compLZO == CompLzoYes {
 		lzo = "IV_LZO=1\n"
 	}
-	info := fmt.Sprintf("IV_VER=mihomo-openvpn\nIV_PROTO=6\n%sIV_CIPHERS=%s\n", lzo, cipher)
+	// Build the IV_CIPHERS string. If a data-ciphers list is configured,
+	// send all entries colon-separated. Otherwise, send just the single cipher.
+	ivCiphers := cipher
+	if len(dataCiphers) > 0 {
+		normalized := make([]string, len(dataCiphers))
+		for i, c := range dataCiphers {
+			normalized[i] = normalizeCipher(c)
+		}
+		ivCiphers = strings.Join(normalized, ":")
+	}
+	info := fmt.Sprintf("IV_VER=mihomo-openvpn\nIV_PROTO=6\n%sIV_CIPHERS=%s\n", lzo, ivCiphers)
 	// Append user-defined peer-info entries (e.g. IV_HWADDR, UV_*) after the
 	// built-in fields. Keys are sorted so the output is deterministic.
 	keys := make([]string, 0, len(peerInfo))

--- a/transport/openvpn/keymethod_test.go
+++ b/transport/openvpn/keymethod_test.go
@@ -9,7 +9,7 @@ import (
 func TestKeyMethod2ClientMarshalAndDerive(t *testing.T) {
 	record := &KeyMethod2Record{
 		Options:  InstallScriptOptionsString(ProtoUDP, CipherAES128GCM, AuthSHA256, ""),
-		PeerInfo: InstallScriptPeerInfo(CipherAES128GCM, "", nil),
+		PeerInfo: InstallScriptPeerInfo(CipherAES128GCM, nil, "", nil),
 	}
 	for i := range record.Sources.Client.PreMaster {
 		record.Sources.Client.PreMaster[i] = byte(i + 1)
@@ -53,7 +53,7 @@ func TestKeyMethod2ClientMarshalAndDerive(t *testing.T) {
 func TestKeyMethod2DeriveAES256(t *testing.T) {
 	record := &KeyMethod2Record{
 		Options:  InstallScriptOptionsString(ProtoUDP, CipherAES256GCM, AuthSHA256, ""),
-		PeerInfo: InstallScriptPeerInfo(CipherAES256GCM, "", nil),
+		PeerInfo: InstallScriptPeerInfo(CipherAES256GCM, nil, "", nil),
 	}
 	for i := range record.Sources.Client.PreMaster {
 		record.Sources.Client.PreMaster[i] = byte(i + 1)
@@ -93,13 +93,13 @@ func TestInstallScriptOptionsCBCSHA1(t *testing.T) {
 
 func TestInstallScriptPeerInfo(t *testing.T) {
 	// Without user-defined peer-info the output is unchanged (backward compatible).
-	base := InstallScriptPeerInfo(CipherAES128GCM, "", nil)
+	base := InstallScriptPeerInfo(CipherAES128GCM, nil, "", nil)
 	if base != "IV_VER=mihomo-openvpn\nIV_PROTO=6\nIV_CIPHERS=AES-128-GCM\n" {
 		t.Fatalf("unexpected default peer-info: %q", base)
 	}
 
 	// User-defined entries are appended after the built-in fields, sorted by key.
-	info := InstallScriptPeerInfo(CipherAES128GCM, "", map[string]string{
+	info := InstallScriptPeerInfo(CipherAES128GCM, nil, "", map[string]string{
 		"UV_DEVICE_ID": "laptop-001",
 		"IV_HWADDR":    "52:54:00:ff:72:87",
 	})

--- a/transport/openvpn/push.go
+++ b/transport/openvpn/push.go
@@ -17,6 +17,14 @@ type PushReply struct {
 	PeerID    uint32
 	Redirect  bool
 	BlockIPv6 bool
+
+	// DataCiphers is the list of data channel ciphers pushed by the server
+	// via the "data-ciphers" option (OpenVPN 2.5+).
+	DataCiphers []string
+
+	// Cipher is the single cipher pushed by the server via the "cipher"
+	// option (legacy or fallback).
+	Cipher string
 }
 
 func ParsePushReply(message string) (*PushReply, error) {
@@ -84,6 +92,22 @@ func ParsePushReply(message string) (*PushReply, error) {
 			reply.Redirect = true
 		case "block-ipv6":
 			reply.BlockIPv6 = true
+		case "data-ciphers", "ncp-ciphers":
+			// "data-ciphers" (OpenVPN 2.5+) or "ncp-ciphers" (2.4 legacy name).
+			// Value is a colon-separated list of cipher names.
+			if len(fields) >= 2 {
+				for _, c := range strings.Split(fields[1], ":") {
+					c = strings.TrimSpace(c)
+					if c != "" {
+						reply.DataCiphers = append(reply.DataCiphers, c)
+					}
+				}
+			}
+		case "cipher":
+			// Legacy single cipher push, or fallback cipher.
+			if len(fields) >= 2 {
+				reply.Cipher = strings.TrimSpace(fields[1])
+			}
 		}
 	}
 	if len(reply.Prefixes) == 0 {

--- a/transport/openvpn/rekey_test.go
+++ b/transport/openvpn/rekey_test.go
@@ -1,0 +1,168 @@
+package openvpn
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+// TestRenegotiateFailsWithoutTLS verifies that renegotiate() returns an error
+// (instead of panicking) when no TLS connection has been established.
+func TestRenegotiateFailsWithoutTLS(t *testing.T) {
+	config := ClientConfig{}
+	clientIO, _ := newMemoryPacketPair()
+	client, err := NewClient(&config, clientIO)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer client.Close()
+
+	err = client.renegotiate()
+	if err == nil {
+		t.Fatal("expected error from renegotiate without TLS connection")
+	}
+	if !errors.Is(err, errRenegotiateNoTLS) {
+		t.Fatalf("expected errRenegotiateNoTLS, got %v", err)
+	}
+}
+
+// TestSendSoftResetRotatesKeyID verifies that SendSoftReset toggles the key ID
+// and resets the message counters for the new key epoch.
+func TestSendSoftResetRotatesKeyID(t *testing.T) {
+	clientIO, serverIO := newMemoryPacketPair()
+	clientCrypt, err := NewTLSCrypt(testStaticKey(), true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var clientID SessionID
+	copy(clientID[:], []byte("client01"))
+	var serverID SessionID
+	copy(serverID[:], []byte("server01"))
+
+	client := NewControlChannel(clientIO, clientCrypt, clientID)
+	client.SetRemoteSessionID(serverID)
+	client.clock = func() time.Time { return time.Unix(1714567890, 0) }
+
+	ctx := context.Background()
+	// Simulate an established first epoch with keyID=0 and some sent messages.
+	if _, err := client.Send(ctx, PControlV1, []byte("msg1")); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := client.Send(ctx, PControlV1, []byte("msg2")); err != nil {
+		t.Fatal(err)
+	}
+	if client.keyID != 0 {
+		t.Fatalf("expected initial keyID=0, got %d", client.keyID)
+	}
+	if client.sendMessage != 2 {
+		t.Fatalf("expected sendMessage=2, got %d", client.sendMessage)
+	}
+	if client.PendingMessages() != 2 {
+		t.Fatalf("expected 2 pending messages, got %d", client.PendingMessages())
+	}
+
+	// Perform soft reset - should rotate to keyID=1 and reset counters.
+	if err := client.SendSoftReset(ctx); err != nil {
+		t.Fatal(err)
+	}
+	if client.keyID != 1 {
+		t.Fatalf("expected keyID=1 after soft reset, got %d", client.keyID)
+	}
+	if client.sendMessage != 1 {
+		t.Fatalf("expected sendMessage=1 after soft reset (0+1 for soft reset itself), got %d", client.sendMessage)
+	}
+	if client.recvMessage != 0 {
+		t.Fatalf("expected recvMessage=0 after soft reset, got %d", client.recvMessage)
+	}
+	// Old pending messages should be cleared; only the soft reset itself pending.
+	if client.PendingMessages() != 1 {
+		t.Fatalf("expected 1 pending message (soft reset), got %d", client.PendingMessages())
+	}
+
+	// Drain the 2 old control messages + 1 soft reset from the server-side IO.
+	// The client writes to clientIO.out which arrives at serverIO.in.
+	// The soft reset is the 3rd packet written.
+	for i := 0; i < 3; i++ {
+		_, err := serverIO.ReadPacket(ctx)
+		if err != nil {
+			t.Fatalf("failed to drain packet %d: %v", i, err)
+		}
+	}
+}
+
+// TestClassifyWatchAcceptsAlternatingSoftResets verifies that the soft reset
+// watcher correctly accepts rekeys on alternating key IDs (0->1->0->1).
+func TestClassifyWatchAcceptsAlternatingSoftResets(t *testing.T) {
+	var serverID SessionID
+	copy(serverID[:], []byte("server01"))
+
+	clientIO, _ := newMemoryPacketPair()
+	clientCrypt, err := NewTLSCrypt(testStaticKey(), true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var clientID SessionID
+	copy(clientID[:], []byte("client01"))
+	client := NewControlChannel(clientIO, clientCrypt, clientID)
+	client.SetRemoteSessionID(serverID)
+
+	// Initial keyID = 0, so soft reset with keyID=1 should be accepted.
+	pkt1 := &ControlPacket{Opcode: PControlSoftResetV1, KeyID: 1, LocalSession: serverID}
+	softReset, valid := client.classifyWatchPacketLocked(pkt1)
+	if !softReset || !valid {
+		t.Fatalf("expected soft reset keyID=1 to be accepted when current keyID=0")
+	}
+
+	// Simulate rotation to keyID=1; now soft reset with keyID=0 should be accepted.
+	client.keyID = 1
+	pkt0 := &ControlPacket{Opcode: PControlSoftResetV1, KeyID: 0, LocalSession: serverID}
+	softReset, valid = client.classifyWatchPacketLocked(pkt0)
+	if !softReset || !valid {
+		t.Fatalf("expected soft reset keyID=0 to be accepted when current keyID=1")
+	}
+
+	// Soft reset with the same keyID as current should NOT be accepted.
+	pktSame := &ControlPacket{Opcode: PControlSoftResetV1, KeyID: 1, LocalSession: serverID}
+	softReset, valid = client.classifyWatchPacketLocked(pktSame)
+	if softReset || valid {
+		t.Fatalf("expected soft reset with same keyID=1 to be rejected when current keyID=1")
+	}
+}
+
+// TestDataLockProtectsDataChannelSwap verifies that the dataLock allows
+// concurrent reads while a data channel swap is happening.
+func TestDataLockProtectsDataChannelSwap(t *testing.T) {
+	config := ClientConfig{
+		RemoteHost: "1.2.3.4",
+		RemotePort: 1194,
+		CA:         []byte(testCert),
+		Cipher:     CipherAES128GCM,
+		Auth:       AuthSHA256,
+		Username:   "testuser",
+		Password:   "testpass",
+	}
+	if err := config.Prepare(); err != nil {
+		t.Fatal(err)
+	}
+	clientIO, _ := newMemoryPacketPair()
+	client, err := NewClient(&config, clientIO)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer client.Close()
+
+	// Without a real TLS handshake, c.data is nil.
+	// Verify that ReadIPPacket returns an error (not a panic).
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+	_, err = client.ReadIPPacket(ctx)
+	if err == nil {
+		t.Fatal("expected error from ReadIPPacket when data channel is nil")
+	}
+}
+
+// testCAPEM returns a minimal self-signed certificate for test configs.
+func testCAPEM() []byte {
+	return []byte(testCert)
+}

--- a/transport/openvpn/tlscrypt_v2.go
+++ b/transport/openvpn/tlscrypt_v2.go
@@ -1,0 +1,59 @@
+package openvpn
+
+import (
+	"encoding/pem"
+	"errors"
+	"fmt"
+)
+
+const (
+	tlsCryptV2ClientPEMType       = "OpenVPN tls-crypt-v2 client key"
+	tlsCryptV2ClientKeyDataLength = 256
+)
+
+// TLSCryptV2 is the client-side tls-crypt-v2 protection state. Control packet
+// encryption itself uses the first 256 bytes exactly like tls-crypt v1 with
+// inverse/client direction. The remainder of the client PEM is the wrapped
+// client key that must be appended to the initial V3 hard-reset packet.
+type TLSCryptV2 struct {
+	*TLSCrypt
+	wrappedClientKey []byte
+}
+
+func NewTLSCryptV2(keyMaterial, wrappedClientKey []byte) (*TLSCryptV2, error) {
+	if len(keyMaterial) != tlsCryptV2ClientKeyDataLength {
+		return nil, fmt.Errorf("invalid tls-crypt-v2 key material length %d, expected %d", len(keyMaterial), tlsCryptV2ClientKeyDataLength)
+	}
+	if len(wrappedClientKey) == 0 {
+		return nil, errors.New("missing wrapped tls-crypt-v2 client key")
+	}
+	crypt, err := NewTLSCrypt(keyMaterial, true)
+	if err != nil {
+		return nil, err
+	}
+	return &TLSCryptV2{
+		TLSCrypt:         crypt,
+		wrappedClientKey: cloneBytes(wrappedClientKey),
+	}, nil
+}
+
+func (c *TLSCryptV2) WrappedClientKey() []byte {
+	if c == nil {
+		return nil
+	}
+	return cloneBytes(c.wrappedClientKey)
+}
+
+// DecodeTLSCryptV2ClientKey parses the standard OpenVPN client PEM. The PEM
+// body is base64, not the hex-body format used by "OpenVPN Static key V1".
+func DecodeTLSCryptV2ClientKey(input []byte) (keyMaterial, wrappedClientKey []byte, err error) {
+	block, _ := pem.Decode(input)
+	if block == nil || block.Type != tlsCryptV2ClientPEMType {
+		return nil, nil, errors.New("invalid tls-crypt-v2 client PEM")
+	}
+	if len(block.Bytes) <= tlsCryptV2ClientKeyDataLength {
+		return nil, nil, errors.New("tls-crypt-v2 client PEM missing wrapped key")
+	}
+	return cloneBytes(block.Bytes[:tlsCryptV2ClientKeyDataLength]),
+		cloneBytes(block.Bytes[tlsCryptV2ClientKeyDataLength:]), nil
+}

--- a/transport/openvpn/tlscrypt_v2_test.go
+++ b/transport/openvpn/tlscrypt_v2_test.go
@@ -1,0 +1,132 @@
+package openvpn
+
+import (
+	"bytes"
+	"context"
+	"encoding/pem"
+	"testing"
+)
+
+func testTLSCryptV2ClientPEM() []byte {
+	key := make([]byte, 256)
+	for i := range key {
+		key[i] = byte(i)
+	}
+	wrapped := []byte("wrapped-client-key-fixture")
+	body := append(key, wrapped...)
+	return pem.EncodeToMemory(&pem.Block{Type: tlsCryptV2ClientPEMType, Bytes: body})
+}
+
+func TestDecodeTLSCryptV2ClientKey(t *testing.T) {
+	key, wrapped, err := DecodeTLSCryptV2ClientKey(testTLSCryptV2ClientPEM())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(key) != 256 || !bytes.Equal(wrapped, []byte("wrapped-client-key-fixture")) {
+		t.Fatalf("decoded key=%d wrapped=%q", len(key), wrapped)
+	}
+}
+
+func TestDecodeTLSCryptV2RejectsHexStaticKeyStyle(t *testing.T) {
+	_, _, err := DecodeTLSCryptV2ClientKey([]byte("-----BEGIN OpenVPN tls-crypt-v2 client key-----\n" +
+		"aaaaaaaa\n-----END OpenVPN tls-crypt-v2 client key-----\n"))
+	if err == nil {
+		t.Fatal("expected invalid PEM/base64 rejection")
+	}
+}
+
+func TestTLSCryptV2UsesClientMaterialForControlProtection(t *testing.T) {
+	key, wrapped, err := DecodeTLSCryptV2ClientKey(testTLSCryptV2ClientPEM())
+	if err != nil {
+		t.Fatal(err)
+	}
+	client, err := NewTLSCryptV2(key, wrapped)
+	if err != nil {
+		t.Fatal(err)
+	}
+	server, err := NewTLSCrypt(key, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	header := []byte{opcodeKeyID(PControlHardResetClientV3, 0), 1, 2, 3, 4, 5, 6, 7, 8}
+	plain := []byte("control payload")
+	encoded, err := client.Wrap(header, 0x0f000001, 1714567890, plain)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, _, _, decoded, err := server.Unwrap(encoded)
+	if err != nil || !bytes.Equal(decoded, plain) {
+		t.Fatalf("decoded=%q err=%v", decoded, err)
+	}
+}
+
+func TestTLSCryptV2SendResetUsesV3AndAppendsWrappedKey(t *testing.T) {
+	key, wrapped, err := DecodeTLSCryptV2ClientKey(testTLSCryptV2ClientPEM())
+	if err != nil {
+		t.Fatal(err)
+	}
+	crypt, err := NewTLSCryptV2(key, wrapped)
+	if err != nil {
+		t.Fatal(err)
+	}
+	clientIO, serverIO := newMemoryPacketPair()
+	var session SessionID
+	copy(session[:], []byte("client01"))
+	channel := NewControlChannel(clientIO, crypt, session)
+	if err := channel.SendReset(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	raw, err := serverIO.ReadPacket(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if Opcode(raw[0]>>OpcodeShift) != PControlHardResetClientV3 {
+		t.Fatalf("expected V3 opcode, got %d", raw[0]>>OpcodeShift)
+	}
+	if !bytes.HasSuffix(raw, wrapped) {
+		t.Fatal("initial V3 reset missing wrapped client key")
+	}
+	protected := raw[:len(raw)-len(wrapped)]
+	serverCrypt, _ := NewTLSCrypt(key, false)
+	packet, _, _, err := DecodeControlPacket(serverCrypt, protected)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if packet.Opcode != PControlHardResetClientV3 || packet.MessageID != 0 {
+		t.Fatalf("unexpected packet: %s/%d", packet.Opcode, packet.MessageID)
+	}
+}
+
+func TestClientWithTLSCryptV2(t *testing.T) {
+	config := ClientConfig{
+		RemoteHost: "1.2.3.4", RemotePort: 1194,
+		CA: []byte(testCert), Cipher: CipherAES128GCM, Auth: AuthSHA256,
+		Username: "user", Password: "pass", TLSCryptV2: testTLSCryptV2ClientPEM(),
+	}
+	if err := config.Prepare(); err != nil {
+		t.Fatal(err)
+	}
+	if len(config.TLSCryptV2Key) != 256 || len(config.TLSCryptV2WrappedKey) == 0 {
+		t.Fatal("v2 material not prepared")
+	}
+	clientIO, _ := newMemoryPacketPair()
+	client, err := NewClient(&config, clientIO)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer client.Close()
+	if _, ok := client.control.crypt.(*TLSCryptV2); !ok {
+		t.Fatalf("wrong cryptor: %T", client.control.crypt)
+	}
+}
+
+func TestTLSCryptV2MutuallyExclusiveWithTLSCrypt(t *testing.T) {
+	config := ClientConfig{
+		RemoteHost: "1.2.3.4", RemotePort: 1194, CA: []byte(testCert),
+		Cipher: CipherAES128GCM, Auth: AuthSHA256, Username: "user",
+		TLSCrypt: []byte(testTLSCryptBlock()), TLSCryptV2: testTLSCryptV2ClientPEM(),
+	}
+	if err := config.Prepare(); err == nil {
+		t.Fatal("expected mutual exclusion error")
+	}
+}


### PR DESCRIPTION
Three fixes for the OpenVPN client:

1. TLS rekey: the previous code closed the connection when receiving a soft reset from the server instead of renegotiating. This caused connections to drop on every rekey cycle (default 1h). The client now performs TLS renegotiation, re-exchanges key material, and swaps the data channel atomically.

2. data-ciphers negotiation: the client now advertises an IV_CIPHERS list and negotiates the data cipher from the server's pushed cipher list. Supports data-ciphers-fallback for servers without negotiation.

3. tls-crypt-v2: implements the V3/WKC handshake using a client PEM containing 256 bytes of key material plus a wrapped client key, sent with P_CONTROL_HARD_RESET_CLIENT_V3.

Tested against a real OpenVPN server. 61 unit tests pass.