### PR TITLE
fix: include the upstream version for tailscale IPNVersion

### DIFF
--- a/adapter/outbound/tailscale.go
+++ b/adapter/outbound/tailscale.go
@@ -20,6 +20,7 @@ import (
 	"github.com/metacubex/mihomo/dns"
 	"github.com/metacubex/mihomo/log"
 
+	ts "github.com/metacubex/tailscale"
 	"github.com/metacubex/tailscale/envknob"
 	"github.com/metacubex/tailscale/hostinfo"
 	"github.com/metacubex/tailscale/ipn"
@@ -66,7 +67,7 @@ type TailscaleOption struct {
 
 func init() {
 	hostinfo.RegisterHostinfoNewHook(func(hi *tailcfg.Hostinfo) {
-		hi.IPNVersion = C.MihomoName + " " + C.Version
+		hi.IPNVersion = fmt.Sprintf("%s-%s-%s", ts.VersionDotTxt, C.MihomoName, C.Version)
 	})
 	envknob.SetNoLogsNoSupport()
 	if runtime.GOOS == "android" { // Android SDK 30 no longer permits Go's net.Interfaces to work (Issue 2293)


### PR DESCRIPTION
Include the upstream tailscale version in **IPNVersion** to conform to tailscale's expected version format.
Tailscale uses the upstream version format to determine compatibility and feature support.

Use previous custom version **Mihomo v1.19.29**, can't edit machine IPv4 on tailscale web admin console with `Device is too old, please upgrade it to the latest version` error.

<img width="1732" height="776" alt="image" src="https://github.com/user-attachments/assets/7c1700ec-f334-43e1-9a55-daed212e4b54" />

Tweak version format to include upstream version, edit machine IPv4 on tailscale web admin console successfully.

Even display uparrow icon to note user when the upstream tailscale version is not the latest, it looks like the tailscale use the upstream version to determine compatibility and feature support.

<img width="1717" height="398" alt="image" src="https://github.com/user-attachments/assets/2e0a8e23-6898-40ac-8fee-5852dd2c3434" />

> refer to [tailscale version.Long format](https://github.com/tailscale/tailscale/blob/v1.102.1/version/version.go#L64)