### PR TITLE
fix: avoid proxy name collisions in provider uniquification

### DIFF
--- a/common/convert/converter.go
+++ b/common/convert/converter.go
@@ -719,11 +719,16 @@ func ConvertsV2Ray(buf []byte) ([]map[string]any, error) {
 func uniqueName(names map[string]int, name string) string {
 	if index, ok := names[name]; ok {
 		index++
-		names[name] = index
-		name = fmt.Sprintf("%s-%02d", name, index)
-	} else {
-		index = 0
-		names[name] = index
+		base := name
+		for {
+			name = fmt.Sprintf("%s-%02d", base, index)
+			if _, exist := names[name]; !exist {
+				break
+			}
+			index++
+		}
+		names[base] = index
 	}
+	names[name] = 0
 	return name
 }

--- a/common/convert/converter_test.go
+++ b/common/convert/converter_test.go
@@ -1,6 +1,7 @@
 package convert_test
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/metacubex/mihomo/adapter"
@@ -8,6 +9,26 @@ import (
 
 	"github.com/stretchr/testify/assert"
 )
+
+func TestConvertsV2Ray_duplicateNames(t *testing.T) {
+	uri := strings.Join([]string{
+		"trojan://pwd@example.com:443#name",
+		"trojan://pwd@example.com:443#name-01",
+		"trojan://pwd@example.com:443#name",
+		"trojan://pwd@example.com:443#name",
+	}, "\n")
+
+	proxies, err := ConvertsV2Ray([]byte(uri))
+
+	assert.Nil(t, err)
+	assert.Len(t, proxies, 4)
+	assert.Equal(t, []string{"name", "name-01", "name-02", "name-03"}, []string{
+		proxies[0]["name"].(string),
+		proxies[1]["name"].(string),
+		proxies[2]["name"].(string),
+		proxies[3]["name"].(string),
+	})
+}
 
 // https://v2.hysteria.network/zh/docs/developers/URI-Scheme/
 func TestConvertsV2Ray_normal(t *testing.T) {


### PR DESCRIPTION
Closes #2931

uniqueName generated name-01 without checking whether that name was already taken (e.g. by another node's own fragment), so the colliding node got dropped later during assembly. The generated name is now registered and the suffix keeps incrementing until a free slot is found.