### PR TITLE
fix: isolate tunnel UDP sessions by listener

### DIFF
--- a/listener/tunnel/packet.go
+++ b/listener/tunnel/packet.go
@@ -9,6 +9,7 @@ import (
 type packet struct {
 	pc      net.PacketConn
 	rAddr   net.Addr
+	keyAddr net.Addr
 	payload []byte
 }
 
@@ -23,7 +24,7 @@ func (c *packet) WriteBack(b []byte, addr net.Addr) (n int, err error) {
 
 // LocalAddr returns the source IP/Port of UDP Packet
 func (c *packet) LocalAddr() net.Addr {
-	return c.rAddr
+	return c.keyAddr
 }
 
 func (c *packet) Drop() {

--- a/listener/tunnel/packet.go
+++ b/listener/tunnel/packet.go
@@ -22,7 +22,7 @@ func (c *packet) WriteBack(b []byte, addr net.Addr) (n int, err error) {
 	return c.pc.WriteTo(b, c.rAddr)
 }
 
-// LocalAddr returns the source IP/Port of UDP Packet
+// LocalAddr returns the listener-scoped address used as the packet's SNAT key.
 func (c *packet) LocalAddr() net.Addr {
 	return c.keyAddr
 }

--- a/listener/tunnel/udp.go
+++ b/listener/tunnel/udp.go
@@ -6,6 +6,7 @@ import (
 	"net"
 
 	"github.com/metacubex/mihomo/adapter/inbound"
+	N "github.com/metacubex/mihomo/common/net"
 	"github.com/metacubex/mihomo/common/pool"
 	C "github.com/metacubex/mihomo/constant"
 	"github.com/metacubex/mihomo/transport/socks5"
@@ -76,9 +77,12 @@ func NewUDP(addr, target, proxy string, lc C.InboundListenConfig, tunnel C.Tunne
 }
 
 func (l *PacketConn) handleUDP(pc net.PacketConn, tunnel C.Tunnel, buf []byte, addr net.Addr, additions ...inbound.Addition) {
+	// Keep associations from different tunnel listeners separate for the same source address.
+	sessionKey := fmt.Sprintf("%s:%s", pc.LocalAddr(), addr)
 	cPacket := &packet{
 		pc:      pc,
 		rAddr:   addr,
+		keyAddr: N.NewCustomAddr(C.TUNNEL.String(), sessionKey, addr),
 		payload: buf,
 	}
 

--- a/listener/tunnel/udp.go
+++ b/listener/tunnel/udp.go
@@ -78,7 +78,7 @@ func NewUDP(addr, target, proxy string, lc C.InboundListenConfig, tunnel C.Tunne
 
 func (l *PacketConn) handleUDP(pc net.PacketConn, tunnel C.Tunnel, buf []byte, addr net.Addr, additions ...inbound.Addition) {
 	// Keep associations from different tunnel listeners separate for the same source address.
-	sessionKey := fmt.Sprintf("%s:%s", pc.LocalAddr(), addr)
+	sessionKey := fmt.Sprintf("%s|%s", pc.LocalAddr().String(), addr.String())
 	cPacket := &packet{
 		pc:      pc,
 		rAddr:   addr,

--- a/listener/tunnel/udp_test.go
+++ b/listener/tunnel/udp_test.go
@@ -1,0 +1,82 @@
+package tunnel
+
+import (
+	"net"
+	"testing"
+	"time"
+
+	C "github.com/metacubex/mihomo/constant"
+	"github.com/metacubex/mihomo/transport/socks5"
+)
+
+func TestHandleUDPUsesListenerAddressInSessionKey(t *testing.T) {
+	source := &net.UDPAddr{IP: net.ParseIP("192.0.2.1"), Port: 51823}
+	packetConnA := &testPacketConn{localAddr: &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 51820}}
+	packetConnB := &testPacketConn{localAddr: &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 51821}}
+	capture := &testTunnel{}
+
+	listenerA := &PacketConn{target: socks5.ParseAddr("198.51.100.20:51820")}
+	listenerB := &PacketConn{target: socks5.ParseAddr("198.51.100.21:51821")}
+	listenerA.handleUDP(packetConnA, capture, []byte("a"), source)
+	listenerB.handleUDP(packetConnB, capture, []byte("b"), source)
+	listenerA.handleUDP(packetConnA, capture, []byte("c"), source)
+
+	if len(capture.packets) != 3 {
+		t.Fatalf("captured %d packets, want 3", len(capture.packets))
+	}
+	if capture.packets[0].Key() == capture.packets[1].Key() {
+		t.Fatalf("session keys collide across listeners: %q", capture.packets[0].Key())
+	}
+	if capture.packets[0].Key() != capture.packets[2].Key() {
+		t.Errorf("session key changed within one listener: %q != %q", capture.packets[0].Key(), capture.packets[2].Key())
+	}
+
+	for i, packet := range capture.packets {
+		if got := packet.Metadata().SourceAddress(); got != source.String() {
+			t.Errorf("packet %d source = %q, want %q", i, got, source)
+		}
+	}
+	if got := capture.packets[0].Metadata().InPort; got != 51820 {
+		t.Errorf("first packet inbound port = %d, want 51820", got)
+	}
+	if got := capture.packets[1].Metadata().InPort; got != 51821 {
+		t.Errorf("second packet inbound port = %d, want 51821", got)
+	}
+
+	if _, err := capture.packets[0].WriteBack([]byte("response"), nil); err != nil {
+		t.Fatalf("write back: %v", err)
+	}
+	if got := packetConnA.writeAddr.String(); got != source.String() {
+		t.Errorf("write-back address = %q, want %q", got, source)
+	}
+}
+
+type testTunnel struct {
+	packets []C.PacketAdapter
+}
+
+func (*testTunnel) HandleTCPConn(net.Conn, *C.Metadata) {}
+
+func (t *testTunnel) HandleUDPPacket(packet C.UDPPacket, metadata *C.Metadata) {
+	t.packets = append(t.packets, C.NewPacketAdapter(packet, metadata))
+}
+
+func (*testTunnel) NatTable() C.NatTable { return nil }
+
+type testPacketConn struct {
+	localAddr net.Addr
+	writeAddr net.Addr
+}
+
+func (*testPacketConn) ReadFrom([]byte) (int, net.Addr, error) { return 0, nil, net.ErrClosed }
+
+func (c *testPacketConn) WriteTo(payload []byte, addr net.Addr) (int, error) {
+	c.writeAddr = addr
+	return len(payload), nil
+}
+
+func (*testPacketConn) Close() error                     { return nil }
+func (c *testPacketConn) LocalAddr() net.Addr            { return c.localAddr }
+func (*testPacketConn) SetDeadline(time.Time) error      { return nil }
+func (*testPacketConn) SetReadDeadline(time.Time) error  { return nil }
+func (*testPacketConn) SetWriteDeadline(time.Time) error { return nil }

--- a/listener/tunnel/udp_test.go
+++ b/listener/tunnel/udp_test.go
@@ -30,6 +30,9 @@ func TestHandleUDPUsesListenerAddressInSessionKey(t *testing.T) {
 	if capture.packets[0].Key() != capture.packets[2].Key() {
 		t.Errorf("session key changed within one listener: %q != %q", capture.packets[0].Key(), capture.packets[2].Key())
 	}
+	if got, want := capture.packets[0].Key(), "127.0.0.1:51820|192.0.2.1:51823"; got != want {
+		t.Errorf("session key = %q, want %q", got, want)
+	}
 
 	for i, packet := range capture.packets {
 		if got := packet.Metadata().SourceAddress(); got != source.String() {


### PR DESCRIPTION
## Summary

- include the tunnel UDP listener address in the SNAT session key
- keep the real client address available for metadata and UDP replies
- add a regression test for one source socket sending through multiple tunnel listeners

## Root cause

UDP packet adapters used only the client source address as their NAT table key. As a result, tunnel listeners receiving packets from the same source IP and port shared one `PacketSender`, even when their listening ports and forwarding targets were different.

The tunnel packet now exposes a listener-scoped custom address for key generation while retaining the real source address as its raw address and write-back destination. Packets from the same source still reuse an association within one listener, but different listeners create independent associations.

## User impact

A single UDP socket can send to multiple tunnel listener ports and each flow is forwarded to its configured target independently. Source metadata, inbound-port metadata, and reply routing remain unchanged.

## Validation

- `go test ./listener/tunnel -count=1`
- `SKIP_INTEROP_TEST=1 CGO_ENABLED=0 go test ./... -count=1`
- `SKIP_INTEROP_TEST=1 CGO_ENABLED=0 go test ./... -count=1 -tags with_gvisor`

Closes #3052
