### PR TITLE
chore: remove dohMaxConnsPerHost & dohMaxIdleConns

### DIFF
--- a/dns/doh.go
+++ b/dns/doh.go
@@ -36,15 +36,8 @@ const (
 	// connections in HTTP transport.
 	transportDefaultIdleConnTimeout = 5 * time.Minute
 
-	// dohMaxConnsPerHost controls the maximum number of connections for
-	// each host.  Note, that setting it to 1 may cause issues with Go's http
-	// implementation, see https://github.com/AdguardTeam/dnsproxy/issues/278.
-	dohMaxConnsPerHost = 2
 	dialTimeout        = 10 * time.Second
 
-	// dohMaxIdleConns controls the maximum number of connections being idle
-	// at the same time.
-	dohMaxIdleConns = 2
 	maxElapsedTime  = time.Second * 30
 )
 
@@ -394,8 +387,6 @@ func (doh *dnsOverHTTPS) createTransport(ctx context.Context) (t http.RoundTripp
 		DisableCompression: true,
 		DialContext:        doh.dialer.DialContext,
 		IdleConnTimeout:    transportDefaultIdleConnTimeout,
-		MaxConnsPerHost:    dohMaxConnsPerHost,
-		MaxIdleConns:       dohMaxIdleConns,
 	}
 
 	if doh.url.Scheme == "http" {


### PR DESCRIPTION
这2个参数当初是这个commit引入的

[featrue: DoH and DoQ are implemented using AdGuardTeam/dnsProxy, DoH support perfer and force http3](https://github.com/MetaCubeX/mihomo/commit/3e20912339ed03b1aab939892d8dad5d2ccf2968#diff-7d0d631828d87b2ef5b7db664d5b432c4c2ab1c7881b0b902bf9e2c24298b487R41)

追溯到dnsProxy那边则是

[Expose MaxConnsPerHost to mobile API](https://github.com/AdguardTeam/dnsproxy/commit/e37b7ff50c7d8c7e76c558ca140e9067f9676108)

为了移动端节省资源引入的，这个commit拍脑袋引入了好几个参数。

中间为了规避go的bug，将 dohMaxConnsPerHost 从 1 改到了 2。

如果把主dns设成doh，且延迟又比较大，又用在类似路由器这样的地方，请求量稍多，单个连接的stream数量很快就会打满，以及连接关闭场景，设这么小，都无法及时的新建tcp连接，进而导致全局dns查询卡住。

这2个参数go的默认值也都是no limit，且有idle conn的设计，最终在闲置一定时间后，也会收敛到 DefaultMaxIdleConnsPerHost = 2 上。

因此删除这2个参数的设置来缓解查询卡住的问题。

