### PR TITLE
fix(reality): update default client version to 26.3.27

### DIFF
--- a/component/tls/reality.go
+++ b/component/tls/reality.go
@@ -71,9 +71,9 @@ func GetRealityConn(ctx context.Context, conn net.Conn, fingerprint UClientHello
 		binary.BigEndian.PutUint64(hello.SessionId, uint64(ntp.Now().Unix()))
 
 		copy(hello.SessionId[8:], realityConfig.ShortID[:])
-		hello.SessionId[0] = 1
-		hello.SessionId[1] = 8
-		hello.SessionId[2] = 2
+		hello.SessionId[0] = 26
+		hello.SessionId[1] = 3
+		hello.SessionId[2] = 27
 
 		//log.Debugln("REALITY hello.sessionId[:16]: %v", hello.SessionId[:16])
 


### PR DESCRIPTION
## What
Bumps the hardcoded REALITY client version from `1.8.2` to `26.3.27`.
## Why
Since Xray-core v26.7.11 the REALITY server defaults `minClientVer` to `26.3.27` (see XTLS/Xray-core commit `af7eb68`, "change it at your own risk"). mihomo still hardcodes `1.8.2` in the ClientHello session ID, so the handshake is rejected by every REALITY server running default settings (`REALITY Authentication: false`).
Per the REALITY author (rprx, https://t.me/projectXtls/3382), the client version should **not** be user-configurable - it must stay coupled with the TLS fingerprint. The correct fix is to bump the built-in default and keep it in sync with the fingerprint going forward.
## Changes
`component/tls/reality.go` - set session ID version bytes to `26.3.27` (no new config option).
Compatible with older servers: they do not enforce a minimum client version, so raising the advertised version is safe.
