### PR TITLE
feat: report the runtime memory limit in the memory endpoint

### DIFF
--- a/hub/route/server.go
+++ b/hub/route/server.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"crypto/subtle"
 	"encoding/json"
+	"math"
 	"net"
 	"os"
 	"path/filepath"
@@ -54,7 +55,7 @@ type Traffic struct {
 
 type Memory struct {
 	Inuse   uint64 `json:"inuse"`
-	OSLimit uint64 `json:"oslimit"` // maybe we need it in the future
+	OSLimit uint64 `json:"oslimit"` // the runtime soft memory limit, 0 when unlimited
 }
 
 type Config struct {
@@ -414,6 +415,19 @@ func traffic(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+// memoryLimit reports the soft memory limit the Go runtime is enforcing, set
+// either through the GOMEMLIMIT environment variable or debug.SetMemoryLimit.
+// It returns 0 when no limit is in effect, since the runtime spells that as
+// math.MaxInt64, which is not a useful number to report.
+func memoryLimit() uint64 {
+	// A negative argument only reads the current limit, it does not set one.
+	limit := debug.SetMemoryLimit(-1)
+	if limit == math.MaxInt64 {
+		return 0
+	}
+	return uint64(limit)
+}
+
 func memory(w http.ResponseWriter, r *http.Request) {
 	var wsConn net.Conn
 	if r.Header.Get("Upgrade") == "websocket" {
@@ -445,9 +459,10 @@ func memory(w http.ResponseWriter, r *http.Request) {
 			inuse = 0
 			first = false
 		}
+		// read inside the loop so a limit changed at runtime is reflected
 		if err := json.NewEncoder(buf).Encode(Memory{
 			Inuse:   inuse,
-			OSLimit: 0,
+			OSLimit: memoryLimit(),
 		}); err != nil {
 			break
 		}

--- a/hub/route/server_test.go
+++ b/hub/route/server_test.go
@@ -1,0 +1,28 @@
+package route
+
+import (
+	"math"
+	"runtime/debug"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMemoryLimit(t *testing.T) {
+	original := debug.SetMemoryLimit(-1)
+	t.Cleanup(func() {
+		debug.SetMemoryLimit(original)
+	})
+
+	// no limit in effect
+	debug.SetMemoryLimit(math.MaxInt64)
+	assert.Equal(t, uint64(0), memoryLimit())
+
+	// a limit is in effect
+	debug.SetMemoryLimit(64 << 20)
+	assert.Equal(t, uint64(64<<20), memoryLimit())
+
+	// reading must not change the limit
+	assert.Equal(t, uint64(64<<20), memoryLimit())
+	assert.Equal(t, int64(64<<20), debug.SetMemoryLimit(-1))
+}


### PR DESCRIPTION
## Problem

The `/memory` endpoint has always reported a hardcoded `oslimit: 0`:

```go
OSLimit uint64 `json:"oslimit"` // maybe we need it in the future
```

Meanwhile the Go runtime's soft memory limit (`GOMEMLIMIT` or `debug.SetMemoryLimit`) has a substantial effect on mihomo's footprint. Measured on linux/amd64 with rule-sets of 112,332 + 26,822 domains and 5,687 CIDRs loaded, anonymous RSS:

| | steady state |
| --- | --- |
| no limit | 15.4 MB |
| `GOMEMLIMIT=37MiB` | 9.6 MB |

On platforms with a hard memory ceiling — an Apple Network Extension gets roughly 50 MB before jetsam kills it, small routers get less — setting this limit is one of the most effective knobs available. But there is currently no way to confirm through the API that a limit is actually in effect: a typo in the environment variable and you silently run unlimited.

## Change

Fill the field with the limit the runtime is actually enforcing:

* `memoryLimit()` reads it via `debug.SetMemoryLimit(-1)` — a negative argument is the documented read-only form and does not modify the limit.
* The runtime spells "no limit" as `math.MaxInt64`, which is not a useful number to hand a dashboard, so that case keeps reporting `0`. **Default behaviour is unchanged**: anyone not setting a limit sees exactly what they see today.
* The value is read inside the once-per-second push loop, so a limit changed at runtime is reflected. The read-only path briefly takes the heap lock and skips the pacer commit (`runtime/mgcpacer.go`, `in < 0` branch); once per second per watcher this is negligible.

Dashboards consuming `/memory` will start receiving a non-zero `oslimit` when (and only when) the user has configured a limit — which is the point: `inuse` against `oslimit` is exactly the "how close am I to the ceiling" view.

## Verification

Unit test covers the mapping in both directions plus the property that reading does not alter the limit (guarding the `-1` read-only form against future edits).

End to end, same config, three runs:

| | `/memory` reports |
| --- | --- |
| no `GOMEMLIMIT` | `{"inuse":38199296,"oslimit":0}` |
| `GOMEMLIMIT=37MiB` | `{"inuse":37253120,"oslimit":38797312}` |
| `GOMEMLIMIT=100MiB` | `{"inuse":43155456,"oslimit":104857600}` |

38797312 = 37 × 1024², 104857600 = 100 × 1024².

## Notes

This only reports the limit; it does not set one. Making the limit a first-class config option (as opposed to an environment variable) may be worth a separate discussion — this change is useful either way, since it also reports limits set via `GOMEMLIMIT` today.
