### PR TITLE
feat(reality): make client-version configurable to support Xray v26.7.11+

### DIFF
--- a/adapter/outbound/reality.go
+++ b/adapter/outbound/reality.go
@@ -14,6 +14,8 @@ type RealityOptions struct {
 	PublicKey string `proxy:"public-key"`
 	ShortID   string `proxy:"short-id,omitempty"`
 
+	ClientVersion string `proxy:"client-version,omitempty"`
+
 	SupportX25519MLKEM768 bool `proxy:"support-x25519mlkem768,omitempty"`
 }
 
@@ -21,6 +23,7 @@ func (o RealityOptions) Parse() (*tlsC.RealityConfig, error) {
 	if o.PublicKey != "" {
 		config := new(tlsC.RealityConfig)
 		config.SupportX25519MLKEM768 = o.SupportX25519MLKEM768
+		config.ClientVer = tlsC.ParseClientVersion(o.ClientVersion)
 
 		const x25519ScalarSize = 32
 		publicKey, err := base64.RawURLEncoding.DecodeString(o.PublicKey)

--- a/component/tls/reality.go
+++ b/component/tls/reality.go
@@ -14,6 +14,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"net"
+	"strconv"
 	"strings"
 	"time"
 
@@ -28,11 +29,35 @@ import (
 
 const RealityMaxShortIDLen = 8
 
+var realityDefaultClientVer = []byte{1, 8, 2}
+
 type RealityConfig struct {
 	PublicKey *ecdh.PublicKey
 	ShortID   [RealityMaxShortIDLen]byte
+	ClientVer []byte
 
 	SupportX25519MLKEM768 bool
+}
+
+// ParseClientVersion converts a string like "26.3.27" into []byte{26, 3, 27}.
+// It falls back to the default version when the input is empty or malformed.
+func ParseClientVersion(version string) []byte {
+	if version == "" {
+		return append([]byte(nil), realityDefaultClientVer...)
+	}
+	parts := strings.Split(version, ".")
+	if len(parts) != 3 {
+		return append([]byte(nil), realityDefaultClientVer...)
+	}
+	parsed := make([]byte, len(parts))
+	for i, part := range parts {
+		val, err := strconv.Atoi(part)
+		if err != nil || val < 0 || val > 255 {
+			return append([]byte(nil), realityDefaultClientVer...)
+		}
+		parsed[i] = byte(val)
+	}
+	return parsed
 }
 
 func GetRealityConn(ctx context.Context, conn net.Conn, fingerprint UClientHelloID, serverName string, realityConfig *RealityConfig) (net.Conn, error) {
@@ -71,9 +96,15 @@ func GetRealityConn(ctx context.Context, conn net.Conn, fingerprint UClientHello
 		binary.BigEndian.PutUint64(hello.SessionId, uint64(ntp.Now().Unix()))
 
 		copy(hello.SessionId[8:], realityConfig.ShortID[:])
-		hello.SessionId[0] = 1
-		hello.SessionId[1] = 8
-		hello.SessionId[2] = 2
+
+		clientVer := realityConfig.ClientVer
+		if len(clientVer) == 0 {
+			clientVer = realityDefaultClientVer
+		}
+		if len(clientVer) > 3 {
+			return nil, errors.New("invalid REALITY client version")
+		}
+		copy(hello.SessionId[:], clientVer)
 
 		//log.Debugln("REALITY hello.sessionId[:16]: %v", hello.SessionId[:16])
 

--- a/component/tls/reality_test.go
+++ b/component/tls/reality_test.go
@@ -15,6 +15,7 @@ func TestParseClientVersion(t *testing.T) {
 	}{
 		{"26.3.27", []byte{26, 3, 27}},
 		{"1.8.2", []byte{1, 8, 2}},
+		{"255.255.255", []byte{255, 255, 255}},
 		{"", defaultVersion},
 		{"26.3", defaultVersion},
 		{"26.3.27.1", defaultVersion},

--- a/component/tls/reality_test.go
+++ b/component/tls/reality_test.go
@@ -1,0 +1,31 @@
+package tls_test
+
+import (
+	"bytes"
+	"testing"
+
+	tlsC "github.com/metacubex/mihomo/component/tls"
+)
+
+func TestParseClientVersion(t *testing.T) {
+	defaultVersion := []byte{1, 8, 2}
+	testCases := []struct {
+		version string
+		want    []byte
+	}{
+		{"26.3.27", []byte{26, 3, 27}},
+		{"1.8.2", []byte{1, 8, 2}},
+		{"", defaultVersion},
+		{"26.3", defaultVersion},
+		{"26.3.27.1", defaultVersion},
+		{"a.b.c", defaultVersion},
+		{"26.3.-1", defaultVersion},
+		{"26.3.256", defaultVersion},
+	}
+	for _, tc := range testCases {
+		got := tlsC.ParseClientVersion(tc.version)
+		if !bytes.Equal(got, tc.want) {
+			t.Fatalf("ParseClientVersion(%q) = %v, want %v", tc.version, got, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
Resolves #3039.

Starting from Xray-core v26.7.11, the minClientVer defaults to 26.3.27. Hardcoding 1.8.2 in mihomo breaks the REALITY handshake for all servers with default settings.

Since blindly bumping the hardcoded version might break backwards compatibility with older servers, this PR introduces a client-version field in reality-opts.

Example usage:

```yaml
reality-opts:
  public-key: xxx
  short-id: xxx
  client-version: "26.3.27"
```

If not specified, it safely falls back to 1.8.2.