### PR TITLE
fix: truncate UDP DNS responses to the client's EDNS0 buffer size and echo back OPT

### DIFF
--- a/component/resolver/relay.go
+++ b/component/resolver/relay.go
@@ -17,6 +17,15 @@ const DefaultDnsRelayTimeout = time.Second * 5
 
 const SafeDnsPacketSize = 2 * 1024 // safe size which is 1232 from https://dnsflagday.net/2020/, so 2048 is enough
 
+// RequestUDPSize returns the UDP payload size a reply to msg may occupy:
+// the client's advertised EDNS0 buffer size, or 512 (D.MinMsgSize) without an OPT record.
+func RequestUDPSize(msg *D.Msg) int {
+	if opt := msg.IsEdns0(); opt != nil {
+		return int(opt.UDPSize())
+	}
+	return D.MinMsgSize
+}
+
 func RelayDnsConn(ctx context.Context, conn net.Conn, readTimeout time.Duration) error {
 	buff := pool.Get(pool.UDPBufferSize)
 	defer func() {
@@ -90,7 +99,10 @@ func relayDnsPacket(ctx context.Context, payload []byte, target []byte, maxSize 
 	}
 
 	r.SetRcode(msg, r.Rcode)
-	if maxSize > 0 {
+	if maxSize > 0 { // udp
+		if size := RequestUDPSize(msg); size < maxSize {
+			maxSize = size
+		}
 		r.Truncate(maxSize)
 	}
 	r.Compress = true

--- a/dns/server.go
+++ b/dns/server.go
@@ -35,6 +35,11 @@ func (s *Server) ServeDNS(w D.ResponseWriter, r *D.Msg) {
 		w.WriteMsg(m)
 		return
 	}
+	if _, isUDP := w.RemoteAddr().(*net.UDPAddr); isUDP {
+		// RFC 6891: fit the reply into the client's advertised buffer size,
+		// setting the TC bit if records must be dropped; 512 when no OPT present
+		msg.Truncate(resolver.RequestUDPSize(r))
+	}
 	msg.Compress = true
 	w.WriteMsg(msg)
 }

--- a/dns/service.go
+++ b/dns/service.go
@@ -19,7 +19,20 @@ func (s *Service) ServeMsg(ctx context.Context, msg *D.Msg) (*D.Msg, error) {
 		return nil, errors.New("at least one question is required")
 	}
 
-	return s.handler(icontext.NewDNSContext(ctx), msg)
+	r, err := s.handler(icontext.NewDNSContext(ctx), msg)
+	if err != nil {
+		return r, err
+	}
+
+	// echo back EDNS0: if the client asked with an OPT, reply with our own OPT.
+	// OPT is a per-hop pseudo-record (RFC 6891), so we generate it here instead of
+	// caching/forwarding the upstream one. Doing it at this convergence point covers
+	// both the listening DNS server (ServeDNS) and the TUN hijack relay path.
+	if reqOpt := msg.IsEdns0(); reqOpt != nil && r != nil && r.IsEdns0() == nil {
+		r.SetEdns0(1232, reqOpt.Do())
+	}
+
+	return r, nil
 }
 
 var _ resolver.Service = (*Service)(nil)


### PR DESCRIPTION
## 1. Fixes #3032
**Symptom**: domains with many records (e.g. `128-a.size.dns.netmeister.org`, 128 A records, ~2KB reply) fail to resolve through mihomo's DNS. Two separate bugs were involved:

**Bug A** — no truncation, no TC flag: both the DNS listener ([dns/server.go](https://github.com/MetaCubeX/mihomo/blob/Alpha/dns/server.go)) and the tun dns-hijack path sent UDP replies as-is, ignoring the client's advertised EDNS0 buffer size, without setting the TC flag. Oversized datagrams cause IP fragmentation (breaks on typical 1280–1420 VPN MTUs), and strict resolvers (dnsmasq, systemd-resolved) never fall back to TCP because TC is missing.

**Bug B** — tun hijack sends zero/garbage packets: `(*dns.Msg).PackBuffer` sizes its scratch buffer by the uncompressed message length; when that exceeds the 2048-byte relay buffer it silently allocates a new slice, but [listener/sing_tun/dns.go](https://github.com/MetaCubeX/mihomo/blob/Alpha/listener/sing_tun/dns.go) sends the original (never-written) buffer — a correct-length datagram full of zeros or stale bytes. This is why clients see ID mismatch / timeouts instead of merely oversized replies. (The TCP hijack path already guarded against this in RelayDnsConn; the UDP path did not.) split to https://github.com/MetaCubeX/mihomo/pull/3037

**Fix**:
[dns/server.go](https://github.com/TWO666/mihomo/blob/Alpha/dns/server.go#L38): for UDP queries, call `msg.Truncate()` with the client's advertised EDNS0 buffer size (512 per RFC 6891 when no OPT is present) before writing. Truncate drops trailing RRs and sets TC automatically. TCP replies are untouched.
[component/resolver/relay.go](https://github.com/TWO666/mihomo/blob/66d058645c7c1cbc382c04516e8d107ca1da3ed3/component/resolver/relay.go#L20): the tun hijack path now truncates to `min(client EDNS0 size, SafeDnsPacketSize)` instead of a hardcoded 2048; and after PackBuffer, if the result is not backed by the caller's buffer, copy it back (truncation guarantees it fits).

**Validation**:
Expected behavior (reference, against 8.8.8.8):
```shell
dig @8.8.8.8 128-a.size.dns.netmeister.org A +notcp+noall +comments +stats +bufsize=1232
```
<img width="1013" height="354" alt="image" src="https://github.com/user-attachments/assets/d68a79e1-fefe-498b-a09b-40d0129b7d9f" />

Before:
```shell
dig @198.18.0.2 128-a.size.dns.netmeister.org A +notcp +noall +comments +stats +bufsize=1232
```
<img width="1040" height="493" alt="image" src="https://github.com/user-attachments/assets/7b6082a9-8102-4aaa-8f76-287481fd0c07" />


After(need https://github.com/MetaCubeX/mihomo/pull/3037):
<img width="1040" height="382" alt="image" src="https://github.com/user-attachments/assets/9a2a3ea3-0490-4062-b832-222780b4f2e0" />



## 2. systemd-resolved logs "Using degraded feature set UDP instead of UDP+EDNS0"
**Cause**: replies never carried an OPT pseudo-record. OPT is per-hop (RFC 6891) and mihomo's cache stores upstream answers without it, so clients that sent EDNS0 queries got plain-DNS answers back and downgraded the feature set.

**Fix**: [dns/service.go](https://github.com/TWO666/mihomo/blob/Alpha/dns/service.go#L27) — in ServeMsg, when the request carries an OPT record and the reply does not, attach our own OPT (advertising 1232, preserving the DO bit). ServeMsg is the convergence point, so both the DNS listener and the tun hijack path benefit.