### PR TITLE
fix: echo edns0 opt in dns replies when the request carries one

### DIFF
--- a/dns/service.go
+++ b/dns/service.go
@@ -19,7 +19,23 @@ func (s *Service) ServeMsg(ctx context.Context, msg *D.Msg) (*D.Msg, error) {
 		return nil, errors.New("at least one question is required")
 	}
 
-	return s.handler(icontext.NewDNSContext(ctx), msg)
+	r, err := s.handler(icontext.NewDNSContext(ctx), msg)
+	if err != nil {
+		return r, err
+	}
+
+	// echo back EDNS0: if the client asked with an OPT, reply with our own OPT.
+	// OPT is a per-hop pseudo-record (RFC 6891), so we generate it here instead of
+	// caching/forwarding the upstream one. Doing it at this convergence point covers
+	// both the listening DNS server (ServeDNS) and the TUN hijack relay path.
+	// 1232 is the fragmentation-safe UDP payload size recommended by
+	// https://dnsflagday.net/2020/ : the IPv6 minimum MTU (1280) minus
+	// the IPv6 and UDP header sizes (40 + 8).
+	if reqOpt := msg.IsEdns0(); reqOpt != nil && r != nil && r.IsEdns0() == nil {
+		r.SetEdns0(1232, reqOpt.Do())
+	}
+
+	return r, nil
 }
 
 var _ resolver.Service = (*Service)(nil)


### PR DESCRIPTION
## What this fixes

RFC 6891 requires a responder to include an OPT record whenever the request
carries one:

> If an OPT record is present in a received request, compliant responders
> **MUST** include an OPT record in their respective responses.
> — [RFC 6891 §6.1.1](https://datatracker.ietf.org/doc/html/rfc6891#section-6.1.1)

mihomo strips the upstream OPT before caching , which is itself correct — OPT
is a per-hop pseudo-record and must not be cached:

> OPT RRs **MUST NOT** be cached, forwarded, or stored in or loaded from
> master files.
> — [RFC 6891 §6.1.1](https://datatracker.ietf.org/doc/html/rfc6891#section-6.1.1)

https://github.com/MetaCubeX/mihomo/blob/f298cd2e963de972fadc580854c2dc3f88445600/dns/util.go#L69-L72

But it never generated a fresh OPT when answering, so cache hits were
plain-DNS replies. Clients such as systemd-resolved treat a missing OPT as an
EDNS0 failure ([`dns_server_packet_bad_opt`](https://github.com/systemd/systemd/blob/main/src/resolve/resolved-dns-transaction.c))
and downgrade the server:

```
Using degraded feature set UDP instead of UDP+EDNS0 for DNS server ...
```

after which they periodically re-probe, adding timeouts and extra round trips.

## Fix

Synthesize an OPT at the `ServeMsg` convergence point (covers both the DNS
listener and the TUN hijack path) when the request has one and the reply does
not:

- advertise 1232 bytes, per [DNS Flag Day 2020](https://www.dnsflagday.net/2020/);
- preserve the client's DNSSEC DO bit, per
  [RFC 3225 §3](https://datatracker.ietf.org/doc/html/rfc3225#section-3):
 > "The DO bit of the query MUST be copied in the response."

## Verification

```console
$ # first query got OPT PSEUDOSECTION
$ dig @127.0.0.3 1024.size.dns.netmeister.org A +notcp +noall +comments +stat +edns=0
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 13592
;; flags: qr aa rd ra ad; QUERY: 1, ANSWER: 60, AUTHORITY: 0, ADDITIONAL: 1

;; OPT PSEUDOSECTION:
; EDNS: version: 0, flags:; udp: 512
;; Query time: 679 msec
;; SERVER: 127.0.0.3#53(127.0.0.3) (UDP)
;; WHEN: Tue Jul 28 22:32:37 CST 2026
;; MSG SIZE  rcvd: 1017

$ # no OPT PSEUDOSECTION
$ dig @127.0.0.3 1024.size.dns.netmeister.org A +notcp +noall +comments +stat +edns=0
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 30885
;; flags: qr aa rd ra ad; QUERY: 1, ANSWER: 60, AUTHORITY: 0, ADDITIONAL: 0

;; Query time: 0 msec
;; SERVER: 127.0.0.3#53(127.0.0.3) (UDP)
;; WHEN: Tue Jul 28 22:32:38 CST 2026
;; MSG SIZE  rcvd: 1006
```

Before the fix the second (cached) reply has no `OPT PSEUDOSECTION`, and
`resolvectl log-level debug` shows the downgrade message above; after the fix
the OPT is present on every reply and the feature set stays `UDP+EDNS0`.

systemd-resolved works well
```console
$ resolvectl dns Mihomo 127.0.0.3
$ resolvectl flush-caches
$ resolvectl reset-server-features
$ journalctl -u systemd-resolved -f
Using feature level UDP+EDNS0 for transaction 4262.
Using DNS server 127.0.0.3 for transaction 4262.
Announcing packet size 65508 in egress EDNS(0) packet.
Emitting UDP, link MTU is 1500, socket MTU is 65535, minimal MTU is 40
Sending query packet with id 4262 of size 57.
Processing query...
Received dns UDP packet of size 1017, ifindex=0, ttl=0, fragsize=0, sender=127.0.0.3, destination=127.0.0.1
Processing incoming packet of size 1017 on transaction 4262 (rcode=SUCCESS).
Verified we get a response at feature level UDP+EDNS0 from DNS server 127.0.0.3.
Regular transaction 4262 for <1024.size.dns.netmeister.org IN A> on scope dns on Mihomo/* now complete with <success> from network (unsigned; non-confidential).
Sending response packet with id 2637 on interface 1/AF_INET of size 1017.
Freeing transaction 4262.
```

dig dns query works well
```console
$ dig @127.0.0.3 1024.size.dns.netmeister.org A +notcp +noall +comments +stat +edns=0
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 36699
;; flags: qr aa rd ra ad; QUERY: 1, ANSWER: 60, AUTHORITY: 0, ADDITIONAL: 1

;; OPT PSEUDOSECTION:
; EDNS: version: 0, flags:; udp: 1232
;; Query time: 1 msec
;; SERVER: 127.0.0.3#53(127.0.0.3) (UDP)
;; WHEN: Tue Jul 28 22:30:28 CST 2026
;; MSG SIZE  rcvd: 1017

$ # second edns query works as expected
$ dig @127.0.0.3 1024.size.dns.netmeister.org A +notcp +noall +comments +stat +edns=0
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 5104
;; flags: qr aa rd ra ad; QUERY: 1, ANSWER: 60, AUTHORITY: 0, ADDITIONAL: 1

;; OPT PSEUDOSECTION:
; EDNS: version: 0, flags:; udp: 1232
;; Query time: 0 msec
;; SERVER: 127.0.0.3#53(127.0.0.3) (UDP)
;; WHEN: Tue Jul 28 22:30:29 CST 2026
;; MSG SIZE  rcvd: 1017

$ # noedns works as expected
$ dig @127.0.0.3 1024.size.dns.netmeister.org A +notcp +noall +comments +stat +noedns
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 36927
;; flags: qr aa rd ra ad; QUERY: 1, ANSWER: 60, AUTHORITY: 0, ADDITIONAL: 0

;; Query time: 0 msec
;; SERVER: 127.0.0.3#53(127.0.0.3) (UDP)
;; WHEN: Tue Jul 28 22:34:57 CST 2026
;; MSG SIZE  rcvd: 1006
```


verify config:
```yaml
mixed-port: 0
mode: direct
log-level: info
ipv6: false
dns:
  enable: true
  listen: 127.0.0.3:53
  ipv6: false
  enhanced-mode: redir-host
  nameserver:
    - 8.8.8.8
  cache-max-size: 1
```