### PR TITLE
feat: sync anytls v0.0.13

### DIFF
--- a/adapter/outbound/anytls.go
+++ b/adapter/outbound/anytls.go
@@ -46,6 +46,7 @@ type AnyTLSOption struct {
 	IdleSessionCheckInterval int              `proxy:"idle-session-check-interval,omitempty"`
 	IdleSessionTimeout       int              `proxy:"idle-session-timeout,omitempty"`
 	MinIdleSession           int              `proxy:"min-idle-session,omitempty"`
+	DisableReuse             bool             `proxy:"disable-reuse,omitempty"`
 }
 
 func (t *AnyTLS) DialContext(ctx context.Context, metadata *C.Metadata) (_ C.Conn, err error) {
@@ -116,6 +117,7 @@ func NewAnyTLS(option AnyTLSOption) (*AnyTLS, error) {
 		IdleSessionCheckInterval: time.Duration(option.IdleSessionCheckInterval) * time.Second,
 		IdleSessionTimeout:       time.Duration(option.IdleSessionTimeout) * time.Second,
 		MinIdleSession:           option.MinIdleSession,
+		DisableReuse:             option.DisableReuse,
 	}
 	echConfig, err := option.ECHOpts.Parse()
 	if err != nil {

--- a/transport/anytls/client.go
+++ b/transport/anytls/client.go
@@ -22,6 +22,7 @@ type ClientConfig struct {
 	IdleSessionCheckInterval time.Duration
 	IdleSessionTimeout       time.Duration
 	MinIdleSession           int
+	DisableReuse             bool
 	Server                   M.Socksaddr
 	Dialer                   N.Dialer
 	TLSConfig                *vmess.TLSConfig
@@ -46,7 +47,7 @@ func NewClient(ctx context.Context, config ClientConfig) *Client {
 	}
 	// Initialize the padding state of this client
 	padding.UpdatePaddingScheme(padding.DefaultPaddingScheme, &c.padding)
-	c.sessionClient = session.NewClient(ctx, c.createOutboundTLSConnection, &c.padding, config.IdleSessionCheckInterval, config.IdleSessionTimeout, config.MinIdleSession)
+	c.sessionClient = session.NewClient(ctx, c.createOutboundTLSConnection, &c.padding, config.IdleSessionCheckInterval, config.IdleSessionTimeout, config.MinIdleSession, config.DisableReuse)
 	return c
 }
 

--- a/transport/anytls/session/client.go
+++ b/transport/anytls/session/client.go
@@ -33,15 +33,17 @@ type Client struct {
 
 	idleSessionTimeout time.Duration
 	minIdleSession     int
+	disableReuse       bool
 }
 
-func NewClient(ctx context.Context, dialOut util.DialOutFunc, _padding *atomic.Pointer[padding.PaddingFactory], idleSessionCheckInterval, idleSessionTimeout time.Duration, minIdleSession int) *Client {
+func NewClient(ctx context.Context, dialOut util.DialOutFunc, _padding *atomic.Pointer[padding.PaddingFactory], idleSessionCheckInterval, idleSessionTimeout time.Duration, minIdleSession int, disableReuse bool) *Client {
 	c := &Client{
 		sessions:           make(map[uint64]*Session),
 		dialOut:            dialOut,
 		padding:            _padding,
 		idleSessionTimeout: idleSessionTimeout,
 		minIdleSession:     minIdleSession,
+		disableReuse:       disableReuse,
 	}
 	if idleSessionCheckInterval <= time.Second*5 {
 		idleSessionCheckInterval = time.Second * 30
@@ -51,7 +53,9 @@ func NewClient(ctx context.Context, dialOut util.DialOutFunc, _padding *atomic.P
 	}
 	c.die, c.dieCancel = context.WithCancel(ctx)
 	c.idleSession = skiplist.NewSkipList[uint64, *Session]()
-	util.StartRoutine(c.die, idleSessionCheckInterval, c.idleCleanup)
+	if !c.disableReuse {
+		util.StartRoutine(c.die, idleSessionCheckInterval, c.idleCleanup)
+	}
 	return c
 }
 
@@ -66,7 +70,9 @@ func (c *Client) CreateStream(ctx context.Context) (net.Conn, error) {
 	var stream *Stream
 	var err error
 
-	session = c.getIdleSession()
+	if !c.disableReuse {
+		session = c.getIdleSession()
+	}
 	if session == nil {
 		session, err = c.createSession(ctx)
 	}
@@ -82,10 +88,15 @@ func (c *Client) CreateStream(ctx context.Context) (net.Conn, error) {
 	stream.dieHook = func() {
 		// If Session is not closed, put this Stream to pool
 		if !session.IsClosed() {
+			if c.disableReuse {
+				session.Close()
+				return
+			}
+
 			select {
 			case <-c.die.Done():
 				// Now client has been closed
-				go session.Close()
+				session.Close()
 			default:
 				c.idleSessionLock.Lock()
 				session.idleSince = time.Now()
@@ -118,9 +129,11 @@ func (c *Client) createSession(ctx context.Context) (*Session, error) {
 	session := NewClientSession(underlying, c.padding)
 	session.seq = c.sessionCounter.Add(1)
 	session.dieHook = func() {
-		c.idleSessionLock.Lock()
-		c.idleSession.Remove(math.MaxUint64 - session.seq)
-		c.idleSessionLock.Unlock()
+		if !c.disableReuse {
+			c.idleSessionLock.Lock()
+			c.idleSession.Remove(math.MaxUint64 - session.seq)
+			c.idleSessionLock.Unlock()
+		}
 
 		c.sessionsLock.Lock()
 		delete(c.sessions, session.seq)

--- a/transport/anytls/session/session.go
+++ b/transport/anytls/session/session.go
@@ -109,6 +109,7 @@ func (s *Session) IsClosed() bool {
 func (s *Session) Close() error {
 	var once bool
 	s.dieOnce.Do(func() {
+		_ = s.conn.SetDeadline(time.Now())
 		close(s.die)
 		once = true
 	})
@@ -368,20 +369,52 @@ func (s *Session) streamClosed(sid uint32) error {
 	return err
 }
 
+// maxFrameDataLen is the maximum payload bytes per data frame. The wire
+// format encodes payload length as a uint16, so a single frame cannot
+// carry more than 65535 bytes. writeDataFrame splits larger writes into
+// multiple frames and sends the whole frame sequence in one writeConn call.
+// That keeps one Stream.Write contiguous relative to other stream/control
+// frame writes.
+const maxFrameDataLen = 0xFFFF
+
 func (s *Session) writeDataFrame(sid uint32, data []byte) (int, error) {
 	dataLen := len(data)
-
-	buffer := buf.NewSize(dataLen + headerOverHeadSize)
-	buffer.WriteByte(cmdPSH)
-	binary.BigEndian.PutUint32(buffer.Extend(4), sid)
-	binary.BigEndian.PutUint16(buffer.Extend(2), uint16(dataLen))
-	buffer.Write(data)
-	_, err := s.writeConn(buffer.Bytes())
-	buffer.Release()
-	if err != nil {
-		return 0, err
+	if dataLen == 0 {
+		return 0, nil
+	}
+	if dataLen <= maxFrameDataLen {
+		buffer := buf.NewSize(dataLen + headerOverHeadSize)
+		buffer.WriteByte(cmdPSH)
+		binary.BigEndian.PutUint32(buffer.Extend(4), sid)
+		binary.BigEndian.PutUint16(buffer.Extend(2), uint16(dataLen))
+		buffer.Write(data)
+		_, err := s.writeConn(buffer.Bytes())
+		buffer.Release()
+		if err != nil {
+			return 0, err
+		}
+		return dataLen, nil
 	}
 
+	frameCount := (dataLen + maxFrameDataLen - 1) / maxFrameDataLen
+	buffer := buf.NewSize(dataLen + frameCount*headerOverHeadSize)
+	defer buffer.Release()
+
+	for written := 0; written < dataLen; {
+		chunk := dataLen - written
+		if chunk > maxFrameDataLen {
+			chunk = maxFrameDataLen
+		}
+		buffer.WriteByte(cmdPSH)
+		binary.BigEndian.PutUint32(buffer.Extend(4), sid)
+		binary.BigEndian.PutUint16(buffer.Extend(2), uint16(chunk))
+		buffer.Write(data[written : written+chunk])
+		written += chunk
+	}
+
+	if _, err := s.writeConn(buffer.Bytes()); err != nil {
+		return 0, err
+	}
 	return dataLen, nil
 }
 

--- a/transport/anytls/session/stream.go
+++ b/transport/anytls/session/stream.go
@@ -89,11 +89,12 @@ func (s *Stream) closeWithError(err error) error {
 		once = true
 	})
 	if once {
+		err := s.sess.streamClosed(s.id)
 		if s.dieHook != nil {
 			s.dieHook()
 			s.dieHook = nil
 		}
-		return s.sess.streamClosed(s.id)
+		return err
 	} else {
 		return s.dieErr
 	}


### PR DESCRIPTION
- Add `disable-reuse` option to control session reuse.
- Support data payloads larger than 64KB by splitting them into multiple frames.
- Adjust stream close sequence to ensure proper session cleanup and hook execution.
