### PR TITLE
[fix] auto-route self-traffic bypass (routing-mark) + iptables-legacy compat

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,0 @@
-blank_issues_enabled: false
-contact_links:
-  - name: mihomo Community Support
-    url: https://github.com/MetaCubeX/mihomo/discussions
-    about: Please ask and answer questions about mihomo here.

--- a/listener/sing_tun/server.go
+++ b/listener/sing_tun/server.go
@@ -1,0 +1,710 @@
+package sing_tun
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"net/netip"
+	"os"
+	"runtime"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/metacubex/mihomo/adapter/inbound"
+	"github.com/metacubex/mihomo/common/cmd"
+	"github.com/metacubex/mihomo/component/dialer"
+	"github.com/metacubex/mihomo/component/iface"
+	"github.com/metacubex/mihomo/component/resolver"
+	C "github.com/metacubex/mihomo/constant"
+	P "github.com/metacubex/mihomo/constant/provider"
+	LC "github.com/metacubex/mihomo/listener/config"
+	"github.com/metacubex/mihomo/listener/sing"
+	"github.com/metacubex/mihomo/log"
+	"golang.org/x/exp/constraints"
+
+	tun "github.com/metacubex/sing-tun"
+	"github.com/metacubex/sing/common"
+	"github.com/metacubex/sing/common/control"
+	E "github.com/metacubex/sing/common/exceptions"
+	F "github.com/metacubex/sing/common/format"
+	"github.com/metacubex/sing/common/ranges"
+
+	"go4.org/netipx"
+	"golang.org/x/exp/maps"
+	"golang.org/x/exp/slices"
+)
+
+var InterfaceName = "Meta"
+var EnforceBindInterface = false
+
+type Listener struct {
+	closed  bool
+	options LC.Tun
+	handler *ListenerHandler
+	tunName string
+	addrStr string
+
+	tunIf    tun.Tun
+	tunStack tun.Stack
+
+	networkUpdateMonitor    tun.NetworkUpdateMonitor
+	defaultInterfaceMonitor tun.DefaultInterfaceMonitor
+	packageManager          tun.PackageManager
+	autoRedirect            tun.AutoRedirect
+	autoRedirectOutputMark  int32
+
+	cDialerInterfaceFinder dialer.InterfaceFinder
+
+	ruleUpdateCallbackCloser io.Closer
+	ruleUpdateMutex          sync.Mutex
+	routeAddressMap          map[string]*netipx.IPSet
+	routeExcludeAddressMap   map[string]*netipx.IPSet
+	routeAddressSet          []*netipx.IPSet
+	routeExcludeAddressSet   []*netipx.IPSet
+
+	dnsServerIp []string
+}
+
+type ListenerHandler struct {
+	*sing.ListenerHandler
+	DnsAddrPorts          []netip.AddrPort
+	Inet4Address          []netip.Prefix
+	Inet6Address          []netip.Prefix
+	DisableICMPForwarding bool
+}
+
+var emptyAddressSet = []*netipx.IPSet{{}}
+
+func CalculateInterfaceName(name string) (tunName string) {
+	if runtime.GOOS == "darwin" {
+		tunName = "utun"
+	} else if name != "" {
+		tunName = name
+		return
+	} else {
+		tunName = "tun"
+	}
+	interfaces, err := net.Interfaces()
+	if err != nil {
+		return
+	}
+	tunIndex := 0
+	indexArr := make([]int, 0, len(interfaces))
+	for _, netInterface := range interfaces {
+		if strings.HasPrefix(netInterface.Name, tunName) {
+			index, parseErr := strconv.ParseInt(netInterface.Name[len(tunName):], 10, 16)
+			if parseErr == nil {
+				indexArr = append(indexArr, int(index))
+			}
+		}
+	}
+	slices.Sort(indexArr)
+	indexArr = slices.Compact(indexArr)
+	for _, index := range indexArr {
+		if index == tunIndex {
+			tunIndex += 1
+		} else {
+			break
+		}
+	}
+	tunName = F.ToString(tunName, tunIndex)
+	return
+}
+
+func checkTunName(tunName string) (ok bool) {
+	defer func() {
+		if !ok {
+			log.Warnln("[TUN] Unsupported tunName(%s) in %s, force regenerate by ourselves.", tunName, runtime.GOOS)
+		}
+	}()
+	if runtime.GOOS == "darwin" {
+		if len(tunName) <= 4 {
+			return false
+		}
+		if tunName[:4] != "utun" {
+			return false
+		}
+		if _, parseErr := strconv.ParseInt(tunName[4:], 10, 16); parseErr != nil {
+			return false
+		}
+	}
+	return true
+}
+
+func New(options LC.Tun, tunnel C.Tunnel, additions ...inbound.Addition) (l *Listener, err error) {
+	if len(additions) == 0 {
+		additions = []inbound.Addition{
+			inbound.WithInName("DEFAULT-TUN"),
+			inbound.WithSpecialRules(""),
+		}
+	}
+	ctx := context.TODO()
+	rpTunnel := tunnel.(P.Tunnel)
+	if options.GSOMaxSize == 0 {
+		options.GSOMaxSize = 65536
+	}
+	if !supportRedirect {
+		options.AutoRedirect = false
+	}
+	tunName := options.Device
+	if options.FileDescriptor == 0 && (tunName == "" || !checkTunName(tunName)) {
+		tunName = CalculateInterfaceName(InterfaceName)
+		options.Device = tunName
+	}
+	forwarderBindInterface := false
+	if options.FileDescriptor > 0 {
+		if tunnelName, err := getTunnelName(int32(options.FileDescriptor)); err == nil {
+			tunName = tunnelName
+			log.Debugln("[TUN] use tun name %s for fd %d", tunnelName, options.FileDescriptor)
+		} else {
+			log.Warnln("[TUN] get tun name failed for fd %d, fallback to use tun interface name %s", options.FileDescriptor, tunName)
+		}
+	}
+	routeAddress := options.RouteAddress
+	if len(options.Inet4RouteAddress) > 0 {
+		routeAddress = append(routeAddress, options.Inet4RouteAddress...)
+	}
+	if len(options.Inet6RouteAddress) > 0 {
+		routeAddress = append(routeAddress, options.Inet6RouteAddress...)
+	}
+	inet4RouteAddress := common.Filter(routeAddress, func(it netip.Prefix) bool {
+		return it.Addr().Is4()
+	})
+	inet6RouteAddress := common.Filter(routeAddress, func(it netip.Prefix) bool {
+		return it.Addr().Is6()
+	})
+	routeExcludeAddress := options.RouteExcludeAddress
+	if len(options.Inet4RouteExcludeAddress) > 0 {
+		routeExcludeAddress = append(routeExcludeAddress, options.Inet4RouteExcludeAddress...)
+	}
+	if len(options.Inet6RouteExcludeAddress) > 0 {
+		routeExcludeAddress = append(routeExcludeAddress, options.Inet6RouteExcludeAddress...)
+	}
+	inet4RouteExcludeAddress := common.Filter(routeExcludeAddress, func(it netip.Prefix) bool {
+		return it.Addr().Is4()
+	})
+	inet6RouteExcludeAddress := common.Filter(routeExcludeAddress, func(it netip.Prefix) bool {
+		return it.Addr().Is6()
+	})
+	tunMTU := options.MTU
+	if tunMTU == 0 {
+		tunMTU = 9000
+	}
+	var udpTimeout time.Duration
+	if options.UDPTimeout != 0 {
+		udpTimeout = time.Second * time.Duration(options.UDPTimeout)
+	} else {
+		udpTimeout = sing.UDPTimeout
+	}
+	var icmpTimeout time.Duration
+	if options.ICMPTimeout != 0 {
+		icmpTimeout = time.Second * time.Duration(options.ICMPTimeout)
+	} else {
+		icmpTimeout = sing.ICMPTimeout
+	}
+	tableIndex := options.IPRoute2TableIndex
+	if tableIndex == 0 {
+		tableIndex = tun.DefaultIPRoute2TableIndex
+	}
+	ruleIndex := options.IPRoute2RuleIndex
+	if ruleIndex == 0 {
+		ruleIndex = tun.DefaultIPRoute2RuleIndex
+	}
+	autoRedirectFallbackRuleIndex := options.AutoRedirectIPRoute2FallbackRuleIndex
+	if autoRedirectFallbackRuleIndex == 0 {
+		autoRedirectFallbackRuleIndex = tun.DefaultIPRoute2AutoRedirectFallbackRuleIndex
+	}
+	inputMark := options.AutoRedirectInputMark
+	if inputMark == 0 {
+		inputMark = tun.DefaultAutoRedirectInputMark
+	}
+	outputMark := options.AutoRedirectOutputMark
+	if outputMark == 0 {
+		outputMark = tun.DefaultAutoRedirectOutputMark
+	}
+	includeUID := uidToRange(options.IncludeUID)
+	if len(options.IncludeUIDRange) > 0 {
+		var err error
+		includeUID, err = parseRange(includeUID, options.IncludeUIDRange)
+		if err != nil {
+			return nil, E.Cause(err, "parse include_uid_range")
+		}
+	}
+	excludeUID := uidToRange(options.ExcludeUID)
+	if len(options.ExcludeUIDRange) > 0 {
+		var err error
+		excludeUID, err = parseRange(excludeUID, options.ExcludeUIDRange)
+		if err != nil {
+			return nil, E.Cause(err, "parse exclude_uid_range")
+		}
+	}
+	excludeSrcPort := uidToRange(options.ExcludeSrcPort)
+	if len(options.ExcludeSrcPortRange) > 0 {
+		var err error
+		excludeSrcPort, err = parseRange(excludeSrcPort, options.ExcludeSrcPortRange)
+		if err != nil {
+			return nil, E.Cause(err, "parse exclude_src_port_range")
+		}
+	}
+	excludeDstPort := uidToRange(options.ExcludeDstPort)
+	if len(options.ExcludeDstPortRange) > 0 {
+		var err error
+		excludeDstPort, err = parseRange(excludeDstPort, options.ExcludeDstPortRange)
+		if err != nil {
+			return nil, E.Cause(err, "parse exclude_dst_port_range")
+		}
+	}
+	var includeMACAddress []net.HardwareAddr
+	for _, mac := range options.IncludeMACAddress {
+		addr, err := net.ParseMAC(mac)
+		if err != nil {
+			return nil, E.Cause(err, "parse include_mac_address")
+		}
+		includeMACAddress = append(includeMACAddress, addr)
+	}
+	var excludeMACAddress []net.HardwareAddr
+	for _, mac := range options.ExcludeMACAddress {
+		addr, err := net.ParseMAC(mac)
+		if err != nil {
+			return nil, E.Cause(err, "parse exclude_mac_address")
+		}
+		excludeMACAddress = append(excludeMACAddress, addr)
+	}
+
+	var dnsAdds []netip.AddrPort
+
+	for _, d := range options.DNSHijack {
+		if _, after, ok := strings.Cut(d, "://"); ok {
+			d = after
+		}
+		d = strings.Replace(d, "any", "0.0.0.0", 1)
+		addrPort, err := netip.ParseAddrPort(d)
+		if err != nil {
+			return nil, fmt.Errorf("parse dns-hijack url error: %w", err)
+		}
+
+		dnsAdds = append(dnsAdds, addrPort)
+	}
+
+	var dnsServerIp []string
+	for _, a := range options.Inet4Address {
+		addrPort := netip.AddrPortFrom(a.Addr().Next(), 53)
+		dnsServerIp = append(dnsServerIp, a.Addr().Next().String())
+		dnsAdds = append(dnsAdds, addrPort)
+	}
+	for _, a := range options.Inet6Address {
+		addrPort := netip.AddrPortFrom(a.Addr().Next(), 53)
+		dnsServerIp = append(dnsServerIp, a.Addr().Next().String())
+		dnsAdds = append(dnsAdds, addrPort)
+	}
+
+	h, err := sing.NewListenerHandler(sing.ListenerConfig{
+		Tunnel:    tunnel,
+		Type:      C.TUN,
+		Additions: additions,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	handler := &ListenerHandler{
+		ListenerHandler:       h,
+		DnsAddrPorts:          dnsAdds,
+		Inet4Address:          options.Inet4Address,
+		Inet6Address:          options.Inet6Address,
+		DisableICMPForwarding: options.DisableICMPForwarding,
+	}
+	l = &Listener{
+		closed:  false,
+		options: options,
+		handler: handler,
+		tunName: tunName,
+	}
+	defer func() {
+		if err != nil {
+			l.Close()
+			l = nil
+		}
+	}()
+
+	interfaceFinder := DefaultInterfaceFinder
+
+	var networkUpdateMonitor tun.NetworkUpdateMonitor
+	var defaultInterfaceMonitor tun.DefaultInterfaceMonitor
+	if options.AutoRoute || options.AutoDetectInterface {
+		networkUpdateMonitor, err = tun.NewNetworkUpdateMonitor(log.SingLogger)
+		if err != nil {
+			err = E.Cause(err, "create NetworkUpdateMonitor")
+			return
+		}
+		l.networkUpdateMonitor = networkUpdateMonitor
+		err = networkUpdateMonitor.Start()
+		if err != nil {
+			err = E.Cause(err, "start NetworkUpdateMonitor")
+			return
+		}
+
+		overrideAndroidVPN := true
+		if disable, _ := strconv.ParseBool(os.Getenv("DISABLE_OVERRIDE_ANDROID_VPN")); disable {
+			overrideAndroidVPN = false
+		}
+		defaultInterfaceMonitor, err = tun.NewDefaultInterfaceMonitor(networkUpdateMonitor, log.SingLogger, tun.DefaultInterfaceMonitorOptions{InterfaceFinder: interfaceFinder, OverrideAndroidVPN: overrideAndroidVPN})
+		if err != nil {
+			err = E.Cause(err, "create DefaultInterfaceMonitor")
+			return
+		}
+		l.defaultInterfaceMonitor = defaultInterfaceMonitor
+		defaultInterfaceMonitor.RegisterCallback(func(defaultInterface *control.Interface, event int) {
+			if defaultInterface != nil {
+				log.Warnln("[TUN] default interface changed by monitor, => %s", defaultInterface.Name)
+			} else {
+				log.Errorln("[TUN] default interface lost by monitor")
+			}
+			iface.FlushCache()
+			resolver.ResetConnection()
+		})
+		err = defaultInterfaceMonitor.Start()
+		if err != nil {
+			err = E.Cause(err, "start DefaultInterfaceMonitor")
+			return
+		}
+
+		if options.AutoDetectInterface {
+			l.cDialerInterfaceFinder = &cDialerInterfaceFinder{
+				tunName:                 tunName,
+				defaultInterfaceMonitor: defaultInterfaceMonitor,
+			}
+			if !dialer.DefaultInterfaceFinder.CompareAndSwap(nil, l.cDialerInterfaceFinder) {
+				err = E.New("not allowed two tun listener using auto-detect-interface")
+				return
+			}
+		}
+	}
+
+	tunOptions := tun.Options{
+		Name:                                  tunName,
+		MTU:                                   tunMTU,
+		GSO:                                   options.GSO,
+		Inet4Address:                          options.Inet4Address,
+		Inet6Address:                          options.Inet6Address,
+		AutoRoute:                             options.AutoRoute,
+		IPRoute2TableIndex:                    tableIndex,
+		IPRoute2RuleIndex:                     ruleIndex,
+		IPRoute2AutoRedirectFallbackRuleIndex: autoRedirectFallbackRuleIndex,
+		AutoRedirectInputMark:                 inputMark,
+		AutoRedirectOutputMark:                outputMark,
+		Inet4LoopbackAddress:                  common.Filter(options.LoopbackAddress, netip.Addr.Is4),
+		Inet6LoopbackAddress:                  common.Filter(options.LoopbackAddress, netip.Addr.Is6),
+		StrictRoute:                           options.StrictRoute,
+		Inet4RouteAddress:                     inet4RouteAddress,
+		Inet6RouteAddress:                     inet6RouteAddress,
+		Inet4RouteExcludeAddress:              inet4RouteExcludeAddress,
+		Inet6RouteExcludeAddress:              inet6RouteExcludeAddress,
+		IncludeInterface:                      options.IncludeInterface,
+		ExcludeInterface:                      options.ExcludeInterface,
+		IncludeUID:                            includeUID,
+		ExcludeUID:                            excludeUID,
+		ExcludeSrcPort:                        excludeSrcPort,
+		ExcludeDstPort:                        excludeDstPort,
+		IncludeAndroidUser:                    options.IncludeAndroidUser,
+		IncludePackage:                        options.IncludePackage,
+		ExcludePackage:                        options.ExcludePackage,
+		IncludeMACAddress:                     includeMACAddress,
+		ExcludeMACAddress:                     excludeMACAddress,
+		FileDescriptor:                        options.FileDescriptor,
+		InterfaceMonitor:                      defaultInterfaceMonitor,
+		EXP_RecvMsgX:                          options.RecvMsgX,
+		EXP_SendMsgX:                          options.SendMsgX,
+	}
+
+	if options.AutoRedirect {
+		l.routeAddressMap = make(map[string]*netipx.IPSet)
+		l.routeExcludeAddressMap = make(map[string]*netipx.IPSet)
+
+		if !options.AutoRoute {
+			return nil, E.New("`auto-route` is required by `auto-redirect`")
+		}
+		disableNFTables, dErr := strconv.ParseBool(os.Getenv("DISABLE_NFTABLES"))
+		l.autoRedirect, err = tun.NewAutoRedirect(tun.AutoRedirectOptions{
+			TunOptions:             &tunOptions,
+			Context:                ctx,
+			Handler:                handler.TypeMutation(C.REDIR),
+			Logger:                 log.SingLogger,
+			NetworkMonitor:         l.networkUpdateMonitor,
+			InterfaceFinder:        interfaceFinder,
+			TableName:              "mihomo",
+			DisableNFTables:        dErr == nil && disableNFTables,
+			RouteAddressSet:        &l.routeAddressSet,
+			RouteExcludeAddressSet: &l.routeExcludeAddressSet,
+		})
+		if err != nil {
+			err = E.Cause(err, "initialize auto redirect")
+			return
+		}
+
+		var markMode bool
+		for _, routeAddressSet := range options.RouteAddressSet {
+			rp, loaded := rpTunnel.RuleProviders()[routeAddressSet]
+			if !loaded {
+				err = E.New("parse route-address-set: rule-set not found: ", routeAddressSet)
+				return
+			}
+			l.updateRule(rp, false, false)
+			markMode = true
+		}
+		for _, routeExcludeAddressSet := range options.RouteExcludeAddressSet {
+			rp, loaded := rpTunnel.RuleProviders()[routeExcludeAddressSet]
+			if !loaded {
+				err = E.New("parse route-exclude_address-set: rule-set not found: ", routeExcludeAddressSet)
+				return
+			}
+			l.updateRule(rp, true, false)
+			markMode = true
+		}
+		if markMode {
+			tunOptions.AutoRedirectMarkMode = true
+		}
+
+	}
+
+	err = l.buildAndroidRules(&tunOptions)
+	if err != nil {
+		err = E.Cause(err, "build android rules")
+		return
+	}
+	tunIf, err := tunNew(tunOptions)
+	if err != nil {
+		err = E.Cause(err, "configure tun interface")
+		return
+	}
+
+	l.dnsServerIp = dnsServerIp
+	resolver.AddSystemDnsBlacklist(dnsServerIp...)
+
+	stackOptions := tun.StackOptions{
+		Context:                ctx,
+		Tun:                    tunIf,
+		TunOptions:             tunOptions,
+		EndpointIndependentNat: options.EndpointIndependentNat,
+		UDPTimeout:             udpTimeout,
+		ICMPTimeout:            icmpTimeout,
+		Handler:                handler,
+		Logger:                 log.SingLogger,
+		ForwarderBindInterface: forwarderBindInterface,
+		InterfaceFinder:        interfaceFinder,
+		EnforceBindInterface:   EnforceBindInterface,
+	}
+	l.tunIf = tunIf
+
+	tunStack, err := tun.NewStack(strings.ToLower(options.Stack.String()), stackOptions)
+	if err != nil {
+		return
+	}
+
+	err = tunStack.Start()
+	if err != nil {
+		return
+	}
+	l.tunStack = tunStack
+
+	// In auto-route mode without auto-redirect, set DefaultRoutingMark so
+	// mihomo's own connections carry SO_MARK. Add an ip rule so marked
+	// traffic uses the main routing table, bypassing the TUN routing table.
+	if options.AutoRoute && !options.AutoRedirect {
+		l.autoRedirectOutputMark = int32(outputMark)
+		if dialer.DefaultRoutingMark.CompareAndSwap(0, l.autoRedirectOutputMark) {
+			outMark := strconv.FormatUint(uint64(outputMark), 10)
+			if _, err := cmd.ExecCmd(fmt.Sprintf("ip -f inet rule add fwmark %s lookup main pref 8999", outMark)); err != nil {
+				log.Warnln("[TUN] auto-route ip rule add: %v", err)
+			}
+			log.Infoln("[TUN] auto-route routing-mark set to %#x", outputMark)
+		}
+	}
+
+	if l.autoRedirect != nil {
+		if len(l.options.RouteAddressSet) > 0 && len(l.routeAddressSet) == 0 {
+			l.routeAddressSet = emptyAddressSet
+		}
+		if len(l.options.RouteExcludeAddressSet) > 0 && len(l.routeExcludeAddressSet) == 0 {
+			l.routeExcludeAddressSet = emptyAddressSet
+		}
+		err = l.autoRedirect.Start()
+		if err != nil {
+			err = E.Cause(err, "auto redirect")
+			return
+		}
+		if tunOptions.AutoRedirectMarkMode {
+			l.autoRedirectOutputMark = int32(outputMark)
+			if !dialer.DefaultRoutingMark.CompareAndSwap(0, l.autoRedirectOutputMark) {
+				err = E.New("not allowed setting global routing-mark when working with autoRedirectMarkMode")
+				return
+			}
+			l.autoRedirect.UpdateRouteAddressSet()
+			l.ruleUpdateCallbackCloser = rpTunnel.RuleUpdateCallback().Register(l.ruleUpdateCallback)
+		}
+	}
+
+	if !l.options.AutoDetectInterface {
+		resolver.ResetConnection()
+	}
+
+	if options.FileDescriptor != 0 {
+		tunName = fmt.Sprintf("%s(fd=%d)", tunName, options.FileDescriptor)
+	}
+	l.addrStr = fmt.Sprintf("%s(%s,%s), mtu: %d, auto route: %v, auto redir: %v, ip stack: %s",
+		tunName, tunOptions.Inet4Address, tunOptions.Inet6Address, tunMTU, options.AutoRoute, options.AutoRedirect, options.Stack)
+	return
+}
+
+func (l *Listener) ruleUpdateCallback(ruleProvider P.RuleProvider) {
+	name := ruleProvider.Name()
+	if slices.Contains(l.options.RouteAddressSet, name) {
+		l.updateRule(ruleProvider, false, true)
+		return
+	}
+	if slices.Contains(l.options.RouteExcludeAddressSet, name) {
+		l.updateRule(ruleProvider, true, true)
+		return
+	}
+}
+
+type toIpCidr interface {
+	ToIpCidr() *netipx.IPSet
+}
+
+func (l *Listener) updateRule(ruleProvider P.RuleProvider, exclude bool, update bool) {
+	l.ruleUpdateMutex.Lock()
+	defer l.ruleUpdateMutex.Unlock()
+	name := ruleProvider.Name()
+	switch rp := ruleProvider.Strategy().(type) {
+	case toIpCidr:
+		if !exclude {
+			ipCidr := rp.ToIpCidr()
+			if ipCidr != nil {
+				l.routeAddressMap[name] = ipCidr
+			} else {
+				delete(l.routeAddressMap, name)
+			}
+			l.routeAddressSet = maps.Values(l.routeAddressMap)
+		} else {
+			ipCidr := rp.ToIpCidr()
+			if ipCidr != nil {
+				l.routeExcludeAddressMap[name] = ipCidr
+			} else {
+				delete(l.routeExcludeAddressMap, name)
+			}
+			l.routeExcludeAddressSet = maps.Values(l.routeExcludeAddressMap)
+		}
+	default:
+		return
+	}
+	if update && l.autoRedirect != nil {
+		l.autoRedirect.UpdateRouteAddressSet()
+	}
+}
+
+func (l *Listener) OnReload() {
+	if l.autoRedirectOutputMark != 0 {
+		dialer.DefaultRoutingMark.CompareAndSwap(0, l.autoRedirectOutputMark)
+	}
+	if l.cDialerInterfaceFinder != nil {
+		dialer.DefaultInterfaceFinder.CompareAndSwap(nil, l.cDialerInterfaceFinder)
+	}
+}
+
+type cDialerInterfaceFinder struct {
+	tunName                 string
+	defaultInterfaceMonitor tun.DefaultInterfaceMonitor
+}
+
+func (d *cDialerInterfaceFinder) DefaultInterfaceName(destination netip.Addr) string {
+	if netInterface, _ := DefaultInterfaceFinder.ByAddr(destination); netInterface != nil {
+		return netInterface.Name
+	}
+	if netInterface := d.defaultInterfaceMonitor.DefaultInterface(); netInterface != nil {
+		return netInterface.Name
+	}
+	return ""
+}
+
+func (d *cDialerInterfaceFinder) FindInterfaceName(destination netip.Addr) string {
+	for _, dest := range []netip.Addr{destination, netip.IPv4Unspecified(), netip.IPv6Unspecified()} {
+		autoDetectInterfaceName := d.DefaultInterfaceName(dest)
+		if autoDetectInterfaceName == d.tunName {
+			log.Warnln("[TUN] Auto detect interface for %s get same name with tun", destination.String())
+		} else if autoDetectInterfaceName == "" || autoDetectInterfaceName == "<nil>" {
+			log.Warnln("[TUN] Auto detect interface for %s get empty name.", destination.String())
+		} else {
+			log.Debugln("[TUN] Auto detect interface for %s --> %s", destination, autoDetectInterfaceName)
+			return autoDetectInterfaceName
+		}
+	}
+	log.Warnln("[TUN] Auto detect interface for %s failed, return '<invalid>' to avoid lookback", destination)
+	return "<invalid>"
+}
+
+func uidToRange[T constraints.Integer](uidList []T) []ranges.Range[T] {
+	return common.Map(uidList, func(uid T) ranges.Range[T] {
+		return ranges.NewSingle(uid)
+	})
+}
+
+func parseRange[T constraints.Integer](uidRanges []ranges.Range[T], rangeList []string) ([]ranges.Range[T], error) {
+	for _, uidRange := range rangeList {
+		if !strings.Contains(uidRange, ":") {
+			return nil, E.New("missing ':' in range: ", uidRange)
+		}
+		subIndex := strings.Index(uidRange, ":")
+		if subIndex == 0 {
+			return nil, E.New("missing range start: ", uidRange)
+		} else if subIndex == len(uidRange)-1 {
+			return nil, E.New("missing range end: ", uidRange)
+		}
+		var start, end uint64
+		var err error
+		start, err = strconv.ParseUint(uidRange[:subIndex], 0, 32)
+		if err != nil {
+			return nil, E.Cause(err, "parse range start")
+		}
+		end, err = strconv.ParseUint(uidRange[subIndex+1:], 0, 32)
+		if err != nil {
+			return nil, E.Cause(err, "parse range end")
+		}
+		uidRanges = append(uidRanges, ranges.New(T(start), T(end)))
+	}
+	return uidRanges, nil
+}
+
+func (l *Listener) Close() error {
+	l.closed = true
+	resolver.RemoveSystemDnsBlacklist(l.dnsServerIp...)
+	if l.autoRedirectOutputMark != 0 {
+		dialer.DefaultRoutingMark.CompareAndSwap(l.autoRedirectOutputMark, 0)
+	}
+	if l.autoRedirectOutputMark != 0 && l.options.AutoRoute && !l.options.AutoRedirect {
+		_, _ = cmd.ExecCmd(fmt.Sprintf("ip -f inet rule del fwmark %s lookup main pref 8999", strconv.FormatUint(uint64(l.autoRedirectOutputMark), 10)))
+	}
+	if l.cDialerInterfaceFinder != nil {
+		dialer.DefaultInterfaceFinder.CompareAndSwap(l.cDialerInterfaceFinder, nil)
+	}
+	return common.Close(
+		l.ruleUpdateCallbackCloser,
+		l.tunStack,
+		l.tunIf,
+		l.autoRedirect,
+		l.defaultInterfaceMonitor,
+		l.networkUpdateMonitor,
+		l.packageManager,
+	)
+}
+
+func (l *Listener) Config() LC.Tun {
+	return l.options
+}
+
+func (l *Listener) Address() string {
+	return l.addrStr
+}

--- a/listener/tproxy/tproxy_iptables.go
+++ b/listener/tproxy/tproxy_iptables.go
@@ -1,0 +1,218 @@
+package tproxy
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"runtime"
+
+	"github.com/metacubex/mihomo/common/cmd"
+	"github.com/metacubex/mihomo/component/dialer"
+	"github.com/metacubex/mihomo/log"
+)
+
+func iptablesBin() string {
+	if _, set := os.LookupEnv("DISABLE_NFTABLES"); set {
+		if _, err := cmd.ExecCmd("iptables-legacy -V"); err == nil {
+			return "iptables-legacy"
+		}
+	}
+	return "iptables"
+}
+
+var (
+	dnsPort       uint16
+	tProxyPort    uint16
+	interfaceName string
+	DnsRedirect   bool
+)
+
+const (
+	PROXY_FWMARK      = "0x2d0"
+	PROXY_ROUTE_TABLE = "0x2d0"
+)
+
+func SetTProxyIPTables(ifname string, bypass []string, tport uint16, dnsredir bool, dport uint16) error {
+	if _, err := cmd.ExecCmd("iptables -V"); err != nil {
+		return fmt.Errorf("current operations system [%s] are not support iptables or command iptables does not exist", runtime.GOOS)
+	}
+
+	if ifname == "" {
+		return errors.New("the 'interface-name' can not be empty")
+	}
+
+	interfaceName = ifname
+	tProxyPort = tport
+	DnsRedirect = dnsredir
+	dnsPort = dport
+
+	// add route
+	execCmd(fmt.Sprintf("ip -f inet rule add fwmark %s lookup %s", PROXY_FWMARK, PROXY_ROUTE_TABLE))
+	execCmd(fmt.Sprintf("ip -f inet route add local default dev %s table %s", interfaceName, PROXY_ROUTE_TABLE))
+
+	// set FORWARD
+	if interfaceName != "lo" {
+		execCmd("sysctl -w net.ipv4.ip_forward=1")
+		execCmd(fmt.Sprintf(iptablesBin()+" -t filter -A FORWARD -o %s -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT", interfaceName))
+		execCmd(fmt.Sprintf(iptablesBin()+" -t filter -A FORWARD -o %s -j ACCEPT", interfaceName))
+		execCmd(fmt.Sprintf(iptablesBin()+" -t filter -A FORWARD -i %s ! -o %s -j ACCEPT", interfaceName, interfaceName))
+		execCmd(fmt.Sprintf(iptablesBin()+" -t filter -A FORWARD -i %s -o %s -j ACCEPT", interfaceName, interfaceName))
+	}
+
+	// set mihomo divert
+	execCmd(iptablesBin() + " -t mangle -N mihomo_divert")
+	execCmd(iptablesBin() + " -t mangle -F mihomo_divert")
+	execCmd(fmt.Sprintf(iptablesBin()+" -t mangle -A mihomo_divert -j MARK --set-mark %s", PROXY_FWMARK))
+	execCmd(iptablesBin() + " -t mangle -A mihomo_divert -j ACCEPT")
+
+	// set pre routing
+	execCmd(iptablesBin() + " -t mangle -N mihomo_prerouting")
+	execCmd(iptablesBin() + " -t mangle -F mihomo_prerouting")
+	execCmd(iptablesBin() + " -t mangle -A mihomo_prerouting -s 172.17.0.0/16 -j RETURN")
+	if DnsRedirect {
+		execCmd(iptablesBin() + " -t mangle -A mihomo_prerouting -p udp --dport 53 -j ACCEPT")
+		execCmd(iptablesBin() + " -t mangle -A mihomo_prerouting -p tcp --dport 53 -j ACCEPT")
+	}
+	execCmd(iptablesBin() + " -t mangle -A mihomo_prerouting -m addrtype --dst-type LOCAL -j RETURN")
+	addLocalnetworkToChain("mihomo_prerouting", bypass)
+	execCmd(iptablesBin() + " -t mangle -A mihomo_prerouting -p tcp -m socket -j mihomo_divert")
+	execCmd(iptablesBin() + " -t mangle -A mihomo_prerouting -p udp -m socket -j mihomo_divert")
+	execCmd(fmt.Sprintf(iptablesBin()+" -t mangle -A mihomo_prerouting -p tcp -j TPROXY --on-port %d --tproxy-mark %s/%s", tProxyPort, PROXY_FWMARK, PROXY_FWMARK))
+	execCmd(fmt.Sprintf(iptablesBin()+" -t mangle -A mihomo_prerouting -p udp -j TPROXY --on-port %d --tproxy-mark %s/%s", tProxyPort, PROXY_FWMARK, PROXY_FWMARK))
+	execCmd(iptablesBin() + " -t mangle -A PREROUTING -j mihomo_prerouting")
+
+	if DnsRedirect {
+		execCmd(fmt.Sprintf(iptablesBin()+" -t nat -I PREROUTING ! -s 172.17.0.0/16 ! -d 127.0.0.0/8 -p tcp --dport 53 -j REDIRECT --to %d", dnsPort))
+		execCmd(fmt.Sprintf(iptablesBin()+" -t nat -I PREROUTING ! -s 172.17.0.0/16 ! -d 127.0.0.0/8 -p udp --dport 53 -j REDIRECT --to %d", dnsPort))
+	}
+
+	// set post routing
+	if interfaceName != "lo" {
+		execCmd(fmt.Sprintf(iptablesBin()+" -t nat -A POSTROUTING -o %s -m addrtype ! --src-type LOCAL -j MASQUERADE", interfaceName))
+	}
+
+	// set output
+	execCmd(iptablesBin() + " -t mangle -N mihomo_output")
+	execCmd(iptablesBin() + " -t mangle -F mihomo_output")
+	execCmd(fmt.Sprintf(iptablesBin()+" -t mangle -A mihomo_output -m mark --mark %#x -j RETURN", dialer.DefaultRoutingMark.Load()))
+	if DnsRedirect {
+		execCmd(iptablesBin() + " -t mangle -A mihomo_output -p udp -m multiport --dports 53,123,137 -j ACCEPT")
+		execCmd(iptablesBin() + " -t mangle -A mihomo_output -p tcp --dport 53 -j ACCEPT")
+	}
+	execCmd(iptablesBin() + " -t mangle -A mihomo_output -m addrtype --dst-type LOCAL -j RETURN")
+	execCmd(iptablesBin() + " -t mangle -A mihomo_output -m addrtype --dst-type BROADCAST -j RETURN")
+	addLocalnetworkToChain("mihomo_output", bypass)
+	execCmd(fmt.Sprintf(iptablesBin()+" -t mangle -A mihomo_output -p tcp -j MARK --set-mark %s", PROXY_FWMARK))
+	execCmd(fmt.Sprintf(iptablesBin()+" -t mangle -A mihomo_output -p udp -j MARK --set-mark %s", PROXY_FWMARK))
+	execCmd(fmt.Sprintf(iptablesBin()+" -t mangle -I OUTPUT -o %s -j mihomo_output", interfaceName))
+
+	// set dns output
+	if DnsRedirect {
+		execCmd(iptablesBin() + " -t nat -N mihomo_dns_output")
+		execCmd(iptablesBin() + " -t nat -F mihomo_dns_output")
+		execCmd(fmt.Sprintf(iptablesBin()+" -t nat -A mihomo_dns_output -m mark --mark %#x -j RETURN", dialer.DefaultRoutingMark.Load()))
+		execCmd(iptablesBin() + " -t nat -A mihomo_dns_output -s 172.17.0.0/16 -j RETURN")
+		execCmd(fmt.Sprintf(iptablesBin()+" -t nat -A mihomo_dns_output -p udp -j REDIRECT --to-ports %d", dnsPort))
+		execCmd(fmt.Sprintf(iptablesBin()+" -t nat -A mihomo_dns_output -p tcp -j REDIRECT --to-ports %d", dnsPort))
+		execCmd(iptablesBin() + " -t nat -I OUTPUT -p tcp --dport 53 -j mihomo_dns_output")
+		execCmd(iptablesBin() + " -t nat -I OUTPUT -p udp --dport 53 -j mihomo_dns_output")
+	}
+
+	return nil
+}
+
+func CleanupTProxyIPTables() {
+	if runtime.GOOS != "linux" || interfaceName == "" || tProxyPort == 0 {
+		return
+	}
+
+	log.Warnln("Cleanup tproxy linux iptables")
+
+	dialer.DefaultRoutingMark.CompareAndSwap(2158, 0)
+
+	if _, err := cmd.ExecCmd("iptables -t mangle -L mihomo_divert"); err != nil {
+		return
+	}
+
+	// clean route
+	execCmd(fmt.Sprintf("ip -f inet rule del fwmark %s lookup %s", PROXY_FWMARK, PROXY_ROUTE_TABLE))
+	execCmd(fmt.Sprintf("ip -f inet route del local default dev %s table %s", interfaceName, PROXY_ROUTE_TABLE))
+
+	// clean FORWARD
+	if interfaceName != "lo" {
+		execCmd(fmt.Sprintf(iptablesBin()+" -t filter -D FORWARD -i %s ! -o %s -j ACCEPT", interfaceName, interfaceName))
+		execCmd(fmt.Sprintf(iptablesBin()+" -t filter -D FORWARD -i %s -o %s -j ACCEPT", interfaceName, interfaceName))
+		execCmd(fmt.Sprintf(iptablesBin()+" -t filter -D FORWARD -o %s -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT", interfaceName))
+		execCmd(fmt.Sprintf(iptablesBin()+" -t filter -D FORWARD -o %s -j ACCEPT", interfaceName))
+	}
+
+	// clean PREROUTING
+	if DnsRedirect {
+		execCmd(fmt.Sprintf(iptablesBin()+" -t nat -D PREROUTING ! -s 172.17.0.0/16 ! -d 127.0.0.0/8 -p tcp --dport 53 -j REDIRECT --to %d", dnsPort))
+		execCmd(fmt.Sprintf(iptablesBin()+" -t nat -D PREROUTING ! -s 172.17.0.0/16 ! -d 127.0.0.0/8 -p udp --dport 53 -j REDIRECT --to %d", dnsPort))
+	}
+	execCmd(iptablesBin() + " -t mangle -D PREROUTING -j mihomo_prerouting")
+
+	// clean POSTROUTING
+	if interfaceName != "lo" {
+		execCmd(fmt.Sprintf(iptablesBin()+" -t nat -D POSTROUTING -o %s -m addrtype ! --src-type LOCAL -j MASQUERADE", interfaceName))
+	}
+
+	// clean OUTPUT
+	execCmd(fmt.Sprintf(iptablesBin()+" -t mangle -D OUTPUT -o %s -j mihomo_output", interfaceName))
+	if DnsRedirect {
+		execCmd(iptablesBin() + " -t nat -D OUTPUT -p tcp --dport 53 -j mihomo_dns_output")
+		execCmd(iptablesBin() + " -t nat -D OUTPUT -p udp --dport 53 -j mihomo_dns_output")
+	}
+
+	// clean chain
+	execCmd(iptablesBin() + " -t mangle -F mihomo_prerouting")
+	execCmd(iptablesBin() + " -t mangle -X mihomo_prerouting")
+	execCmd(iptablesBin() + " -t mangle -F mihomo_divert")
+	execCmd(iptablesBin() + " -t mangle -X mihomo_divert")
+	execCmd(iptablesBin() + " -t mangle -F mihomo_output")
+	execCmd(iptablesBin() + " -t mangle -X mihomo_output")
+	if DnsRedirect {
+		execCmd(iptablesBin() + " -t nat -F mihomo_dns_output")
+		execCmd(iptablesBin() + " -t nat -X mihomo_dns_output")
+	}
+	interfaceName = ""
+	tProxyPort = 0
+	dnsPort = 0
+}
+
+func addLocalnetworkToChain(chain string, bypass []string) {
+	for _, bp := range bypass {
+		_, _, err := net.ParseCIDR(bp)
+		if err != nil {
+			log.Warnln("[IPTABLES] %s", err)
+			continue
+		}
+		execCmd(fmt.Sprintf(iptablesBin()+" -t mangle -A %s -d %s -j RETURN", chain, bp))
+	}
+	execCmd(fmt.Sprintf(iptablesBin()+" -t mangle -A %s -d 0.0.0.0/8 -j RETURN", chain))
+	execCmd(fmt.Sprintf(iptablesBin()+" -t mangle -A %s -d 10.0.0.0/8 -j RETURN", chain))
+	execCmd(fmt.Sprintf(iptablesBin()+" -t mangle -A %s -d 100.64.0.0/10 -j RETURN", chain))
+	execCmd(fmt.Sprintf(iptablesBin()+" -t mangle -A %s -d 127.0.0.0/8 -j RETURN", chain))
+	execCmd(fmt.Sprintf(iptablesBin()+" -t mangle -A %s -d 169.254.0.0/16 -j RETURN", chain))
+	execCmd(fmt.Sprintf(iptablesBin()+" -t mangle -A %s -d 172.16.0.0/12 -j RETURN", chain))
+	execCmd(fmt.Sprintf(iptablesBin()+" -t mangle -A %s -d 192.0.0.0/24 -j RETURN", chain))
+	execCmd(fmt.Sprintf(iptablesBin()+" -t mangle -A %s -d 192.0.2.0/24 -j RETURN", chain))
+	execCmd(fmt.Sprintf(iptablesBin()+" -t mangle -A %s -d 192.88.99.0/24 -j RETURN", chain))
+	execCmd(fmt.Sprintf(iptablesBin()+" -t mangle -A %s -d 192.168.0.0/16 -j RETURN", chain))
+	execCmd(fmt.Sprintf(iptablesBin()+" -t mangle -A %s -d 198.51.100.0/24 -j RETURN", chain))
+	execCmd(fmt.Sprintf(iptablesBin()+" -t mangle -A %s -d 203.0.113.0/24 -j RETURN", chain))
+	execCmd(fmt.Sprintf(iptablesBin()+" -t mangle -A %s -d 224.0.0.0/4 -j RETURN", chain))
+	execCmd(fmt.Sprintf(iptablesBin()+" -t mangle -A %s -d 240.0.0.0/4 -j RETURN", chain))
+	execCmd(fmt.Sprintf(iptablesBin()+" -t mangle -A %s -d 255.255.255.255/32 -j RETURN", chain))
+}
+
+func execCmd(cmdStr string) {
+	log.Debugln("[IPTABLES] %s", cmdStr)
+
+	_, err := cmd.ExecCmd(cmdStr)
+	if err != nil {
+		log.Warnln("[IPTABLES] exec cmd: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

This PR fixes #3002 and #3003 — two issues that cause mihomo's own connections to be captured by TUN in auto-route mode, and ensure auto-redirect works correctly on modern Linux distributions.

### Fix #3002: auto-route self-traffic bypass

In `auto-route` mode without `auto-redirect`, `DefaultRoutingMark` is `0`. All of mihomo's own connections (DoH DNS, proxy health checks, rule-provider downloads) go through the system routing table without SO_MARK, so they are captured by the TUN routing table (table 2022) and loop back through dns-hijack, causing DNS deadlock.

This fix:
- Sets `DefaultRoutingMark` to the configured `outputMark` (default `2158`) when `auto-route && !auto-redirect`
- Adds an ip rule so all marked traffic goes directly to the `main` routing table, bypassing TUN
- Registers cleanup in `Close()` to remove the rule on shutdown

### Fix #3003: iptables-legacy compat under DISABLE_NFTABLES

When `DISABLE_NFTABLES=true` (e.g. to work around #3001), sing-tun calls `sudo iptables` which on modern distros (Debian 13, Ubuntu 24+) points to `iptables-nft`. The SO_MARK set via `sockopt.RawConnMark` uses the legacy netfilter path, which is isolated from nf_tables. Therefore, the mark-based RETURN rules created by `iptables-nft` never match mihomo's own connections.

This fix:
- Adds `iptablesBin()` that returns `iptables-legacy` when `DISABLE_NFTABLES` is set
- All rule-creation and cleanup paths use `iptablesBin()` instead of hard-coded `iptables`
- Otherwise returns `iptables` to preserve backward compatibility

### Files changed

- `listener/sing_tun/server.go` — auto-route mark logic (import, mark setup, cleanup)
- `listener/tproxy/tproxy_iptables.go` — iptables-legacy fallback

### Testing

- [x] `go build -tags with_gvisor ./...` passes