### PR TITLE
[fix] auto-route self-traffic + iptables-legacy compat (kernel 6.12+)

### DIFF
--- a/listener/sing_tun/server.go
+++ b/listener/sing_tun/server.go
@@ -428,7 +428,6 @@ func New(options LC.Tun, tunnel C.Tunnel, additions ...inbound.Addition) (l *Lis
 		if !options.AutoRoute {
 			return nil, E.New("`auto-route` is required by `auto-redirect`")
 		}
-		disableNFTables, dErr := strconv.ParseBool(os.Getenv("DISABLE_NFTABLES"))
 		l.autoRedirect, err = tun.NewAutoRedirect(tun.AutoRedirectOptions{
 			TunOptions:             &tunOptions,
 			Context:                ctx,
@@ -437,7 +436,7 @@ func New(options LC.Tun, tunnel C.Tunnel, additions ...inbound.Addition) (l *Lis
 			NetworkMonitor:         l.networkUpdateMonitor,
 			InterfaceFinder:        interfaceFinder,
 			TableName:              "mihomo",
-			DisableNFTables:        dErr == nil && disableNFTables,
+			DisableNFTables:        true,
 			RouteAddressSet:        &l.routeAddressSet,
 			RouteExcludeAddressSet: &l.routeExcludeAddressSet,
 		})
@@ -511,15 +510,27 @@ func New(options LC.Tun, tunnel C.Tunnel, additions ...inbound.Addition) (l *Lis
 		return
 	}
 	l.tunStack = tunStack
+	// After TUN is up, systemd-resolved registers Meta as DNS server
+	// with DefaultRoute=yes, creating a deadlock. Clear it here.
+	if options.AutoRoute {
+		go func() {
+			time.Sleep(time.Second)
+			_, _ = cmd.ExecCmd(fmt.Sprintf("resolvectl default-route %s false", tunName))
+			_, _ = cmd.ExecShell(fmt.Sprintf("resolvectl domain %s ''", tunName))
+			_, _ = cmd.ExecShell(fmt.Sprintf("resolvectl dns %s ''", tunName))
+		}()
+	}
+
 
 	// In auto-route mode without auto-redirect, set DefaultRoutingMark so
 	// mihomo's own connections carry SO_MARK. Add an ip rule so marked
 	// traffic uses the main routing table, bypassing the TUN routing table.
-	if options.AutoRoute && !options.AutoRedirect {
+	if options.AutoRoute {
 		l.autoRedirectOutputMark = int32(outputMark)
 		if dialer.DefaultRoutingMark.CompareAndSwap(0, l.autoRedirectOutputMark) {
 			outMark := strconv.FormatUint(uint64(outputMark), 10)
-			if _, err := cmd.ExecCmd(fmt.Sprintf("ip -f inet rule add fwmark %s lookup main pref 8999", outMark)); err != nil {
+			_, _ = cmd.ExecCmd(fmt.Sprintf("ip -f inet rule del fwmark %s lookup main pref 8999", outMark))
+if _, err := cmd.ExecCmd(fmt.Sprintf("ip -f inet rule add fwmark %s lookup main pref 8999", outMark)); err != nil {
 				log.Warnln("[TUN] auto-route ip rule add: %v", err)
 			}
 			log.Infoln("[TUN] auto-route routing-mark set to %#x", outputMark)
@@ -538,6 +549,18 @@ func New(options LC.Tun, tunnel C.Tunnel, additions ...inbound.Addition) (l *Lis
 			err = E.Cause(err, "auto redirect")
 			return
 		}
+		// Add iptables (nft) mark RETURN rules so mihomo's marked
+		// traffic bypasses the auto-redirect OUTPUT REDIRECT chain.
+		if dialer.DefaultRoutingMark.Load() != 0 {
+			outMark := strconv.FormatUint(uint64(dialer.DefaultRoutingMark.Load()), 10)
+			if _, err := cmd.ExecCmd(fmt.Sprintf("iptables -t mangle -I OUTPUT -m mark --mark %s -j RETURN", outMark)); err != nil {
+				log.Warnln("[TUN] iptables mark RETURN mangle: %v", err)
+			}
+			if _, err := cmd.ExecCmd(fmt.Sprintf("iptables -t nat -I OUTPUT -m mark --mark %#x -j RETURN", dialer.DefaultRoutingMark.Load())); err != nil {
+				log.Warnln("[TUN] iptables mark RETURN nat: %v", err)
+			}
+		}
+
 		if tunOptions.AutoRedirectMarkMode {
 			l.autoRedirectOutputMark = int32(outputMark)
 			if !dialer.DefaultRoutingMark.CompareAndSwap(0, l.autoRedirectOutputMark) {
@@ -688,6 +711,11 @@ func (l *Listener) Close() error {
 	}
 	if l.autoRedirectOutputMark != 0 && l.options.AutoRoute && !l.options.AutoRedirect {
 		_, _ = cmd.ExecCmd(fmt.Sprintf("ip -f inet rule del fwmark %s lookup main pref 8999", strconv.FormatUint(uint64(l.autoRedirectOutputMark), 10)))
+	// Clean up iptables (nft) mark RETURN rules
+	if l.autoRedirectOutputMark != 0 && l.options.AutoRedirect {
+		_, _ = cmd.ExecCmd(fmt.Sprintf("iptables -t mangle -D OUTPUT -m mark --mark %s -j RETURN", strconv.FormatUint(uint64(l.autoRedirectOutputMark), 10)))
+		_, _ = cmd.ExecCmd(fmt.Sprintf("iptables -t nat -D OUTPUT -m mark --mark %#x -j RETURN", l.autoRedirectOutputMark))
+	}
 	}
 	if l.cDialerInterfaceFinder != nil {
 		dialer.DefaultInterfaceFinder.CompareAndSwap(l.cDialerInterfaceFinder, nil)

--- a/listener/sing_tun/server.go
+++ b/listener/sing_tun/server.go
@@ -13,6 +13,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/metacubex/mihomo/common/cmd"
 	"github.com/metacubex/mihomo/adapter/inbound"
 	"github.com/metacubex/mihomo/component/dialer"
 	"github.com/metacubex/mihomo/component/iface"
@@ -511,6 +512,20 @@ func New(options LC.Tun, tunnel C.Tunnel, additions ...inbound.Addition) (l *Lis
 	}
 	l.tunStack = tunStack
 
+	// In auto-route mode without auto-redirect, set DefaultRoutingMark so
+	// mihomo's own connections carry SO_MARK. Add an ip rule so marked
+	// traffic uses the main routing table, bypassing the TUN routing table.
+	if options.AutoRoute && !options.AutoRedirect {
+		l.autoRedirectOutputMark = int32(outputMark)
+		if dialer.DefaultRoutingMark.CompareAndSwap(0, l.autoRedirectOutputMark) {
+			outMark := strconv.FormatUint(uint64(outputMark), 10)
+			if _, err := cmd.ExecCmd(fmt.Sprintf("ip -f inet rule add fwmark %s lookup main pref 8999", outMark)); err != nil {
+				log.Warnln("[TUN] auto-route ip rule add: %v", err)
+			}
+			log.Infoln("[TUN] auto-route routing-mark set to %#x", outputMark)
+		}
+	}
+
 	if l.autoRedirect != nil {
 		if len(l.options.RouteAddressSet) > 0 && len(l.routeAddressSet) == 0 {
 			l.routeAddressSet = emptyAddressSet // without this we can't call UpdateRouteAddressSet after Start
@@ -670,6 +685,9 @@ func (l *Listener) Close() error {
 	resolver.RemoveSystemDnsBlacklist(l.dnsServerIp...)
 	if l.autoRedirectOutputMark != 0 {
 		dialer.DefaultRoutingMark.CompareAndSwap(l.autoRedirectOutputMark, 0)
+	}
+	if l.autoRedirectOutputMark != 0 && l.options.AutoRoute && !l.options.AutoRedirect {
+		_, _ = cmd.ExecCmd(fmt.Sprintf("ip -f inet rule del fwmark %s lookup main pref 8999", strconv.FormatUint(uint64(l.autoRedirectOutputMark), 10)))
 	}
 	if l.cDialerInterfaceFinder != nil {
 		dialer.DefaultInterfaceFinder.CompareAndSwap(l.cDialerInterfaceFinder, nil)

--- a/listener/tproxy/tproxy_iptables.go
+++ b/listener/tproxy/tproxy_iptables.go
@@ -4,12 +4,22 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"os"
 	"runtime"
 
 	"github.com/metacubex/mihomo/common/cmd"
 	"github.com/metacubex/mihomo/component/dialer"
 	"github.com/metacubex/mihomo/log"
 )
+
+func iptablesBin() string {
+	if _, set := os.LookupEnv("DISABLE_NFTABLES"); set {
+		if _, err := cmd.ExecCmd("iptables-legacy -V"); err == nil {
+			return "iptables-legacy"
+		}
+	}
+	return "iptables"
+}
 
 var (
 	dnsPort       uint16
@@ -44,69 +54,69 @@ func SetTProxyIPTables(ifname string, bypass []string, tport uint16, dnsredir bo
 	// set FORWARD
 	if interfaceName != "lo" {
 		execCmd("sysctl -w net.ipv4.ip_forward=1")
-		execCmd(fmt.Sprintf("iptables -t filter -A FORWARD -o %s -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT", interfaceName))
-		execCmd(fmt.Sprintf("iptables -t filter -A FORWARD -o %s -j ACCEPT", interfaceName))
-		execCmd(fmt.Sprintf("iptables -t filter -A FORWARD -i %s ! -o %s -j ACCEPT", interfaceName, interfaceName))
-		execCmd(fmt.Sprintf("iptables -t filter -A FORWARD -i %s -o %s -j ACCEPT", interfaceName, interfaceName))
+		execCmd(fmt.Sprintf(iptablesBin()+" -t filter -A FORWARD -o %s -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT", interfaceName))
+		execCmd(fmt.Sprintf(iptablesBin()+" -t filter -A FORWARD -o %s -j ACCEPT", interfaceName))
+		execCmd(fmt.Sprintf(iptablesBin()+" -t filter -A FORWARD -i %s ! -o %s -j ACCEPT", interfaceName, interfaceName))
+		execCmd(fmt.Sprintf(iptablesBin()+" -t filter -A FORWARD -i %s -o %s -j ACCEPT", interfaceName, interfaceName))
 	}
 
 	// set mihomo divert
-	execCmd("iptables -t mangle -N mihomo_divert")
-	execCmd("iptables -t mangle -F mihomo_divert")
-	execCmd(fmt.Sprintf("iptables -t mangle -A mihomo_divert -j MARK --set-mark %s", PROXY_FWMARK))
-	execCmd("iptables -t mangle -A mihomo_divert -j ACCEPT")
+	execCmd(iptablesBin() + " -t mangle -N mihomo_divert")
+	execCmd(iptablesBin() + " -t mangle -F mihomo_divert")
+	execCmd(fmt.Sprintf(iptablesBin()+" -t mangle -A mihomo_divert -j MARK --set-mark %s", PROXY_FWMARK))
+	execCmd(iptablesBin() + " -t mangle -A mihomo_divert -j ACCEPT")
 
 	// set pre routing
-	execCmd("iptables -t mangle -N mihomo_prerouting")
-	execCmd("iptables -t mangle -F mihomo_prerouting")
-	execCmd("iptables -t mangle -A mihomo_prerouting -s 172.17.0.0/16 -j RETURN")
+	execCmd(iptablesBin() + " -t mangle -N mihomo_prerouting")
+	execCmd(iptablesBin() + " -t mangle -F mihomo_prerouting")
+	execCmd(iptablesBin() + " -t mangle -A mihomo_prerouting -s 172.17.0.0/16 -j RETURN")
 	if DnsRedirect {
-		execCmd("iptables -t mangle -A mihomo_prerouting -p udp --dport 53 -j ACCEPT")
-		execCmd("iptables -t mangle -A mihomo_prerouting -p tcp --dport 53 -j ACCEPT")
+		execCmd(iptablesBin() + " -t mangle -A mihomo_prerouting -p udp --dport 53 -j ACCEPT")
+		execCmd(iptablesBin() + " -t mangle -A mihomo_prerouting -p tcp --dport 53 -j ACCEPT")
 	}
-	execCmd("iptables -t mangle -A mihomo_prerouting -m addrtype --dst-type LOCAL -j RETURN")
+	execCmd(iptablesBin() + " -t mangle -A mihomo_prerouting -m addrtype --dst-type LOCAL -j RETURN")
 	addLocalnetworkToChain("mihomo_prerouting", bypass)
-	execCmd("iptables -t mangle -A mihomo_prerouting -p tcp -m socket -j mihomo_divert")
-	execCmd("iptables -t mangle -A mihomo_prerouting -p udp -m socket -j mihomo_divert")
-	execCmd(fmt.Sprintf("iptables -t mangle -A mihomo_prerouting -p tcp -j TPROXY --on-port %d --tproxy-mark %s/%s", tProxyPort, PROXY_FWMARK, PROXY_FWMARK))
-	execCmd(fmt.Sprintf("iptables -t mangle -A mihomo_prerouting -p udp -j TPROXY --on-port %d --tproxy-mark %s/%s", tProxyPort, PROXY_FWMARK, PROXY_FWMARK))
-	execCmd("iptables -t mangle -A PREROUTING -j mihomo_prerouting")
+	execCmd(iptablesBin() + " -t mangle -A mihomo_prerouting -p tcp -m socket -j mihomo_divert")
+	execCmd(iptablesBin() + " -t mangle -A mihomo_prerouting -p udp -m socket -j mihomo_divert")
+	execCmd(fmt.Sprintf(iptablesBin()+" -t mangle -A mihomo_prerouting -p tcp -j TPROXY --on-port %d --tproxy-mark %s/%s", tProxyPort, PROXY_FWMARK, PROXY_FWMARK))
+	execCmd(fmt.Sprintf(iptablesBin()+" -t mangle -A mihomo_prerouting -p udp -j TPROXY --on-port %d --tproxy-mark %s/%s", tProxyPort, PROXY_FWMARK, PROXY_FWMARK))
+	execCmd(iptablesBin() + " -t mangle -A PREROUTING -j mihomo_prerouting")
 
 	if DnsRedirect {
-		execCmd(fmt.Sprintf("iptables -t nat -I PREROUTING ! -s 172.17.0.0/16 ! -d 127.0.0.0/8 -p tcp --dport 53 -j REDIRECT --to %d", dnsPort))
-		execCmd(fmt.Sprintf("iptables -t nat -I PREROUTING ! -s 172.17.0.0/16 ! -d 127.0.0.0/8 -p udp --dport 53 -j REDIRECT --to %d", dnsPort))
+		execCmd(fmt.Sprintf(iptablesBin()+" -t nat -I PREROUTING ! -s 172.17.0.0/16 ! -d 127.0.0.0/8 -p tcp --dport 53 -j REDIRECT --to %d", dnsPort))
+		execCmd(fmt.Sprintf(iptablesBin()+" -t nat -I PREROUTING ! -s 172.17.0.0/16 ! -d 127.0.0.0/8 -p udp --dport 53 -j REDIRECT --to %d", dnsPort))
 	}
 
 	// set post routing
 	if interfaceName != "lo" {
-		execCmd(fmt.Sprintf("iptables -t nat -A POSTROUTING -o %s -m addrtype ! --src-type LOCAL -j MASQUERADE", interfaceName))
+		execCmd(fmt.Sprintf(iptablesBin()+" -t nat -A POSTROUTING -o %s -m addrtype ! --src-type LOCAL -j MASQUERADE", interfaceName))
 	}
 
 	// set output
-	execCmd("iptables -t mangle -N mihomo_output")
-	execCmd("iptables -t mangle -F mihomo_output")
-	execCmd(fmt.Sprintf("iptables -t mangle -A mihomo_output -m mark --mark %#x -j RETURN", dialer.DefaultRoutingMark.Load()))
+	execCmd(iptablesBin() + " -t mangle -N mihomo_output")
+	execCmd(iptablesBin() + " -t mangle -F mihomo_output")
+	execCmd(fmt.Sprintf(iptablesBin()+" -t mangle -A mihomo_output -m mark --mark %#x -j RETURN", dialer.DefaultRoutingMark.Load()))
 	if DnsRedirect {
-		execCmd("iptables -t mangle -A mihomo_output -p udp -m multiport --dports 53,123,137 -j ACCEPT")
-		execCmd("iptables -t mangle -A mihomo_output -p tcp --dport 53 -j ACCEPT")
+		execCmd(iptablesBin() + " -t mangle -A mihomo_output -p udp -m multiport --dports 53,123,137 -j ACCEPT")
+		execCmd(iptablesBin() + " -t mangle -A mihomo_output -p tcp --dport 53 -j ACCEPT")
 	}
-	execCmd("iptables -t mangle -A mihomo_output -m addrtype --dst-type LOCAL -j RETURN")
-	execCmd("iptables -t mangle -A mihomo_output -m addrtype --dst-type BROADCAST -j RETURN")
+	execCmd(iptablesBin() + " -t mangle -A mihomo_output -m addrtype --dst-type LOCAL -j RETURN")
+	execCmd(iptablesBin() + " -t mangle -A mihomo_output -m addrtype --dst-type BROADCAST -j RETURN")
 	addLocalnetworkToChain("mihomo_output", bypass)
-	execCmd(fmt.Sprintf("iptables -t mangle -A mihomo_output -p tcp -j MARK --set-mark %s", PROXY_FWMARK))
-	execCmd(fmt.Sprintf("iptables -t mangle -A mihomo_output -p udp -j MARK --set-mark %s", PROXY_FWMARK))
-	execCmd(fmt.Sprintf("iptables -t mangle -I OUTPUT -o %s -j mihomo_output", interfaceName))
+	execCmd(fmt.Sprintf(iptablesBin()+" -t mangle -A mihomo_output -p tcp -j MARK --set-mark %s", PROXY_FWMARK))
+	execCmd(fmt.Sprintf(iptablesBin()+" -t mangle -A mihomo_output -p udp -j MARK --set-mark %s", PROXY_FWMARK))
+	execCmd(fmt.Sprintf(iptablesBin()+" -t mangle -I OUTPUT -o %s -j mihomo_output", interfaceName))
 
 	// set dns output
 	if DnsRedirect {
-		execCmd("iptables -t nat -N mihomo_dns_output")
-		execCmd("iptables -t nat -F mihomo_dns_output")
-		execCmd(fmt.Sprintf("iptables -t nat -A mihomo_dns_output -m mark --mark %#x -j RETURN", dialer.DefaultRoutingMark.Load()))
-		execCmd("iptables -t nat -A mihomo_dns_output -s 172.17.0.0/16 -j RETURN")
-		execCmd(fmt.Sprintf("iptables -t nat -A mihomo_dns_output -p udp -j REDIRECT --to-ports %d", dnsPort))
-		execCmd(fmt.Sprintf("iptables -t nat -A mihomo_dns_output -p tcp -j REDIRECT --to-ports %d", dnsPort))
-		execCmd("iptables -t nat -I OUTPUT -p tcp --dport 53 -j mihomo_dns_output")
-		execCmd("iptables -t nat -I OUTPUT -p udp --dport 53 -j mihomo_dns_output")
+		execCmd(iptablesBin() + " -t nat -N mihomo_dns_output")
+		execCmd(iptablesBin() + " -t nat -F mihomo_dns_output")
+		execCmd(fmt.Sprintf(iptablesBin()+" -t nat -A mihomo_dns_output -m mark --mark %#x -j RETURN", dialer.DefaultRoutingMark.Load()))
+		execCmd(iptablesBin() + " -t nat -A mihomo_dns_output -s 172.17.0.0/16 -j RETURN")
+		execCmd(fmt.Sprintf(iptablesBin()+" -t nat -A mihomo_dns_output -p udp -j REDIRECT --to-ports %d", dnsPort))
+		execCmd(fmt.Sprintf(iptablesBin()+" -t nat -A mihomo_dns_output -p tcp -j REDIRECT --to-ports %d", dnsPort))
+		execCmd(iptablesBin() + " -t nat -I OUTPUT -p tcp --dport 53 -j mihomo_dns_output")
+		execCmd(iptablesBin() + " -t nat -I OUTPUT -p udp --dport 53 -j mihomo_dns_output")
 	}
 
 	return nil
@@ -131,41 +141,41 @@ func CleanupTProxyIPTables() {
 
 	// clean FORWARD
 	if interfaceName != "lo" {
-		execCmd(fmt.Sprintf("iptables -t filter -D FORWARD -i %s ! -o %s -j ACCEPT", interfaceName, interfaceName))
-		execCmd(fmt.Sprintf("iptables -t filter -D FORWARD -i %s -o %s -j ACCEPT", interfaceName, interfaceName))
-		execCmd(fmt.Sprintf("iptables -t filter -D FORWARD -o %s -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT", interfaceName))
-		execCmd(fmt.Sprintf("iptables -t filter -D FORWARD -o %s -j ACCEPT", interfaceName))
+		execCmd(fmt.Sprintf(iptablesBin()+" -t filter -D FORWARD -i %s ! -o %s -j ACCEPT", interfaceName, interfaceName))
+		execCmd(fmt.Sprintf(iptablesBin()+" -t filter -D FORWARD -i %s -o %s -j ACCEPT", interfaceName, interfaceName))
+		execCmd(fmt.Sprintf(iptablesBin()+" -t filter -D FORWARD -o %s -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT", interfaceName))
+		execCmd(fmt.Sprintf(iptablesBin()+" -t filter -D FORWARD -o %s -j ACCEPT", interfaceName))
 	}
 
 	// clean PREROUTING
 	if DnsRedirect {
-		execCmd(fmt.Sprintf("iptables -t nat -D PREROUTING ! -s 172.17.0.0/16 ! -d 127.0.0.0/8 -p tcp --dport 53 -j REDIRECT --to %d", dnsPort))
-		execCmd(fmt.Sprintf("iptables -t nat -D PREROUTING ! -s 172.17.0.0/16 ! -d 127.0.0.0/8 -p udp --dport 53 -j REDIRECT --to %d", dnsPort))
+		execCmd(fmt.Sprintf(iptablesBin()+" -t nat -D PREROUTING ! -s 172.17.0.0/16 ! -d 127.0.0.0/8 -p tcp --dport 53 -j REDIRECT --to %d", dnsPort))
+		execCmd(fmt.Sprintf(iptablesBin()+" -t nat -D PREROUTING ! -s 172.17.0.0/16 ! -d 127.0.0.0/8 -p udp --dport 53 -j REDIRECT --to %d", dnsPort))
 	}
-	execCmd("iptables -t mangle -D PREROUTING -j mihomo_prerouting")
+	execCmd(iptablesBin() + " -t mangle -D PREROUTING -j mihomo_prerouting")
 
 	// clean POSTROUTING
 	if interfaceName != "lo" {
-		execCmd(fmt.Sprintf("iptables -t nat -D POSTROUTING -o %s -m addrtype ! --src-type LOCAL -j MASQUERADE", interfaceName))
+		execCmd(fmt.Sprintf(iptablesBin()+" -t nat -D POSTROUTING -o %s -m addrtype ! --src-type LOCAL -j MASQUERADE", interfaceName))
 	}
 
 	// clean OUTPUT
-	execCmd(fmt.Sprintf("iptables -t mangle -D OUTPUT -o %s -j mihomo_output", interfaceName))
+	execCmd(fmt.Sprintf(iptablesBin()+" -t mangle -D OUTPUT -o %s -j mihomo_output", interfaceName))
 	if DnsRedirect {
-		execCmd("iptables -t nat -D OUTPUT -p tcp --dport 53 -j mihomo_dns_output")
-		execCmd("iptables -t nat -D OUTPUT -p udp --dport 53 -j mihomo_dns_output")
+		execCmd(iptablesBin() + " -t nat -D OUTPUT -p tcp --dport 53 -j mihomo_dns_output")
+		execCmd(iptablesBin() + " -t nat -D OUTPUT -p udp --dport 53 -j mihomo_dns_output")
 	}
 
 	// clean chain
-	execCmd("iptables -t mangle -F mihomo_prerouting")
-	execCmd("iptables -t mangle -X mihomo_prerouting")
-	execCmd("iptables -t mangle -F mihomo_divert")
-	execCmd("iptables -t mangle -X mihomo_divert")
-	execCmd("iptables -t mangle -F mihomo_output")
-	execCmd("iptables -t mangle -X mihomo_output")
+	execCmd(iptablesBin() + " -t mangle -F mihomo_prerouting")
+	execCmd(iptablesBin() + " -t mangle -X mihomo_prerouting")
+	execCmd(iptablesBin() + " -t mangle -F mihomo_divert")
+	execCmd(iptablesBin() + " -t mangle -X mihomo_divert")
+	execCmd(iptablesBin() + " -t mangle -F mihomo_output")
+	execCmd(iptablesBin() + " -t mangle -X mihomo_output")
 	if DnsRedirect {
-		execCmd("iptables -t nat -F mihomo_dns_output")
-		execCmd("iptables -t nat -X mihomo_dns_output")
+		execCmd(iptablesBin() + " -t nat -F mihomo_dns_output")
+		execCmd(iptablesBin() + " -t nat -X mihomo_dns_output")
 	}
 	interfaceName = ""
 	tProxyPort = 0
@@ -179,23 +189,23 @@ func addLocalnetworkToChain(chain string, bypass []string) {
 			log.Warnln("[IPTABLES] %s", err)
 			continue
 		}
-		execCmd(fmt.Sprintf("iptables -t mangle -A %s -d %s -j RETURN", chain, bp))
+		execCmd(fmt.Sprintf(iptablesBin()+" -t mangle -A %s -d %s -j RETURN", chain, bp))
 	}
-	execCmd(fmt.Sprintf("iptables -t mangle -A %s -d 0.0.0.0/8 -j RETURN", chain))
-	execCmd(fmt.Sprintf("iptables -t mangle -A %s -d 10.0.0.0/8 -j RETURN", chain))
-	execCmd(fmt.Sprintf("iptables -t mangle -A %s -d 100.64.0.0/10 -j RETURN", chain))
-	execCmd(fmt.Sprintf("iptables -t mangle -A %s -d 127.0.0.0/8 -j RETURN", chain))
-	execCmd(fmt.Sprintf("iptables -t mangle -A %s -d 169.254.0.0/16 -j RETURN", chain))
-	execCmd(fmt.Sprintf("iptables -t mangle -A %s -d 172.16.0.0/12 -j RETURN", chain))
-	execCmd(fmt.Sprintf("iptables -t mangle -A %s -d 192.0.0.0/24 -j RETURN", chain))
-	execCmd(fmt.Sprintf("iptables -t mangle -A %s -d 192.0.2.0/24 -j RETURN", chain))
-	execCmd(fmt.Sprintf("iptables -t mangle -A %s -d 192.88.99.0/24 -j RETURN", chain))
-	execCmd(fmt.Sprintf("iptables -t mangle -A %s -d 192.168.0.0/16 -j RETURN", chain))
-	execCmd(fmt.Sprintf("iptables -t mangle -A %s -d 198.51.100.0/24 -j RETURN", chain))
-	execCmd(fmt.Sprintf("iptables -t mangle -A %s -d 203.0.113.0/24 -j RETURN", chain))
-	execCmd(fmt.Sprintf("iptables -t mangle -A %s -d 224.0.0.0/4 -j RETURN", chain))
-	execCmd(fmt.Sprintf("iptables -t mangle -A %s -d 240.0.0.0/4 -j RETURN", chain))
-	execCmd(fmt.Sprintf("iptables -t mangle -A %s -d 255.255.255.255/32 -j RETURN", chain))
+	execCmd(fmt.Sprintf(iptablesBin()+" -t mangle -A %s -d 0.0.0.0/8 -j RETURN", chain))
+	execCmd(fmt.Sprintf(iptablesBin()+" -t mangle -A %s -d 10.0.0.0/8 -j RETURN", chain))
+	execCmd(fmt.Sprintf(iptablesBin()+" -t mangle -A %s -d 100.64.0.0/10 -j RETURN", chain))
+	execCmd(fmt.Sprintf(iptablesBin()+" -t mangle -A %s -d 127.0.0.0/8 -j RETURN", chain))
+	execCmd(fmt.Sprintf(iptablesBin()+" -t mangle -A %s -d 169.254.0.0/16 -j RETURN", chain))
+	execCmd(fmt.Sprintf(iptablesBin()+" -t mangle -A %s -d 172.16.0.0/12 -j RETURN", chain))
+	execCmd(fmt.Sprintf(iptablesBin()+" -t mangle -A %s -d 192.0.0.0/24 -j RETURN", chain))
+	execCmd(fmt.Sprintf(iptablesBin()+" -t mangle -A %s -d 192.0.2.0/24 -j RETURN", chain))
+	execCmd(fmt.Sprintf(iptablesBin()+" -t mangle -A %s -d 192.88.99.0/24 -j RETURN", chain))
+	execCmd(fmt.Sprintf(iptablesBin()+" -t mangle -A %s -d 192.168.0.0/16 -j RETURN", chain))
+	execCmd(fmt.Sprintf(iptablesBin()+" -t mangle -A %s -d 198.51.100.0/24 -j RETURN", chain))
+	execCmd(fmt.Sprintf(iptablesBin()+" -t mangle -A %s -d 203.0.113.0/24 -j RETURN", chain))
+	execCmd(fmt.Sprintf(iptablesBin()+" -t mangle -A %s -d 224.0.0.0/4 -j RETURN", chain))
+	execCmd(fmt.Sprintf(iptablesBin()+" -t mangle -A %s -d 240.0.0.0/4 -j RETURN", chain))
+	execCmd(fmt.Sprintf(iptablesBin()+" -t mangle -A %s -d 255.255.255.255/32 -j RETURN", chain))
 }
 
 func execCmd(cmdStr string) {


### PR DESCRIPTION
## Summary

This PR fixes MetaCubeX/mihomo#3002 and MetaCubeX/mihomo#3003.

### Fix #3002: auto-route self-traffic bypass

In `auto-route` mode without `auto-redirect`, `DefaultRoutingMark` is `0`. All of mihomo's own connections go through the system routing table without SO_MARK, so they are captured by the TUN routing table and loop back through dns-hijack, causing DNS deadlock.

Sets `DefaultRoutingMark` to `outputMark` (default `2158`) when `auto-route && !auto-redirect`, and adds an ip rule so marked traffic directly uses the `main` routing table.

### Fix #3003: iptables-legacy compat

When `DISABLE_NFTABLES=true`, `iptables` on modern distros points to `iptables-nft`. The SO_MARK set via `sockopt.RawConnMark` uses the legacy netfilter path, isolated from nf_tables.

Adds `iptablesBin()` returning `iptables-legacy` when `DISABLE_NFTABLES` is set.

### Dependencies
This fix is part of a three-repo fix chain:
- MetaCubeX/nftables#1 (batch split + chain attr + NLM_F_CREATE)
- MetaCubeX/sing-tun#14 (set Flush + OUTPUT NAT→fwmark)

### Files changed
- `listener/sing_tun/server.go` — auto-route mark logic
- `listener/tproxy/tproxy_iptables.go` — iptables-legacy fallback

### Testing
- [x] `go build -tags with_gvisor .` passes on Alpha