### PR TITLE
fix: stop retrying on local socket exhaustion

### DIFF
--- a/tunnel/retry_error_test.go
+++ b/tunnel/retry_error_test.go
@@ -1,0 +1,71 @@
+package tunnel
+
+import (
+	"context"
+	"errors"
+	"net"
+	"os"
+	"testing"
+)
+
+type namedRetryError struct {
+	name string
+	err  error
+}
+
+func TestShouldStopRetryLocalResourceExhaustion(t *testing.T) {
+	for _, test := range localResourceExhaustionTestCases() {
+		t.Run(test.name+"/direct", func(t *testing.T) {
+			if !shouldStopRetry(test.err) {
+				t.Fatal("shouldStopRetry() = false, want true")
+			}
+		})
+
+		t.Run(test.name+"/wrapped", func(t *testing.T) {
+			err := &net.OpError{
+				Op:  "dial",
+				Net: "tcp",
+				Err: &os.SyscallError{Syscall: "connect", Err: test.err},
+			}
+			if !shouldStopRetry(err) {
+				t.Fatal("shouldStopRetry() = false, want true")
+			}
+		})
+	}
+}
+
+func TestRetryStopsOnLocalResourceExhaustion(t *testing.T) {
+	resourceErr := localResourceExhaustionTestCases()[0].err
+	attempts := 0
+	_, err := retry(context.Background(), func(context.Context) (struct{}, error) {
+		attempts++
+		return struct{}{}, resourceErr
+	}, nil)
+	if !errors.Is(err, resourceErr) {
+		t.Fatalf("retry() error = %v, want %v", err, resourceErr)
+	}
+	if attempts != 1 {
+		t.Fatalf("retry() attempts = %d, want 1", attempts)
+	}
+}
+
+func TestRetryPreservesTransientErrorBehavior(t *testing.T) {
+	transientErr := errors.New("transient network error")
+	attempts := 0
+	result, err := retry(context.Background(), func(context.Context) (string, error) {
+		attempts++
+		if attempts == 1 {
+			return "", transientErr
+		}
+		return "connected", nil
+	}, nil)
+	if err != nil {
+		t.Fatalf("retry() error = %v, want nil", err)
+	}
+	if result != "connected" {
+		t.Fatalf("retry() result = %q, want connected", result)
+	}
+	if attempts != 2 {
+		t.Fatalf("retry() attempts = %d, want 2", attempts)
+	}
+}

--- a/tunnel/retry_error_unix.go
+++ b/tunnel/retry_error_unix.go
@@ -1,0 +1,15 @@
+//go:build !windows
+
+package tunnel
+
+import (
+	"errors"
+	"syscall"
+)
+
+func isLocalResourceExhaustion(err error) bool {
+	return errors.Is(err, syscall.EADDRNOTAVAIL) ||
+		errors.Is(err, syscall.EMFILE) ||
+		errors.Is(err, syscall.ENFILE) ||
+		errors.Is(err, syscall.ENOBUFS)
+}

--- a/tunnel/retry_error_unix_test.go
+++ b/tunnel/retry_error_unix_test.go
@@ -1,0 +1,14 @@
+//go:build !windows
+
+package tunnel
+
+import "syscall"
+
+func localResourceExhaustionTestCases() []namedRetryError {
+	return []namedRetryError{
+		{name: "EADDRNOTAVAIL", err: syscall.EADDRNOTAVAIL},
+		{name: "EMFILE", err: syscall.EMFILE},
+		{name: "ENFILE", err: syscall.ENFILE},
+		{name: "ENOBUFS", err: syscall.ENOBUFS},
+	}
+}

--- a/tunnel/retry_error_windows.go
+++ b/tunnel/retry_error_windows.go
@@ -1,0 +1,16 @@
+//go:build windows
+
+package tunnel
+
+import (
+	"errors"
+
+	"golang.org/x/sys/windows"
+)
+
+func isLocalResourceExhaustion(err error) bool {
+	return errors.Is(err, windows.WSAEADDRNOTAVAIL) ||
+		errors.Is(err, windows.WSAEMFILE) ||
+		errors.Is(err, windows.ERROR_TOO_MANY_OPEN_FILES) ||
+		errors.Is(err, windows.WSAENOBUFS)
+}

--- a/tunnel/retry_error_windows_test.go
+++ b/tunnel/retry_error_windows_test.go
@@ -1,0 +1,14 @@
+//go:build windows
+
+package tunnel
+
+import "golang.org/x/sys/windows"
+
+func localResourceExhaustionTestCases() []namedRetryError {
+	return []namedRetryError{
+		{name: "WSAEADDRNOTAVAIL", err: windows.WSAEADDRNOTAVAIL},
+		{name: "WSAEMFILE", err: windows.WSAEMFILE},
+		{name: "ERROR_TOO_MANY_OPEN_FILES", err: windows.ERROR_TOO_MANY_OPEN_FILES},
+		{name: "WSAENOBUFS", err: windows.WSAENOBUFS},
+	}
+}

--- a/tunnel/tunnel.go
+++ b/tunnel/tunnel.go
@@ -721,6 +721,9 @@ func getRules(metadata *C.Metadata) []C.Rule {
 }
 
 func shouldStopRetry(err error) bool {
+	if isLocalResourceExhaustion(err) {
+		return true
+	}
 	if errors.Is(err, resolver.ErrIPNotFound) {
 		return true
 	}


### PR DESCRIPTION
## Summary

Stop the tunnel dial retry loop immediately when the local host reports socket resource exhaustion, including `EADDRNOTAVAIL`.

## Root cause

`tunnel.retry` currently attempts most failed dials up to 10 times. Local resource exhaustion is not transient on the retry loop's millisecond-to-second time scale. Retrying `EADDRNOTAVAIL`, `EMFILE`, `ENFILE`, or `ENOBUFS` cannot free the exhausted resource and may amplify an existing connection storm.

In one macOS TUN incident, the IPv4 ephemeral port range contained 16,384 ports while the host had approximately 16,477 TCP sockets in `TIME_WAIT`. IPv4 loopback connections then failed with errno 49 / `EADDRNOTAVAIL`, even though the local services were still listening. Multiple rule providers and health checks continued dialing through the same retry path.

## Changes

- classify local socket resource exhaustion as non-retryable by the fast dial retry loop;
- use the native WinSock/Win32 equivalents on Windows;
- preserve the existing behavior for ordinary transient network errors;
- add tests for direct and wrapped syscall errors and attempt counts.

## Impact

This does not attempt to repair an already exhausted OS socket table. It prevents Mihomo from multiplying each failed dial into up to 10 attempts, reducing the chance that a degraded network state escalates into complete local IPv4 connection failure.

## Validation

- `go vet ./tunnel`
- `go test ./tunnel -count=1`
- `GOTOOLCHAIN=go1.20.14 go test ./tunnel -count=1`
- `SKIP_INTEROP_TEST=1 go test ./... -count=1`
- `SKIP_INTEROP_TEST=1 go test ./... -tags with_gvisor -count=1`
- compiled the `tunnel` test binary for Darwin/arm64, Linux/amd64, and Windows/amd64
- compiled the Windows/amd64 `tunnel` test binary with Go 1.20.14

Related downstream report: https://github.com/clash-verge-rev/clash-verge-rev/issues/7532
