### PR TITLE
fix: trim trailing newline from Tailscale VersionDotTxt in IPNVersion

### DIFF
--- a/adapter/outbound/tailscale.go
+++ b/adapter/outbound/tailscale.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"net/netip"
 	"runtime"
+	"strings"
 	"sync"
 	"time"
 
@@ -67,7 +68,8 @@ type TailscaleOption struct {
 
 func init() {
 	hostinfo.RegisterHostinfoNewHook(func(hi *tailcfg.Hostinfo) {
-		hi.IPNVersion = fmt.Sprintf("%s-%s-%s", ts.VersionDotTxt, C.MihomoName, C.Version)
+		versionDotTxt := strings.TrimSpace(ts.VersionDotTxt)
+		hi.IPNVersion = fmt.Sprintf("%s-%s-%s", versionDotTxt, C.MihomoName, C.Version)
 	})
 	envknob.SetNoLogsNoSupport()
 	if runtime.GOOS == "android" { // Android SDK 30 no longer permits Go's net.Interfaces to work (Issue 2293)


### PR DESCRIPTION
When reporting the Tailscale `IPNVersion`, the version string contained a
spurious space, e.g. `1.102.0 -mihomo-8dbaa95e`.

<img width="428" height="378" alt="微信图片_20260805095251_164_132" src="https://github.com/user-attachments/assets/e80a60ce-c62b-41d9-b99b-f5b8462ee48f" />