### PR TITLE
feat: Unix Socket support for listeners

### DIFF
--- a/adapter/inbound/ipfilter.go
+++ b/adapter/inbound/ipfilter.go
@@ -27,6 +27,9 @@ func DisAllowedIPs() []netip.Prefix {
 }
 
 func IsRemoteAddrDisAllowed(addr net.Addr) bool {
+	if _, ok := addr.(*net.UnixAddr); ok {
+		return true
+	}
 	m := C.Metadata{}
 	if err := m.SetRemoteAddr(addr); err != nil {
 		return false

--- a/adapter/inbound/ipfilter_test.go
+++ b/adapter/inbound/ipfilter_test.go
@@ -1,0 +1,12 @@
+package inbound
+
+import (
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestUnixRemoteAddrIsAllowed(t *testing.T) {
+	require.True(t, IsRemoteAddrDisAllowed(&net.UnixAddr{Name: "/tmp/mihomo.sock", Net: "unix"}))
+}

--- a/docs/config.yaml
+++ b/docs/config.yaml
@@ -1957,6 +1957,8 @@ sub-rules:
     - DOMAIN,dns.alidns.com,REJECT
 
 # 流量入站
+# http、socks、mixed、shadowsocks、snell、vmess、trojan、anytls、sudoku、tunnel、trusttunnel 和 hysteria2-realm
+# 可将 port 配置为 UNIX socket 的绝对路径。UNIX socket 仅支持 TCP，且不能同时配置 listen、routing-mark 或 UDP transport。
 listeners:
   - name: socks5-in-1
     type: socks

--- a/listener/inbound/anytls.go
+++ b/listener/inbound/anytls.go
@@ -36,7 +36,7 @@ type AnyTLS struct {
 }
 
 func NewAnyTLS(options *AnyTLSOption) (*AnyTLS, error) {
-	base, err := NewBase(&options.BaseOption)
+	base, err := newBase(&options.BaseOption, true)
 	if err != nil {
 		return nil, err
 	}

--- a/listener/inbound/base.go
+++ b/listener/inbound/base.go
@@ -1,9 +1,12 @@
 package inbound
 
 import (
+	"context"
 	"encoding/json"
+	"fmt"
 	"net"
 	"net/netip"
+	"path/filepath"
 	"strconv"
 	"strings"
 
@@ -18,9 +21,36 @@ type Base struct {
 	specialRules string
 	listenAddr   netip.Addr
 	ports        utils.IntRanges[uint16]
+	unixSocket   string
 }
 
 func NewBase(options *BaseOption) (*Base, error) {
+	return newBase(options, false)
+}
+
+func newBase(options *BaseOption, allowUnixSocket bool) (*Base, error) {
+	if filepath.IsAbs(options.Port) {
+		if !allowUnixSocket {
+			return nil, fmt.Errorf("unix socket is not supported by this listener type")
+		}
+		if options.Listen != "" {
+			return nil, fmt.Errorf("listen cannot be used with a unix socket")
+		}
+		if options.RoutingMark != 0 {
+			return nil, fmt.Errorf("routing-mark cannot be used with a unix socket")
+		}
+		path := filepath.Clean(options.Port)
+		if path == string(filepath.Separator) || strings.Contains(path, ",") {
+			return nil, fmt.Errorf("invalid unix socket path: %s", options.Port)
+		}
+		options.Port = path
+		return &Base{
+			name:         options.Name(),
+			specialRules: options.SpecialRules,
+			unixSocket:   path,
+			config:       options,
+		}, nil
+	}
 	if options.Listen == "" {
 		options.Listen = "0.0.0.0"
 	}
@@ -63,6 +93,9 @@ func (b *Base) Name() string {
 
 // RawAddress implements constant.InboundListener
 func (b *Base) RawAddress() string {
+	if b.unixSocket != "" {
+		return b.unixSocket
+	}
 	if len(b.ports) == 0 {
 		return net.JoinHostPort(b.listenAddr.String(), "0")
 	}
@@ -84,7 +117,27 @@ func (b *Base) Additions() []inbound.Addition {
 }
 
 func (b *Base) ListenConfig() C.InboundListenConfig {
-	return b.config.ListenConfig()
+	lc := b.config.ListenConfig()
+	if b.unixSocket != "" {
+		return unixSocketListenConfig{InboundListenConfig: lc, path: b.unixSocket}
+	}
+	return lc
+}
+
+type unixSocketListenConfig struct {
+	C.InboundListenConfig
+	path string
+}
+
+func (c unixSocketListenConfig) Listen(ctx context.Context, network, address string) (net.Listener, error) {
+	if network != "tcp" || address != c.path {
+		return nil, fmt.Errorf("invalid unix socket listen request: %s %s", network, address)
+	}
+	return c.InboundListenConfig.Listen(ctx, "unix", address)
+}
+
+func (c unixSocketListenConfig) ListenPacket(context.Context, string, string) (net.PacketConn, error) {
+	return nil, fmt.Errorf("unix socket listener is stream-only")
 }
 
 var _ C.InboundListener = (*Base)(nil)

--- a/listener/inbound/base_test.go
+++ b/listener/inbound/base_test.go
@@ -1,0 +1,172 @@
+package inbound
+
+import (
+	"context"
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	C "github.com/metacubex/mihomo/constant"
+	"github.com/stretchr/testify/require"
+)
+
+type recordingListenConfig struct {
+	network string
+	address string
+}
+
+func (c *recordingListenConfig) Listen(_ context.Context, network, address string) (net.Listener, error) {
+	c.network = network
+	c.address = address
+	return net.Listen(network, address)
+}
+
+func (*recordingListenConfig) ListenPacket(_ context.Context, network, address string) (net.PacketConn, error) {
+	return net.ListenPacket(network, address)
+}
+
+func unixSocketPath(t *testing.T, name string) string {
+	t.Helper()
+	dir, err := os.MkdirTemp("/tmp", "mihomo-unix-")
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, os.RemoveAll(dir)) })
+	return filepath.Join(dir, name)
+}
+
+func TestUnixSocketListenConfig(t *testing.T) {
+	path := unixSocketPath(t, "mihomo.sock")
+	recording := &recordingListenConfig{}
+	base, err := newBase(&BaseOption{
+		NameStr:            "unix-in",
+		Port:               path,
+		ListenConfigForAPI: recording,
+	}, true)
+	require.NoError(t, err)
+	require.Equal(t, path, base.RawAddress())
+
+	l, err := base.ListenConfig().Listen(context.Background(), "tcp", path)
+	require.NoError(t, err)
+	require.Equal(t, "unix", recording.network)
+	require.Equal(t, path, recording.address)
+
+	c, err := net.Dial("unix", path)
+	require.NoError(t, err)
+	require.NoError(t, c.Close())
+	require.NoError(t, l.Close())
+	require.NoFileExists(t, path)
+}
+
+func TestUnixSocketBaseValidation(t *testing.T) {
+	path := unixSocketPath(t, "mihomo.sock")
+
+	_, err := NewBase(&BaseOption{Port: path})
+	require.ErrorContains(t, err, "not supported")
+
+	_, err = newBase(&BaseOption{Port: path, Listen: "127.0.0.1"}, true)
+	require.ErrorContains(t, err, "listen cannot be used")
+
+	_, err = newBase(&BaseOption{Port: path, RoutingMark: 1}, true)
+	require.ErrorContains(t, err, "routing-mark cannot be used")
+
+	_, err = newBase(&BaseOption{Port: "relative.sock"}, true)
+	require.Error(t, err)
+}
+
+func TestUnixSocketInboundListeners(t *testing.T) {
+	tests := []struct {
+		name  string
+		first byte
+		new   func(BaseOption) (C.InboundListener, error)
+	}{
+		{
+			name:  "http",
+			first: 'G',
+			new: func(base BaseOption) (C.InboundListener, error) {
+				return NewHTTP(&HTTPOption{BaseOption: base})
+			},
+		},
+		{
+			name:  "socks",
+			first: 5,
+			new: func(base BaseOption) (C.InboundListener, error) {
+				return NewSocks(&SocksOption{BaseOption: base})
+			},
+		},
+		{
+			name:  "mixed",
+			first: 'G',
+			new: func(base BaseOption) (C.InboundListener, error) {
+				return NewMixed(&MixedOption{BaseOption: base})
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := unixSocketPath(t, tt.name+".sock")
+			l, err := tt.new(BaseOption{NameStr: tt.name, Port: path})
+			require.NoError(t, err)
+			require.NoError(t, l.Listen(nil))
+			t.Cleanup(func() { require.NoError(t, l.Close()) })
+
+			conn, err := net.Dial("unix", path)
+			require.NoError(t, err)
+			defer conn.Close()
+			require.NoError(t, conn.SetDeadline(time.Now().Add(200*time.Millisecond)))
+			_, err = conn.Write([]byte{tt.first})
+			require.NoError(t, err)
+			_, err = conn.Read(make([]byte, 1))
+			netErr, ok := err.(net.Error)
+			require.True(t, ok && netErr.Timeout(), "listener closed a UNIX peer: %v", err)
+		})
+	}
+}
+
+func TestUnixSocketProtocolInboundListenersBind(t *testing.T) {
+	tests := []struct {
+		name string
+		new  func(BaseOption) (C.InboundListener, error)
+	}{
+		{name: "shadowsocks", new: func(base BaseOption) (C.InboundListener, error) {
+			return NewShadowSocks(&ShadowSocksOption{BaseOption: base, Cipher: "aes-128-gcm", Password: "test"})
+		}},
+		{name: "snell", new: func(base BaseOption) (C.InboundListener, error) {
+			return NewSnell(&SnellOption{BaseOption: base, Psk: "test"})
+		}},
+		{name: "vmess", new: func(base BaseOption) (C.InboundListener, error) {
+			return NewVmess(&VmessOption{BaseOption: base, Users: []VmessUser{{UUID: "00000000-0000-0000-0000-000000000000"}}})
+		}},
+		{name: "trojan", new: func(base BaseOption) (C.InboundListener, error) {
+			return NewTrojan(&TrojanOption{BaseOption: base, Users: []TrojanUser{{Password: "test"}}, AllowInsecure: true})
+		}},
+		{name: "anytls", new: func(base BaseOption) (C.InboundListener, error) {
+			return NewAnyTLS(&AnyTLSOption{BaseOption: base, Users: map[string]string{"test": "test"}, AllowInsecure: true})
+		}},
+		{name: "sudoku", new: func(base BaseOption) (C.InboundListener, error) {
+			return NewSudoku(&SudokuOption{BaseOption: base, Key: "test"})
+		}},
+		{name: "tunnel", new: func(base BaseOption) (C.InboundListener, error) {
+			return NewTunnel(&TunnelOption{BaseOption: base, Network: []string{"tcp"}, Target: "127.0.0.1:80"})
+		}},
+		{name: "hysteria2-realm", new: func(base BaseOption) (C.InboundListener, error) {
+			options := DefaultHysteria2RealmServerOption()
+			options.BaseOption = base
+			options.Token = "test"
+			return NewHysteria2RealmServer(options)
+		}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := unixSocketPath(t, tt.name+".sock")
+			l, err := tt.new(BaseOption{NameStr: tt.name, Port: path})
+			require.NoError(t, err)
+			require.NoError(t, l.Listen(nil))
+			require.FileExists(t, path)
+			require.NoError(t, l.Close())
+			require.NoFileExists(t, path)
+		})
+	}
+}

--- a/listener/inbound/http.go
+++ b/listener/inbound/http.go
@@ -33,7 +33,7 @@ type HTTP struct {
 }
 
 func NewHTTP(options *HTTPOption) (*HTTP, error) {
-	base, err := NewBase(&options.BaseOption)
+	base, err := newBase(&options.BaseOption, true)
 	if err != nil {
 		return nil, err
 	}

--- a/listener/inbound/hysteria2_realm.go
+++ b/listener/inbound/hysteria2_realm.go
@@ -45,7 +45,7 @@ type Hysteria2RealmServer struct {
 }
 
 func NewHysteria2RealmServer(options *Hysteria2RealmServerOption) (*Hysteria2RealmServer, error) {
-	base, err := NewBase(&options.BaseOption)
+	base, err := newBase(&options.BaseOption, true)
 	if err != nil {
 		return nil, err
 	}

--- a/listener/inbound/mixed.go
+++ b/listener/inbound/mixed.go
@@ -37,9 +37,12 @@ type Mixed struct {
 }
 
 func NewMixed(options *MixedOption) (*Mixed, error) {
-	base, err := NewBase(&options.BaseOption)
+	base, err := newBase(&options.BaseOption, true)
 	if err != nil {
 		return nil, err
+	}
+	if base.unixSocket != "" && options.UDP {
+		return nil, fmt.Errorf("udp cannot be used with a unix socket")
 	}
 	return &Mixed{
 		Base:   base,

--- a/listener/inbound/shadowsocks.go
+++ b/listener/inbound/shadowsocks.go
@@ -1,6 +1,7 @@
 package inbound
 
 import (
+	"fmt"
 	"strings"
 
 	C "github.com/metacubex/mihomo/constant"
@@ -46,9 +47,17 @@ type ShadowSocks struct {
 }
 
 func NewShadowSocks(options *ShadowSocksOption) (*ShadowSocks, error) {
-	base, err := NewBase(&options.BaseOption)
+	base, err := newBase(&options.BaseOption, true)
 	if err != nil {
 		return nil, err
+	}
+	if base.unixSocket != "" {
+		if options.UDP {
+			return nil, fmt.Errorf("udp cannot be used with a unix socket")
+		}
+		if options.KcpTun.Enable {
+			return nil, fmt.Errorf("kcp-tun cannot be used with a unix socket")
+		}
 	}
 	return &ShadowSocks{
 		Base:   base,

--- a/listener/inbound/snell.go
+++ b/listener/inbound/snell.go
@@ -38,7 +38,7 @@ type Snell struct {
 }
 
 func NewSnell(options *SnellOption) (*Snell, error) {
-	base, err := NewBase(&options.BaseOption)
+	base, err := newBase(&options.BaseOption, true)
 	if err != nil {
 		return nil, err
 	}

--- a/listener/inbound/socks.go
+++ b/listener/inbound/socks.go
@@ -36,9 +36,12 @@ type Socks struct {
 }
 
 func NewSocks(options *SocksOption) (*Socks, error) {
-	base, err := NewBase(&options.BaseOption)
+	base, err := newBase(&options.BaseOption, true)
 	if err != nil {
 		return nil, err
+	}
+	if base.unixSocket != "" && options.UDP {
+		return nil, fmt.Errorf("udp cannot be used with a unix socket")
 	}
 	return &Socks{
 		Base:   base,

--- a/listener/inbound/sudoku.go
+++ b/listener/inbound/sudoku.go
@@ -53,7 +53,7 @@ func NewSudoku(options *SudokuOption) (*Sudoku, error) {
 	if options.Key == "" {
 		return nil, fmt.Errorf("sudoku inbound requires key")
 	}
-	base, err := NewBase(&options.BaseOption)
+	base, err := newBase(&options.BaseOption, true)
 	if err != nil {
 		return nil, err
 	}

--- a/listener/inbound/trojan.go
+++ b/listener/inbound/trojan.go
@@ -52,7 +52,7 @@ type Trojan struct {
 }
 
 func NewTrojan(options *TrojanOption) (*Trojan, error) {
-	base, err := NewBase(&options.BaseOption)
+	base, err := newBase(&options.BaseOption, true)
 	if err != nil {
 		return nil, err
 	}

--- a/listener/inbound/trusttunnel.go
+++ b/listener/inbound/trusttunnel.go
@@ -1,6 +1,7 @@
 package inbound
 
 import (
+	"fmt"
 	"strings"
 
 	C "github.com/metacubex/mihomo/constant"
@@ -35,9 +36,16 @@ type TrustTunnel struct {
 }
 
 func NewTrustTunnel(options *TrustTunnelOption) (*TrustTunnel, error) {
-	base, err := NewBase(&options.BaseOption)
+	base, err := newBase(&options.BaseOption, true)
 	if err != nil {
 		return nil, err
+	}
+	if base.unixSocket != "" {
+		for _, network := range options.Network {
+			if network != "tcp" {
+				return nil, fmt.Errorf("network %s cannot be used with a unix socket", network)
+			}
+		}
 	}
 	users := make(map[string]string)
 	for _, user := range options.Users {

--- a/listener/inbound/tunnel.go
+++ b/listener/inbound/tunnel.go
@@ -28,9 +28,16 @@ type Tunnel struct {
 }
 
 func NewTunnel(options *TunnelOption) (*Tunnel, error) {
-	base, err := NewBase(&options.BaseOption)
+	base, err := newBase(&options.BaseOption, true)
 	if err != nil {
 		return nil, err
+	}
+	if base.unixSocket != "" {
+		for _, network := range options.Network {
+			if network != "tcp" {
+				return nil, fmt.Errorf("network %s cannot be used with a unix socket", network)
+			}
+		}
 	}
 	return &Tunnel{
 		Base:   base,

--- a/listener/inbound/vmess.go
+++ b/listener/inbound/vmess.go
@@ -1,6 +1,7 @@
 package inbound
 
 import (
+	"fmt"
 	"strings"
 
 	C "github.com/metacubex/mihomo/constant"
@@ -47,9 +48,12 @@ type Vmess struct {
 }
 
 func NewVmess(options *VmessOption) (*Vmess, error) {
-	base, err := NewBase(&options.BaseOption)
+	base, err := newBase(&options.BaseOption, true)
 	if err != nil {
 		return nil, err
+	}
+	if base.unixSocket != "" && options.MKCPConfig.Enable {
+		return nil, fmt.Errorf("mkcp cannot be used with a unix socket")
 	}
 	users := make([]LC.VmessUser, len(options.Users))
 	for i, v := range options.Users {

--- a/listener/parse.go
+++ b/listener/parse.go
@@ -2,6 +2,7 @@ package listener
 
 import (
 	"fmt"
+	"path/filepath"
 
 	"github.com/metacubex/mihomo/common/structure"
 	C "github.com/metacubex/mihomo/constant"
@@ -21,7 +22,7 @@ func ParseListener(mapping map[string]any) (C.InboundListener, error) {
 	)
 	switch proxyType {
 	case "socks":
-		socksOption := &IN.SocksOption{UDP: true}
+		socksOption := &IN.SocksOption{UDP: defaultUDP(mapping)}
 		err = decoder.Decode(mapping, socksOption)
 		if err != nil {
 			return nil, err
@@ -49,7 +50,7 @@ func ParseListener(mapping map[string]any) (C.InboundListener, error) {
 		}
 		listener, err = IN.NewRedir(redirOption)
 	case "mixed":
-		mixedOption := &IN.MixedOption{UDP: true}
+		mixedOption := &IN.MixedOption{UDP: defaultUDP(mapping)}
 		err = decoder.Decode(mapping, mixedOption)
 		if err != nil {
 			return nil, err
@@ -73,7 +74,7 @@ func ParseListener(mapping map[string]any) (C.InboundListener, error) {
 		}
 		listener, err = IN.NewTun(tunOption)
 	case "shadowsocks":
-		shadowsocksOption := &IN.ShadowSocksOption{UDP: true}
+		shadowsocksOption := &IN.ShadowSocksOption{UDP: defaultUDP(mapping)}
 		err = decoder.Decode(mapping, shadowsocksOption)
 		if err != nil {
 			return nil, err
@@ -179,4 +180,13 @@ func ParseListener(mapping map[string]any) (C.InboundListener, error) {
 		return nil, fmt.Errorf("unsupport proxy type: %s", proxyType)
 	}
 	return listener, err
+}
+
+func defaultUDP(mapping map[string]any) bool {
+	_, configured := mapping["udp"]
+	if configured {
+		return true
+	}
+	port, _ := mapping["port"].(string)
+	return !filepath.IsAbs(port)
 }

--- a/listener/parse_test.go
+++ b/listener/parse_test.go
@@ -1,0 +1,132 @@
+package listener
+
+import (
+	"path/filepath"
+	"testing"
+
+	IN "github.com/metacubex/mihomo/listener/inbound"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseUnixSocketListener(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "mihomo.sock")
+
+	tests := []struct {
+		listenerType string
+		extra        map[string]any
+	}{
+		{listenerType: "http"},
+		{listenerType: "socks"},
+		{listenerType: "mixed"},
+		{listenerType: "shadowsocks", extra: map[string]any{"cipher": "aes-128-gcm", "password": "test"}},
+		{listenerType: "snell", extra: map[string]any{"psk": "test"}},
+		{listenerType: "vmess", extra: map[string]any{"users": []map[string]any{{"uuid": "00000000-0000-0000-0000-000000000000"}}}},
+		{listenerType: "trojan", extra: map[string]any{"users": []map[string]any{{"password": "test"}}}},
+		{listenerType: "anytls"},
+		{listenerType: "sudoku", extra: map[string]any{"key": "test"}},
+		{listenerType: "tunnel", extra: map[string]any{"network": []string{"tcp"}, "target": "127.0.0.1:80"}},
+		{listenerType: "trusttunnel", extra: map[string]any{"certificate": "test", "private-key": "test"}},
+		{listenerType: "hysteria2-realm", extra: map[string]any{"token": "test"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.listenerType, func(t *testing.T) {
+			mapping := map[string]any{
+				"name": "unix-in",
+				"type": tt.listenerType,
+				"port": path,
+			}
+			for key, value := range tt.extra {
+				mapping[key] = value
+			}
+			l, err := ParseListener(mapping)
+			require.NoError(t, err)
+			require.Equal(t, path, l.RawAddress())
+
+			switch config := l.Config().(type) {
+			case *IN.SocksOption:
+				require.False(t, config.UDP)
+			case *IN.MixedOption:
+				require.False(t, config.UDP)
+			case *IN.ShadowSocksOption:
+				require.False(t, config.UDP)
+			}
+		})
+	}
+}
+
+func TestParseUnixSocketListenerRejectsUDP(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "mihomo.sock")
+	for _, listenerType := range []string{"socks", "mixed", "shadowsocks"} {
+		mapping := map[string]any{
+			"name": "unix-in",
+			"type": listenerType,
+			"port": path,
+			"udp":  true,
+		}
+		if listenerType == "shadowsocks" {
+			mapping["cipher"] = "aes-128-gcm"
+			mapping["password"] = "test"
+		}
+		_, err := ParseListener(mapping)
+		require.ErrorContains(t, err, "udp cannot be used")
+	}
+}
+
+func TestParseUnixSocketListenerRejectsUnsupportedType(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "mihomo.sock")
+	tests := []struct {
+		listenerType string
+		extra        map[string]any
+	}{
+		{listenerType: "redir"},
+		{listenerType: "tproxy"},
+		{listenerType: "tun"},
+		{listenerType: "vless", extra: map[string]any{"users": []map[string]any{{"uuid": "00000000-0000-0000-0000-000000000000"}}}},
+		{listenerType: "mieru", extra: map[string]any{"transport": "TCP", "users": map[string]string{"test": "test"}}},
+		{listenerType: "tuic", extra: map[string]any{"certificate": "test", "private-key": "test"}},
+		{listenerType: "hysteria2", extra: map[string]any{"certificate": "test", "private-key": "test"}},
+		{listenerType: "shadowquic", extra: map[string]any{"jls-upstream": map[string]any{"addr": "127.0.0.1:443"}}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.listenerType, func(t *testing.T) {
+			mapping := map[string]any{
+				"name": "unix-in",
+				"type": tt.listenerType,
+				"port": path,
+			}
+			for key, value := range tt.extra {
+				mapping[key] = value
+			}
+			_, err := ParseListener(mapping)
+			require.ErrorContains(t, err, "not supported")
+		})
+	}
+}
+
+func TestParseUnixSocketListenerRejectsPacketTransports(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "mihomo.sock")
+	tests := []map[string]any{
+		{"type": "shadowsocks", "cipher": "aes-128-gcm", "password": "test", "kcp-tun": map[string]any{"enable": true}},
+		{"type": "vmess", "users": []map[string]any{{"uuid": "00000000-0000-0000-0000-000000000000"}}, "mkcp-config": map[string]any{"enable": true}},
+		{"type": "tunnel", "network": []string{"udp"}, "target": "127.0.0.1:80"},
+		{"type": "trusttunnel", "certificate": "test", "private-key": "test", "network": []string{"tcp", "udp"}},
+	}
+	for _, mapping := range tests {
+		mapping["name"] = "unix-in"
+		mapping["port"] = path
+		_, err := ParseListener(mapping)
+		require.ErrorContains(t, err, "cannot be used with a unix socket")
+	}
+}
+
+func TestParseNumericListenerKeepsUDPDefault(t *testing.T) {
+	l, err := ParseListener(map[string]any{
+		"name": "socks-in",
+		"type": "socks",
+		"port": 0,
+	})
+	require.NoError(t, err)
+	require.True(t, l.Config().(*IN.SocksOption).UDP)
+}


### PR DESCRIPTION
Add UNIX Socket support for listeners.

The configuration reuses the existing `port` configuration for simplicity (and to avoid potential duplicated listening misunderstandings).

Example usage:

```yaml
listeners:
- name: unix-socket-socks5
  type: socks5
  port: /tmp/example-socks5.sock
```

A `newBase` private method is introduced for inbound Unix Socket support. This is to avoid changing the original `NewBase` public method.

Extra validations are also added to prevent UDP-enabled listeners from using Unix Sockets (Pure UDP protocols like Hysteria and TUIC, partial UDP relays like Shadowsocks when UDP is enabled).

Related test cases are added/updated to validate my changes. Example configuration has been updated.