### PR TITLE
feat(dns): add explicit mdns resolver

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1240,6 +1240,11 @@ func parseNameServer(servers []string, respectRules bool, preferH3 bool) ([]dns.
 			dnsNetType = "quic" // DNS over QUIC
 		case "system":
 			dnsNetType = "system" // System DNS
+		case "mdns":
+			dnsNetType = "mdns" // Multicast DNS
+			if u.Host != "" || u.Path != "" || u.RawQuery != "" || u.Fragment != "" {
+				err = errors.New("mDNS nameserver does not accept an address or parameters")
+			}
 		case "ts", "tailscale":
 			addr = u.Host
 			dnsNetType = "tailscale" // Tailscale DNS via proxy name
@@ -1274,7 +1279,7 @@ func parseNameServer(servers []string, respectRules bool, preferH3 bool) ([]dns.
 			return nil, fmt.Errorf("DNS NameServer[%d] format error: %s", idx, err.Error())
 		}
 
-		if respectRules && len(proxyName) == 0 {
+		if respectRules && len(proxyName) == 0 && dnsNetType != "mdns" {
 			proxyName = dns.RespectRules
 		}
 

--- a/config/dns_nameserver_test.go
+++ b/config/dns_nameserver_test.go
@@ -1,0 +1,36 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/metacubex/mihomo/common/orderedmap"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseMDNSNameServer(t *testing.T) {
+	nameservers, err := parseNameServer([]string{"mdns://"}, true, false)
+	require.NoError(t, err)
+	require.Len(t, nameservers, 1)
+	assert.Equal(t, "mdns", nameservers[0].Net)
+	assert.Empty(t, nameservers[0].Addr)
+	assert.Empty(t, nameservers[0].ProxyName)
+}
+
+func TestParseMDNSNameServerPolicy(t *testing.T) {
+	rawPolicy := orderedmap.New[string, any]()
+	rawPolicy.Set("+.local", []string{"mdns://"})
+
+	policy, err := parseNameServerPolicy(rawPolicy, nil, false, false)
+	require.NoError(t, err)
+	require.Len(t, policy, 1)
+	assert.Equal(t, "+.local", policy[0].Domain)
+	require.Len(t, policy[0].NameServers, 1)
+	assert.Equal(t, "mdns", policy[0].NameServers[0].Net)
+}
+
+func TestParseMDNSNameServerRejectsAddress(t *testing.T) {
+	_, err := parseNameServer([]string{"mdns://127.0.0.1"}, false, false)
+	assert.ErrorContains(t, err, "does not accept an address or parameters")
+}

--- a/dns/mdns.go
+++ b/dns/mdns.go
@@ -9,6 +9,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/metacubex/mihomo/log"
+
 	D "github.com/miekg/dns"
 	"golang.org/x/net/ipv4"
 	"golang.org/x/net/ipv6"
@@ -22,6 +24,7 @@ const (
 	mdnsCacheFlush      = uint16(1 << 15)
 	mdnsClassMask       = ^mdnsCacheFlush
 	mdnsMaxDatagramSize = 65535
+	mdnsMaxResponses    = 256
 )
 
 var (
@@ -43,20 +46,33 @@ type mdnsTarget struct {
 }
 
 type mdnsEvent struct {
-	msg    *D.Msg
-	err    error
-	packet bool
-	done   bool
+	response *mdnsResponse
+	err      error
+	packet   bool
+	done     bool
+}
+
+type mdnsResponse struct {
+	msg *D.Msg
+	// ifIndex identifies the ingress interface. Records from different
+	// interfaces are never linked into one CNAME chain.
+	ifIndex     int
+	source      *net.UDPAddr
+	destination net.IP
+	// hopLimit is retained for diagnostics and policy decisions. RFC 6762
+	// recommends 255, but does not require receivers to reject other values.
+	hopLimit int
 }
 
 type mdnsClient struct {
-	timeout  time.Duration
-	settle   time.Duration
-	platform func(context.Context, *D.Msg) (*D.Msg, bool, error)
-	targets  func() ([]mdnsTarget, error)
-	socketMu sync.Mutex
-	sockets  map[net.Conn]struct{}
-	closed   bool
+	timeout             time.Duration
+	settle              time.Duration
+	platform            func(context.Context, *D.Msg) (*D.Msg, bool, error)
+	targets             func() ([]mdnsTarget, error)
+	platformFallbackLog sync.Once
+	socketMu            sync.Mutex
+	sockets             map[net.Conn]struct{}
+	closed              bool
 }
 
 var _ dnsClient = (*mdnsClient)(nil)
@@ -76,7 +92,7 @@ func (c *mdnsClient) Address() string {
 	return "mdns://"
 }
 
-func (c *mdnsClient) ExchangeContext(ctx context.Context, request *D.Msg) (*D.Msg, error) {
+func (c *mdnsClient) ExchangeContext(ctx context.Context, request *D.Msg) (response *D.Msg, err error) {
 	if len(request.Question) == 0 {
 		return nil, errors.New("mDNS query should have one question at least")
 	}
@@ -86,11 +102,26 @@ func (c *mdnsClient) ExchangeContext(ctx context.Context, request *D.Msg) (*D.Ms
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
+
+	queryCtx, cancel := context.WithTimeout(ctx, c.timeout)
+	defer cancel()
+
+	var platformErr error
 	if c.platform != nil {
-		if response, handled, err := c.platform(ctx, request); handled {
+		if response, handled, err := c.platform(queryCtx, request); handled {
 			return response, err
+		} else if err != nil {
+			platformErr = err
+			c.platformFallbackLog.Do(func() {
+				log.Warnln("[DNS] %v; falling back to portable multicast", err)
+			})
 		}
 	}
+	defer func() {
+		if err != nil && platformErr != nil {
+			err = fmt.Errorf("mDNS platform resolver and multicast fallback failed: %w", errors.Join(platformErr, err))
+		}
+	}()
 
 	targets, err := c.targets()
 	if err != nil {
@@ -108,9 +139,6 @@ func (c *mdnsClient) ExchangeContext(ctx context.Context, request *D.Msg) (*D.Ms
 	if err != nil {
 		return nil, fmt.Errorf("pack mDNS query: %w", err)
 	}
-
-	queryCtx, cancel := context.WithTimeout(ctx, c.timeout)
-	defer cancel()
 
 	events := make(chan mdnsEvent, len(targets)*2)
 	connections := make([]*net.UDPConn, 0, len(targets))
@@ -149,10 +177,11 @@ func (c *mdnsClient) ExchangeContext(ctx context.Context, request *D.Msg) (*D.Ms
 		}
 
 		connections = append(connections, conn)
+		target := target
 		readers.Add(1)
 		go func() {
 			defer readers.Done()
-			readMDNSResponses(queryCtx, conn, query, events)
+			readMDNSResponses(queryCtx, conn, target, events)
 		}()
 	}
 
@@ -164,7 +193,9 @@ func (c *mdnsClient) ExchangeContext(ctx context.Context, request *D.Msg) (*D.Ms
 	}
 
 	var (
-		responses     []*D.Msg
+		responses     []mdnsResponse
+		merged        *D.Msg
+		mergedKey     string
 		firstError    error
 		activeReaders = len(connections)
 		packetCount   int
@@ -183,8 +214,8 @@ func (c *mdnsClient) ExchangeContext(ctx context.Context, request *D.Msg) (*D.Ms
 			if event.done {
 				activeReaders--
 				if activeReaders == 0 {
-					if len(responses) > 0 {
-						return mergeMDNSResponses(request, responses), nil
+					if merged != nil {
+						return merged, nil
 					}
 					if c.isClosed() {
 						return nil, errMDNSClientClosed
@@ -212,10 +243,25 @@ func (c *mdnsClient) ExchangeContext(ctx context.Context, request *D.Msg) (*D.Ms
 			if event.packet {
 				packetCount++
 			}
-			if event.msg == nil {
+			if event.response == nil {
 				continue
 			}
-			responses = append(responses, event.msg)
+			if len(responses) == mdnsMaxResponses {
+				copy(responses, responses[1:])
+				responses[len(responses)-1] = *event.response
+			} else {
+				responses = append(responses, *event.response)
+			}
+			candidate, available := mergeMDNSResponses(request, responses)
+			if !available {
+				continue
+			}
+			candidateKey := candidate.String()
+			merged = candidate
+			if candidateKey == mergedKey {
+				continue
+			}
+			mergedKey = candidateKey
 			if settleTimer == nil {
 				settleTimer = time.NewTimer(c.settle)
 			} else {
@@ -229,10 +275,10 @@ func (c *mdnsClient) ExchangeContext(ctx context.Context, request *D.Msg) (*D.Ms
 			}
 			settleC = settleTimer.C
 		case <-settleC:
-			return mergeMDNSResponses(request, responses), nil
+			return merged, nil
 		case <-queryCtx.Done():
-			if len(responses) > 0 {
-				return mergeMDNSResponses(request, responses), nil
+			if merged != nil {
+				return merged, nil
 			}
 			if err := ctx.Err(); err != nil {
 				return nil, err
@@ -416,7 +462,10 @@ func openMDNSSocket(target mdnsTarget) (*net.UDPConn, error) {
 	switch target.network {
 	case "udp4":
 		packetConn := ipv4.NewPacketConn(conn)
-		if err = packetConn.SetMulticastInterface(target.iface); err == nil {
+		if err = packetConn.SetControlMessage(ipv4.FlagTTL|ipv4.FlagDst|ipv4.FlagInterface, true); err == nil {
+			err = packetConn.SetMulticastInterface(target.iface)
+		}
+		if err == nil {
 			err = packetConn.SetMulticastTTL(mdnsMulticastTTL)
 		}
 		if err == nil {
@@ -424,7 +473,10 @@ func openMDNSSocket(target mdnsTarget) (*net.UDPConn, error) {
 		}
 	case "udp6":
 		packetConn := ipv6.NewPacketConn(conn)
-		if err = packetConn.SetMulticastInterface(target.iface); err == nil {
+		if err = packetConn.SetControlMessage(ipv6.FlagHopLimit|ipv6.FlagDst|ipv6.FlagInterface, true); err == nil {
+			err = packetConn.SetMulticastInterface(target.iface)
+		}
+		if err == nil {
 			err = packetConn.SetMulticastHopLimit(mdnsMulticastTTL)
 		}
 		if err == nil {
@@ -438,16 +490,18 @@ func openMDNSSocket(target mdnsTarget) (*net.UDPConn, error) {
 	return conn, nil
 }
 
-func readMDNSResponses(ctx context.Context, conn *net.UDPConn, query *D.Msg, events chan<- mdnsEvent) {
+func readMDNSResponses(ctx context.Context, conn *net.UDPConn, target mdnsTarget, events chan<- mdnsEvent) {
 	defer func() {
 		select {
 		case events <- mdnsEvent{done: true}:
 		case <-ctx.Done():
 		}
 	}()
+
+	readPacket := mdnsPacketReader(conn, target)
 	buffer := make([]byte, mdnsMaxDatagramSize)
 	for {
-		n, _, err := conn.ReadFromUDP(buffer)
+		n, response, err := readPacket(buffer)
 		if err != nil {
 			if ctx.Err() == nil {
 				select {
@@ -457,15 +511,21 @@ func readMDNSResponses(ctx context.Context, conn *net.UDPConn, query *D.Msg, eve
 			}
 			return
 		}
-
-		response := &D.Msg{}
-		if err = response.Unpack(buffer[:n]); err != nil {
+		event := mdnsEvent{packet: true}
+		if !validMDNSTransport(response, target) {
+			select {
+			case events <- event:
+			case <-ctx.Done():
+				return
+			}
 			continue
 		}
-		event := mdnsEvent{packet: true}
-		if isMDNSResponseForQuery(response, query) {
-			event.msg = response
+
+		response.msg = &D.Msg{}
+		if err = response.msg.Unpack(buffer[:n]); err != nil || !validMDNSMessage(response.msg) {
+			continue
 		}
+		event.response = response
 		select {
 		case events <- event:
 		case <-ctx.Done():
@@ -474,98 +534,218 @@ func readMDNSResponses(ctx context.Context, conn *net.UDPConn, query *D.Msg, eve
 	}
 }
 
-func isMDNSResponseForQuery(response, query *D.Msg) bool {
-	if !response.Response || response.Rcode != D.RcodeSuccess {
-		return false
-	}
-	if response.Id != 0 && response.Id != query.Id {
-		return false
+func mdnsPacketReader(conn *net.UDPConn, target mdnsTarget) func([]byte) (int, *mdnsResponse, error) {
+	if target.iface == nil || !target.addr.IP.IsMulticast() {
+		return func(buffer []byte) (int, *mdnsResponse, error) {
+			n, source, err := conn.ReadFromUDP(buffer)
+			return n, &mdnsResponse{source: source}, err
+		}
 	}
 
-	wanted := query.Question[0]
-	for _, question := range response.Question {
-		if strings.EqualFold(question.Name, wanted.Name) &&
-			question.Qtype == wanted.Qtype &&
-			question.Qclass&mdnsClassMask == wanted.Qclass&mdnsClassMask {
-			return true
+	switch target.network {
+	case "udp4":
+		packetConn := ipv4.NewPacketConn(conn)
+		return func(buffer []byte) (int, *mdnsResponse, error) {
+			n, control, source, err := packetConn.ReadFrom(buffer)
+			response := &mdnsResponse{source: asUDPAddr(source)}
+			if control != nil {
+				response.ifIndex = control.IfIndex
+				response.destination = append(net.IP(nil), control.Dst...)
+				response.hopLimit = control.TTL
+			}
+			return n, response, err
+		}
+	case "udp6":
+		packetConn := ipv6.NewPacketConn(conn)
+		return func(buffer []byte) (int, *mdnsResponse, error) {
+			n, control, source, err := packetConn.ReadFrom(buffer)
+			response := &mdnsResponse{source: asUDPAddr(source)}
+			if control != nil {
+				response.ifIndex = control.IfIndex
+				response.destination = append(net.IP(nil), control.Dst...)
+				response.hopLimit = control.HopLimit
+			}
+			return n, response, err
+		}
+	default:
+		return func([]byte) (int, *mdnsResponse, error) {
+			return 0, nil, fmt.Errorf("unsupported mDNS network %q", target.network)
 		}
 	}
-	for _, record := range append(response.Answer, response.Extra...) {
-		header := record.Header()
-		if !strings.EqualFold(header.Name, wanted.Name) ||
-			header.Class&mdnsClassMask != wanted.Qclass&mdnsClassMask {
-			continue
-		}
-		if header.Rrtype == wanted.Qtype || header.Rrtype == D.TypeCNAME || wanted.Qtype == D.TypeANY {
-			return true
-		}
-	}
-	return false
 }
 
-func mergeMDNSResponses(request *D.Msg, responses []*D.Msg) *D.Msg {
+func asUDPAddr(addr net.Addr) *net.UDPAddr {
+	if addr == nil {
+		return nil
+	}
+	udpAddr, _ := addr.(*net.UDPAddr)
+	return udpAddr
+}
+
+func validMDNSTransport(response *mdnsResponse, target mdnsTarget) bool {
+	if response == nil {
+		return false
+	}
+	if target.iface == nil || !target.addr.IP.IsMulticast() {
+		return true
+	}
+	return response.source != nil &&
+		response.source.Port == mdnsPort &&
+		response.ifIndex == target.iface.Index &&
+		response.destination.Equal(target.addr.IP)
+}
+
+func validMDNSMessage(response *D.Msg) bool {
+	return response.Response &&
+		response.Opcode == D.OpcodeQuery &&
+		response.Rcode == D.RcodeSuccess
+}
+
+// mergeMDNSResponses resolves CNAME chains independently on each ingress
+// interface, then returns the union of interfaces with a positive answer.
+// Identical records are collapsed using the greatest observed TTL. This keeps
+// same-named hosts on different links independent while allowing all distinct
+// addresses to be returned to Mihomo's interface-agnostic DNS layer.
+func mergeMDNSResponses(request *D.Msg, responses []mdnsResponse) (*D.Msg, bool) {
 	response := &D.Msg{}
 	response.SetReply(request)
 	response.Authoritative = true
 	response.RecursionAvailable = false
 
 	question := request.Question[0]
-	names := map[string]struct{}{canonicalMDNSName(question.Name): {}}
-	records := make([]D.RR, 0)
-	for _, message := range responses {
-		records = append(records, message.Answer...)
-		records = append(records, message.Extra...)
+	interfaceOrder := make([]int, 0)
+	interfaceRecords := map[int][]D.RR{}
+	for _, item := range responses {
+		if item.msg == nil {
+			continue
+		}
+		if _, exists := interfaceRecords[item.ifIndex]; !exists {
+			interfaceOrder = append(interfaceOrder, item.ifIndex)
+		}
+		interfaceRecords[item.ifIndex] = append(interfaceRecords[item.ifIndex], item.msg.Answer...)
+		interfaceRecords[item.ifIndex] = append(interfaceRecords[item.ifIndex], item.msg.Ns...)
+		interfaceRecords[item.ifIndex] = append(interfaceRecords[item.ifIndex], item.msg.Extra...)
 	}
 
-	for {
-		changed := false
-		for _, record := range records {
-			cname, ok := record.(*D.CNAME)
-			if !ok {
+	type interfaceResult struct {
+		answers  []D.RR
+		negative []D.RR
+		positive bool
+	}
+	results := make([]interfaceResult, 0, len(interfaceOrder))
+	hasPositive := false
+	hasNegative := false
+	for _, ifIndex := range interfaceOrder {
+		records := interfaceRecords[ifIndex]
+		rootName := canonicalMDNSName(question.Name)
+		names := map[string]struct{}{rootName: {}}
+		orderedNames := []string{rootName}
+		cnameOwners := map[string]struct{}{}
+		cnameAnswers := make([]D.RR, 0)
+		for nameIndex := 0; nameIndex < len(orderedNames); nameIndex++ {
+			name := orderedNames[nameIndex]
+			for _, record := range records {
+				cname, ok := record.(*D.CNAME)
+				if !ok || cname.Hdr.Class&mdnsClassMask != D.ClassINET {
+					continue
+				}
+				owner := canonicalMDNSName(cname.Hdr.Name)
+				if owner != name {
+					continue
+				}
+				cnameOwners[owner] = struct{}{}
+				cnameAnswers = append(cnameAnswers, record)
+				target := canonicalMDNSName(cname.Target)
+				if _, ok = names[target]; !ok {
+					names[target] = struct{}{}
+					orderedNames = append(orderedNames, target)
+				}
+			}
+		}
+
+		result := interfaceResult{answers: cnameAnswers}
+		if (question.Qtype == D.TypeCNAME || question.Qtype == D.TypeANY) && len(cnameAnswers) > 0 {
+			result.positive = true
+		}
+		for _, name := range orderedNames {
+			for _, record := range records {
+				header := record.Header()
+				if header.Class&mdnsClassMask != D.ClassINET ||
+					canonicalMDNSName(header.Name) != name {
+					continue
+				}
+				switch {
+				case header.Rrtype == D.TypeCNAME:
+					// CNAMEs were appended above in chain order.
+				case (header.Rrtype == question.Qtype || question.Qtype == D.TypeANY) &&
+					header.Rrtype != D.TypeNSEC:
+					result.answers = append(result.answers, record)
+					result.positive = true
+				case header.Rrtype == D.TypeNSEC:
+					if _, hasCNAME := cnameOwners[name]; !hasCNAME {
+						if nsec, ok := record.(*D.NSEC); ok && mdnsNSECExcludes(nsec, question.Qtype) {
+							result.negative = append(result.negative, record)
+						}
+					}
+				}
+			}
+		}
+		if result.positive {
+			hasPositive = true
+		} else if len(result.negative) > 0 {
+			hasNegative = true
+		}
+		results = append(results, result)
+	}
+
+	answerSeen := map[string]int{}
+	negativeSeen := map[string]int{}
+	for _, result := range results {
+		if hasPositive {
+			if !result.positive {
 				continue
 			}
-			if _, ok = names[canonicalMDNSName(cname.Hdr.Name)]; !ok {
-				continue
+			for _, record := range result.answers {
+				appendMDNSRecord(&response.Answer, answerSeen, record)
 			}
-			target := canonicalMDNSName(cname.Target)
-			if _, ok = names[target]; !ok {
-				names[target] = struct{}{}
-				changed = true
+		} else if hasNegative && len(result.negative) > 0 {
+			for _, record := range result.answers {
+				appendMDNSRecord(&response.Answer, answerSeen, record)
 			}
-		}
-		if !changed {
-			break
+			for _, record := range result.negative {
+				appendMDNSRecord(&response.Ns, negativeSeen, record)
+			}
 		}
 	}
+	return response, hasPositive || hasNegative
+}
 
-	seen := map[string]int{}
-	for _, record := range records {
-		header := record.Header()
-		if header.Class&mdnsClassMask != D.ClassINET {
-			continue
-		}
-		if _, ok := names[canonicalMDNSName(header.Name)]; !ok {
-			continue
-		}
-		if header.Rrtype != question.Qtype && header.Rrtype != D.TypeCNAME && question.Qtype != D.TypeANY {
-			continue
-		}
-
-		record = D.Copy(record)
-		record.Header().Class &= mdnsClassMask
-		keyRecord := D.Copy(record)
-		keyRecord.Header().Ttl = 0
-		key := strings.ToLower(keyRecord.String())
-		if index, ok := seen[key]; ok {
-			if response.Answer[index].Header().Ttl < record.Header().Ttl {
-				response.Answer[index].Header().Ttl = record.Header().Ttl
-			}
-			continue
-		}
-		seen[key] = len(response.Answer)
-		response.Answer = append(response.Answer, record)
+func mdnsNSECExcludes(nsec *D.NSEC, qtype uint16) bool {
+	if qtype == D.TypeANY {
+		return false
 	}
-	return response
+	for _, existingType := range nsec.TypeBitMap {
+		if existingType == qtype {
+			return false
+		}
+	}
+	return true
+}
+
+func appendMDNSRecord(records *[]D.RR, seen map[string]int, record D.RR) {
+	record = D.Copy(record)
+	record.Header().Class &= mdnsClassMask
+	keyRecord := D.Copy(record)
+	keyRecord.Header().Ttl = 0
+	key := strings.ToLower(keyRecord.String())
+	if index, ok := seen[key]; ok {
+		if (*records)[index].Header().Ttl < record.Header().Ttl {
+			(*records)[index].Header().Ttl = record.Header().Ttl
+		}
+		return
+	}
+	seen[key] = len(*records)
+	*records = append(*records, record)
 }
 
 func canonicalMDNSName(name string) string {

--- a/dns/mdns.go
+++ b/dns/mdns.go
@@ -1,0 +1,580 @@
+package dns
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"strings"
+	"sync"
+	"time"
+
+	D "github.com/miekg/dns"
+	"golang.org/x/net/ipv4"
+	"golang.org/x/net/ipv6"
+)
+
+const (
+	mdnsPort            = 5353
+	mdnsDefaultTimeout  = time.Second
+	mdnsResponseSettle  = 100 * time.Millisecond
+	mdnsMulticastTTL    = 255
+	mdnsCacheFlush      = uint16(1 << 15)
+	mdnsClassMask       = ^mdnsCacheFlush
+	mdnsMaxDatagramSize = 65535
+)
+
+var (
+	errMDNSClientClosed = errors.New("mDNS client is closed")
+	errMDNSTimeout      = errors.New("mDNS query timed out")
+)
+
+type mdnsInterface struct {
+	iface net.Interface
+	ipv4  net.IP
+	ipv6  net.IP
+}
+
+type mdnsTarget struct {
+	network   string
+	iface     *net.Interface
+	localAddr *net.UDPAddr
+	addr      *net.UDPAddr
+}
+
+type mdnsEvent struct {
+	msg    *D.Msg
+	err    error
+	packet bool
+	done   bool
+}
+
+type mdnsClient struct {
+	timeout  time.Duration
+	settle   time.Duration
+	platform func(context.Context, *D.Msg) (*D.Msg, bool, error)
+	targets  func() ([]mdnsTarget, error)
+	socketMu sync.Mutex
+	sockets  map[net.Conn]struct{}
+	closed   bool
+}
+
+var _ dnsClient = (*mdnsClient)(nil)
+
+func newMDNSClient() *mdnsClient {
+	client := &mdnsClient{
+		timeout: mdnsDefaultTimeout,
+		settle:  mdnsResponseSettle,
+		targets: discoverMDNSTargets,
+		sockets: map[net.Conn]struct{}{},
+	}
+	client.platform = client.exchangeMDNSPlatform
+	return client
+}
+
+func (c *mdnsClient) Address() string {
+	return "mdns://"
+}
+
+func (c *mdnsClient) ExchangeContext(ctx context.Context, request *D.Msg) (*D.Msg, error) {
+	if len(request.Question) == 0 {
+		return nil, errors.New("mDNS query should have one question at least")
+	}
+	if c.isClosed() {
+		return nil, errMDNSClientClosed
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	if c.platform != nil {
+		if response, handled, err := c.platform(ctx, request); handled {
+			return response, err
+		}
+	}
+
+	targets, err := c.targets()
+	if err != nil {
+		return nil, err
+	}
+	if len(targets) == 0 {
+		return nil, errors.New("no multicast-capable network interface")
+	}
+
+	query := request.Copy()
+	query.Id = 0
+	query.Response = false
+	query.RecursionDesired = false
+	wire, err := query.Pack()
+	if err != nil {
+		return nil, fmt.Errorf("pack mDNS query: %w", err)
+	}
+
+	queryCtx, cancel := context.WithTimeout(ctx, c.timeout)
+	defer cancel()
+
+	events := make(chan mdnsEvent, len(targets)*2)
+	connections := make([]*net.UDPConn, 0, len(targets))
+	var readers sync.WaitGroup
+	defer func() {
+		cancel()
+		for _, conn := range connections {
+			_ = conn.Close()
+		}
+		readers.Wait()
+		for _, conn := range connections {
+			c.unregisterSocket(conn)
+		}
+	}()
+
+	var setupErrors []error
+	for _, target := range targets {
+		conn, err := openMDNSSocket(target)
+		if err != nil {
+			setupErrors = append(setupErrors, err)
+			continue
+		}
+		if !c.registerSocket(conn) {
+			_ = conn.Close()
+			return nil, errMDNSClientClosed
+		}
+
+		if deadline, ok := queryCtx.Deadline(); ok {
+			_ = conn.SetReadDeadline(deadline)
+		}
+		if _, err = conn.WriteToUDP(wire, target.addr); err != nil {
+			c.unregisterSocket(conn)
+			_ = conn.Close()
+			setupErrors = append(setupErrors, fmt.Errorf("send mDNS query on %s: %w", target, err))
+			continue
+		}
+
+		connections = append(connections, conn)
+		readers.Add(1)
+		go func() {
+			defer readers.Done()
+			readMDNSResponses(queryCtx, conn, query, events)
+		}()
+	}
+
+	if len(connections) == 0 {
+		if len(setupErrors) == 0 {
+			return nil, errors.New("unable to open an mDNS socket")
+		}
+		return nil, fmt.Errorf("unable to open an mDNS socket: %w", errors.Join(setupErrors...))
+	}
+
+	var (
+		responses     []*D.Msg
+		firstError    error
+		activeReaders = len(connections)
+		packetCount   int
+		settleC       <-chan time.Time
+		settleTimer   *time.Timer
+	)
+	defer func() {
+		if settleTimer != nil {
+			settleTimer.Stop()
+		}
+	}()
+
+	for {
+		select {
+		case event := <-events:
+			if event.done {
+				activeReaders--
+				if activeReaders == 0 {
+					if len(responses) > 0 {
+						return mergeMDNSResponses(request, responses), nil
+					}
+					if c.isClosed() {
+						return nil, errMDNSClientClosed
+					}
+					if err := ctx.Err(); err != nil {
+						return nil, err
+					}
+					if firstError != nil {
+						var netError net.Error
+						if errors.As(firstError, &netError) && netError.Timeout() {
+							return nil, fmt.Errorf("%w after receiving %d packets: %w", errMDNSTimeout, packetCount, firstError)
+						}
+						return nil, fmt.Errorf("all mDNS sockets closed: %w", firstError)
+					}
+					return nil, errors.New("all mDNS sockets closed without a response")
+				}
+				continue
+			}
+			if event.err != nil {
+				if firstError == nil {
+					firstError = event.err
+				}
+				continue
+			}
+			if event.packet {
+				packetCount++
+			}
+			if event.msg == nil {
+				continue
+			}
+			responses = append(responses, event.msg)
+			if settleTimer == nil {
+				settleTimer = time.NewTimer(c.settle)
+			} else {
+				if !settleTimer.Stop() {
+					select {
+					case <-settleTimer.C:
+					default:
+					}
+				}
+				settleTimer.Reset(c.settle)
+			}
+			settleC = settleTimer.C
+		case <-settleC:
+			return mergeMDNSResponses(request, responses), nil
+		case <-queryCtx.Done():
+			if len(responses) > 0 {
+				return mergeMDNSResponses(request, responses), nil
+			}
+			if err := ctx.Err(); err != nil {
+				return nil, err
+			}
+			if firstError != nil && !errors.Is(firstError, net.ErrClosed) {
+				return nil, fmt.Errorf("%w after receiving %d packets: %w", errMDNSTimeout, packetCount, firstError)
+			}
+			return nil, fmt.Errorf("%w after receiving %d packets: %w", errMDNSTimeout, packetCount, queryCtx.Err())
+		}
+	}
+}
+
+func (c *mdnsClient) ResetConnection() {
+	c.closeSockets(false)
+}
+
+func (c *mdnsClient) Close() error {
+	c.closeSockets(true)
+	return nil
+}
+
+func (c *mdnsClient) closeSockets(closeClient bool) {
+	c.socketMu.Lock()
+	if closeClient {
+		c.closed = true
+	}
+	sockets := make([]net.Conn, 0, len(c.sockets))
+	for conn := range c.sockets {
+		sockets = append(sockets, conn)
+	}
+	c.socketMu.Unlock()
+
+	for _, conn := range sockets {
+		_ = conn.Close()
+	}
+}
+
+func (c *mdnsClient) registerSocket(conn net.Conn) bool {
+	c.socketMu.Lock()
+	defer c.socketMu.Unlock()
+	if c.closed {
+		return false
+	}
+	c.sockets[conn] = struct{}{}
+	return true
+}
+
+func (c *mdnsClient) unregisterSocket(conn net.Conn) {
+	c.socketMu.Lock()
+	delete(c.sockets, conn)
+	c.socketMu.Unlock()
+}
+
+func (c *mdnsClient) activeSockets() int {
+	c.socketMu.Lock()
+	defer c.socketMu.Unlock()
+	return len(c.sockets)
+}
+
+func (c *mdnsClient) isClosed() bool {
+	c.socketMu.Lock()
+	defer c.socketMu.Unlock()
+	return c.closed
+}
+
+func discoverMDNSTargets() ([]mdnsTarget, error) {
+	interfaces, err := discoverMDNSInterfaces()
+	if err != nil {
+		return nil, err
+	}
+	return targetsForMDNSInterfaces(interfaces), nil
+}
+
+func discoverMDNSInterfaces() ([]mdnsInterface, error) {
+	interfaces, err := net.Interfaces()
+	if err != nil {
+		return nil, fmt.Errorf("list network interfaces for mDNS: %w", err)
+	}
+
+	result := make([]mdnsInterface, 0, len(interfaces))
+	for _, iface := range interfaces {
+		if iface.Flags&net.FlagUp == 0 ||
+			iface.Flags&net.FlagMulticast == 0 ||
+			iface.Flags&net.FlagPointToPoint != 0 {
+			continue
+		}
+
+		addrs, err := iface.Addrs()
+		if err != nil {
+			continue
+		}
+		item := mdnsInterface{iface: iface}
+		for _, rawAddr := range addrs {
+			ip, _, err := net.ParseCIDR(rawAddr.String())
+			if err != nil {
+				if ipAddr, ok := rawAddr.(*net.IPAddr); ok {
+					ip = ipAddr.IP
+				} else {
+					continue
+				}
+			}
+			if ip.To4() != nil {
+				if item.ipv4 == nil {
+					item.ipv4 = ip.To4()
+				}
+			} else if ip.To16() != nil {
+				if item.ipv6 == nil || ip.IsLinkLocalUnicast() {
+					item.ipv6 = ip.To16()
+				}
+			}
+		}
+		if item.ipv4 != nil || item.ipv6 != nil {
+			result = append(result, item)
+		}
+	}
+	return result, nil
+}
+
+func targetsForMDNSInterfaces(interfaces []mdnsInterface) []mdnsTarget {
+	targets := make([]mdnsTarget, 0, len(interfaces)*2)
+	for i := range interfaces {
+		item := &interfaces[i]
+		if item.iface.Flags&net.FlagUp == 0 ||
+			item.iface.Flags&net.FlagMulticast == 0 ||
+			item.iface.Flags&net.FlagPointToPoint != 0 {
+			continue
+		}
+		if item.ipv4 != nil {
+			targets = append(targets, mdnsTarget{
+				network:   "udp4",
+				iface:     &item.iface,
+				localAddr: &net.UDPAddr{IP: item.ipv4},
+				addr:      &net.UDPAddr{IP: net.IPv4(224, 0, 0, 251), Port: mdnsPort},
+			})
+		}
+		if item.ipv6 != nil {
+			targets = append(targets, mdnsTarget{
+				network:   "udp6",
+				iface:     &item.iface,
+				localAddr: &net.UDPAddr{IP: item.ipv6, Zone: item.iface.Name},
+				addr:      &net.UDPAddr{IP: net.ParseIP("ff02::fb"), Port: mdnsPort, Zone: item.iface.Name},
+			})
+		}
+	}
+	return targets
+}
+
+func openMDNSSocket(target mdnsTarget) (*net.UDPConn, error) {
+	var (
+		conn *net.UDPConn
+		err  error
+	)
+	if target.iface != nil && target.addr.IP.IsMulticast() {
+		conn, err = net.ListenMulticastUDP(target.network, target.iface, target.addr)
+	} else {
+		localAddr := target.localAddr
+		if localAddr == nil {
+			localAddr = &net.UDPAddr{}
+		}
+		switch target.network {
+		case "udp4":
+			if localAddr.IP == nil {
+				localAddr.IP = net.IPv4zero
+			}
+		case "udp6":
+			if localAddr.IP == nil {
+				localAddr.IP = net.IPv6unspecified
+			}
+		default:
+			return nil, fmt.Errorf("unsupported mDNS network %q", target.network)
+		}
+		conn, err = net.ListenUDP(target.network, localAddr)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("listen for mDNS on %s: %w", target, err)
+	}
+	if target.iface == nil {
+		return conn, nil
+	}
+
+	switch target.network {
+	case "udp4":
+		packetConn := ipv4.NewPacketConn(conn)
+		if err = packetConn.SetMulticastInterface(target.iface); err == nil {
+			err = packetConn.SetMulticastTTL(mdnsMulticastTTL)
+		}
+		if err == nil {
+			err = packetConn.SetMulticastLoopback(true)
+		}
+	case "udp6":
+		packetConn := ipv6.NewPacketConn(conn)
+		if err = packetConn.SetMulticastInterface(target.iface); err == nil {
+			err = packetConn.SetMulticastHopLimit(mdnsMulticastTTL)
+		}
+		if err == nil {
+			err = packetConn.SetMulticastLoopback(true)
+		}
+	}
+	if err != nil {
+		_ = conn.Close()
+		return nil, fmt.Errorf("configure mDNS socket on %s: %w", target, err)
+	}
+	return conn, nil
+}
+
+func readMDNSResponses(ctx context.Context, conn *net.UDPConn, query *D.Msg, events chan<- mdnsEvent) {
+	defer func() {
+		select {
+		case events <- mdnsEvent{done: true}:
+		case <-ctx.Done():
+		}
+	}()
+	buffer := make([]byte, mdnsMaxDatagramSize)
+	for {
+		n, _, err := conn.ReadFromUDP(buffer)
+		if err != nil {
+			if ctx.Err() == nil {
+				select {
+				case events <- mdnsEvent{err: err}:
+				case <-ctx.Done():
+				}
+			}
+			return
+		}
+
+		response := &D.Msg{}
+		if err = response.Unpack(buffer[:n]); err != nil {
+			continue
+		}
+		event := mdnsEvent{packet: true}
+		if isMDNSResponseForQuery(response, query) {
+			event.msg = response
+		}
+		select {
+		case events <- event:
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+func isMDNSResponseForQuery(response, query *D.Msg) bool {
+	if !response.Response || response.Rcode != D.RcodeSuccess {
+		return false
+	}
+	if response.Id != 0 && response.Id != query.Id {
+		return false
+	}
+
+	wanted := query.Question[0]
+	for _, question := range response.Question {
+		if strings.EqualFold(question.Name, wanted.Name) &&
+			question.Qtype == wanted.Qtype &&
+			question.Qclass&mdnsClassMask == wanted.Qclass&mdnsClassMask {
+			return true
+		}
+	}
+	for _, record := range append(response.Answer, response.Extra...) {
+		header := record.Header()
+		if !strings.EqualFold(header.Name, wanted.Name) ||
+			header.Class&mdnsClassMask != wanted.Qclass&mdnsClassMask {
+			continue
+		}
+		if header.Rrtype == wanted.Qtype || header.Rrtype == D.TypeCNAME || wanted.Qtype == D.TypeANY {
+			return true
+		}
+	}
+	return false
+}
+
+func mergeMDNSResponses(request *D.Msg, responses []*D.Msg) *D.Msg {
+	response := &D.Msg{}
+	response.SetReply(request)
+	response.Authoritative = true
+	response.RecursionAvailable = false
+
+	question := request.Question[0]
+	names := map[string]struct{}{canonicalMDNSName(question.Name): {}}
+	records := make([]D.RR, 0)
+	for _, message := range responses {
+		records = append(records, message.Answer...)
+		records = append(records, message.Extra...)
+	}
+
+	for {
+		changed := false
+		for _, record := range records {
+			cname, ok := record.(*D.CNAME)
+			if !ok {
+				continue
+			}
+			if _, ok = names[canonicalMDNSName(cname.Hdr.Name)]; !ok {
+				continue
+			}
+			target := canonicalMDNSName(cname.Target)
+			if _, ok = names[target]; !ok {
+				names[target] = struct{}{}
+				changed = true
+			}
+		}
+		if !changed {
+			break
+		}
+	}
+
+	seen := map[string]int{}
+	for _, record := range records {
+		header := record.Header()
+		if header.Class&mdnsClassMask != D.ClassINET {
+			continue
+		}
+		if _, ok := names[canonicalMDNSName(header.Name)]; !ok {
+			continue
+		}
+		if header.Rrtype != question.Qtype && header.Rrtype != D.TypeCNAME && question.Qtype != D.TypeANY {
+			continue
+		}
+
+		record = D.Copy(record)
+		record.Header().Class &= mdnsClassMask
+		keyRecord := D.Copy(record)
+		keyRecord.Header().Ttl = 0
+		key := strings.ToLower(keyRecord.String())
+		if index, ok := seen[key]; ok {
+			if response.Answer[index].Header().Ttl < record.Header().Ttl {
+				response.Answer[index].Header().Ttl = record.Header().Ttl
+			}
+			continue
+		}
+		seen[key] = len(response.Answer)
+		response.Answer = append(response.Answer, record)
+	}
+	return response
+}
+
+func canonicalMDNSName(name string) string {
+	return strings.ToLower(D.Fqdn(name))
+}
+
+func (t mdnsTarget) String() string {
+	if t.iface == nil {
+		return fmt.Sprintf("%s/%s", t.network, t.addr)
+	}
+	return fmt.Sprintf("%s/%s/%s", t.network, t.iface.Name, t.addr)
+}

--- a/dns/mdns_darwin.go
+++ b/dns/mdns_darwin.go
@@ -1,0 +1,237 @@
+//go:build darwin
+
+package dns
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"time"
+
+	D "github.com/miekg/dns"
+)
+
+// This is the versioned IPC protocol used by Apple's public dns_sd.h client
+// library. Keeping the small A/AAAA subset here lets release builds remain
+// CGO-free while still using the shared mDNSResponder service as Apple
+// recommends. Protocol definitions:
+// https://github.com/apple-oss-distributions/mDNSResponder/blob/main/mDNSShared/dnssd_ipc.h
+const (
+	mdnsResponderDefaultSocket  = "/var/run/mDNSResponder"
+	mdnsResponderIPCVersion     = 1
+	mdnsResponderHeaderSize     = 28
+	mdnsResponderReplyHeader    = 12
+	mdnsResponderAddrInfoOp     = 15
+	mdnsResponderAddrInfoReply  = 72
+	mdnsResponderForceMulticast = 0x400
+	mdnsResponderFlagAdd        = 0x2
+	mdnsResponderProtocolIPv4   = 0x1
+	mdnsResponderProtocolIPv6   = 0x2
+	mdnsResponderTimeoutError   = -65568
+)
+
+func (c *mdnsClient) exchangeMDNSPlatform(ctx context.Context, request *D.Msg) (*D.Msg, bool, error) {
+	question := request.Question[0]
+	var protocol uint32
+	switch question.Qtype {
+	case D.TypeA:
+		protocol = mdnsResponderProtocolIPv4
+	case D.TypeAAAA:
+		protocol = mdnsResponderProtocolIPv6
+	default:
+		return nil, false, nil
+	}
+
+	queryCtx, cancel := context.WithTimeout(ctx, c.timeout)
+	defer cancel()
+
+	socketPath := os.Getenv("DNSSD_UDS_PATH")
+	if socketPath == "" {
+		socketPath = mdnsResponderDefaultSocket
+	}
+	conn, err := (&net.Dialer{}).DialContext(queryCtx, "unix", socketPath)
+	if err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return nil, true, ctxErr
+		}
+		return nil, false, nil // Let the portable multicast transport try.
+	}
+	if !c.registerSocket(conn) {
+		_ = conn.Close()
+		return nil, true, errMDNSClientClosed
+	}
+	defer func() {
+		_ = conn.Close()
+		c.unregisterSocket(conn)
+	}()
+
+	stopCancellation := make(chan struct{})
+	defer close(stopCancellation)
+	go func() {
+		select {
+		case <-queryCtx.Done():
+			_ = conn.Close()
+		case <-stopCancellation:
+		}
+	}()
+
+	if deadline, ok := queryCtx.Deadline(); ok {
+		_ = conn.SetDeadline(deadline)
+	}
+	if err = writeMDNSResponderRequest(conn, question.Name, protocol); err != nil {
+		return nil, true, c.mdnsResponderError(queryCtx, err)
+	}
+
+	var initialError [4]byte
+	if _, err = io.ReadFull(conn, initialError[:]); err != nil {
+		return nil, true, c.mdnsResponderError(queryCtx, err)
+	}
+	if code := int32(binary.BigEndian.Uint32(initialError[:])); code != 0 {
+		return nil, true, fmt.Errorf("mDNSResponder rejected query: error %d", code)
+	}
+
+	var responses []*D.Msg
+	for {
+		message, flags, code, err := readMDNSResponderReply(conn, request)
+		if err != nil {
+			if len(responses) > 0 && isTimeoutError(err) {
+				return mergeMDNSResponses(request, responses), true, nil
+			}
+			return nil, true, c.mdnsResponderError(queryCtx, err)
+		}
+		if code != 0 {
+			if code == mdnsResponderTimeoutError {
+				if len(responses) > 0 {
+					return mergeMDNSResponses(request, responses), true, nil
+				}
+				return nil, true, fmt.Errorf("%w: mDNSResponder error %d", errMDNSTimeout, code)
+			}
+			return nil, true, fmt.Errorf("mDNSResponder query failed: error %d", code)
+		}
+		if flags&mdnsResponderFlagAdd != 0 && message != nil {
+			responses = append(responses, message)
+			_ = conn.SetReadDeadline(time.Now().Add(c.settle))
+		}
+	}
+}
+
+func (c *mdnsClient) mdnsResponderError(ctx context.Context, err error) error {
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		if errors.Is(ctxErr, context.DeadlineExceeded) {
+			return fmt.Errorf("%w: %w", errMDNSTimeout, ctxErr)
+		}
+		return ctxErr
+	}
+	if c.isClosed() {
+		return errMDNSClientClosed
+	}
+	if isTimeoutError(err) {
+		return fmt.Errorf("%w: %w", errMDNSTimeout, err)
+	}
+	return fmt.Errorf("mDNSResponder IPC: %w", err)
+}
+
+func writeMDNSResponderRequest(writer io.Writer, hostname string, protocol uint32) error {
+	hostname = D.Fqdn(hostname)
+	dataLength := 3*4 + len(hostname) + 1
+	message := make([]byte, mdnsResponderHeaderSize+dataLength)
+	binary.BigEndian.PutUint32(message[0:4], mdnsResponderIPCVersion)
+	binary.BigEndian.PutUint32(message[4:8], uint32(dataLength))
+	binary.BigEndian.PutUint32(message[12:16], mdnsResponderAddrInfoOp)
+	binary.BigEndian.PutUint32(message[28:32], mdnsResponderForceMulticast)
+	binary.BigEndian.PutUint32(message[32:36], 0) // All eligible interfaces.
+	binary.BigEndian.PutUint32(message[36:40], protocol)
+	copy(message[40:], hostname)
+	return writeAll(writer, message)
+}
+
+func readMDNSResponderReply(reader io.Reader, request *D.Msg) (*D.Msg, uint32, int32, error) {
+	header := make([]byte, mdnsResponderHeaderSize)
+	if _, err := io.ReadFull(reader, header); err != nil {
+		return nil, 0, 0, err
+	}
+	if version := binary.BigEndian.Uint32(header[0:4]); version != mdnsResponderIPCVersion {
+		return nil, 0, 0, fmt.Errorf("unsupported mDNSResponder IPC version %d", version)
+	}
+	dataLength := binary.BigEndian.Uint32(header[4:8])
+	if dataLength < mdnsResponderReplyHeader || dataLength > mdnsMaxDatagramSize {
+		return nil, 0, 0, fmt.Errorf("invalid mDNSResponder reply length %d", dataLength)
+	}
+	if operation := binary.BigEndian.Uint32(header[12:16]); operation != mdnsResponderAddrInfoReply {
+		return nil, 0, 0, fmt.Errorf("unexpected mDNSResponder reply operation %d", operation)
+	}
+
+	body := make([]byte, dataLength)
+	if _, err := io.ReadFull(reader, body); err != nil {
+		return nil, 0, 0, err
+	}
+	flags := binary.BigEndian.Uint32(body[0:4])
+	code := int32(binary.BigEndian.Uint32(body[8:12]))
+	if code != 0 {
+		return nil, flags, code, nil
+	}
+
+	nameEnd := bytes.IndexByte(body[mdnsResponderReplyHeader:], 0)
+	if nameEnd < 0 {
+		return nil, 0, 0, errors.New("unterminated hostname in mDNSResponder reply")
+	}
+	nameEnd += mdnsResponderReplyHeader
+	name := string(body[mdnsResponderReplyHeader:nameEnd])
+	offset := nameEnd + 1
+	if len(body)-offset < 3*2+4 {
+		return nil, 0, 0, errors.New("truncated mDNSResponder reply")
+	}
+	rrType := binary.BigEndian.Uint16(body[offset : offset+2])
+	rrClass := binary.BigEndian.Uint16(body[offset+2 : offset+4])
+	rdLength := int(binary.BigEndian.Uint16(body[offset+4 : offset+6]))
+	offset += 6
+	if len(body)-offset < rdLength+4 {
+		return nil, 0, 0, errors.New("invalid rdata length in mDNSResponder reply")
+	}
+	rdata := body[offset : offset+rdLength]
+	ttl := binary.BigEndian.Uint32(body[offset+rdLength : offset+rdLength+4])
+
+	headerRR := D.RR_Header{Name: D.Fqdn(name), Rrtype: rrType, Class: rrClass, Ttl: ttl}
+	var answer D.RR
+	switch {
+	case rrType == D.TypeA && rdLength == net.IPv4len:
+		answer = &D.A{Hdr: headerRR, A: net.IP(append([]byte(nil), rdata...))}
+	case rrType == D.TypeAAAA && rdLength == net.IPv6len:
+		answer = &D.AAAA{Hdr: headerRR, AAAA: net.IP(append([]byte(nil), rdata...))}
+	default:
+		return nil, flags, code, nil
+	}
+	return mdnsReplyForRequest(request, answer), flags, code, nil
+}
+
+func mdnsReplyForRequest(request *D.Msg, answer D.RR) *D.Msg {
+	response := &D.Msg{}
+	response.SetReply(request)
+	response.Authoritative = true
+	response.Answer = []D.RR{answer}
+	return response
+}
+
+func writeAll(writer io.Writer, data []byte) error {
+	for len(data) > 0 {
+		n, err := writer.Write(data)
+		if err != nil {
+			return err
+		}
+		if n == 0 {
+			return io.ErrUnexpectedEOF
+		}
+		data = data[n:]
+	}
+	return nil
+}
+
+func isTimeoutError(err error) bool {
+	var netError net.Error
+	return errors.As(err, &netError) && netError.Timeout()
+}

--- a/dns/mdns_darwin.go
+++ b/dns/mdns_darwin.go
@@ -32,6 +32,8 @@ const (
 	mdnsResponderFlagAdd        = 0x2
 	mdnsResponderProtocolIPv4   = 0x1
 	mdnsResponderProtocolIPv6   = 0x2
+	mdnsResponderNoSuchName     = -65538
+	mdnsResponderNoSuchRecord   = -65554
 	mdnsResponderTimeoutError   = -65568
 )
 
@@ -47,19 +49,16 @@ func (c *mdnsClient) exchangeMDNSPlatform(ctx context.Context, request *D.Msg) (
 		return nil, false, nil
 	}
 
-	queryCtx, cancel := context.WithTimeout(ctx, c.timeout)
-	defer cancel()
-
 	socketPath := os.Getenv("DNSSD_UDS_PATH")
 	if socketPath == "" {
 		socketPath = mdnsResponderDefaultSocket
 	}
-	conn, err := (&net.Dialer{}).DialContext(queryCtx, "unix", socketPath)
+	conn, err := (&net.Dialer{}).DialContext(ctx, "unix", socketPath)
 	if err != nil {
 		if ctxErr := ctx.Err(); ctxErr != nil {
 			return nil, true, ctxErr
 		}
-		return nil, false, nil // Let the portable multicast transport try.
+		return nil, false, fmt.Errorf("mDNSResponder unavailable: %w", err)
 	}
 	if !c.registerSocket(conn) {
 		_ = conn.Close()
@@ -74,50 +73,68 @@ func (c *mdnsClient) exchangeMDNSPlatform(ctx context.Context, request *D.Msg) (
 	defer close(stopCancellation)
 	go func() {
 		select {
-		case <-queryCtx.Done():
+		case <-ctx.Done():
 			_ = conn.Close()
 		case <-stopCancellation:
 		}
 	}()
 
-	if deadline, ok := queryCtx.Deadline(); ok {
+	if deadline, ok := ctx.Deadline(); ok {
 		_ = conn.SetDeadline(deadline)
 	}
 	if err = writeMDNSResponderRequest(conn, question.Name, protocol); err != nil {
-		return nil, true, c.mdnsResponderError(queryCtx, err)
+		return c.mdnsResponderFailure(ctx, err)
 	}
 
 	var initialError [4]byte
 	if _, err = io.ReadFull(conn, initialError[:]); err != nil {
-		return nil, true, c.mdnsResponderError(queryCtx, err)
+		return c.mdnsResponderFailure(ctx, err)
 	}
 	if code := int32(binary.BigEndian.Uint32(initialError[:])); code != 0 {
 		return nil, true, fmt.Errorf("mDNSResponder rejected query: error %d", code)
 	}
 
-	var responses []*D.Msg
+	var responses []mdnsResponse
 	for {
-		message, flags, code, err := readMDNSResponderReply(conn, request)
+		response, flags, code, err := readMDNSResponderReply(conn, request)
 		if err != nil {
-			if len(responses) > 0 && isTimeoutError(err) {
-				return mergeMDNSResponses(request, responses), true, nil
+			if len(responses) > 0 {
+				if merged, available := mergeMDNSResponses(request, responses); available {
+					return merged, true, nil
+				}
 			}
-			return nil, true, c.mdnsResponderError(queryCtx, err)
+			return c.mdnsResponderFailure(ctx, err)
 		}
 		if code != 0 {
-			if code == mdnsResponderTimeoutError {
+			switch code {
+			case mdnsResponderTimeoutError:
 				if len(responses) > 0 {
-					return mergeMDNSResponses(request, responses), true, nil
+					if merged, available := mergeMDNSResponses(request, responses); available {
+						return merged, true, nil
+					}
 				}
 				return nil, true, fmt.Errorf("%w: mDNSResponder error %d", errMDNSTimeout, code)
+			case mdnsResponderNoSuchRecord:
+				return mdnsNegativeReply(request, D.RcodeSuccess), true, nil
+			case mdnsResponderNoSuchName:
+				return mdnsNegativeReply(request, D.RcodeNameError), true, nil
+			default:
+				return nil, true, fmt.Errorf("mDNSResponder query failed: error %d", code)
 			}
-			return nil, true, fmt.Errorf("mDNSResponder query failed: error %d", code)
 		}
-		if flags&mdnsResponderFlagAdd != 0 && message != nil {
-			responses = append(responses, message)
+		if flags&mdnsResponderFlagAdd != 0 && response != nil {
+			responses = append(responses, *response)
 			_ = conn.SetReadDeadline(time.Now().Add(c.settle))
 		}
 	}
+}
+
+func (c *mdnsClient) mdnsResponderFailure(ctx context.Context, err error) (*D.Msg, bool, error) {
+	mappedErr := c.mdnsResponderError(ctx, err)
+	if ctx.Err() != nil || c.isClosed() || isTimeoutError(err) {
+		return nil, true, mappedErr
+	}
+	return nil, false, mappedErr
 }
 
 func (c *mdnsClient) mdnsResponderError(ctx context.Context, err error) error {
@@ -150,7 +167,7 @@ func writeMDNSResponderRequest(writer io.Writer, hostname string, protocol uint3
 	return writeAll(writer, message)
 }
 
-func readMDNSResponderReply(reader io.Reader, request *D.Msg) (*D.Msg, uint32, int32, error) {
+func readMDNSResponderReply(reader io.Reader, request *D.Msg) (*mdnsResponse, uint32, int32, error) {
 	header := make([]byte, mdnsResponderHeaderSize)
 	if _, err := io.ReadFull(reader, header); err != nil {
 		return nil, 0, 0, err
@@ -171,6 +188,7 @@ func readMDNSResponderReply(reader io.Reader, request *D.Msg) (*D.Msg, uint32, i
 		return nil, 0, 0, err
 	}
 	flags := binary.BigEndian.Uint32(body[0:4])
+	ifIndex := int(binary.BigEndian.Uint32(body[4:8]))
 	code := int32(binary.BigEndian.Uint32(body[8:12]))
 	if code != 0 {
 		return nil, flags, code, nil
@@ -206,7 +224,7 @@ func readMDNSResponderReply(reader io.Reader, request *D.Msg) (*D.Msg, uint32, i
 	default:
 		return nil, flags, code, nil
 	}
-	return mdnsReplyForRequest(request, answer), flags, code, nil
+	return &mdnsResponse{msg: mdnsReplyForRequest(request, answer), ifIndex: ifIndex}, flags, code, nil
 }
 
 func mdnsReplyForRequest(request *D.Msg, answer D.RR) *D.Msg {
@@ -214,6 +232,15 @@ func mdnsReplyForRequest(request *D.Msg, answer D.RR) *D.Msg {
 	response.SetReply(request)
 	response.Authoritative = true
 	response.Answer = []D.RR{answer}
+	return response
+}
+
+func mdnsNegativeReply(request *D.Msg, rcode int) *D.Msg {
+	response := &D.Msg{}
+	response.SetReply(request)
+	response.Authoritative = true
+	response.RecursionAvailable = false
+	response.Rcode = rcode
 	return response
 }
 

--- a/dns/mdns_darwin_test.go
+++ b/dns/mdns_darwin_test.go
@@ -1,0 +1,258 @@
+//go:build darwin
+
+package dns
+
+import (
+	"context"
+	"encoding/binary"
+	"errors"
+	"io"
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	D "github.com/miekg/dns"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type mdnsResponderTestRequest struct {
+	flags    uint32
+	iface    uint32
+	protocol uint32
+	hostname string
+}
+
+func startMDNSResponderTestServer(t *testing.T, handler func(net.Conn)) string {
+	t.Helper()
+
+	socketDir, err := os.MkdirTemp("", "mihomo-mdns-")
+	require.NoError(t, err)
+	socketPath := filepath.Join(socketDir, "socket")
+	listener, err := net.Listen("unix", socketPath)
+	require.NoError(t, err)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		conn, err := listener.Accept()
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		handler(conn)
+	}()
+	t.Cleanup(func() {
+		_ = listener.Close()
+		_ = os.RemoveAll(socketDir)
+		select {
+		case <-done:
+		case <-time.After(time.Second):
+			t.Error("fake mDNSResponder did not stop")
+		}
+	})
+	return socketPath
+}
+
+func readMDNSResponderTestRequest(t *testing.T, conn net.Conn) mdnsResponderTestRequest {
+	t.Helper()
+
+	header := make([]byte, mdnsResponderHeaderSize)
+	_, err := io.ReadFull(conn, header)
+	require.NoError(t, err)
+	require.Equal(t, uint32(mdnsResponderIPCVersion), binary.BigEndian.Uint32(header[0:4]))
+	require.Equal(t, uint32(mdnsResponderAddrInfoOp), binary.BigEndian.Uint32(header[12:16]))
+	body := make([]byte, binary.BigEndian.Uint32(header[4:8]))
+	_, err = io.ReadFull(conn, body)
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, len(body), 13)
+	require.Zero(t, body[len(body)-1])
+	return mdnsResponderTestRequest{
+		flags:    binary.BigEndian.Uint32(body[0:4]),
+		iface:    binary.BigEndian.Uint32(body[4:8]),
+		protocol: binary.BigEndian.Uint32(body[8:12]),
+		hostname: string(body[12 : len(body)-1]),
+	}
+}
+
+func writeMDNSResponderTestInitialError(t *testing.T, conn net.Conn, code int32) {
+	t.Helper()
+	var data [4]byte
+	binary.BigEndian.PutUint32(data[:], uint32(code))
+	require.NoError(t, writeAll(conn, data[:]))
+}
+
+func writeMDNSResponderTestReply(t *testing.T, conn net.Conn, name string, rrType uint16, rdata net.IP, ttl uint32) {
+	t.Helper()
+
+	if rrType == D.TypeA {
+		rdata = rdata.To4()
+	} else {
+		rdata = rdata.To16()
+	}
+	dataLength := mdnsResponderReplyHeader + len(name) + 1 + 3*2 + len(rdata) + 4
+	message := make([]byte, mdnsResponderHeaderSize+dataLength)
+	binary.BigEndian.PutUint32(message[0:4], mdnsResponderIPCVersion)
+	binary.BigEndian.PutUint32(message[4:8], uint32(dataLength))
+	binary.BigEndian.PutUint32(message[12:16], mdnsResponderAddrInfoReply)
+	body := message[mdnsResponderHeaderSize:]
+	binary.BigEndian.PutUint32(body[0:4], mdnsResponderFlagAdd)
+	binary.BigEndian.PutUint32(body[4:8], 25)
+	offset := mdnsResponderReplyHeader
+	copy(body[offset:], name)
+	offset += len(name) + 1
+	binary.BigEndian.PutUint16(body[offset:offset+2], rrType)
+	binary.BigEndian.PutUint16(body[offset+2:offset+4], D.ClassINET)
+	binary.BigEndian.PutUint16(body[offset+4:offset+6], uint16(len(rdata)))
+	offset += 6
+	copy(body[offset:], rdata)
+	offset += len(rdata)
+	binary.BigEndian.PutUint32(body[offset:offset+4], ttl)
+	require.NoError(t, writeAll(conn, message))
+}
+
+func newMDNSResponderTestClient(t *testing.T, socketPath string) *mdnsClient {
+	t.Helper()
+	t.Setenv("DNSSD_UDS_PATH", socketPath)
+	client := newMDNSClient()
+	client.timeout = 300 * time.Millisecond
+	client.settle = 20 * time.Millisecond
+	client.targets = func() ([]mdnsTarget, error) {
+		return nil, errors.New("unexpected portable multicast fallback")
+	}
+	return client
+}
+
+func TestMDNSResponderUnavailableFallsBack(t *testing.T) {
+	client := newMDNSResponderTestClient(t, filepath.Join(t.TempDir(), "missing"))
+
+	response, handled, err := client.exchangeMDNSPlatform(context.Background(), mdnsQuery("host.local", D.TypeA))
+	assert.Nil(t, response)
+	assert.False(t, handled)
+	assert.NoError(t, err)
+}
+
+func TestMDNSResponderAAndAAAA(t *testing.T) {
+	tests := []struct {
+		name       string
+		qtype      uint16
+		protocol   uint32
+		ip         net.IP
+		expectedIP string
+	}{
+		{name: "A", qtype: D.TypeA, protocol: mdnsResponderProtocolIPv4, ip: net.IPv4(192, 0, 2, 30), expectedIP: "192.0.2.30"},
+		{name: "AAAA", qtype: D.TypeAAAA, protocol: mdnsResponderProtocolIPv6, ip: net.ParseIP("2001:db8::30"), expectedIP: "2001:db8::30"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			socketPath := startMDNSResponderTestServer(t, func(conn net.Conn) {
+				request := readMDNSResponderTestRequest(t, conn)
+				assert.Equal(t, uint32(mdnsResponderForceMulticast), request.flags)
+				assert.Zero(t, request.iface)
+				assert.Equal(t, test.protocol, request.protocol)
+				assert.Equal(t, "host.local.", request.hostname)
+				writeMDNSResponderTestInitialError(t, conn, 0)
+				writeMDNSResponderTestReply(t, conn, "host.local.", test.qtype, test.ip, 300)
+				_, _ = io.Copy(io.Discard, conn)
+			})
+			client := newMDNSResponderTestClient(t, socketPath)
+
+			response, err := client.ExchangeContext(context.Background(), mdnsQuery("host.local", test.qtype))
+			require.NoError(t, err)
+			require.Len(t, response.Answer, 1)
+			assert.Equal(t, uint32(300), response.Answer[0].Header().Ttl)
+			switch answer := response.Answer[0].(type) {
+			case *D.A:
+				assert.Equal(t, test.expectedIP, answer.A.String())
+			case *D.AAAA:
+				assert.Equal(t, test.expectedIP, answer.AAAA.String())
+			default:
+				t.Fatalf("unexpected answer type %T", answer)
+			}
+		})
+	}
+}
+
+func TestMDNSResponderMergesMultipleResponses(t *testing.T) {
+	socketPath := startMDNSResponderTestServer(t, func(conn net.Conn) {
+		_ = readMDNSResponderTestRequest(t, conn)
+		writeMDNSResponderTestInitialError(t, conn, 0)
+		writeMDNSResponderTestReply(t, conn, "multi.local.", D.TypeA, net.IPv4(192, 0, 2, 1), 60)
+		writeMDNSResponderTestReply(t, conn, "multi.local.", D.TypeA, net.IPv4(192, 0, 2, 2), 120)
+		_, _ = io.Copy(io.Discard, conn)
+	})
+	client := newMDNSResponderTestClient(t, socketPath)
+
+	response, err := client.ExchangeContext(context.Background(), mdnsQuery("multi.local", D.TypeA))
+	require.NoError(t, err)
+	assert.Len(t, response.Answer, 2)
+}
+
+func TestMDNSResponderTimeout(t *testing.T) {
+	socketPath := startMDNSResponderTestServer(t, func(conn net.Conn) {
+		_ = readMDNSResponderTestRequest(t, conn)
+		writeMDNSResponderTestInitialError(t, conn, 0)
+		_, _ = io.Copy(io.Discard, conn)
+	})
+	client := newMDNSResponderTestClient(t, socketPath)
+	client.timeout = 50 * time.Millisecond
+
+	_, err := client.ExchangeContext(context.Background(), mdnsQuery("silent.local", D.TypeA))
+	assert.ErrorIs(t, err, errMDNSTimeout)
+}
+
+func TestMDNSResponderContextCancellation(t *testing.T) {
+	queryReceived := make(chan struct{})
+	socketPath := startMDNSResponderTestServer(t, func(conn net.Conn) {
+		_ = readMDNSResponderTestRequest(t, conn)
+		writeMDNSResponderTestInitialError(t, conn, 0)
+		close(queryReceived)
+		_, _ = io.Copy(io.Discard, conn)
+	})
+	client := newMDNSResponderTestClient(t, socketPath)
+	ctx, cancel := context.WithCancel(context.Background())
+	result := make(chan error, 1)
+	go func() {
+		_, err := client.ExchangeContext(ctx, mdnsQuery("cancel.local", D.TypeA))
+		result <- err
+	}()
+
+	<-queryReceived
+	cancel()
+	select {
+	case err := <-result:
+		assert.ErrorIs(t, err, context.Canceled)
+	case <-time.After(time.Second):
+		t.Fatal("mDNSResponder query did not stop after context cancellation")
+	}
+}
+
+func TestMDNSResponderCloseReleasesSocket(t *testing.T) {
+	queryReceived := make(chan struct{})
+	socketPath := startMDNSResponderTestServer(t, func(conn net.Conn) {
+		_ = readMDNSResponderTestRequest(t, conn)
+		writeMDNSResponderTestInitialError(t, conn, 0)
+		close(queryReceived)
+		_, _ = io.Copy(io.Discard, conn)
+	})
+	client := newMDNSResponderTestClient(t, socketPath)
+	client.timeout = time.Second
+	result := make(chan error, 1)
+	go func() {
+		_, err := client.ExchangeContext(context.Background(), mdnsQuery("close.local", D.TypeA))
+		result <- err
+	}()
+
+	<-queryReceived
+	require.Eventually(t, func() bool { return client.activeSockets() == 1 }, time.Second, 10*time.Millisecond)
+	require.NoError(t, client.Close())
+	select {
+	case err := <-result:
+		assert.ErrorIs(t, err, errMDNSClientClosed)
+	case <-time.After(time.Second):
+		t.Fatal("mDNSResponder query did not stop after client close")
+	}
+	assert.Eventually(t, func() bool { return client.activeSockets() == 0 }, time.Second, 10*time.Millisecond)
+}

--- a/dns/mdns_darwin_test.go
+++ b/dns/mdns_darwin_test.go
@@ -3,6 +3,7 @@
 package dns
 
 import (
+	"bytes"
 	"context"
 	"encoding/binary"
 	"errors"
@@ -76,14 +77,14 @@ func readMDNSResponderTestRequest(t *testing.T, conn net.Conn) mdnsResponderTest
 	}
 }
 
-func writeMDNSResponderTestInitialError(t *testing.T, conn net.Conn, code int32) {
+func writeMDNSResponderTestInitialError(t *testing.T, writer io.Writer, code int32) {
 	t.Helper()
 	var data [4]byte
 	binary.BigEndian.PutUint32(data[:], uint32(code))
-	require.NoError(t, writeAll(conn, data[:]))
+	require.NoError(t, writeAll(writer, data[:]))
 }
 
-func writeMDNSResponderTestReply(t *testing.T, conn net.Conn, name string, rrType uint16, rdata net.IP, ttl uint32) {
+func writeMDNSResponderTestReply(t *testing.T, writer io.Writer, name string, rrType uint16, rdata net.IP, ttl uint32) {
 	t.Helper()
 
 	if rrType == D.TypeA {
@@ -109,7 +110,31 @@ func writeMDNSResponderTestReply(t *testing.T, conn net.Conn, name string, rrTyp
 	copy(body[offset:], rdata)
 	offset += len(rdata)
 	binary.BigEndian.PutUint32(body[offset:offset+4], ttl)
-	require.NoError(t, writeAll(conn, message))
+	require.NoError(t, writeAll(writer, message))
+}
+
+func writeMDNSResponderTestErrorReply(t *testing.T, writer io.Writer, code int32) {
+	t.Helper()
+
+	message := make([]byte, mdnsResponderHeaderSize+mdnsResponderReplyHeader)
+	binary.BigEndian.PutUint32(message[0:4], mdnsResponderIPCVersion)
+	binary.BigEndian.PutUint32(message[4:8], mdnsResponderReplyHeader)
+	binary.BigEndian.PutUint32(message[12:16], mdnsResponderAddrInfoReply)
+	body := message[mdnsResponderHeaderSize:]
+	binary.BigEndian.PutUint32(body[0:4], mdnsResponderFlagAdd)
+	binary.BigEndian.PutUint32(body[4:8], 25)
+	binary.BigEndian.PutUint32(body[8:12], uint32(code))
+	require.NoError(t, writeAll(writer, message))
+}
+
+func writeMDNSResponderTestUnsupportedVersion(t *testing.T, writer io.Writer) {
+	t.Helper()
+
+	message := make([]byte, mdnsResponderHeaderSize)
+	binary.BigEndian.PutUint32(message[0:4], mdnsResponderIPCVersion+1)
+	binary.BigEndian.PutUint32(message[4:8], mdnsResponderReplyHeader)
+	binary.BigEndian.PutUint32(message[12:16], mdnsResponderAddrInfoReply)
+	require.NoError(t, writeAll(writer, message))
 }
 
 func newMDNSResponderTestClient(t *testing.T, socketPath string) *mdnsClient {
@@ -124,13 +149,99 @@ func newMDNSResponderTestClient(t *testing.T, socketPath string) *mdnsClient {
 	return client
 }
 
-func TestMDNSResponderUnavailableFallsBack(t *testing.T) {
+func TestMDNSResponderUnavailableIsFallbackEligible(t *testing.T) {
 	client := newMDNSResponderTestClient(t, filepath.Join(t.TempDir(), "missing"))
 
 	response, handled, err := client.exchangeMDNSPlatform(context.Background(), mdnsQuery("host.local", D.TypeA))
 	assert.Nil(t, response)
 	assert.False(t, handled)
-	assert.NoError(t, err)
+	assert.ErrorContains(t, err, "mDNSResponder unavailable")
+}
+
+func TestMDNSResponderProtocolErrorFallsBackToMulticast(t *testing.T) {
+	socketPath := startMDNSResponderTestServer(t, func(conn net.Conn) {
+		_ = readMDNSResponderTestRequest(t, conn)
+		writeMDNSResponderTestInitialError(t, conn, 0)
+		writeMDNSResponderTestUnsupportedVersion(t, conn)
+	})
+	responder := startMDNSTestResponder(t, "udp4", func(query *D.Msg) []*D.Msg {
+		return []*D.Msg{mdnsReply(query, &D.A{
+			Hdr: D.RR_Header{Name: "fallback.local.", Rrtype: D.TypeA, Class: D.ClassINET, Ttl: 60},
+			A:   net.IPv4(192, 0, 2, 80),
+		})}
+	})
+	t.Setenv("DNSSD_UDS_PATH", socketPath)
+	client := newMDNSClient()
+	client.timeout = 300 * time.Millisecond
+	client.settle = 20 * time.Millisecond
+	client.targets = func() ([]mdnsTarget, error) {
+		return []mdnsTarget{responder.target()}, nil
+	}
+
+	response, err := client.ExchangeContext(context.Background(), mdnsQuery("fallback.local", D.TypeA))
+	require.NoError(t, err)
+	require.Len(t, response.Answer, 1)
+	assert.Equal(t, "192.0.2.80", response.Answer[0].(*D.A).A.String())
+}
+
+func TestMDNSResponderProtocolAndFallbackErrorsAreBothReported(t *testing.T) {
+	socketPath := startMDNSResponderTestServer(t, func(conn net.Conn) {
+		_ = readMDNSResponderTestRequest(t, conn)
+		writeMDNSResponderTestInitialError(t, conn, 0)
+		writeMDNSResponderTestUnsupportedVersion(t, conn)
+	})
+	t.Setenv("DNSSD_UDS_PATH", socketPath)
+	client := newMDNSClient()
+	client.targets = func() ([]mdnsTarget, error) {
+		return nil, errors.New("portable target discovery failed")
+	}
+
+	_, err := client.ExchangeContext(context.Background(), mdnsQuery("failure.local", D.TypeA))
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "mDNS platform resolver and multicast fallback failed")
+	assert.ErrorContains(t, err, "unsupported mDNSResponder IPC version")
+	assert.ErrorContains(t, err, "portable target discovery failed")
+}
+
+func TestReadMDNSResponderReplyKeepsInterface(t *testing.T) {
+	var wire bytes.Buffer
+	writeMDNSResponderTestReply(t, &wire, "host.local.", D.TypeA, net.IPv4(192, 0, 2, 81), 300)
+
+	response, flags, code, err := readMDNSResponderReply(&wire, mdnsQuery("host.local", D.TypeA))
+	require.NoError(t, err)
+	require.NotNil(t, response)
+	assert.Equal(t, uint32(mdnsResponderFlagAdd), flags)
+	assert.Zero(t, code)
+	assert.Equal(t, 25, response.ifIndex)
+	require.Len(t, response.msg.Answer, 1)
+	assert.Equal(t, uint32(300), response.msg.Answer[0].Header().Ttl)
+}
+
+func TestMDNSResponderExplicitNegativeResults(t *testing.T) {
+	tests := []struct {
+		name          string
+		code          int32
+		expectedRcode int
+	}{
+		{name: "no record is NODATA", code: mdnsResponderNoSuchRecord, expectedRcode: D.RcodeSuccess},
+		{name: "no name is NXDOMAIN", code: mdnsResponderNoSuchName, expectedRcode: D.RcodeNameError},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			socketPath := startMDNSResponderTestServer(t, func(conn net.Conn) {
+				_ = readMDNSResponderTestRequest(t, conn)
+				writeMDNSResponderTestInitialError(t, conn, 0)
+				writeMDNSResponderTestErrorReply(t, conn, test.code)
+			})
+			client := newMDNSResponderTestClient(t, socketPath)
+
+			response, err := client.ExchangeContext(context.Background(), mdnsQuery("missing.local", D.TypeA))
+			require.NoError(t, err)
+			assert.Equal(t, test.expectedRcode, response.Rcode)
+			assert.Empty(t, response.Answer)
+		})
+	}
 }
 
 func TestMDNSResponderAAndAAAA(t *testing.T) {

--- a/dns/mdns_other.go
+++ b/dns/mdns_other.go
@@ -1,0 +1,13 @@
+//go:build !darwin
+
+package dns
+
+import (
+	"context"
+
+	D "github.com/miekg/dns"
+)
+
+func (c *mdnsClient) exchangeMDNSPlatform(context.Context, *D.Msg) (*D.Msg, bool, error) {
+	return nil, false, nil
+}

--- a/dns/mdns_test.go
+++ b/dns/mdns_test.go
@@ -1,0 +1,349 @@
+package dns
+
+import (
+	"context"
+	"errors"
+	"net"
+	"sort"
+	"testing"
+	"time"
+
+	D "github.com/miekg/dns"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type mdnsTestResponder struct {
+	network string
+	conn    *net.UDPConn
+	queries chan *D.Msg
+	done    chan struct{}
+	handler func(*D.Msg) []*D.Msg
+}
+
+func startMDNSTestResponder(t *testing.T, network string, handler func(*D.Msg) []*D.Msg) *mdnsTestResponder {
+	t.Helper()
+
+	var listenAddr *net.UDPAddr
+	switch network {
+	case "udp4":
+		listenAddr = &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1)}
+	case "udp6":
+		listenAddr = &net.UDPAddr{IP: net.ParseIP("::1")}
+	default:
+		t.Fatalf("unsupported test network %q", network)
+	}
+	conn, err := net.ListenUDP(network, listenAddr)
+	if err != nil && network == "udp6" {
+		t.Skipf("IPv6 loopback is unavailable: %v", err)
+	}
+	require.NoError(t, err)
+
+	responder := &mdnsTestResponder{
+		network: network,
+		conn:    conn,
+		queries: make(chan *D.Msg, 8),
+		done:    make(chan struct{}),
+		handler: handler,
+	}
+	go responder.serve()
+	t.Cleanup(func() {
+		_ = responder.conn.Close()
+		<-responder.done
+	})
+	return responder
+}
+
+func (r *mdnsTestResponder) serve() {
+	defer close(r.done)
+	buffer := make([]byte, mdnsMaxDatagramSize)
+	for {
+		n, remote, err := r.conn.ReadFromUDP(buffer)
+		if err != nil {
+			return
+		}
+		query := &D.Msg{}
+		if err = query.Unpack(buffer[:n]); err != nil {
+			continue
+		}
+		select {
+		case r.queries <- query.Copy():
+		default:
+		}
+		if r.handler == nil {
+			continue
+		}
+		for _, response := range r.handler(query) {
+			wire, err := response.Pack()
+			if err != nil {
+				continue
+			}
+			_, _ = r.conn.WriteToUDP(wire, remote)
+		}
+	}
+}
+
+func (r *mdnsTestResponder) target() mdnsTarget {
+	addr := *r.conn.LocalAddr().(*net.UDPAddr)
+	return mdnsTarget{network: r.network, addr: &addr}
+}
+
+func newTestMDNSClient(responder *mdnsTestResponder) *mdnsClient {
+	client := newMDNSClient()
+	client.timeout = 300 * time.Millisecond
+	client.settle = 20 * time.Millisecond
+	client.platform = func(context.Context, *D.Msg) (*D.Msg, bool, error) {
+		return nil, false, nil
+	}
+	client.targets = func() ([]mdnsTarget, error) {
+		return []mdnsTarget{responder.target()}, nil
+	}
+	return client
+}
+
+func mdnsQuery(name string, qtype uint16) *D.Msg {
+	query := &D.Msg{}
+	query.SetQuestion(D.Fqdn(name), qtype)
+	return query
+}
+
+func mdnsReply(query *D.Msg, answers ...D.RR) *D.Msg {
+	response := &D.Msg{}
+	response.SetReply(query)
+	response.Authoritative = true
+	response.Answer = answers
+	return response
+}
+
+func TestMDNSClientAAndAAAA(t *testing.T) {
+	tests := []struct {
+		name       string
+		network    string
+		qtype      uint16
+		answer     D.RR
+		expectedIP string
+	}{
+		{
+			name:       "IPv4A",
+			network:    "udp4",
+			qtype:      D.TypeA,
+			answer:     &D.A{Hdr: D.RR_Header{Name: "printer.local.", Rrtype: D.TypeA, Class: D.ClassINET | mdnsCacheFlush, Ttl: 120}, A: net.IPv4(192, 0, 2, 10)},
+			expectedIP: "192.0.2.10",
+		},
+		{
+			name:       "IPv6AAAA",
+			network:    "udp6",
+			qtype:      D.TypeAAAA,
+			answer:     &D.AAAA{Hdr: D.RR_Header{Name: "printer.local.", Rrtype: D.TypeAAAA, Class: D.ClassINET | mdnsCacheFlush, Ttl: 4500}, AAAA: net.ParseIP("2001:db8::10")},
+			expectedIP: "2001:db8::10",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			responder := startMDNSTestResponder(t, test.network, func(query *D.Msg) []*D.Msg {
+				return []*D.Msg{mdnsReply(query, test.answer)}
+			})
+			client := newTestMDNSClient(responder)
+
+			response, err := client.ExchangeContext(context.Background(), mdnsQuery("printer.local", test.qtype))
+			require.NoError(t, err)
+			require.Len(t, response.Answer, 1)
+			assert.Equal(t, uint16(D.ClassINET), response.Answer[0].Header().Class)
+			assert.Equal(t, test.answer.Header().Ttl, response.Answer[0].Header().Ttl)
+			switch answer := response.Answer[0].(type) {
+			case *D.A:
+				assert.Equal(t, test.expectedIP, answer.A.String())
+			case *D.AAAA:
+				assert.Equal(t, test.expectedIP, answer.AAAA.String())
+			default:
+				t.Fatalf("unexpected answer type %T", answer)
+			}
+		})
+	}
+}
+
+func TestMDNSClientMergesMultipleResponses(t *testing.T) {
+	responder := startMDNSTestResponder(t, "udp4", func(query *D.Msg) []*D.Msg {
+		return []*D.Msg{
+			mdnsReply(query, &D.A{Hdr: D.RR_Header{Name: "multi.local.", Rrtype: D.TypeA, Class: D.ClassINET, Ttl: 60}, A: net.IPv4(192, 0, 2, 1)}),
+			mdnsReply(query, &D.A{Hdr: D.RR_Header{Name: "multi.local.", Rrtype: D.TypeA, Class: D.ClassINET, Ttl: 120}, A: net.IPv4(192, 0, 2, 2)}),
+		}
+	})
+	client := newTestMDNSClient(responder)
+
+	response, err := client.ExchangeContext(context.Background(), mdnsQuery("multi.local", D.TypeA))
+	require.NoError(t, err)
+	require.Len(t, response.Answer, 2)
+	ips := []string{response.Answer[0].(*D.A).A.String(), response.Answer[1].(*D.A).A.String()}
+	sort.Strings(ips)
+	assert.Equal(t, []string{"192.0.2.1", "192.0.2.2"}, ips)
+}
+
+func TestMDNSClientTimeout(t *testing.T) {
+	responder := startMDNSTestResponder(t, "udp4", nil)
+	client := newTestMDNSClient(responder)
+	client.timeout = 50 * time.Millisecond
+
+	start := time.Now()
+	_, err := client.ExchangeContext(context.Background(), mdnsQuery("silent.local", D.TypeA))
+	assert.ErrorIs(t, err, errMDNSTimeout)
+	assert.Less(t, time.Since(start), 500*time.Millisecond)
+}
+
+func TestMDNSClientContextCancellation(t *testing.T) {
+	responder := startMDNSTestResponder(t, "udp4", nil)
+	client := newTestMDNSClient(responder)
+	client.timeout = time.Second
+	ctx, cancel := context.WithCancel(context.Background())
+	result := make(chan error, 1)
+	go func() {
+		_, err := client.ExchangeContext(ctx, mdnsQuery("cancel.local", D.TypeA))
+		result <- err
+	}()
+
+	select {
+	case <-responder.queries:
+	case <-time.After(time.Second):
+		t.Fatal("mDNS query was not received")
+	}
+	cancel()
+
+	select {
+	case err := <-result:
+		assert.ErrorIs(t, err, context.Canceled)
+	case <-time.After(time.Second):
+		t.Fatal("mDNS query did not stop after context cancellation")
+	}
+}
+
+func TestMDNSClientContextAlreadyCanceled(t *testing.T) {
+	client := newMDNSClient()
+	client.platform = nil
+	client.targets = func() ([]mdnsTarget, error) {
+		return nil, errors.New("target discovery should not run")
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := client.ExchangeContext(ctx, mdnsQuery("cancel.local", D.TypeA))
+	assert.ErrorIs(t, err, context.Canceled)
+}
+
+func TestMDNSClientNoRecords(t *testing.T) {
+	responder := startMDNSTestResponder(t, "udp4", func(query *D.Msg) []*D.Msg {
+		return []*D.Msg{mdnsReply(query)}
+	})
+	client := newTestMDNSClient(responder)
+
+	response, err := client.ExchangeContext(context.Background(), mdnsQuery("missing.local", D.TypeA))
+	require.NoError(t, err)
+	assert.Equal(t, D.RcodeSuccess, response.Rcode)
+	assert.Empty(t, response.Answer)
+}
+
+func TestMDNSClientIgnoresUnrelatedResponseWithoutQuestion(t *testing.T) {
+	responder := startMDNSTestResponder(t, "udp4", func(query *D.Msg) []*D.Msg {
+		unrelated := mdnsReply(query, &D.A{
+			Hdr: D.RR_Header{Name: "other.local.", Rrtype: D.TypeA, Class: D.ClassINET, Ttl: 30},
+			A:   net.IPv4(192, 0, 2, 21),
+		})
+		unrelated.Question = nil
+		expected := mdnsReply(query, &D.A{
+			Hdr: D.RR_Header{Name: "wanted.local.", Rrtype: D.TypeA, Class: D.ClassINET, Ttl: 30},
+			A:   net.IPv4(192, 0, 2, 22),
+		})
+		expected.Question = nil
+		return []*D.Msg{unrelated, expected}
+	})
+	client := newTestMDNSClient(responder)
+
+	response, err := client.ExchangeContext(context.Background(), mdnsQuery("wanted.local", D.TypeA))
+	require.NoError(t, err)
+	require.Len(t, response.Answer, 1)
+	assert.Equal(t, "192.0.2.22", response.Answer[0].(*D.A).A.String())
+}
+
+func TestMDNSClientAllowsExplicitNonLocalName(t *testing.T) {
+	responder := startMDNSTestResponder(t, "udp4", func(query *D.Msg) []*D.Msg {
+		return []*D.Msg{mdnsReply(query, &D.A{
+			Hdr: D.RR_Header{Name: "explicit.example.", Rrtype: D.TypeA, Class: D.ClassINET, Ttl: 30},
+			A:   net.IPv4(192, 0, 2, 20),
+		})}
+	})
+	client := newTestMDNSClient(responder)
+
+	response, err := client.ExchangeContext(context.Background(), mdnsQuery("explicit.example", D.TypeA))
+	require.NoError(t, err)
+	require.Len(t, response.Answer, 1)
+	assert.Equal(t, "192.0.2.20", response.Answer[0].(*D.A).A.String())
+}
+
+func TestMDNSClientCloseReleasesSockets(t *testing.T) {
+	responder := startMDNSTestResponder(t, "udp4", nil)
+	client := newTestMDNSClient(responder)
+	client.timeout = time.Second
+	result := make(chan error, 1)
+	go func() {
+		_, err := client.ExchangeContext(context.Background(), mdnsQuery("close.local", D.TypeA))
+		result <- err
+	}()
+
+	select {
+	case <-responder.queries:
+	case <-time.After(time.Second):
+		t.Fatal("mDNS query was not received")
+	}
+	require.Eventually(t, func() bool { return client.activeSockets() == 1 }, time.Second, 10*time.Millisecond)
+	require.NoError(t, client.Close())
+
+	select {
+	case err := <-result:
+		assert.True(t, errors.Is(err, errMDNSClientClosed) || errors.Is(err, net.ErrClosed), "unexpected error: %v", err)
+	case <-time.After(time.Second):
+		t.Fatal("mDNS query did not stop after client close")
+	}
+	assert.Eventually(t, func() bool { return client.activeSockets() == 0 }, time.Second, 10*time.Millisecond)
+
+	_, err := client.ExchangeContext(context.Background(), mdnsQuery("closed.local", D.TypeA))
+	assert.ErrorIs(t, err, errMDNSClientClosed)
+}
+
+func TestTargetsForMDNSInterfaces(t *testing.T) {
+	interfaces := []mdnsInterface{
+		{
+			iface: net.Interface{Index: 2, Name: "en0", Flags: net.FlagUp | net.FlagMulticast},
+			ipv4:  net.IPv4(192, 0, 2, 1),
+			ipv6:  net.ParseIP("fe80::1"),
+		},
+		{
+			iface: net.Interface{Index: 3, Name: "en1", Flags: net.FlagUp | net.FlagMulticast},
+			ipv4:  net.IPv4(198, 51, 100, 1),
+		},
+		{
+			iface: net.Interface{Index: 4, Name: "down0", Flags: net.FlagMulticast},
+			ipv4:  net.IPv4(203, 0, 113, 1),
+			ipv6:  net.ParseIP("fe80::2"),
+		},
+	}
+
+	targets := targetsForMDNSInterfaces(interfaces)
+	require.Len(t, targets, 3)
+	assert.Equal(t, "udp4", targets[0].network)
+	assert.Equal(t, "en0", targets[0].iface.Name)
+	assert.Equal(t, "192.0.2.1:0", targets[0].localAddr.String())
+	assert.Equal(t, "224.0.0.251:5353", targets[0].addr.String())
+	assert.Equal(t, "udp6", targets[1].network)
+	assert.Equal(t, "[fe80::1%en0]:0", targets[1].localAddr.String())
+	assert.Equal(t, "en0", targets[1].addr.Zone)
+	assert.Equal(t, "[ff02::fb%en0]:5353", targets[1].addr.String())
+	assert.Equal(t, "udp4", targets[2].network)
+	assert.Equal(t, "en1", targets[2].iface.Name)
+}
+
+func TestTransformMDNSNameServer(t *testing.T) {
+	clients := transform([]NameServer{{Net: "mdns"}}, nil)
+	require.Len(t, clients, 1)
+	assert.IsType(t, &mdnsClient{}, clients[0])
+	assert.Equal(t, "mdns://", clients[0].Address())
+}

--- a/dns/mdns_test.go
+++ b/dns/mdns_test.go
@@ -111,6 +111,8 @@ func mdnsReply(query *D.Msg, answers ...D.RR) *D.Msg {
 	response := &D.Msg{}
 	response.SetReply(query)
 	response.Authoritative = true
+	// Multicast DNS responses normally omit the Question section.
+	response.Question = nil
 	response.Answer = answers
 	return response
 }
@@ -232,7 +234,13 @@ func TestMDNSClientContextAlreadyCanceled(t *testing.T) {
 
 func TestMDNSClientNoRecords(t *testing.T) {
 	responder := startMDNSTestResponder(t, "udp4", func(query *D.Msg) []*D.Msg {
-		return []*D.Msg{mdnsReply(query)}
+		response := mdnsReply(query)
+		response.Ns = []D.RR{&D.NSEC{
+			Hdr:        D.RR_Header{Name: "missing.local.", Rrtype: D.TypeNSEC, Class: D.ClassINET | mdnsCacheFlush, Ttl: 120},
+			NextDomain: "missing.local.",
+			TypeBitMap: []uint16{D.TypeAAAA},
+		}}
+		return []*D.Msg{response}
 	})
 	client := newTestMDNSClient(responder)
 
@@ -240,6 +248,178 @@ func TestMDNSClientNoRecords(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, D.RcodeSuccess, response.Rcode)
 	assert.Empty(t, response.Answer)
+	require.Len(t, response.Ns, 1)
+	assert.Equal(t, uint16(D.ClassINET), response.Ns[0].Header().Class)
+	assert.Equal(t, uint32(120), response.Ns[0].Header().Ttl)
+}
+
+func TestMDNSClientEmptyResponseDoesNotProveNoData(t *testing.T) {
+	responder := startMDNSTestResponder(t, "udp4", func(query *D.Msg) []*D.Msg {
+		return []*D.Msg{mdnsReply(query)}
+	})
+	client := newTestMDNSClient(responder)
+	client.timeout = 50 * time.Millisecond
+
+	_, err := client.ExchangeContext(context.Background(), mdnsQuery("missing.local", D.TypeA))
+	assert.ErrorIs(t, err, errMDNSTimeout)
+}
+
+func TestMDNSClientCNAMEAcrossPackets(t *testing.T) {
+	tests := []struct {
+		name          string
+		targetFirst   bool
+		threePacket   bool
+		expectedNames []string
+	}{
+		{name: "target before CNAME", targetFirst: true, expectedNames: []string{"alias.local.", "target.local."}},
+		{name: "CNAME before target", expectedNames: []string{"alias.local.", "target.local."}},
+		{name: "three packet chain", threePacket: true, expectedNames: []string{"alias.local.", "middle.local.", "target.local."}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			responder := startMDNSTestResponder(t, "udp4", func(query *D.Msg) []*D.Msg {
+				firstCNAME := mdnsReply(query, &D.CNAME{
+					Hdr:    D.RR_Header{Name: "alias.local.", Rrtype: D.TypeCNAME, Class: D.ClassINET, Ttl: 120},
+					Target: "target.local.",
+				})
+				targetA := mdnsReply(query, &D.A{
+					Hdr: D.RR_Header{Name: "target.local.", Rrtype: D.TypeA, Class: D.ClassINET, Ttl: 60},
+					A:   net.IPv4(192, 0, 2, 40),
+				})
+				if test.threePacket {
+					firstCNAME.Answer[0].(*D.CNAME).Target = "middle.local."
+					secondCNAME := mdnsReply(query, &D.CNAME{
+						Hdr:    D.RR_Header{Name: "middle.local.", Rrtype: D.TypeCNAME, Class: D.ClassINET, Ttl: 90},
+						Target: "target.local.",
+					})
+					return []*D.Msg{targetA, secondCNAME, firstCNAME}
+				}
+				if test.targetFirst {
+					return []*D.Msg{targetA, firstCNAME}
+				}
+				return []*D.Msg{firstCNAME, targetA}
+			})
+			client := newTestMDNSClient(responder)
+
+			response, err := client.ExchangeContext(context.Background(), mdnsQuery("alias.local", D.TypeA))
+			require.NoError(t, err)
+			require.Len(t, response.Answer, len(test.expectedNames))
+			actualNames := make([]string, 0, len(response.Answer))
+			for _, answer := range response.Answer {
+				actualNames = append(actualNames, answer.Header().Name)
+			}
+			assert.Equal(t, test.expectedNames, actualNames)
+			assert.Equal(t, "192.0.2.40", response.Answer[len(response.Answer)-1].(*D.A).A.String())
+		})
+	}
+}
+
+func TestMergeMDNSResponsesKeepsInterfacesIndependent(t *testing.T) {
+	request := mdnsQuery("alias.local", D.TypeA)
+	responses := []mdnsResponse{
+		{
+			ifIndex: 2,
+			msg: mdnsReply(request, &D.CNAME{
+				Hdr:    D.RR_Header{Name: "alias.local.", Rrtype: D.TypeCNAME, Class: D.ClassINET, Ttl: 120},
+				Target: "target.local.",
+			}),
+		},
+		{
+			ifIndex: 3,
+			msg: mdnsReply(request, &D.A{
+				Hdr: D.RR_Header{Name: "target.local.", Rrtype: D.TypeA, Class: D.ClassINET, Ttl: 60},
+				A:   net.IPv4(192, 0, 2, 50),
+			}),
+		},
+	}
+
+	response, available := mergeMDNSResponses(request, responses)
+	assert.False(t, available)
+	assert.Empty(t, response.Answer)
+}
+
+func TestMergeMDNSResponsesUnionsInterfacesAndMaxTTL(t *testing.T) {
+	request := mdnsQuery("host.local", D.TypeA)
+	responses := []mdnsResponse{
+		{
+			ifIndex: 2,
+			msg: mdnsReply(request, &D.A{
+				Hdr: D.RR_Header{Name: "host.local.", Rrtype: D.TypeA, Class: D.ClassINET, Ttl: 60},
+				A:   net.IPv4(192, 0, 2, 60),
+			}),
+		},
+		{
+			ifIndex: 3,
+			msg: mdnsReply(request,
+				&D.A{
+					Hdr: D.RR_Header{Name: "host.local.", Rrtype: D.TypeA, Class: D.ClassINET, Ttl: 120},
+					A:   net.IPv4(192, 0, 2, 60),
+				},
+				&D.A{
+					Hdr: D.RR_Header{Name: "host.local.", Rrtype: D.TypeA, Class: D.ClassINET, Ttl: 90},
+					A:   net.IPv4(198, 51, 100, 60),
+				},
+			),
+		},
+	}
+
+	response, available := mergeMDNSResponses(request, responses)
+	require.True(t, available)
+	require.Len(t, response.Answer, 2)
+	assert.Equal(t, uint32(120), response.Answer[0].Header().Ttl)
+	assert.Equal(t, "192.0.2.60", response.Answer[0].(*D.A).A.String())
+	assert.Equal(t, "198.51.100.60", response.Answer[1].(*D.A).A.String())
+}
+
+func TestValidMDNSTransport(t *testing.T) {
+	iface := &net.Interface{Index: 7, Name: "en7"}
+	target := mdnsTarget{
+		network: "udp4",
+		iface:   iface,
+		addr:    &net.UDPAddr{IP: net.IPv4(224, 0, 0, 251), Port: mdnsPort},
+	}
+	valid := &mdnsResponse{
+		source:      &net.UDPAddr{IP: net.IPv4(192, 0, 2, 70), Port: mdnsPort},
+		ifIndex:     iface.Index,
+		destination: net.IPv4(224, 0, 0, 251),
+		hopLimit:    64,
+	}
+
+	// RFC 6762 requires source port 5353 and recommends, but does not require,
+	// an IP TTL/hop limit of 255. Retain the latter without rejecting it.
+	assert.True(t, validMDNSTransport(valid, target))
+
+	wrongPort := *valid
+	wrongPort.source = &net.UDPAddr{IP: valid.source.IP, Port: 12345}
+	assert.False(t, validMDNSTransport(&wrongPort, target))
+
+	wrongInterface := *valid
+	wrongInterface.ifIndex++
+	assert.False(t, validMDNSTransport(&wrongInterface, target))
+
+	wrongDestination := *valid
+	wrongDestination.destination = net.IPv4(224, 0, 0, 252)
+	assert.False(t, validMDNSTransport(&wrongDestination, target))
+}
+
+func TestValidMDNSMessageIgnoresQuestionAndID(t *testing.T) {
+	response := mdnsReply(mdnsQuery("host.local", D.TypeA))
+	response.Id = 1234
+	response.Question = []D.Question{{Name: "other.local.", Qtype: D.TypeAAAA, Qclass: D.ClassINET}}
+	assert.True(t, validMDNSMessage(response))
+
+	query := response.Copy()
+	query.Response = false
+	assert.False(t, validMDNSMessage(query))
+
+	badOpcode := response.Copy()
+	badOpcode.Opcode = D.OpcodeStatus
+	assert.False(t, validMDNSMessage(badOpcode))
+
+	badRcode := response.Copy()
+	badRcode.Rcode = D.RcodeServerFailure
+	assert.False(t, validMDNSMessage(badRcode))
 }
 
 func TestMDNSClientIgnoresUnrelatedResponseWithoutQuestion(t *testing.T) {

--- a/dns/util.go
+++ b/dns/util.go
@@ -126,6 +126,8 @@ func transform(servers []NameServer, resolver resolver.Resolver) []dnsClient {
 			c = newDHCPClient(s.Addr)
 		case "system":
 			c = newSystemClient()
+		case "mdns":
+			c = newMDNSClient()
 		case "tailscale":
 			c = newTailscaleClient(s.Addr)
 		case "rcode":

--- a/docs/config.yaml
+++ b/docs/config.yaml
@@ -302,7 +302,7 @@ dns:
   respect-rules: false
 
   # DNS 主要域名配置
-  # 支持 UDP，TCP，DoT，DoH，DoQ
+  # 支持 UDP，TCP，DoT，DoH，DoQ，mDNS
   # 这部分为主要 DNS 配置，影响所有直连，确保使用对大陆解析精准的 DNS
   nameserver:
     - 114.114.114.114 # default value
@@ -313,6 +313,7 @@ dns:
     - https://mozilla.cloudflare-dns.com/dns-query#DNS&h3=true # 指定策略组和使用 HTTP/3
     - dhcp://en0 # dns from dhcp
     - quic://dns.adguard.com:784 # DNS over QUIC
+    # - mdns:// # Multicast DNS，仅在显式配置时使用；macOS 使用系统 mDNSResponder
     # - ts://tailscale # 使用指定 Tailscale 出站的 DNS 配置查询
     # - '8.8.8.8#RULES' # 效果同respect-rules，但仅对该服务器生效
     # - '8.8.8.8#en0' # 兼容指定 DNS 出口网卡
@@ -357,6 +358,7 @@ dns:
   nameserver-policy:
     #   'www.baidu.com': '114.114.114.114'
     #   '+.internal.crop.com': '10.0.0.1'
+    #   '+.local': 'mdns://'
     "geosite:cn,private,apple":
       - https://doh.pub/dns-query
       - https://dns.alidns.com/dns-query

--- a/docs/config.yaml
+++ b/docs/config.yaml
@@ -313,7 +313,10 @@ dns:
     - https://mozilla.cloudflare-dns.com/dns-query#DNS&h3=true # 指定策略组和使用 HTTP/3
     - dhcp://en0 # dns from dhcp
     - quic://dns.adguard.com:784 # DNS over QUIC
-    # - mdns:// # Multicast DNS，仅在显式配置时使用；macOS 使用系统 mDNSResponder
+    # - mdns:// # Multicast DNS，仅在显式配置时使用；macOS 优先使用系统 mDNSResponder
+    # mDNS 无响应会返回超时，使同组中其他成功的 nameserver 可以胜出；有效 NSEC 返回 NODATA
+    # macOS mDNSResponder 的明确否定响应保留 NODATA/NXDOMAIN 语义
+    # 多接口上的 CNAME 链分别解析，最终合并各接口的不同地址
     # - ts://tailscale # 使用指定 Tailscale 出站的 DNS 配置查询
     # - '8.8.8.8#RULES' # 效果同respect-rules，但仅对该服务器生效
     # - '8.8.8.8#en0' # 兼容指定 DNS 出口网卡


### PR DESCRIPTION
Closes #3027

#### Summary

This adds an explicit `mdns://` DNS nameserver without changing `system://` or
automatically routing `.local` names.

```yaml
dns:
  fake-ip-filter:
    - +.local
  nameserver-policy:
    '+.local':
      - mdns://
```

#### Root cause

Mihomo's current system resolver enumerates configured unicast DNS servers and
queries them through Mihomo's ordinary DNS client. On macOS this bypasses
mDNSResponder, so a hostname may resolve through `dscacheutil`/`dns-sd` but
return `NXDOMAIN` through Mihomo.

#### Design

- registers `mdns://` in nameserver parsing and client construction
- rejects addresses, URL parameters, and proxy fragments for the link-local
  transport
- leaves `system://` unchanged and does not add implicit `.local` routing
- adds no CGO or third-party dependency
- uses a pure-Go multicast client on supported platforms and the CGO-free
  mDNSResponder Unix-domain IPC on macOS for A/AAAA

The portable transport:

- queries IPv4 and IPv6 on every up, multicast-capable,
  non-point-to-point interface
- sends with TTL/hop limit 255
- receives IPv4/IPv6 packet control metadata and retains source address,
  destination multicast address, ingress interface index, and TTL/hop limit
- requires response source port 5353 and the expected multicast destination
  and ingress interface, as required/recommended by
  [RFC 6762](https://datatracker.ietf.org/doc/html/rfc6762)
- records but does not reject a received TTL/hop limit other than 255: RFC 6762
  says senders SHOULD use 255, while a packet received at the link-local
  multicast destination is already known to be local
- merges Answer, Authority, and Additional records across multiple packets
- builds CNAME chains only from records received on the same interface, so a
  CNAME on one link cannot attach to a target record from another link
- returns the union of distinct positive addresses from all interfaces;
  identical records are collapsed with the greatest observed TTL
- strips the mDNS cache-flush bit before returning ordinary DNS records
- bounds retained responses and releases sockets/goroutines on completion,
  timeout, reset, cancellation, or close

This also fixes CNAME targets that arrive in an earlier packet than the CNAME:
filtering is deferred until the per-interface record set has been assembled.

#### Negative and fallback semantics

- multicast silence or an empty response is not proof of non-existence and
  returns a timeout error; another successful nameserver in the same policy
  group may therefore win
- an applicable RFC 6762 NSEC record returns `NOERROR`/NODATA with its TTL
- macOS mDNSResponder `NoSuchRecord` returns NODATA and `NoSuchName` returns
  `NXDOMAIN`
- if mDNSResponder is unavailable or its IPC stream is incompatible/malformed,
  Mihomo logs a clear diagnostic and falls back to portable multicast within
  the original query deadline
- cancellation, close, timeout, and explicit daemon query errors remain final;
  if both IPC and multicast fail, the returned error contains both causes

#### Tests

Coverage includes:

- nameserver parsing and resolver registration
- A and AAAA over controlled local IPv4/IPv6 responders
- multiple packets, multiple answers, duplicate TTL selection, and cache-flush
  handling
- CNAME-first, target-first, and three-packet CNAME chains
- per-interface CNAME isolation and cross-interface positive union semantics
- source-port, destination, interface, and hop-limit metadata policy
- NSEC NODATA, empty-response timeout, ordinary timeout, and context
  cancellation
- explicit non-`.local` queries
- socket/goroutine release after close
- macOS IPC A/AAAA, interface index retention, explicit negative results,
  incompatible-protocol fallback, and joined fallback diagnostics

Passed locally:

```text
CGO_ENABLED=1 go test -race ./dns ./config -count=1
CGO_ENABLED=0 go test ./dns ./config -count=1
GOTOOLCHAIN=go1.20.14 CGO_ENABLED=0 go test ./dns ./config -count=1

# Equivalent to the repository's macOS CI, which removes listener/inbound tests:
go list ./... | rg -v '/listener/inbound$' | xargs env CGO_ENABLED=0 SKIP_INTEROP_TEST=1 go test -count=1
go list -tags with_gvisor ./... | rg -v '/listener/inbound$' | xargs env CGO_ENABLED=0 SKIP_INTEROP_TEST=1 go test -tags with_gvisor -count=1

go vet ./dns ./config
golangci-lint run --new-from-rev origin/Alpha ./...
git diff --check
```

Running `go test ./...` without the repository's macOS exclusion reproduces an
unrelated `TestInboundSudoku_HTTPMaskMode/Concurrent` connection-reset failure
on an untouched `origin/Alpha` worktree. The CI-equivalent standard and
`with_gvisor` suites pass.

The full non-incremental lint command still reports existing findings in
`dns/dhcp.go`, `dns/dot.go`, `dns/service.go`, and `dns/doq.go`. Incremental
lint for this PR is clean.

#### Build compatibility

CGO-free `with_gvisor` builds passed for:

```text
darwin/arm64
darwin/amd64
linux/amd64
linux/arm64
windows/amd64
freebsd/amd64
```

#### Real verification

An isolated Mihomo instance on `127.0.0.1:10554` returned:

```text
open-webui.orb.local.  300  IN  A     192.168.138.3
open-webui.orb.local.  300  IN  AAAA  fd07:b51a:cc66:0:a617:db5e:c0a8:8a03
```

Both replies were `NOERROR`, matched the macOS host resolver, and the debug log
showed `from mdns://`. The existing Clash, OrbStack, routing, firewall, system
DNS, and TUN configuration were not changed.

#### Why `system://` is unchanged

`system://` is an established unicast-DNS abstraction. Adding mDNS implicitly
would change resolution order and could break private unicast-DNS deployments
that intentionally use `.local`. An explicit scheme keeps the behavior opt-in
and policy-controlled.

#### Known limitations

- The macOS path intentionally implements only the A/AAAA portion required by
  Mihomo's IP resolver.
- The mDNSResponder IPC is versioned and lower-level than the public
  `dns_sd.h` API. Incompatible protocol/transport errors now fall back with a
  clear diagnostic, but a future incompatible protocol may still require an
  adapter update.
- The ordinary DNS response model cannot attach an IPv6 interface zone to an
  AAAA record. Interface metadata is retained for validation and per-interface
  merging, but a returned `fe80::/10` address cannot carry its zone downstream.
- Portable multicast depends on host UDP multicast and interface enumeration;
  sandboxes and containers may restrict either capability.
- `mdns://` is a direct link-local transport; proxy selection and
  `respect-rules` are intentionally not applied.

#### CI/merge gate

This PR should not be merged until the upstream Test and Build workflows have
actually run and passed. Fork workflow runs currently require a MetaCubeX
maintainer to approve execution.
