### PR TITLE
fix(xhttp): stop waiting for packet-up responses

### DIFF
--- a/transport/xhttp/client.go
+++ b/transport/xhttp/client.go
@@ -126,18 +126,50 @@ func (c *PacketUpWriter) write(b []byte) (int, error) {
 	}
 	req.Host = c.cfg.Host
 
-	resp, err := c.transport.RoundTrip(req)
-	if err != nil {
+	requestWritten := make(chan error, 1)
+	var requestWrittenOnce sync.Once
+	reportRequestWritten := func(err error) {
+		requestWrittenOnce.Do(func() {
+			requestWritten <- err
+		})
+	}
+	req = req.WithContext(httptrace.WithClientTrace(req.Context(), &httptrace.ClientTrace{
+		WroteRequest: func(info httptrace.WroteRequestInfo) {
+			reportRequestWritten(info.Err)
+		},
+	}))
+
+	go func() {
+		resp, err := c.transport.RoundTrip(req)
+		reportRequestWritten(err)
+		if err == nil {
+			defer resp.Body.Close()
+			_, _ = io.Copy(io.Discard, resp.Body)
+			if resp.StatusCode != http.StatusOK {
+				err = fmt.Errorf("xhttp packet-up bad status: %s", resp.Status)
+			}
+		}
+		if err != nil {
+			c.setError(err)
+		}
+	}()
+
+	if err := <-requestWritten; err != nil {
 		return 0, err
 	}
-	defer resp.Body.Close()
-	_, _ = io.Copy(io.Discard, resp.Body)
-
-	if resp.StatusCode != http.StatusOK {
-		return 0, fmt.Errorf("xhttp packet-up bad status: %s", resp.Status)
-	}
-
 	return len(b), nil
+}
+
+func (c *PacketUpWriter) setError(err error) {
+	c.writeMu.Lock()
+	if c.flushErr == nil {
+		c.flushErr = err
+		c.writeCond.Broadcast()
+	}
+	c.writeMu.Unlock()
+	if c.cancel != nil {
+		c.cancel()
+	}
 }
 
 func (c *PacketUpWriter) Close() error {

--- a/transport/xhttp/client_test.go
+++ b/transport/xhttp/client_test.go
@@ -1,0 +1,70 @@
+package xhttp
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/metacubex/http"
+	"github.com/metacubex/http/httptrace"
+	"github.com/stretchr/testify/require"
+)
+
+type roundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripperFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+func TestPacketUpWriteReturnsAfterRequest(t *testing.T) {
+	releaseResponse := make(chan struct{})
+	var releaseOnce sync.Once
+	release := func() {
+		releaseOnce.Do(func() { close(releaseResponse) })
+	}
+	t.Cleanup(release)
+
+	transport := roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		httptrace.ContextClientTrace(req.Context()).WroteRequest(httptrace.WroteRequestInfo{})
+		<-releaseResponse
+		return &http.Response{
+			Status:     "503 Service Unavailable",
+			StatusCode: http.StatusServiceUnavailable,
+			Body:       http.NoBody,
+		}, nil
+	})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	writer := PacketUpWriter{
+		ctx:       ctx,
+		cancel:    cancel,
+		cfg:       &Config{Host: "example.com"},
+		transport: transport,
+	}
+	writer.writeCond.L = &writer.writeMu
+
+	writeDone := make(chan error, 1)
+	go func() {
+		_, err := writer.write([]byte("payload"))
+		writeDone <- err
+	}()
+
+	select {
+	case err := <-writeDone:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("packet upload waited for the response")
+	}
+
+	release()
+	select {
+	case <-ctx.Done():
+	case <-time.After(time.Second):
+		t.Fatal("response error was not reported")
+	}
+	writer.writeMu.Lock()
+	err := writer.flushErr
+	writer.writeMu.Unlock()
+	require.ErrorContains(t, err, "503")
+}


### PR DESCRIPTION
Packet-up sends each chunk in a separate HTTP request. The XHTTP design requires the previous request body to be sent before sending the next one, but does not require waiting for its response:

https://github.com/XTLS/Xray-core/discussions/4113

`PacketUpWriter.write` currently waits for `RoundTrip` to return and drains the complete response before allowing the next write. This serializes uploads on response latency.

Use `httptrace.WroteRequest` to complete the write after the request has been sent. The response is still drained and validated asynchronously. Transport and HTTP status errors cancel the connection and are returned by subsequent writes.

The regression test holds a 503 response until the write completes, then verifies that the delayed error is propagated.

Tests:
- `go test -race -count=20 ./transport/xhttp`
- `go vet ./transport/xhttp`