### PR TITLE
fix: avoid attributing forwarded traffic to local processes

### DIFF
--- a/tunnel/tunnel.go
+++ b/tunnel/tunnel.go
@@ -15,6 +15,7 @@ import (
 	"github.com/metacubex/mihomo/common/atomic"
 	N "github.com/metacubex/mihomo/common/net"
 	"github.com/metacubex/mihomo/common/utils"
+	"github.com/metacubex/mihomo/component/iface"
 	"github.com/metacubex/mihomo/component/loopback"
 	"github.com/metacubex/mihomo/component/nat"
 	"github.com/metacubex/mihomo/component/process"
@@ -286,6 +287,16 @@ func needLookupIP(metadata *C.Metadata) bool {
 	return resolver.MappingEnabled() && metadata.Host == "" && metadata.DstIP.IsValid()
 }
 
+func shouldFindProcess(srcIP netip.Addr) bool {
+	srcIP = srcIP.Unmap().WithZone("")
+	if !srcIP.IsValid() || srcIP.IsLoopback() {
+		return true
+	}
+
+	local, err := iface.IsLocalIp(srcIP)
+	return err != nil || local
+}
+
 func preHandleMetadata(metadata *C.Metadata) error {
 	// preprocess enhanced-mode metadata
 	if needLookupIP(metadata) {
@@ -351,6 +362,9 @@ func resolveMetadata(metadata *C.Metadata) (proxy C.Proxy, rule C.Rule, err erro
 		FindProcess: func() {
 			if attemptProcessLookup {
 				attemptProcessLookup = false
+				if !shouldFindProcess(metadata.SrcIP) {
+					return
+				}
 				if !features.CMFA {
 					// normal check for process
 					uid, path, err := process.FindProcessName(metadata.NetWork.String(), metadata.SrcIP, int(metadata.SrcPort))


### PR DESCRIPTION
Forwarded connections can be attributed to an unrelated local process when their source port collides with a local socket, causing PROCESS-NAME rules to match traffic from another host.

This skips process lookup only when the source address is not owned by the mihomo host. Unlike exact-match-only changes in the Linux socket resolver, it leaves the existing netlink fallback intact for local traffic, including wildcard/NAT cases where strict matching may fail.
