### PR TITLE
component: avoid pre-allocating untrusted lengths in the binary set readers

### DIFF
--- a/component/cidr/fuzz_test.go
+++ b/component/cidr/fuzz_test.go
@@ -1,0 +1,12 @@
+package cidr
+
+import (
+	"bytes"
+	"testing"
+)
+
+func FuzzReadIpCidrSet(f *testing.F) {
+	f.Fuzz(func(t *testing.T, data []byte) {
+		_, _ = ReadIpCidrSet(bytes.NewReader(data))
+	})
+}

--- a/component/cidr/ipcidr_set_bin.go
+++ b/component/cidr/ipcidr_set_bin.go
@@ -57,7 +57,13 @@ func ReadIpCidrSet(r io.Reader) (ss *IpCidrSet, err error) {
 	if length < 1 {
 		return nil, errors.New("length is invalid")
 	}
-	ss.rr = make([]netipx.IPRange, length)
+	// length is untrusted; grow via append so a crafted huge length hits EOF while reading the
+	// ranges instead of OOMing the process on the allocation.
+	rrCap := length
+	if rrCap > 64 {
+		rrCap = 64
+	}
+	ss.rr = make([]netipx.IPRange, 0, rrCap)
 	for i := int64(0); i < length; i++ {
 		var a16 [16]byte
 		err = binary.Read(r, binary.BigEndian, &a16)
@@ -70,7 +76,7 @@ func ReadIpCidrSet(r io.Reader) (ss *IpCidrSet, err error) {
 			return nil, err
 		}
 		to := netip.AddrFrom16(a16).Unmap()
-		ss.rr[i] = netipx.IPRangeFrom(from, to)
+		ss.rr = append(ss.rr, netipx.IPRangeFrom(from, to))
 	}
 
 	return ss, nil

--- a/component/trie/domain_set_bin.go
+++ b/component/trie/domain_set_bin.go
@@ -1,6 +1,7 @@
 package trie
 
 import (
+	"bytes"
 	"encoding/binary"
 	"errors"
 	"io"
@@ -72,12 +73,19 @@ func ReadDomainSetBin(r io.Reader) (ds *DomainSet, err error) {
 	if length < 1 {
 		return nil, errors.New("length is invalid")
 	}
-	ds.leaves = make([]uint64, length)
+	// length is untrusted; grow via append so a crafted huge length hits EOF while reading the
+	// elements instead of OOMing the process on the allocation.
+	leavesCap := length
+	if leavesCap > 64 {
+		leavesCap = 64
+	}
+	ds.leaves = make([]uint64, 0, leavesCap)
 	for i := int64(0); i < length; i++ {
-		err = binary.Read(r, binary.BigEndian, &ds.leaves[i])
-		if err != nil {
+		var value uint64
+		if err = binary.Read(r, binary.BigEndian, &value); err != nil {
 			return nil, err
 		}
+		ds.leaves = append(ds.leaves, value)
 	}
 
 	// labelBitmap
@@ -88,12 +96,17 @@ func ReadDomainSetBin(r io.Reader) (ds *DomainSet, err error) {
 	if length < 1 {
 		return nil, errors.New("length is invalid")
 	}
-	ds.labelBitmap = make([]uint64, length)
+	labelBitmapCap := length
+	if labelBitmapCap > 64 {
+		labelBitmapCap = 64
+	}
+	ds.labelBitmap = make([]uint64, 0, labelBitmapCap)
 	for i := int64(0); i < length; i++ {
-		err = binary.Read(r, binary.BigEndian, &ds.labelBitmap[i])
-		if err != nil {
+		var value uint64
+		if err = binary.Read(r, binary.BigEndian, &value); err != nil {
 			return nil, err
 		}
+		ds.labelBitmap = append(ds.labelBitmap, value)
 	}
 
 	// labels
@@ -104,11 +117,17 @@ func ReadDomainSetBin(r io.Reader) (ds *DomainSet, err error) {
 	if length < 1 {
 		return nil, errors.New("length is invalid")
 	}
-	ds.labels = make([]byte, length)
-	_, err = io.ReadFull(r, ds.labels)
+	// length is untrusted; read via io.CopyN so the buffer grows only as bytes actually arrive,
+	// instead of pre-allocating make([]byte, length) and OOMing on a crafted length.
+	var labelsBuf bytes.Buffer
+	_, err = io.CopyN(&labelsBuf, r, length)
 	if err != nil {
 		return nil, err
 	}
+	if int64(labelsBuf.Len()) != length {
+		return nil, io.ErrUnexpectedEOF
+	}
+	ds.labels = labelsBuf.Bytes()
 
 	ds.init()
 	return ds, nil

--- a/component/trie/fuzz_test.go
+++ b/component/trie/fuzz_test.go
@@ -1,0 +1,12 @@
+package trie
+
+import (
+	"bytes"
+	"testing"
+)
+
+func FuzzReadDomainSetBin(f *testing.F) {
+	f.Fuzz(func(t *testing.T, data []byte) {
+		_, _ = ReadDomainSetBin(bytes.NewReader(data))
+	})
+}

--- a/rules/provider/mrs_reader.go
+++ b/rules/provider/mrs_reader.go
@@ -57,9 +57,10 @@ func rulesMrsParse(buf []byte, strategy ruleStrategy) (ruleStrategy, error) {
 			return nil, errors.New("length is invalid")
 		}
 		if length > 0 {
-			extra := make([]byte, length)
-			_, err = io.ReadFull(reader, extra)
-			if err != nil {
+			// length is untrusted and the extra bytes are currently unused; discard them via
+			// io.CopyN (which streams) instead of make([]byte, length), which a crafted huge
+			// length would otherwise use to OOM the process before any body is read.
+			if _, err = io.CopyN(io.Discard, reader, length); err != nil {
 				return nil, err
 			}
 		}

--- a/rules/provider/mrs_reader_oom_test.go
+++ b/rules/provider/mrs_reader_oom_test.go
@@ -1,0 +1,38 @@
+package provider
+
+import (
+	"bytes"
+	"encoding/binary"
+	"testing"
+
+	"github.com/klauspost/compress/zstd"
+)
+
+// TestRulesMrsParseExtraNoOOM crafts an .mrs whose "extra" length field is a huge untrusted value
+// with no body following it. Before the fix, rulesMrsParse did make([]byte, length) here and a
+// crafted length aborts the process with an OOM. After the fix the extra bytes are streamed to
+// io.Discard, so a bogus length returns a short-read error instead of allocating.
+func TestRulesMrsParseExtraNoOOM(t *testing.T) {
+	var body bytes.Buffer
+	body.Write(MrsMagicBytes[:])                                  // magic "MRS\x01"
+	body.WriteByte(0)                                             // behavior = Domain (0)
+	binary.Write(&body, binary.BigEndian, int64(0))              // count
+	binary.Write(&body, binary.BigEndian, int64(1)<<40)         // extra length ~1 TiB, no body follows
+
+	var packed bytes.Buffer
+	enc, err := zstd.NewWriter(&packed)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := enc.Write(body.Bytes()); err != nil {
+		t.Fatal(err)
+	}
+	if err := enc.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Must return an error (short read on the extra field), not OOM the process.
+	if _, err := rulesMrsParse(packed.Bytes(), NewDomainStrategy()); err == nil {
+		t.Fatal("expected an error for a bogus extra length, got nil")
+	}
+}


### PR DESCRIPTION
## component: avoid pre-allocating untrusted lengths in the binary set readers

`ReadDomainSetBin` (`component/trie`) and `ReadIpCidrSet` (`component/cidr`) read a length with
`binary.Read` and immediately allocate a slice of that size
(`make([]uint64, length)` / `make([]byte, length)` / `make([]netipx.IPRange, length)`) before
reading the elements. The length is only checked for `< 1`, not for an upper bound, so a crafted
binary set — reachable from an `.mrs` rule-set, including remote rule-providers
(`rules/provider` fetches provider content over HTTP and calls `rulesMrsParse`) — can declare a
huge length and either OOM the process on the allocation or panic with
`makeslice: len out of range`.

Found by fuzzing (`go test -fuzz`); the readers crash on a tiny input immediately.

### Fix
Read incrementally instead of trusting the length for a single allocation:
- element slices grow via `append` with a capped initial capacity, so a bogus length hits EOF
  while reading the elements;
- the byte slice is read through `io.CopyN` into a growable buffer.

Adds `FuzzReadDomainSetBin` / `FuzzReadIpCidrSet`. Existing tests pass; valid sets still decode.
