### PR TITLE
fix(xhttp): avoid blocking packet uploads on responses

### DIFF
--- a/transport/xhttp/client.go
+++ b/transport/xhttp/client.go
@@ -52,6 +52,7 @@ type PacketUpWriter struct {
 	buf                  []byte
 	timer                *time.Timer
 	flushErr             error
+	onError              func(error)
 }
 
 func (c *PacketUpWriter) Write(b []byte) (int, error) {
@@ -121,23 +122,64 @@ func (c *PacketUpWriter) write(b []byte) (int, error) {
 	seqStr := strconv.FormatUint(c.seq, 10)
 	c.seq++
 
-	if err := c.cfg.FillPacketRequest(req, c.sessionID, seqStr, b); err != nil {
+	payload := bytes.Clone(b)
+	if err := c.cfg.FillPacketRequest(req, c.sessionID, seqStr, payload); err != nil {
 		return 0, err
 	}
 	req.Host = c.cfg.Host
 
-	resp, err := c.transport.RoundTrip(req)
-	if err != nil {
-		return 0, err
-	}
-	defer resp.Body.Close()
-	_, _ = io.Copy(io.Discard, resp.Body)
+	requestWritten := make(chan struct{})
+	var requestWrittenOnce sync.Once
+	req = req.WithContext(httptrace.WithClientTrace(req.Context(), &httptrace.ClientTrace{
+		WroteRequest: func(httptrace.WroteRequestInfo) {
+			requestWrittenOnce.Do(func() {
+				close(requestWritten)
+			})
+		},
+	}))
 
-	if resp.StatusCode != http.StatusOK {
-		return 0, fmt.Errorf("xhttp packet-up bad status: %s", resp.Status)
-	}
+	result := make(chan error, 1)
+	go func() {
+		resp, err := c.transport.RoundTrip(req)
+		if err == nil {
+			defer resp.Body.Close()
+			_, _ = io.Copy(io.Discard, resp.Body)
+			if resp.StatusCode != http.StatusOK {
+				err = fmt.Errorf("xhttp packet-up bad status: %s", resp.Status)
+			}
+		}
+		result <- err
+	}()
 
-	return len(b), nil
+	select {
+	case <-requestWritten:
+		go c.collectResult(result)
+		return len(b), nil
+	case err := <-result:
+		if err != nil {
+			return 0, err
+		}
+		return len(b), nil
+	}
+}
+
+func (c *PacketUpWriter) collectResult(result <-chan error) {
+	if err := <-result; err != nil {
+		if c.cancel != nil {
+			c.cancel()
+		}
+		c.writeMu.Lock()
+		var onError func(error)
+		if c.flushErr == nil {
+			c.flushErr = err
+			onError = c.onError
+		}
+		c.writeCond.Broadcast()
+		c.writeMu.Unlock()
+		if onError != nil {
+			onError(err)
+		}
+	}
 }
 
 func (c *PacketUpWriter) Close() error {
@@ -644,6 +686,11 @@ func (c *Client) DialPacketUp(ctx context.Context) (net.Conn, error) {
 	downloadReq.Host = downloadCfg.Host
 
 	wrc := NewWaitReadCloser()
+	writer.onError = func(error) {
+		reqCancel()
+		_ = wrc.Close()
+		httputils.CloseTransport(downloadTransport)
+	}
 
 	go func() {
 		resp, err := downloadTransport.RoundTrip(downloadReq)

--- a/transport/xhttp/client_test.go
+++ b/transport/xhttp/client_test.go
@@ -1,0 +1,145 @@
+package xhttp
+
+import (
+	"context"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/metacubex/http"
+	"github.com/metacubex/http/httptest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const packetUpTestTimeout = 5 * time.Second
+
+func TestPacketUpWriterDoesNotWaitForResponse(t *testing.T) {
+	received := make(chan string, 2)
+	releaseFirstResponse := make(chan struct{})
+	defer func() {
+		select {
+		case <-releaseFirstResponse:
+		default:
+			close(releaseFirstResponse)
+		}
+	}()
+
+	server := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seq := r.URL.Path[len(r.URL.Path)-1:]
+		received <- seq
+		if seq == "0" {
+			<-releaseFirstResponse
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	server.EnableHTTP2 = true
+	server.StartTLS()
+	defer server.Close()
+
+	serverURL, err := url.Parse(server.URL)
+	require.NoError(t, err)
+	config := Config{
+		Host:             serverURL.Host,
+		Path:             "/xhttp",
+		UplinkHTTPMethod: http.MethodPost,
+		XPaddingBytes:    "0",
+	}
+	writer := PacketUpWriter{
+		ctx:       context.Background(),
+		cfg:       &config,
+		sessionID: "session",
+		transport: server.Client().Transport,
+	}
+
+	firstWrite := make(chan error, 1)
+	go func() {
+		_, err := writer.write([]byte("first"))
+		firstWrite <- err
+	}()
+
+	select {
+	case err := <-firstWrite:
+		require.NoError(t, err)
+	case <-time.After(packetUpTestTimeout):
+		t.Fatal("first packet upload waited for the response")
+	}
+
+	secondWrite := make(chan error, 1)
+	go func() {
+		_, err := writer.write([]byte("second"))
+		secondWrite <- err
+	}()
+
+	select {
+	case err := <-secondWrite:
+		require.NoError(t, err)
+	case <-time.After(packetUpTestTimeout):
+		t.Fatal("second packet upload was blocked by the first response")
+	}
+
+	assert.Equal(t, "0", <-received)
+	assert.Equal(t, "1", <-received)
+	close(releaseFirstResponse)
+}
+
+func TestPacketUpWriterReportsAsynchronousResponseError(t *testing.T) {
+	requestReceived := make(chan struct{})
+	releaseResponse := make(chan struct{})
+	server := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		close(requestReceived)
+		<-releaseResponse
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	server.EnableHTTP2 = true
+	server.StartTLS()
+	defer server.Close()
+
+	serverURL, err := url.Parse(server.URL)
+	require.NoError(t, err)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	asyncError := make(chan error, 1)
+	config := Config{
+		Host:             serverURL.Host,
+		Path:             "/xhttp",
+		UplinkHTTPMethod: http.MethodPost,
+		XPaddingBytes:    "0",
+	}
+	writer := PacketUpWriter{
+		ctx:       ctx,
+		cancel:    cancel,
+		cfg:       &config,
+		sessionID: "session",
+		transport: server.Client().Transport,
+		onError: func(err error) {
+			asyncError <- err
+		},
+	}
+
+	writeComplete := make(chan error, 1)
+	go func() {
+		_, err := writer.write([]byte("payload"))
+		writeComplete <- err
+	}()
+
+	select {
+	case <-requestReceived:
+	case <-time.After(packetUpTestTimeout):
+		t.Fatal("packet upload was not sent")
+	}
+	select {
+	case err := <-writeComplete:
+		require.NoError(t, err)
+	case <-time.After(packetUpTestTimeout):
+		t.Fatal("packet upload waited for the response")
+	}
+
+	close(releaseResponse)
+	select {
+	case err := <-asyncError:
+		assert.ErrorContains(t, err, http.StatusText(http.StatusServiceUnavailable))
+	case <-time.After(packetUpTestTimeout):
+		t.Fatal("asynchronous response error was not reported")
+	}
+}


### PR DESCRIPTION
## Problem

Packet-up currently waits for the complete HTTP response after every upload request. If a server or intermediary delays the response, the next packet cannot be sent and the upload stalls.

## Changes

- complete a packet write once the request has been written
- collect and validate the response asynchronously
- propagate delayed response errors by cancelling the packet-up connection
- clone the payload before starting the asynchronous request

## Tests

- `go test ./transport/xhttp`
- `go test -count=20 ./transport/xhttp`
- `go vet ./transport/xhttp`