### PR TITLE
feat(reality): make client version configurable (reality-opts.client-ver)

### DIFF
--- a/adapter/outbound/reality.go
+++ b/adapter/outbound/reality.go
@@ -15,6 +15,7 @@ type RealityOptions struct {
 	ShortID   string `proxy:"short-id,omitempty"`
 
 	SupportX25519MLKEM768 bool `proxy:"support-x25519mlkem768,omitempty"`
+	ClientVer             string `proxy:"client-ver,omitempty"` // 覆盖 REALITY 声明的客户端版本, 如 "26.7.28"
 }
 
 func (o RealityOptions) Parse() (*tlsC.RealityConfig, error) {
@@ -39,6 +40,14 @@ func (o RealityOptions) Parse() (*tlsC.RealityConfig, error) {
 		n, err = hex.Decode(config.ShortID[:], []byte(o.ShortID))
 		if err != nil || n > tlsC.RealityMaxShortIDLen {
 			return nil, errors.New("invalid REALITY short ID")
+		}
+
+		if o.ClientVer != "" {
+			var a, b, c int
+			if _, err := fmt.Sscanf(o.ClientVer, "%d.%d.%d", &a, &b, &c); err != nil {
+				return nil, fmt.Errorf("invalid REALITY client-ver %q: %w", o.ClientVer, err)
+			}
+			config.ClientVer = [3]byte{byte(a), byte(b), byte(c)}
 		}
 
 		return config, nil

--- a/component/tls/reality.go
+++ b/component/tls/reality.go
@@ -33,6 +33,7 @@ type RealityConfig struct {
 	ShortID   [RealityMaxShortIDLen]byte
 
 	SupportX25519MLKEM768 bool
+	ClientVer             [3]byte // REALITY 声明的客户端版本;[0,0,0]=用构建默认
 }
 
 func GetRealityConn(ctx context.Context, conn net.Conn, fingerprint UClientHelloID, serverName string, realityConfig *RealityConfig) (net.Conn, error) {
@@ -71,9 +72,15 @@ func GetRealityConn(ctx context.Context, conn net.Conn, fingerprint UClientHello
 		binary.BigEndian.PutUint64(hello.SessionId, uint64(ntp.Now().Unix()))
 
 		copy(hello.SessionId[8:], realityConfig.ShortID[:])
-		hello.SessionId[0] = 1
-		hello.SessionId[1] = 8
-		hello.SessionId[2] = 2
+		if realityConfig.ClientVer != ([3]byte{}) {
+			hello.SessionId[0] = realityConfig.ClientVer[0]
+			hello.SessionId[1] = realityConfig.ClientVer[1]
+			hello.SessionId[2] = realityConfig.ClientVer[2]
+		} else {
+			hello.SessionId[0] = 26
+			hello.SessionId[1] = 7
+			hello.SessionId[2] = 28
+		}
 
 		//log.Debugln("REALITY hello.sessionId[:16]: %v", hello.SessionId[:16])
 


### PR DESCRIPTION

### Summary
The REALITY uTLS ClientHello embeds a hard-coded client version `{1, 8, 2}` in `SessionId[0..2]` and never bumps it. Xray-core v26.7.x defaults `minClientVer` to `{26, 3, 27}` for REALITY servers that don't set it explicitly, and **rejects** any lower version. As a result mihomo (even latest) fails to connect to such servers with `authentication failed`, regardless of flow.

This PR makes the declared client version **configurable** via a new `client-ver` field in `reality-opts`, keeping the current value as the default.

### Motivation
- Fixes #2967 (mihomo can't connect to Xray v26.7.x REALITY inbounds). Also see XTLS/Xray-core#6477.
- The version bytes are only used for a **numeric `minClientVer` comparison** on the server (no maximum, no feature gating), so declaring a compatible version is safe and faithful to how Xray's own client behaves (it reports its build version).

### Changes
- `component/tls/reality.go`: add `ClientVer [3]byte` to `RealityConfig`; `SessionId[0..2]` uses it when set, otherwise falls back to the current default.
- `adapter/outbound/reality.go`: add `client-ver` (`"x.y.z"`) to `RealityOptions`, parsed into `ClientVer`.

### Usage
```yaml
reality-opts:
  public-key: <pubkey>
  short-id: <hex>
  client-ver: "26.7.28"   # optional; override the declared REALITY client version
```

### Testing
- mihomo → Xray-core 26.7.28 REALITY inbound (default `minClientVer` 26.3.27): rejected before, connects after (with `client-ver` ≥ server minimum).
- Backward compatible: unset `client-ver` keeps existing behavior.

### Notes for maintainers
The default value is a judgment call — this PR keeps it minimal and only adds the knob; happy to align the default (keep `1.8.2`, bump, or auto-derive) to whatever you prefer.

---

