### PR TITLE
fix: include first proxy in url-test fast existence check

### DIFF
--- a/adapter/outboundgroup/urltest.go
+++ b/adapter/outboundgroup/urltest.go
@@ -119,7 +119,7 @@ func (u *URLTest) fast(touch bool) C.Proxy {
 		minDelay := fast.LastDelayForTestUrl(u.testUrl)
 		fastNotExist := true
 
-		for _, proxy := range proxies[1:] {
+		for _, proxy := range proxies {
 			if u.fastNode != nil && proxy.Name() == u.fastNode.Name() {
 				fastNotExist = false
 			}


### PR DESCRIPTION
Closes #2945

fastNotExist skipped proxies[0], so when the selected node happened to be the first in the list it was treated as missing and the group switched even within tolerance.