### PR TITLE
fix: tun dns hijack sending zero-filled or stale packets when PackBuffer reallocates

### DIFF
--- a/component/resolver/relay.go
+++ b/component/resolver/relay.go
@@ -94,7 +94,17 @@ func relayDnsPacket(ctx context.Context, payload []byte, target []byte, maxSize 
 		r.Truncate(maxSize)
 	}
 	r.Compress = true
-	return r.PackBuffer(target)
+	data, err := r.PackBuffer(target)
+	if err != nil {
+		return nil, err
+	}
+	// PackBuffer sizes its scratch space by the *uncompressed* message length and may
+	// have allocated a new slice even though the compressed result fits into target.
+	// Callers (e.g. the tun dns hijack) assume the result is backed by target, so copy it back.
+	if len(data) > 0 && len(data) <= len(target) && &data[0] != &target[0] {
+		data = target[:copy(target, data)]
+	}
+	return data, nil
 }
 
 // RelayDnsPacket will truncate udp message up to SafeDnsPacketSize


### PR DESCRIPTION
Split out of #3034 as requested.

`(*dns.Msg).PackBuffer` sizes its scratch space by the uncompressed message length and silently allocates a new slice when that exceeds the given buffer — even though the compressed result would fit. The udp hijack path in `listener/sing_tun/dns.go` assumes the packed result is backed by `writeBuff` and always sends the original buffer, so whenever a reply's uncompressed size exceeds `SafeDnsPacketSize (2048)`, the client receives a correct-length datagram full of zeros or stale bytes.

This is easy to hit with replies containing many records for the same name: e.g. `128-a.size.dns.netmeister.org` (128 A records) compresses to ~2KB but is ~5.6KB uncompressed. Through the tun dns hijack, clients see timeouts and ID mismatch warnings (the "IDs" are actually leftover bytes from recycled buffers).

The tcp path in `RelayDnsConn` already guards against this reallocation (the `&msg[0] == &outBuff[0]` check); the udp path did not. Fix it centrally in `relayDnsPacket`: after `PackBuffer`, if the result is not backed by the caller's buffer but fits, copy it back.