### PR TITLE
fix(reality): use x509 fallback when ed25519 HMAC verification fails

### DIFF
--- a/component/tls/reality.go
+++ b/component/tls/reality.go
@@ -183,19 +183,6 @@ func (c *realityVerifier) VerifyConnection(state utls.ConnectionState) error {
 			c.verified = true
 			return nil
 		}
-
-		if c.HandshakeState.ServerHello != nil &&
-			c.HandshakeState.ServerHello.Certificate != nil &&
-			len(c.HandshakeState.ServerHello.Certificate.Certificate) > 0 {
-			rawCert := c.HandshakeState.ServerHello.Certificate.Certificate[0]
-			if len(rawCert) >= 64 {
-				actualMAC := rawCert[len(rawCert)-64:]
-				if bytes.Equal(expectedMAC, actualMAC) {
-					c.verified = true
-					return nil
-				}
-			}
-		}
 	}
 	opts := x509.VerifyOptions{
 		DNSName:       c.serverName,

--- a/component/tls/reality.go
+++ b/component/tls/reality.go
@@ -177,9 +177,24 @@ func (c *realityVerifier) VerifyConnection(state utls.ConnectionState) error {
 	if pub, ok := certs[0].PublicKey.(ed25519.PublicKey); ok {
 		h := hmac.New(sha512.New, c.authKey)
 		h.Write(pub)
-		if bytes.Equal(h.Sum(nil), certs[0].Signature) {
+		expectedMAC := h.Sum(nil)
+
+		if bytes.Equal(expectedMAC, certs[0].Signature) {
 			c.verified = true
 			return nil
+		}
+
+		if c.HandshakeState.ServerHello != nil &&
+			c.HandshakeState.ServerHello.Certificate != nil &&
+			len(c.HandshakeState.ServerHello.Certificate.Certificate) > 0 {
+			rawCert := c.HandshakeState.ServerHello.Certificate.Certificate[0]
+			if len(rawCert) >= 64 {
+				actualMAC := rawCert[len(rawCert)-64:]
+				if bytes.Equal(expectedMAC, actualMAC) {
+					c.verified = true
+					return nil
+				}
+			}
 		}
 	}
 	opts := x509.VerifyOptions{

--- a/component/tls/reality.go
+++ b/component/tls/reality.go
@@ -195,5 +195,6 @@ func (c *realityVerifier) VerifyConnection(state utls.ConnectionState) error {
 	if _, err := certs[0].Verify(opts); err != nil {
 		return err
 	}
+	c.verified = true
 	return nil
 }


### PR DESCRIPTION
## Problem

Reality authentication fails with sing-box/remnawave servers. The ed25519 HMAC check in VerifyConnection compares HMAC(authKey, pub) against cert.Signature, but sing-box servers send the certificate with HMAC appended after the DER data. x509.ParseCertificate only reads DER bytes, so cert.Signature contains the DER signature, not the HMAC — verification always fails.

The x509 fallback path exists in the code but never sets verified = true, causing GetRealityConn to reject the connection.

## Fix

Set c.verified = true after successful x509 certificate verification in the fallback path.

## Security

- ed25519 HMAC remains the primary verification method
- x509 fallback only activates when HMAC check fails
- x509 verifies DNS name, time validity, and certificate chain

(edits by ai, sorry for all - just prototype)