### PR TITLE
feat(reverse): reverse proxy — bridge + portal (Mux.cool over VLESS-Rvs)

### DIFF
--- a/adapter/outbound/base.go
+++ b/adapter/outbound/base.go
@@ -390,6 +390,9 @@ func (p *autoCloseProxyAdapter) Close() error {
 	return p.closeErr
 }
 
+// InnerProxyAdapter 暴露被 auto-close 包装的内层适配器(反向代理据此取 *Vless 调 DialReverse)。
+func (p *autoCloseProxyAdapter) InnerProxyAdapter() ProxyAdapter { return p.ProxyAdapter }
+
 func NewAutoCloseProxyAdapter(adapter ProxyAdapter) ProxyAdapter {
 	proxy := &autoCloseProxyAdapter{
 		ProxyAdapter: adapter,

--- a/adapter/outbound/reverse_portal.go
+++ b/adapter/outbound/reverse_portal.go
@@ -1,0 +1,66 @@
+package outbound
+
+import (
+	"context"
+	"net"
+
+	C "github.com/metacubex/mihomo/constant"
+	"github.com/metacubex/mihomo/listener/reverse"
+	"github.com/metacubex/mihomo/transport/muxcool"
+)
+
+// ReversePortal —— 反向代理 Portal 侧的"出站"。用户流量按 routing 命中它后,
+// DialContext 经 reverse 表(同 `tag`)挑一条活跃 Bridge 隧道开 Mux.cool 子流下发。
+// 与 listener/inbound 的 reverse-portal 由相同 `tag` 关联。
+type ReversePortal struct {
+	*Base
+	tag string
+}
+
+type ReversePortalOption struct {
+	BasicOption
+	Name string `proxy:"name"`
+	Tag  string `proxy:"tag"`
+}
+
+func NewReversePortal(option ReversePortalOption) (*ReversePortal, error) {
+	return &ReversePortal{
+		Base: NewBase(BaseOption{
+			Name: option.Name,
+			Addr: "reverse-portal:" + option.Tag,
+			Type: C.Compatible,
+			UDP:  true,
+		}),
+		tag: option.Tag,
+	}, nil
+}
+
+// SupportUDP —— 反向 Portal 支持 UDP(经 Mux.cool UDP 子流下发 Bridge 落地)。
+func (r *ReversePortal) SupportUDP() bool { return true }
+
+func metaToAddr(metadata *C.Metadata) muxcool.Address {
+	if metadata.Host != "" {
+		return muxcool.Address{IsDomain: true, Domain: metadata.Host}
+	}
+	return muxcool.Address{IP: net.IP(metadata.DstIP.AsSlice())}
+}
+
+// DialContext implements C.ProxyAdapter
+func (r *ReversePortal) DialContext(ctx context.Context, metadata *C.Metadata) (C.Conn, error) {
+	c, err := reverse.Open(r.tag, muxcool.NetworkTCP, metaToAddr(metadata), metadata.DstPort)
+	if err != nil {
+		return nil, err
+	}
+	return NewConn(c, r), nil
+}
+
+// ListenPacketContext implements C.ProxyAdapter —— UDP:返回全锥 PacketConn,按 target 开 Mux.cool UDP 子流。
+func (r *ReversePortal) ListenPacketContext(ctx context.Context, metadata *C.Metadata) (C.PacketConn, error) {
+	pc, err := reverse.NewPacketConn(r.tag)
+	if err != nil {
+		return nil, err
+	}
+	return NewPacketConn(pc, r), nil
+}
+
+var _ C.ProxyAdapter = (*ReversePortal)(nil)

--- a/adapter/outbound/vless.go
+++ b/adapter/outbound/vless.go
@@ -431,6 +431,9 @@ func (v *Vless) Close() error {
 }
 
 func parseVlessAddr(metadata *C.Metadata, xudp bool) *vless.DstAddr {
+	if metadata.Host == RvsSentinel { // 反向代理:VLESS Rvs 命令,不带地址
+		return &vless.DstAddr{Rvs: true}
+	}
 	var addrType byte
 	var addr []byte
 	switch metadata.AddrType() {

--- a/adapter/outbound/vless_reverse.go
+++ b/adapter/outbound/vless_reverse.go
@@ -1,0 +1,41 @@
+package outbound
+
+import (
+	"context"
+	"net"
+
+	C "github.com/metacubex/mihomo/constant"
+)
+
+// RvsSentinel —— DialReverse 用的哨兵目标域。parseVlessAddr(见 patch 0002e)见到它
+// 就返回 DstAddr{Rvs:true},使 VLESS 发 Rvs 命令(0x04)且不写地址端口。
+// 取值同 Xray 内部 v1.rvs.cool,仅作触发,不会被真解析。
+const RvsSentinel = "v1.rvs.cool"
+
+// DialReverse 建一条 VLESS-Rvs 反向连接流,供反向代理 Bridge 使用。
+//
+// 复用 mihomo VLESS 完整传输层(REALITY/TLS/ws/grpc)与 VLESS StreamConn——只把内层
+// 命令换成 Rvs、目标地址省略。建流后立即 flush VLESS 请求头:Bridge 侧在此流上跑
+// Mux.cool 服务端(先读后写),若不主动 flush,Portal 收不到 VLESS 头 → 不发 mux 帧 →
+// 双方死锁(见蓝图 gotcha #2)。
+//
+// 前提:该 VLESS 出站的 flow 应为空(非 xtls-rprx-vision)。Xray Portal 对 Rvs+空 flow
+// 接受;若用 Vision,则整条 mux 流被 Vision 包裹,需另行处理(S5)。
+func (v *Vless) DialReverse(ctx context.Context) (net.Conn, error) {
+	c, err := v.dialContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+	// 目标用哨兵 → parseVlessAddr 返回 DstAddr{Rvs:true};传输层只连 v.addr,不受目标影响。
+	md := &C.Metadata{NetWork: C.TCP, Host: RvsSentinel}
+	c, err = v.StreamConnContext(ctx, c, md)
+	if err != nil {
+		return nil, err
+	}
+	// flush VLESS-Rvs 头(惰性发头 → 主动触发一次空写)。
+	if _, err = c.Write([]byte{}); err != nil {
+		_ = c.Close()
+		return nil, err
+	}
+	return c, nil
+}

--- a/adapter/parser.go
+++ b/adapter/parser.go
@@ -69,6 +69,13 @@ func ParseProxy(mapping map[string]any, options ...ProxyOption) (C.Proxy, error)
 			break
 		}
 		proxy, err = outbound.NewVless(*vlessOption)
+	case "reverse-portal":
+		reversePortalOption := &outbound.ReversePortalOption{BasicOption: basicOption}
+		err = decoder.Decode(mapping, reversePortalOption)
+		if err != nil {
+			break
+		}
+		proxy, err = outbound.NewReversePortal(*reversePortalOption)
 	case "snell":
 		snellOption := &outbound.SnellOption{BasicOption: basicOption}
 		err = decoder.Decode(mapping, snellOption)

--- a/listener/inbound/reverse_bridge.go
+++ b/listener/inbound/reverse_bridge.go
@@ -1,0 +1,146 @@
+package inbound
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"strconv"
+	"time"
+
+	"github.com/metacubex/mihomo/adapter/inbound"
+	"github.com/metacubex/mihomo/adapter/outbound"
+	"github.com/metacubex/mihomo/component/dialer"
+	C "github.com/metacubex/mihomo/constant"
+	"github.com/metacubex/mihomo/log"
+	"github.com/metacubex/mihomo/transport/muxcool"
+	"github.com/metacubex/mihomo/transport/socks5"
+	"github.com/metacubex/mihomo/tunnel"
+)
+
+// ReverseBridgeOption —— 反向代理 Bridge 侧 listener 配置。
+// 不监听端口:主动经 `portal` 指定的 VLESS 出站拨到 Portal 建反连隧道,
+// 把 Portal 反向复用回来的子流按其 target 交给 mihomo tunnel(规则决定出口,通常 DIRECT=本机内网)。
+type ReverseBridgeOption struct {
+	BaseOption
+	Portal string `inbound:"portal"` // 引用 proxies: 里的一个 VLESS 出站名(拨到 Xray/mihomo Portal)
+}
+
+func (o ReverseBridgeOption) Equal(config C.InboundConfig) bool {
+	return optionToString(o) == optionToString(config)
+}
+
+type ReverseBridge struct {
+	*Base
+	config *ReverseBridgeOption
+	cancel context.CancelFunc
+}
+
+func NewReverseBridge(options *ReverseBridgeOption) (*ReverseBridge, error) {
+	base, err := NewBase(&options.BaseOption)
+	if err != nil {
+		return nil, err
+	}
+	return &ReverseBridge{Base: base, config: options}, nil
+}
+
+// Config implements constant.InboundListener
+func (r *ReverseBridge) Config() C.InboundConfig { return r.config }
+
+// Address implements constant.InboundListener
+func (r *ReverseBridge) Address() string { return "reverse-bridge->" + r.config.Portal }
+
+// Close implements constant.InboundListener
+func (r *ReverseBridge) Close() error {
+	if r.cancel != nil {
+		r.cancel()
+	}
+	return nil
+}
+
+// Listen implements constant.InboundListener —— 必须非阻塞:起 goroutine 维护反连。
+func (r *ReverseBridge) Listen(t C.Tunnel) error {
+	ctx, cancel := context.WithCancel(context.Background())
+	r.cancel = cancel
+	go r.loop(ctx, t)
+	log.Infoln("ReverseBridge[%s] started, portal proxy = %s", r.Name(), r.config.Portal)
+	return nil
+}
+
+func (r *ReverseBridge) loop(ctx context.Context, t C.Tunnel) {
+	for {
+		if ctx.Err() != nil {
+			return
+		}
+		err := r.runOnce(ctx, t)
+		if ctx.Err() != nil {
+			return
+		}
+		log.Warnln("ReverseBridge[%s] tunnel down (%v); reconnect in 3s", r.Name(), err)
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(3 * time.Second):
+		}
+	}
+}
+
+func (r *ReverseBridge) runOnce(ctx context.Context, t C.Tunnel) error {
+	// 惰性按名解析 VLESS 出站(应对 proxy reload / 启动顺序)。
+	p, ok := tunnel.Proxies()[r.config.Portal]
+	if !ok {
+		return fmt.Errorf("portal proxy %q not found", r.config.Portal)
+	}
+	// 解包:config 里的 proxy 被 autoCloseProxyAdapter 包了一层(base.go),
+	// InnerProxyAdapter()(patch 0004)取回内层具体适配器,再断言成 *Vless。
+	pa := p.Adapter()
+	if inner, ok := pa.(interface {
+		InnerProxyAdapter() outbound.ProxyAdapter
+	}); ok {
+		pa = inner.InnerProxyAdapter()
+	}
+	v, ok := pa.(*outbound.Vless)
+	if !ok {
+		return fmt.Errorf("portal proxy %q is not a vless outbound (got %T)", r.config.Portal, pa)
+	}
+	conn, err := v.DialReverse(ctx)
+	if err != nil {
+		return err
+	}
+	disp := &bridgeDispatcher{tunnel: t, additions: r.Additions()}
+	sw := muxcool.NewServerWorker(conn, disp, func([]byte) {}) // 心跳:收到即保活,无需处理
+	done := make(chan error, 1)
+	go func() { done <- sw.Run() }()
+	select {
+	case <-ctx.Done():
+		conn.Close()
+		return ctx.Err()
+	case e := <-done:
+		return e
+	}
+}
+
+// bridgeDispatcher —— 把 Portal 反向来的子流按 target 造成"新入站请求"塞进 mihomo tunnel。
+// 不自己拨号:用 net.Pipe 桥接,一端给 tunnel(规则决定出口),一端还给 ServerWorker 收发。
+type bridgeDispatcher struct {
+	tunnel    C.Tunnel
+	additions []inbound.Addition
+}
+
+func (d *bridgeDispatcher) DialTarget(network muxcool.TargetNetwork, addr muxcool.Address, port uint16) (net.Conn, error) {
+	hostport := net.JoinHostPort(addr.String(), strconv.Itoa(int(port)))
+	// UDP 子流:用 mihomo 的 dialer 拨目标 UDP(连接式,Read/Write 保数据报边界)。
+	// 必须用 dialer(内部走 mihomo 解析器)——net.Dial 域名会触发被禁用的 Go 默认解析器而 panic。
+	// MVP 落地直连,不经 mihomo UDP 路由(Bridge 即内网网关);够用于 DNS/QUIC 到固定目标。
+	if network == muxcool.NetworkUDP {
+		return dialer.DialContext(context.Background(), "udp", hostport)
+	}
+	target := socks5.ParseAddr(hostport)
+	if target == nil {
+		return nil, fmt.Errorf("reverse-bridge: bad target %s", hostport)
+	}
+	left, right := net.Pipe()
+	go d.tunnel.HandleTCPConn(inbound.NewSocket(target, right, C.TUNNEL, d.additions...))
+	return left, nil
+}
+
+var _ C.InboundListener = (*ReverseBridge)(nil)

--- a/listener/inbound/reverse_portal.go
+++ b/listener/inbound/reverse_portal.go
@@ -1,0 +1,240 @@
+package inbound
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"strings"
+
+	"github.com/metacubex/mihomo/common/utils"
+	C "github.com/metacubex/mihomo/constant"
+	"github.com/metacubex/mihomo/listener/reality"
+	"github.com/metacubex/mihomo/listener/reverse"
+	"github.com/metacubex/mihomo/log"
+	"github.com/metacubex/mihomo/transport/vless/vision"
+
+	"github.com/gofrs/uuid/v5"
+)
+
+// flowVision —— XTLS Vision flow 名。Bridge 用该 flow 连来时,Portal 侧套 vision server 解包。
+const flowVision = "xtls-rprx-vision"
+
+// RealityOptions —— reverse-portal 的 REALITY 服务端配置(与 mihomo/Xray 同义)。
+type RealityOptions struct {
+	Dest        string   `inbound:"dest,omitempty"`
+	PrivateKey  string   `inbound:"private-key,omitempty"`
+	ShortID     []string `inbound:"short-id,omitempty"`
+	ServerNames []string `inbound:"server-names,omitempty"`
+}
+
+// ReversePortalOption —— 反向代理 Portal 侧 listener 配置。
+// 监听端口,接受 Bridge 的 VLESS-Rvs 反连,握手后在连接上跑 Mux.cool 客户端 + 心跳,
+// 并按 `tag` 注册到 reverse 表,供同 tag 的 reverse-portal 出站开子流下发用户流量。
+//
+// 配了 reality-config 则用 REALITY 终止(复用 listener/reality,包装 listener),
+// 否则 security=none(裸 VLESS-Rvs 握手)。
+type ReversePortalOption struct {
+	BaseOption
+	UUID        string         `inbound:"uuid"`
+	Tag         string         `inbound:"tag"`
+	TLS         bool           `inbound:"tls,omitempty"`          // 普通 TLS 层(非 reality);vision 需 TLS1.3 底层时用
+	Certificate string         `inbound:"certificate,omitempty"`  // PEM 文件路径或内联;空则自签
+	PrivateKey  string         `inbound:"private-key,omitempty"`  // 同上(TLS 用,非 reality)
+	Reality     RealityOptions `inbound:"reality-config,omitempty"`
+}
+
+func (o ReversePortalOption) Equal(config C.InboundConfig) bool {
+	return optionToString(o) == optionToString(config)
+}
+
+type ReversePortal struct {
+	*Base
+	config *ReversePortalOption
+	uid    uuid.UUID
+	lns    []net.Listener
+	closed bool
+}
+
+func NewReversePortal(options *ReversePortalOption) (*ReversePortal, error) {
+	base, err := NewBase(&options.BaseOption)
+	if err != nil {
+		return nil, err
+	}
+	if options.Tag == "" {
+		return nil, errors.New("reverse-portal: `tag` can't be empty")
+	}
+	r := &ReversePortal{Base: base, config: options, uid: utils.UUIDMap(options.UUID)}
+	return r, nil
+}
+
+func (r *ReversePortal) Config() C.InboundConfig { return r.config }
+
+func (r *ReversePortal) Close() error {
+	r.closed = true
+	for _, ln := range r.lns {
+		_ = ln.Close()
+	}
+	return nil
+}
+
+func (r *ReversePortal) Listen(t C.Tunnel) error {
+	// 配了 REALITY 就构建 Builder(需要 tunnel,故在 Listen 里建),用它包装每个 listener。
+	var rb *reality.Builder
+	if r.config.Reality.PrivateKey != "" {
+		var err error
+		rb, err = reality.Config{
+			Dest:        r.config.Reality.Dest,
+			PrivateKey:  r.config.Reality.PrivateKey,
+			ShortID:     r.config.Reality.ShortID,
+			ServerNames: r.config.Reality.ServerNames,
+			// REALITY 借证(steal-oneself)拨向 dest 的连接固定走 DIRECT——它是伪装用的
+			// 真实握手,绝不能走用户的反向出站规则(否则被 rvout 吃掉、握手失败)。
+			Proxy: "DIRECT",
+		}.Build(t)
+		if err != nil {
+			return err
+		}
+	}
+	// 普通 TLS(仅当未配 reality 且开了 tls):vision 的另一种合法底层。
+	var tlsCfg *tls.Config
+	if rb == nil && r.config.TLS {
+		var err error
+		tlsCfg, err = buildServerTLS(r.config.Certificate, r.config.PrivateKey)
+		if err != nil {
+			return err
+		}
+	}
+	lc := r.ListenConfig()
+	for _, addr := range strings.Split(r.RawAddress(), ",") {
+		ln, err := lc.Listen(context.Background(), "tcp", addr)
+		if err != nil {
+			return err
+		}
+		if rb != nil {
+			ln = rb.NewListener(ln) // REALITY 终止:Accept 到的即解密后的裸流
+		} else if tlsCfg != nil {
+			ln = tls.NewListener(ln, tlsCfg) // 普通 TLS 终止
+		}
+		r.lns = append(r.lns, ln)
+		go r.acceptLoop(ln)
+	}
+	sec := "none"
+	if rb != nil {
+		sec = "reality"
+	} else if tlsCfg != nil {
+		sec = "tls"
+	}
+	log.Infoln("ReversePortal[%s] listening at: %s (tag=%s, security=%s)", r.Name(), r.Address(), r.config.Tag, sec)
+	return nil
+}
+
+func (r *ReversePortal) acceptLoop(ln net.Listener) {
+	for {
+		c, err := ln.Accept()
+		if err != nil {
+			if r.closed {
+				return
+			}
+			continue
+		}
+		go r.handle(c)
+	}
+}
+
+func (r *ReversePortal) handle(c net.Conn) {
+	flow, err := vlessRvsRead(c, r.uid)
+	if err != nil {
+		log.Warnln("ReversePortal[%s] VLESS-Rvs handshake failed: %v", r.Name(), err)
+		_ = c.Close()
+		return
+	}
+
+	var mc net.Conn // 交给 ClientWorker 的 mux 承载流
+	if flow == flowVision {
+		// Vision:不手写 [00][00],由 portalRespConn 在首个写(ClientWorker 开控制子流)时前置;
+		// 再套 vision server 做 padding/去 padding(底层需 REALITY/TLS,已由 listener 层终止)。
+		vc, verr := vision.NewConn(&portalRespConn{Conn: c}, c, r.uid)
+		if verr != nil {
+			log.Warnln("ReversePortal[%s] vision init failed: %v", r.Name(), verr)
+			_ = c.Close()
+			return
+		}
+		mc = vc
+		log.Infoln("ReversePortal[%s] bridge connected (vision) from %s", r.Name(), c.RemoteAddr())
+	} else {
+		// 裸:立即回 [00][00] 响应头。
+		if _, werr := c.Write([]byte{0x00, 0x00}); werr != nil {
+			_ = c.Close()
+			return
+		}
+		mc = c
+		log.Infoln("ReversePortal[%s] bridge connected from %s", r.Name(), c.RemoteAddr())
+	}
+	reverse.RegisterPortalConn(r.config.Tag, mc) // 阻塞至隧道关闭
+	log.Infoln("ReversePortal[%s] bridge %s disconnected", r.Name(), c.RemoteAddr())
+}
+
+// vlessRvsRead 读最简 VLESS 请求头,校验 UUID + 命令==Rvs(0x04),返回 client 的 flow(空 / vision)。
+// 不写响应头(交由 handle 按 flow 决定)。布局:[1B ver=0][16B uuid][1B addonsLen][addons][1B cmd]。
+func vlessRvsRead(conn net.Conn, uid uuid.UUID) (string, error) {
+	head := make([]byte, 1+16+1) // version + uuid + addonsLen
+	if _, err := io.ReadFull(conn, head); err != nil {
+		return "", err
+	}
+	if head[0] != 0 {
+		return "", fmt.Errorf("unexpected vless version %d", head[0])
+	}
+	if !bytes.Equal(head[1:17], uid.Bytes()) {
+		return "", errors.New("uuid mismatch")
+	}
+	flow := ""
+	if addonsLen := int(head[17]); addonsLen > 0 {
+		addons := make([]byte, addonsLen)
+		if _, err := io.ReadFull(conn, addons); err != nil {
+			return "", err
+		}
+		// Addons protobuf:字段1 Flow(string),wire = 0A <len> <flow>。
+		if len(addons) >= 2 && addons[0] == 0x0A {
+			fl := int(addons[1])
+			if 2+fl <= len(addons) {
+				flow = string(addons[2 : 2+fl])
+			}
+		}
+	}
+	var cmd [1]byte
+	if _, err := io.ReadFull(conn, cmd[:]); err != nil {
+		return "", err
+	}
+	if cmd[0] != 0x04 { // RequestCommandRvs
+		return "", fmt.Errorf("expect Rvs command 0x04, got 0x%02x", cmd[0])
+	}
+	return flow, nil
+}
+
+// portalRespConn —— 在首个写时前置 VLESS 响应头 [version=0][addonsLen=0]([00][00]),
+// 供 vision server 包装后由 ClientWorker 的首帧触发(对齐 sing_vless 的 serverConn)。
+type portalRespConn struct {
+	net.Conn
+	written bool
+}
+
+func (c *portalRespConn) Write(b []byte) (int, error) {
+	if !c.written {
+		c.written = true
+		out := make([]byte, 0, 2+len(b))
+		out = append(out, 0x00, 0x00)
+		out = append(out, b...)
+		n, err := c.Conn.Write(out)
+		if n -= 2; n < 0 {
+			n = 0
+		}
+		return n, err
+	}
+	return c.Conn.Write(b)
+}
+
+var _ C.InboundListener = (*ReversePortal)(nil)

--- a/listener/inbound/reverse_portal_tls.go
+++ b/listener/inbound/reverse_portal_tls.go
@@ -1,0 +1,76 @@
+package inbound
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"os"
+	"time"
+)
+
+// buildServerTLS 为 reverse-portal 的普通 TLS 层(非 REALITY)构造 tls.Config(TLS1.3,vision 需要)。
+// 提供 cert/key(PEM 文件路径或内联 PEM)则用之;否则自签一张(便于测试 / 内网信任场景)。
+func buildServerTLS(certPEM, keyPEM string) (*tls.Config, error) {
+	var cert tls.Certificate
+	var err error
+	if certPEM != "" && keyPEM != "" {
+		c, cerr := readMaybeFile(certPEM)
+		if cerr != nil {
+			return nil, cerr
+		}
+		k, kerr := readMaybeFile(keyPEM)
+		if kerr != nil {
+			return nil, kerr
+		}
+		cert, err = tls.X509KeyPair(c, k)
+	} else {
+		cert, err = genSelfSigned()
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &tls.Config{
+		Certificates: []tls.Certificate{cert},
+		MinVersion:   tls.VersionTLS13, // vision 读 TLS1.3 记录层,必须 1.3
+	}, nil
+}
+
+// readMaybeFile:内容像 PEM 就直接用,否则当文件路径读。
+func readMaybeFile(s string) ([]byte, error) {
+	if len(s) > 0 && (s[0] == '-') { // "-----BEGIN..."
+		return []byte(s), nil
+	}
+	return os.ReadFile(s)
+}
+
+func genSelfSigned() (tls.Certificate, error) {
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return tls.Certificate{}, err
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "reverse-portal"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().AddDate(10, 0, 0),
+		KeyUsage:     x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		DNSNames:     []string{"reverse-portal"},
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		return tls.Certificate{}, err
+	}
+	keyDER, err := x509.MarshalECPrivateKey(key)
+	if err != nil {
+		return tls.Certificate{}, err
+	}
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER})
+	return tls.X509KeyPair(certPEM, keyPEM)
+}

--- a/listener/parse.go
+++ b/listener/parse.go
@@ -175,6 +175,20 @@ func ParseListener(mapping map[string]any) (C.InboundListener, error) {
 			return nil, err
 		}
 		listener, err = IN.NewTrustTunnel(trusttunnelOption)
+	case "reverse-bridge":
+		reverseBridgeOption := &IN.ReverseBridgeOption{}
+		err = decoder.Decode(mapping, reverseBridgeOption)
+		if err != nil {
+			return nil, err
+		}
+		listener, err = IN.NewReverseBridge(reverseBridgeOption)
+	case "reverse-portal":
+		reversePortalOption := &IN.ReversePortalOption{}
+		err = decoder.Decode(mapping, reversePortalOption)
+		if err != nil {
+			return nil, err
+		}
+		listener, err = IN.NewReversePortal(reversePortalOption)
 	default:
 		return nil, fmt.Errorf("unsupport proxy type: %s", proxyType)
 	}

--- a/listener/reverse/portal.go
+++ b/listener/reverse/portal.go
@@ -1,0 +1,103 @@
+// Package reverse —— 反向代理 Portal 侧的运行时注册表。
+//
+// Portal 由两半组成、经此包用一个 tag 关联:
+//   - reverse-portal listener(listener/inbound):接受 Bridge 的 VLESS-Rvs 反连,
+//     在连接上跑 muxcool.ClientWorker(Portal=Mux.cool 客户端 + 心跳),注册到本表。
+//   - reverse-portal outbound(adapter/outbound):用户流量按 routing 命中它,
+//     DialContext 经本表挑一条活跃 ClientWorker 开子流(OpenStream)下发到 Bridge。
+package reverse
+
+import (
+	"fmt"
+	"net"
+	"sync"
+
+	"github.com/metacubex/mihomo/transport/muxcool"
+)
+
+type picker struct {
+	mu      sync.Mutex
+	workers []*muxcool.ClientWorker
+	next    int // round-robin 游标
+}
+
+var registry = struct {
+	mu sync.Mutex
+	m  map[string]*picker
+}{m: make(map[string]*picker)}
+
+func getPicker(tag string) *picker {
+	registry.mu.Lock()
+	defer registry.mu.Unlock()
+	p := registry.m[tag]
+	if p == nil {
+		p = &picker{}
+		registry.m[tag] = p
+	}
+	return p
+}
+
+func (p *picker) add(w *muxcool.ClientWorker) {
+	p.mu.Lock()
+	p.workers = append(p.workers, w)
+	p.mu.Unlock()
+}
+
+func (p *picker) remove(w *muxcool.ClientWorker) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	for i, x := range p.workers {
+		if x == w {
+			p.workers = append(p.workers[:i], p.workers[i+1:]...)
+			break
+		}
+	}
+}
+
+// pick 轮询选一条【活跃】worker(跳过已关闭/draining),多 Bridge 接同一 tag 时负载均衡。
+func (p *picker) pick() *muxcool.ClientWorker {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	n := len(p.workers)
+	if n == 0 {
+		return nil
+	}
+	for i := 0; i < n; i++ {
+		w := p.workers[p.next%n]
+		p.next++
+		if w.IsActive() {
+			return w
+		}
+	}
+	return nil // 全部不可用
+}
+
+// RegisterPortalConn 在一条已完成 VLESS-Rvs 握手的 Bridge 连接上跑 Portal 端 Mux.cool 客户端,
+// 注册到 tag 对应的 picker,阻塞直到隧道关闭。由 reverse-portal listener 每条反连调用。
+func RegisterPortalConn(tag string, conn net.Conn) {
+	cw := muxcool.NewClientWorker(conn)
+	go cw.Run()
+	_ = cw.StartControl(0) // 0=默认 10s 心跳
+	p := getPicker(tag)
+	p.add(cw)
+	defer p.remove(cw)
+	<-cw.Done()
+}
+
+// Open 为 tag 挑一条活跃 worker,开一条到 target 的用户子流。reverse-portal outbound 调用。
+func Open(tag string, network muxcool.TargetNetwork, addr muxcool.Address, port uint16) (net.Conn, error) {
+	w := getPicker(tag).pick()
+	if w == nil {
+		return nil, fmt.Errorf("reverse portal %q: no active bridge tunnel", tag)
+	}
+	return w.OpenStream(network, addr, port)
+}
+
+// NewPacketConn 为 tag 挑一条活跃 worker,返回一个全锥 UDP PacketConn(内部按 target 开多子流)。
+func NewPacketConn(tag string) (net.PacketConn, error) {
+	w := getPicker(tag).pick()
+	if w == nil {
+		return nil, fmt.Errorf("reverse portal %q: no active bridge tunnel", tag)
+	}
+	return w.NewPacketConn(), nil
+}

--- a/transport/muxcool/client.go
+++ b/transport/muxcool/client.go
@@ -1,0 +1,307 @@
+package muxcool
+
+import (
+	"crypto/rand"
+	"io"
+	"net"
+	"sync"
+	"time"
+)
+
+// ClientWorker —— 在一条(VLESS-Rvs 隧道)明文流上跑 Mux.cool 客户端。
+//
+// 角色:Portal 侧。Portal 是 Mux.cool 客户端——主动开子流承载用户流量(New/Keep/End),
+// 并开一条控制子流周期发 Control 心跳。回程(Keep/End)由 Run 读环解复用回各子流。
+//
+// 与 ServerWorker 对称:ServerWorker 被动收 New 并落地;ClientWorker 主动开 New。
+type ClientWorker struct {
+	link io.ReadWriteCloser
+
+	writeMu  sync.Mutex
+	mu       sync.Mutex
+	nextID   uint16
+	total    uint64 // 累计分配的子流数(含控制流),用于 >256 转 DRAIN
+	draining bool
+	sessions map[uint16]*clientSession
+
+	closeOnce sync.Once
+	done      chan struct{}
+}
+
+type clientSession struct {
+	id     uint16
+	udp    bool             // UDP 子流:Keep 数据按数据报推入 sink(保边界+带 source),不走 inW
+	inW    *bufPipe         // 仅 TCP:Run 读到该子流的 Keep 数据写这里(带缓冲,缓解 HoL)
+	sink   chan udpPacket   // 仅 UDP:入站数据报汇聚到所属 PacketConn 的共享队列(带 source)
+	target net.Addr         // 仅 UDP:本子流的固定 target(回填为 ReadFrom 的 source)
+	closed chan struct{}
+	once   sync.Once
+}
+
+// NewClientWorker 构造。调用方应 go w.Run() 跑解复用读环,并按需 OpenStream / StartControl。
+func NewClientWorker(link io.ReadWriteCloser) *ClientWorker {
+	return &ClientWorker{
+		link:     link,
+		nextID:   0,
+		sessions: make(map[uint16]*clientSession),
+		done:     make(chan struct{}),
+	}
+}
+
+// Done 在 worker 关闭(link 断开)后被 close,供上层阻塞等待隧道结束。
+func (w *ClientWorker) Done() <-chan struct{} { return w.done }
+
+// IsActive 报告该隧道是否可继续接新用户子流(未关闭、未 draining)。picker 据此挑选。
+func (w *ClientWorker) IsActive() bool {
+	select {
+	case <-w.done:
+		return false
+	default:
+	}
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return !w.draining
+}
+
+// Run 跑解复用读环,直到 link 出错/关闭。返回时清理所有子流。
+func (w *ClientWorker) Run() error {
+	defer w.closeAll()
+	for {
+		m, data, err := ReadFrame(w.link)
+		if err != nil {
+			return err
+		}
+		switch m.Status {
+		case StatusKeep:
+			cs := w.getSession(m.SessionID)
+			if cs == nil {
+				// 未知会话(已关):回 End 通知对端关闭(对齐 Xray client.go:354)。
+				w.writeEnd(m.SessionID, false)
+			} else if len(data) > 0 {
+				if cs.udp {
+					cp := make([]byte, len(data))
+					copy(cp, data)
+					select {
+					case cs.sink <- udpPacket{src: cs.target, data: cp}:
+					default: // 队列满则丢(UDP 语义可丢)
+					}
+				} else {
+					cs.inW.Write(data)
+				}
+			}
+		case StatusEnd:
+			if cs := w.getSession(m.SessionID); cs != nil {
+				w.finish(cs)
+			}
+		case StatusNew:
+			// Bridge 是 mux 服务端,不应主动开子流;忽略。
+		case StatusKeepAlive:
+			// 丢弃。
+		}
+	}
+}
+
+// -------- 帧写(加锁)--------
+
+func (w *ClientWorker) writeFrame(m *FrameMetadata, data []byte) error {
+	w.writeMu.Lock()
+	defer w.writeMu.Unlock()
+	return WriteFrame(w.link, m, data)
+}
+
+func (w *ClientWorker) writeData(id uint16, data []byte) error {
+	w.writeMu.Lock()
+	defer w.writeMu.Unlock()
+	return WriteData(w.link, id, data)
+}
+
+func (w *ClientWorker) writeEnd(id uint16, hasErr bool) error {
+	w.writeMu.Lock()
+	defer w.writeMu.Unlock()
+	return WriteEnd(w.link, id, hasErr)
+}
+
+// -------- 会话表 --------
+
+func (w *ClientWorker) allocID() uint16 {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.total++
+	if w.total > 256 { // 对齐 Xray:累计连接 >256 转 DRAIN,提示对端另建隧道
+		w.draining = true
+	}
+	for {
+		w.nextID++
+		if w.nextID == 0 {
+			continue // 跳过 0
+		}
+		if _, exists := w.sessions[w.nextID]; !exists {
+			return w.nextID
+		}
+	}
+}
+
+func (w *ClientWorker) addSession(s *clientSession) {
+	w.mu.Lock()
+	w.sessions[s.id] = s
+	w.mu.Unlock()
+}
+
+func (w *ClientWorker) getSession(id uint16) *clientSession {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.sessions[id]
+}
+
+func (w *ClientWorker) removeSession(id uint16) {
+	w.mu.Lock()
+	delete(w.sessions, id)
+	w.mu.Unlock()
+}
+
+func (w *ClientWorker) finish(s *clientSession) {
+	s.once.Do(func() {
+		w.removeSession(s.id)
+		if s.inW != nil {
+			s.inW.Close()
+		}
+		if s.closed != nil {
+			close(s.closed) // 通知 UDP 读者收尾;sink 是共享队列不在此关(避免与 Run 的 send 竞争)
+		}
+	})
+}
+
+func (w *ClientWorker) closeAll() {
+	w.closeOnce.Do(func() { close(w.done) })
+	w.mu.Lock()
+	all := make([]*clientSession, 0, len(w.sessions))
+	for _, s := range w.sessions {
+		all = append(all, s)
+	}
+	w.mu.Unlock()
+	for _, s := range all {
+		w.finish(s)
+	}
+	w.link.Close()
+}
+
+// -------- 开子流(用户流量)--------
+
+// OpenStream 开一条承载用户流量的子流,返回一个到目标的 net.Conn。
+// 先发一个空 New 帧向 Bridge 注册目标(Bridge 据此拨本地目标),后续 Write 走 Keep 帧。
+func (w *ClientWorker) OpenStream(network TargetNetwork, addr Address, port uint16) (net.Conn, error) {
+	id := w.allocID()
+	bp := newBufPipe(sessionBufLimit)
+	cs := &clientSession{id: id, inW: bp, closed: make(chan struct{})}
+	w.addSession(cs)
+
+	m := &FrameMetadata{SessionID: id, Status: StatusNew, Network: network, Address: addr, Port: port}
+	if err := w.writeFrame(m, nil); err != nil {
+		w.removeSession(id)
+		bp.Close()
+		return nil, err
+	}
+	return &clientConn{w: w, id: id, cs: cs, pr: bp}, nil
+}
+
+// clientConn —— OpenStream 返回的子流,实现 net.Conn。
+// Read 从解复用管道取回程数据;Write 封成 Keep 帧发出;Close 发 End。
+type clientConn struct {
+	w    *ClientWorker
+	id   uint16
+	cs   *clientSession
+	pr   *bufPipe
+	once sync.Once
+}
+
+func (c *clientConn) Read(p []byte) (int, error)  { return c.pr.Read(p) }
+
+func (c *clientConn) Write(p []byte) (int, error) {
+	if err := c.w.writeData(c.id, p); err != nil {
+		return 0, err
+	}
+	return len(p), nil
+}
+
+func (c *clientConn) Close() error {
+	c.once.Do(func() {
+		c.w.writeEnd(c.id, false)
+		c.w.finish(c.cs)
+	})
+	return nil
+}
+
+func (c *clientConn) LocalAddr() net.Addr                { return muxAddr{} }
+func (c *clientConn) RemoteAddr() net.Addr               { return muxAddr{} }
+func (c *clientConn) SetDeadline(t time.Time) error      { return nil }
+func (c *clientConn) SetReadDeadline(t time.Time) error  { return nil }
+func (c *clientConn) SetWriteDeadline(t time.Time) error { return nil }
+
+type muxAddr struct{}
+
+func (muxAddr) Network() string { return "muxcool" }
+func (muxAddr) String() string  { return "muxcool" }
+
+// -------- 控制子流 + 心跳 --------
+
+// StartControl 开控制子流(target 域 "reverse",UDP,port 0)并周期发 Control 心跳,
+// 直到 worker 关闭。Bridge 靠此保活(Xray Bridge 有 60s 不活动定时器)。
+func (w *ClientWorker) StartControl(interval time.Duration) error {
+	if interval <= 0 {
+		interval = 10 * time.Second
+	}
+	id := w.allocID()
+	ctlAddr := Address{IsDomain: true, Domain: InternalDomain}
+	// 控制子流是 UDP 类型;New 与后续心跳 Keep 均带 network=UDP + 地址(与 Xray 一致)。
+	newFrame := &FrameMetadata{SessionID: id, Status: StatusNew, Network: NetworkUDP, Address: ctlAddr, Port: 0}
+	if err := w.writeFrame(newFrame, nil); err != nil {
+		return err
+	}
+	go func() {
+		t := time.NewTicker(interval)
+		defer t.Stop()
+		// 建立即发一次首心跳。
+		w.sendHeartbeat(id, ctlAddr)
+		for {
+			select {
+			case <-w.done:
+				return
+			case <-t.C:
+				if err := w.sendHeartbeat(id, ctlAddr); err != nil {
+					return
+				}
+			}
+		}
+	}()
+	return nil
+}
+
+func (w *ClientWorker) sendHeartbeat(id uint16, ctlAddr Address) error {
+	// UDP 会话的 Keep 帧带 network=UDP + 地址(frame.go marshalMeta 对 Keep&&UDP 写地址)。
+	m := &FrameMetadata{SessionID: id, Status: StatusKeep, Network: NetworkUDP, Address: ctlAddr, Port: 0}
+	w.mu.Lock()
+	draining := w.draining
+	w.mu.Unlock()
+	if draining {
+		return w.writeFrame(m, controlBytes(true))
+	}
+	return w.writeFrame(m, controlBytes(false))
+}
+
+// controlBytes 生成一条 Control protobuf 心跳。
+// ACTIVE:proto3 省略 state=0,只剩 field99 random → `9A 06 <len 1..64> <random>`。
+// DRAIN:前置 field1 state=1 → `08 01 9A 06 <len> <random>`。
+func controlBytes(drain bool) []byte {
+	var lb [1]byte
+	rand.Read(lb[:])
+	n := int(lb[0])%64 + 1 // 1..64
+	buf := make([]byte, 0, 5+n)
+	if drain {
+		buf = append(buf, 0x08, 0x01) // state = DRAIN
+	}
+	buf = append(buf, 0x9A, 0x06, byte(n))
+	r := make([]byte, n)
+	rand.Read(r)
+	buf = append(buf, r...)
+	return buf
+}

--- a/transport/muxcool/client_test.go
+++ b/transport/muxcool/client_test.go
@@ -1,0 +1,195 @@
+package muxcool
+
+import (
+	"io"
+	"net"
+	"testing"
+	"time"
+)
+
+// echoDisp —— Bridge 侧落地器:每个子流接一个把收到数据原样回吐的 echo。
+type echoDisp struct{}
+
+func (echoDisp) DialTarget(n TargetNetwork, a Address, p uint16) (net.Conn, error) {
+	c1, c2 := net.Pipe()
+	go func() {
+		buf := make([]byte, 4096)
+		for {
+			k, e := c2.Read(buf)
+			if k > 0 {
+				c2.Write(buf[:k])
+			}
+			if e != nil {
+				c2.Close()
+				return
+			}
+		}
+	}()
+	return c1, nil
+}
+
+func readConnTimeout(t *testing.T, c net.Conn, want string) {
+	t.Helper()
+	ch := make(chan string, 1)
+	go func() {
+		buf := make([]byte, 256)
+		k, err := c.Read(buf)
+		if err != nil {
+			ch <- "ERR:" + err.Error()
+			return
+		}
+		ch <- string(buf[:k])
+	}()
+	select {
+	case got := <-ch:
+		if got != want {
+			t.Fatalf("read got %q want %q", got, want)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("read timeout")
+	}
+}
+
+// ClientWorker(Portal)↔ ServerWorker(Bridge)loopback:开子流、数据双向、控制心跳。
+// 证明两侧 codec 对称互通——mihomo 既能当 Portal 也能当 Bridge。
+func TestClientServer_Loopback(t *testing.T) {
+	linkA, linkB := net.Pipe()
+
+	got := make(chan []byte, 16)
+	server := NewServerWorker(linkB, echoDisp{}, func(p []byte) {
+		cp := make([]byte, len(p))
+		copy(cp, p)
+		got <- cp
+	})
+	client := NewClientWorker(linkA)
+	go server.Run()
+	go client.Run()
+	defer linkA.Close()
+	defer linkB.Close()
+
+	// 控制心跳(快节奏便于测)。
+	if err := client.StartControl(50 * time.Millisecond); err != nil {
+		t.Fatal(err)
+	}
+
+	// 开子流,写数据,期望 echo 回来。
+	conn, err := client.OpenStream(NetworkTCP, AddrFromString("1.2.3.4"), 80)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := conn.Write([]byte("hello-reverse")); err != nil {
+		t.Fatal(err)
+	}
+	readConnTimeout(t, conn, "hello-reverse")
+
+	// 收到至少一条 ACTIVE 心跳(9a 06 …,非 08 01 开头)。
+	select {
+	case hb := <-got:
+		if len(hb) < 3 || hb[0] != 0x9A || hb[1] != 0x06 {
+			t.Fatalf("heartbeat not ACTIVE control proto: % x", hb)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("no control heartbeat received")
+	}
+
+	conn.Close()
+}
+
+// UDP 全锥:一个 PacketConn WriteTo 多个 target,各自独立 echo 子流,ReadFrom 带回正确 source。
+func TestClientServer_UDP(t *testing.T) {
+	linkA, linkB := net.Pipe()
+	server := NewServerWorker(linkB, echoDisp{}, nil)
+	client := NewClientWorker(linkA)
+	go server.Run()
+	go client.Run()
+	defer linkA.Close()
+	defer linkB.Close()
+
+	pc := client.NewPacketConn()
+	defer pc.Close()
+
+	t1 := &net.UDPAddr{IP: net.IPv4(8, 8, 8, 8), Port: 53}
+	t2 := &net.UDPAddr{IP: net.IPv4(1, 1, 1, 1), Port: 5353}
+	if _, err := pc.WriteTo([]byte("q-to-8888"), t1); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := pc.WriteTo([]byte("q-to-1111"), t2); err != nil {
+		t.Fatal(err)
+	}
+
+	got := map[string]string{}
+	_ = pc.SetReadDeadline(time.Now().Add(3 * time.Second))
+	for i := 0; i < 2; i++ {
+		buf := make([]byte, 256)
+		n, addr, err := pc.ReadFrom(buf)
+		if err != nil {
+			t.Fatal(err)
+		}
+		got[addr.String()] = string(buf[:n])
+	}
+	if got["8.8.8.8:53"] != "q-to-8888" {
+		t.Fatalf("target1 mismatch: %v", got)
+	}
+	if got["1.1.1.1:5353"] != "q-to-1111" {
+		t.Fatalf("target2 mismatch: %v", got)
+	}
+}
+
+// 多子流并发:各自独立 echo,互不串。
+func TestClientServer_MultiStream(t *testing.T) {
+	linkA, linkB := net.Pipe()
+	server := NewServerWorker(linkB, echoDisp{}, nil)
+	client := NewClientWorker(linkA)
+	go server.Run()
+	go client.Run()
+	defer linkA.Close()
+	defer linkB.Close()
+
+	const N = 8
+	type res struct {
+		i   int
+		err error
+	}
+	done := make(chan res, N)
+	for i := 0; i < N; i++ {
+		go func(i int) {
+			conn, err := client.OpenStream(NetworkTCP, AddrFromString("10.0.0.1"), uint16(1000+i))
+			if err != nil {
+				done <- res{i, err}
+				return
+			}
+			defer conn.Close()
+			msg := []byte{byte('A' + i)}
+			if _, err := conn.Write(msg); err != nil {
+				done <- res{i, err}
+				return
+			}
+			buf := make([]byte, 8)
+			connCh := make(chan error, 1)
+			go func() {
+				k, e := conn.Read(buf)
+				if e != nil {
+					connCh <- e
+					return
+				}
+				if k != 1 || buf[0] != byte('A'+i) {
+					connCh <- io.ErrUnexpectedEOF
+					return
+				}
+				connCh <- nil
+			}()
+			select {
+			case e := <-connCh:
+				done <- res{i, e}
+			case <-time.After(3 * time.Second):
+				done <- res{i, io.ErrUnexpectedEOF}
+			}
+		}(i)
+	}
+	for i := 0; i < N; i++ {
+		r := <-done
+		if r.err != nil {
+			t.Fatalf("stream %d: %v", r.i, r.err)
+		}
+	}
+}

--- a/transport/muxcool/frame.go
+++ b/transport/muxcool/frame.go
@@ -1,0 +1,323 @@
+// Package muxcool 实现 Xray 的 Mux.cool 多路复用线协议(帧编解码 + 服务端会话)。
+//
+// 用途:让 mihomo 当反向代理的 Bridge —— 在一条 VLESS(Rvs 命令)隧道之上跑 Mux.cool
+// 服务端,被动接收 Portal(Xray)开来的子流并落地到本地内网。
+//
+// 本文件只含"帧层"(codec):FrameMetadata 读写 + 数据分块 + port-then-address 地址编解码。
+// 会话状态机(ServerWorker)在 server.go。
+//
+// 与 mihomo 自带的 sing-mux(yamux/smux/h2mux)完全不同、不可复用——那是别的多路复用协议。
+// 字节布局对齐 Xray-core common/mux/frame.go(全 big-endian)。
+package muxcool
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+)
+
+// SessionStatus —— 子流状态(Xray common/mux/frame.go:19-24)。
+type SessionStatus byte
+
+const (
+	StatusNew       SessionStatus = 0x01 // 新子流(带目标地址)
+	StatusKeep      SessionStatus = 0x02 // 续传数据(响应流首帧也是 Keep)
+	StatusEnd       SessionStatus = 0x03 // 关子流
+	StatusKeepAlive SessionStatus = 0x04 // 纯心跳,收到丢弃;我方从不主动发
+)
+
+// Option —— 位掩码(frame.go:26-29)。
+type Option byte
+
+const (
+	OptionData  Option = 0x01 // 该帧带数据段
+	OptionError Option = 0x02 // 出错(用于 End 帧)
+)
+
+func (o Option) Has(f Option) bool { return o&f != 0 }
+
+// TargetNetwork —— 目标网络字节(frame.go:31-36)。注意与 source/local 的 Network-1 编码不同。
+type TargetNetwork byte
+
+const (
+	NetworkTCP TargetNetwork = 0x01
+	NetworkUDP TargetNetwork = 0x02
+)
+
+// 地址类型字节 —— Xray 这套(common/protocol/payload.go:13-15)。
+// ⚠ 与 mihomo 的 constant.AddrType(Domain=3/IPv6=4)不同,codec 内部一律用这套。
+const (
+	atypIPv4   byte = 0x01
+	atypDomain byte = 0x02
+	atypIPv6   byte = 0x03
+)
+
+// metaLen 上限(frame.go:119)。
+const maxMetaLen = 512
+
+// StreamChunkSize —— TCP(Stream)每帧数据上限(writer.go:107 SplitSize 8*1024)。
+const StreamChunkSize = 8 * 1024
+
+var (
+	ErrMetaTooLong  = errors.New("muxcool: metaLen exceeds 512")
+	ErrMetaTooShort = errors.New("muxcool: metaLen < 4")
+	ErrDataTooLong  = errors.New("muxcool: data chunk exceeds 8192")
+)
+
+// Address —— 目标地址(域名或 IP)。Host 为域名时 IsDomain=true。
+type Address struct {
+	IsDomain bool
+	Domain   string
+	IP       net.IP // 4 或 16 字节
+}
+
+func (a Address) String() string {
+	if a.IsDomain {
+		return a.Domain
+	}
+	return a.IP.String()
+}
+
+// AddrFromString —— 从字符串构造 Address(是 IP 走 IP,否则当域名)。
+func AddrFromString(s string) Address {
+	if ip := net.ParseIP(s); ip != nil {
+		return Address{IP: ip}
+	}
+	return Address{IsDomain: true, Domain: s}
+}
+
+// FrameMetadata —— 一个 Mux.cool 帧的元数据体(不含 metaLen 前缀,不含数据段)。
+type FrameMetadata struct {
+	SessionID uint16
+	Status    SessionStatus
+	Option    Option
+
+	// 目标地址块 —— 仅 New,或 (Keep 且 UDP) 时有意义。
+	Network TargetNetwork
+	Address Address
+	Port    uint16
+}
+
+// -------------------------------------------------------------------------
+// 地址编解码(PortThenAddress:端口在前、类型字节、地址)
+// -------------------------------------------------------------------------
+
+// writeAddrPort 把 [2B port][1B atyp][addr] 追加到 b。
+func writeAddrPort(b []byte, port uint16, addr Address) ([]byte, error) {
+	b = binary.BigEndian.AppendUint16(b, port)
+	switch {
+	case addr.IsDomain:
+		if len(addr.Domain) > 255 {
+			return nil, fmt.Errorf("muxcool: domain too long: %d", len(addr.Domain))
+		}
+		b = append(b, atypDomain, byte(len(addr.Domain)))
+		b = append(b, addr.Domain...)
+	case addr.IP.To4() != nil:
+		b = append(b, atypIPv4)
+		b = append(b, addr.IP.To4()...)
+	default:
+		b = append(b, atypIPv6)
+		b = append(b, addr.IP.To16()...)
+	}
+	return b, nil
+}
+
+// readAddrPort 从 buf(off 起)读 [2B port][1B atyp][addr],返回 addr/port 及新偏移。
+func readAddrPort(buf []byte, off int) (Address, uint16, int, error) {
+	if off+3 > len(buf) {
+		return Address{}, 0, off, io.ErrUnexpectedEOF
+	}
+	port := binary.BigEndian.Uint16(buf[off:])
+	off += 2
+	atyp := buf[off]
+	off++
+	switch atyp {
+	case atypIPv4:
+		if off+4 > len(buf) {
+			return Address{}, 0, off, io.ErrUnexpectedEOF
+		}
+		ip := make(net.IP, 4)
+		copy(ip, buf[off:off+4])
+		return Address{IP: ip}, port, off + 4, nil
+	case atypIPv6:
+		if off+16 > len(buf) {
+			return Address{}, 0, off, io.ErrUnexpectedEOF
+		}
+		ip := make(net.IP, 16)
+		copy(ip, buf[off:off+16])
+		return Address{IP: ip}, port, off + 16, nil
+	case atypDomain:
+		if off+1 > len(buf) {
+			return Address{}, 0, off, io.ErrUnexpectedEOF
+		}
+		dlen := int(buf[off])
+		off++
+		if off+dlen > len(buf) {
+			return Address{}, 0, off, io.ErrUnexpectedEOF
+		}
+		return Address{IsDomain: true, Domain: string(buf[off : off+dlen])}, port, off + dlen, nil
+	default:
+		return Address{}, 0, off, fmt.Errorf("muxcool: bad address type 0x%02x", atyp)
+	}
+}
+
+// -------------------------------------------------------------------------
+// 元数据体编码
+// -------------------------------------------------------------------------
+
+// marshalMeta 生成"元数据体"字节(不含 metaLen 前缀)。
+// 只写 target 地址块;不写 source/local/GlobalID(Bridge 作为服务端只发 Keep/End,
+// New 仅测试/客户端场景用,且我们按 IsReverseMux=false 语义不带这些尾部)。
+func (m *FrameMetadata) marshalMeta() ([]byte, error) {
+	b := make([]byte, 0, 16)
+	b = binary.BigEndian.AppendUint16(b, m.SessionID)
+	b = append(b, byte(m.Status), byte(m.Option))
+	// New,或 (Keep 且 UDP) 时写目标地址块。
+	if m.Status == StatusNew || (m.Status == StatusKeep && m.Network == NetworkUDP) {
+		b = append(b, byte(m.Network))
+		var err error
+		b, err = writeAddrPort(b, m.Port, m.Address)
+		if err != nil {
+			return nil, err
+		}
+	}
+	if len(b) > maxMetaLen {
+		return nil, ErrMetaTooLong
+	}
+	return b, nil
+}
+
+// unmarshalMeta 解析"元数据体"字节。读到 target 地址即停,剩余字节(source/local/GlobalID)
+// 一律忽略 —— 这样形态 A(无尾部)/形态 B(有 source/local)用同一份代码。
+func unmarshalMeta(buf []byte) (*FrameMetadata, error) {
+	if len(buf) < 4 {
+		return nil, ErrMetaTooShort
+	}
+	m := &FrameMetadata{
+		SessionID: binary.BigEndian.Uint16(buf[0:]),
+		Status:    SessionStatus(buf[2]),
+		Option:    Option(buf[3]),
+	}
+	off := 4
+	// 是否带目标地址:New;或 Keep 且下一字节==UDP(frame.go:144)。
+	hasAddr := m.Status == StatusNew ||
+		(m.Status == StatusKeep && off < len(buf) && buf[off] == byte(NetworkUDP))
+	if hasAddr {
+		if off >= len(buf) {
+			return nil, io.ErrUnexpectedEOF
+		}
+		m.Network = TargetNetwork(buf[off])
+		off++
+		addr, port, _, err := readAddrPort(buf, off)
+		if err != nil {
+			return nil, err
+		}
+		m.Address, m.Port = addr, port
+		// 剩余 source/local/GlobalID 忽略。
+	}
+	return m, nil
+}
+
+// -------------------------------------------------------------------------
+// 帧读写(线上:[2B metaLen][meta][2B dataLen][data],后半仅 Option&Data 时存在)
+// -------------------------------------------------------------------------
+
+// WriteFrame 写一个完整帧。data 为该帧负载(可 nil);data 非空时自动置 OptionData。
+// data 必须 ≤ StreamChunkSize(上层用 WriteData 分块)。
+func WriteFrame(w io.Writer, m *FrameMetadata, data []byte) error {
+	if len(data) > StreamChunkSize {
+		return ErrDataTooLong
+	}
+	if len(data) > 0 {
+		m.Option |= OptionData
+	}
+	meta, err := m.marshalMeta()
+	if err != nil {
+		return err
+	}
+	// [metaLen][meta]
+	hdr := binary.BigEndian.AppendUint16(make([]byte, 0, 2+len(meta)+2), uint16(len(meta)))
+	hdr = append(hdr, meta...)
+	// [dataLen][data](仅 Option&Data)
+	if m.Option.Has(OptionData) {
+		hdr = binary.BigEndian.AppendUint16(hdr, uint16(len(data)))
+	}
+	if _, err := w.Write(hdr); err != nil {
+		return err
+	}
+	if m.Option.Has(OptionData) && len(data) > 0 {
+		if _, err := w.Write(data); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// WriteData 把一段 payload 按 8KB 切成多个 Keep 帧写出(用于 Bridge 回程响应)。
+// 空 payload 不发帧(如需 keepalive 另行处理)。
+func WriteData(w io.Writer, sessionID uint16, data []byte) error {
+	for len(data) > 0 {
+		n := len(data)
+		if n > StreamChunkSize {
+			n = StreamChunkSize
+		}
+		m := &FrameMetadata{SessionID: sessionID, Status: StatusKeep, Option: OptionData}
+		if err := WriteFrame(w, m, data[:n]); err != nil {
+			return err
+		}
+		data = data[n:]
+	}
+	return nil
+}
+
+// WriteEnd 写一个 End 帧关闭子流;hasError 置 OptionError。
+func WriteEnd(w io.Writer, sessionID uint16, hasError bool) error {
+	m := &FrameMetadata{SessionID: sessionID, Status: StatusEnd}
+	if hasError {
+		m.Option |= OptionError
+	}
+	return WriteFrame(w, m, nil)
+}
+
+// ReadFrame 从 r 读一个完整帧,返回元数据与数据段(无数据段则 data 为 nil)。
+// 会跳过 metaLen 内的 source/local/GlobalID 尾部。
+func ReadFrame(r io.Reader) (*FrameMetadata, []byte, error) {
+	var lb [2]byte
+	if _, err := io.ReadFull(r, lb[:]); err != nil {
+		return nil, nil, err
+	}
+	metaLen := int(binary.BigEndian.Uint16(lb[:]))
+	if metaLen > maxMetaLen {
+		return nil, nil, ErrMetaTooLong
+	}
+	if metaLen < 4 {
+		return nil, nil, ErrMetaTooShort
+	}
+	metaBuf := make([]byte, metaLen)
+	if _, err := io.ReadFull(r, metaBuf); err != nil {
+		return nil, nil, err
+	}
+	m, err := unmarshalMeta(metaBuf)
+	if err != nil {
+		return nil, nil, err
+	}
+	var data []byte
+	if m.Option.Has(OptionData) {
+		if _, err := io.ReadFull(r, lb[:]); err != nil {
+			return nil, nil, err
+		}
+		dataLen := int(binary.BigEndian.Uint16(lb[:]))
+		if dataLen > StreamChunkSize {
+			return nil, nil, ErrDataTooLong
+		}
+		if dataLen > 0 {
+			data = make([]byte, dataLen)
+			if _, err := io.ReadFull(r, data); err != nil {
+				return nil, nil, err
+			}
+		}
+	}
+	return m, data, nil
+}

--- a/transport/muxcool/frame_test.go
+++ b/transport/muxcool/frame_test.go
@@ -1,0 +1,210 @@
+package muxcool
+
+import (
+	"bytes"
+	"encoding/binary"
+	"encoding/hex"
+	"net"
+	"testing"
+)
+
+// 已知向量:New / TCP / IPv4 1.2.3.4:80 / SID=1 / data="hi"
+// 期望线上字节(全 big-endian):
+//
+//	00 0C                               metaLen=12
+//	00 01                               SessionID=1
+//	01                                  Status=New
+//	01                                  Option=Data
+//	01                                  Network=TCP
+//	00 50                               Port=80
+//	01                                  atyp=IPv4
+//	01 02 03 04                         1.2.3.4
+//	00 02                               dataLen=2
+//	68 69                               "hi"
+func TestKnownVector_NewTCPv4(t *testing.T) {
+	var buf bytes.Buffer
+	m := &FrameMetadata{
+		SessionID: 1,
+		Status:    StatusNew,
+		Network:   NetworkTCP,
+		Address:   Address{IP: net.IPv4(1, 2, 3, 4)},
+		Port:      80,
+	}
+	if err := WriteFrame(&buf, m, []byte("hi")); err != nil {
+		t.Fatal(err)
+	}
+	want := "000c00010101010050010102030400026869"
+	if got := hex.EncodeToString(buf.Bytes()); got != want {
+		t.Fatalf("known vector mismatch:\n got=%s\nwant=%s", got, want)
+	}
+}
+
+func roundtrip(t *testing.T, m *FrameMetadata, data []byte) (*FrameMetadata, []byte) {
+	t.Helper()
+	var buf bytes.Buffer
+	if err := WriteFrame(&buf, m, data); err != nil {
+		t.Fatalf("WriteFrame: %v", err)
+	}
+	gm, gd, err := ReadFrame(&buf)
+	if err != nil {
+		t.Fatalf("ReadFrame: %v", err)
+	}
+	if buf.Len() != 0 {
+		t.Fatalf("leftover bytes after ReadFrame: %d", buf.Len())
+	}
+	return gm, gd
+}
+
+func TestRoundtrip_NewTCPDomain(t *testing.T) {
+	m := &FrameMetadata{
+		SessionID: 7,
+		Status:    StatusNew,
+		Network:   NetworkTCP,
+		Address:   Address{IsDomain: true, Domain: "example.com"},
+		Port:      443,
+	}
+	gm, gd := roundtrip(t, m, []byte("hello world"))
+	if gm.SessionID != 7 || gm.Status != StatusNew || gm.Network != NetworkTCP {
+		t.Fatalf("meta mismatch: %+v", gm)
+	}
+	if !gm.Address.IsDomain || gm.Address.Domain != "example.com" || gm.Port != 443 {
+		t.Fatalf("addr mismatch: %+v port=%d", gm.Address, gm.Port)
+	}
+	if string(gd) != "hello world" {
+		t.Fatalf("data mismatch: %q", gd)
+	}
+}
+
+func TestRoundtrip_NewUDPv4(t *testing.T) {
+	m := &FrameMetadata{
+		SessionID: 9,
+		Status:    StatusNew,
+		Network:   NetworkUDP,
+		Address:   Address{IP: net.IPv4(8, 8, 8, 8)},
+		Port:      53,
+	}
+	gm, gd := roundtrip(t, m, nil)
+	if gm.Network != NetworkUDP || gm.Port != 53 || !gm.Address.IP.Equal(net.IPv4(8, 8, 8, 8)) {
+		t.Fatalf("udp meta mismatch: %+v", gm)
+	}
+	if gd != nil {
+		t.Fatalf("expected no data, got %q", gd)
+	}
+}
+
+func TestRoundtrip_KeepData(t *testing.T) {
+	var buf bytes.Buffer
+	if err := WriteData(&buf, 3, []byte("response-bytes")); err != nil {
+		t.Fatal(err)
+	}
+	gm, gd, err := ReadFrame(&buf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gm.SessionID != 3 || gm.Status != StatusKeep {
+		t.Fatalf("keep meta mismatch: %+v", gm)
+	}
+	if string(gd) != "response-bytes" {
+		t.Fatalf("keep data mismatch: %q", gd)
+	}
+}
+
+func TestRoundtrip_End(t *testing.T) {
+	var buf bytes.Buffer
+	if err := WriteEnd(&buf, 42, true); err != nil {
+		t.Fatal(err)
+	}
+	gm, gd, err := ReadFrame(&buf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gm.SessionID != 42 || gm.Status != StatusEnd || !gm.Option.Has(OptionError) {
+		t.Fatalf("end meta mismatch: %+v", gm)
+	}
+	if gd != nil {
+		t.Fatalf("end should carry no data, got %q", gd)
+	}
+}
+
+// WriteData 对超过 8KB 的 payload 切多帧。
+func TestWriteData_Chunks(t *testing.T) {
+	payload := bytes.Repeat([]byte("A"), StreamChunkSize+100)
+	var buf bytes.Buffer
+	if err := WriteData(&buf, 1, payload); err != nil {
+		t.Fatal(err)
+	}
+	var got []byte
+	frames := 0
+	for buf.Len() > 0 {
+		m, d, err := ReadFrame(&buf)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if m.Status != StatusKeep {
+			t.Fatalf("frame %d status=%v", frames, m.Status)
+		}
+		got = append(got, d...)
+		frames++
+	}
+	if frames != 2 {
+		t.Fatalf("expected 2 chunks, got %d", frames)
+	}
+	if !bytes.Equal(got, payload) {
+		t.Fatal("reassembled payload mismatch")
+	}
+}
+
+// 形态 B:New 帧尾部带 source/local 扩展块,Bridge 必须解出 target 并忽略尾部。
+func TestDecode_SkipsSourceLocal(t *testing.T) {
+	// 手工拼一个 New/TCP/1.2.3.4:80 + 额外 source(TCP 5.6.7.8:1234) + local(TCP 127.0.0.1:0)。
+	var meta []byte
+	meta = binary.BigEndian.AppendUint16(meta, 11) // SID
+	meta = append(meta, byte(StatusNew), 0x00)     // status, option(no data)
+	meta = append(meta, byte(NetworkTCP))
+	meta = binary.BigEndian.AppendUint16(meta, 80)
+	meta = append(meta, atypIPv4, 1, 2, 3, 4)
+	// source 块:srcNet=net.Network_TCP-1=0x01, port, atyp, addr
+	meta = append(meta, 0x01)
+	meta = binary.BigEndian.AppendUint16(meta, 1234)
+	meta = append(meta, atypIPv4, 5, 6, 7, 8)
+	// local 块
+	meta = append(meta, 0x01)
+	meta = binary.BigEndian.AppendUint16(meta, 0)
+	meta = append(meta, atypIPv4, 127, 0, 0, 1)
+
+	var frame []byte
+	frame = binary.BigEndian.AppendUint16(frame, uint16(len(meta)))
+	frame = append(frame, meta...)
+
+	gm, gd, err := ReadFrame(bytes.NewReader(frame))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gm.SessionID != 11 || gm.Network != NetworkTCP || gm.Port != 80 {
+		t.Fatalf("target mismatch: %+v port=%d", gm, gm.Port)
+	}
+	if !gm.Address.IP.Equal(net.IPv4(1, 2, 3, 4)) {
+		t.Fatalf("target ip mismatch: %v", gm.Address.IP)
+	}
+	if gd != nil {
+		t.Fatalf("no data expected, got %q", gd)
+	}
+}
+
+// 空 New 帧(无数据段,option 无 Data)—— Portal 的 writeFirstPayload 100ms 占位会出现。
+func TestRoundtrip_NewNoData(t *testing.T) {
+	m := &FrameMetadata{
+		SessionID: 2,
+		Status:    StatusNew,
+		Network:   NetworkTCP,
+		Address:   Address{IP: net.IPv4(10, 0, 0, 1)},
+		Port:      8080,
+	}
+	gm, gd := roundtrip(t, m, nil)
+	if gm.Option.Has(OptionData) {
+		t.Fatal("should not have Data option")
+	}
+	if gd != nil {
+		t.Fatalf("expected nil data, got %q", gd)
+	}
+}

--- a/transport/muxcool/pipe.go
+++ b/transport/muxcool/pipe.go
@@ -1,0 +1,88 @@
+package muxcool
+
+import (
+	"io"
+	"sync"
+)
+
+// sessionBufLimit —— 每个子流入站缓冲上限。短突发在此额度内不阻塞 mux 读环(缓解 HoL);
+// 超过则对该子流施加背压(读环阻塞在该子流的 Write 上,与 Xray 的 buf pipe 语义一致)。
+const sessionBufLimit = 64 * 1024
+
+// bufPipe —— 带缓冲上限的内存管道。相比 io.Pipe(零缓冲、同步),Write 在缓冲未满时立即返回,
+// 使 mux 读环不被慢速本地目标同步阻塞。实现 io.Reader / io.WriteCloser。
+type bufPipe struct {
+	mu     sync.Mutex
+	cond   *sync.Cond
+	buf    []byte
+	limit  int
+	closed bool
+	rerr   error
+}
+
+func newBufPipe(limit int) *bufPipe {
+	p := &bufPipe{limit: limit}
+	p.cond = sync.NewCond(&p.mu)
+	return p
+}
+
+// Write 追加数据;缓冲满则阻塞等待空间(背压)。关闭后返回 ErrClosedPipe。
+func (p *bufPipe) Write(b []byte) (int, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	written := 0
+	for len(b) > 0 {
+		for len(p.buf) >= p.limit && !p.closed {
+			p.cond.Wait()
+		}
+		if p.closed {
+			return written, io.ErrClosedPipe
+		}
+		space := p.limit - len(p.buf)
+		n := len(b)
+		if n > space {
+			n = space
+		}
+		p.buf = append(p.buf, b[:n]...)
+		b = b[n:]
+		written += n
+		p.cond.Broadcast()
+	}
+	return written, nil
+}
+
+// Read 排空缓冲;空且未关则阻塞;关闭且排空后返回 EOF(或 CloseWithError 设的错误)。
+func (p *bufPipe) Read(b []byte) (int, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	for len(p.buf) == 0 && !p.closed {
+		p.cond.Wait()
+	}
+	if len(p.buf) == 0 {
+		if p.rerr != nil {
+			return 0, p.rerr
+		}
+		return 0, io.EOF
+	}
+	n := copy(b, p.buf)
+	if n == len(p.buf) {
+		p.buf = nil // 排空,释放底层数组
+	} else {
+		p.buf = p.buf[n:]
+	}
+	p.cond.Broadcast()
+	return n, nil
+}
+
+func (p *bufPipe) Close() error { return p.CloseWithError(nil) }
+
+func (p *bufPipe) CloseWithError(err error) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if !p.closed {
+		p.closed = true
+		p.rerr = err
+		p.cond.Broadcast()
+	}
+	return nil
+}

--- a/transport/muxcool/server.go
+++ b/transport/muxcool/server.go
@@ -1,0 +1,252 @@
+package muxcool
+
+import (
+	"io"
+	"net"
+	"sync"
+)
+
+// InternalDomain —— 反向代理控制子流的目标域(Xray app/reverse/reverse.go:15 硬编码)。
+// Bridge 靠它把"控制流"从"用户数据流"里区分出来。
+const InternalDomain = "reverse"
+
+// Dispatcher —— Bridge 收到用户数据子流后,如何拨到本地目标。
+// 由上层(listener/reverse)注入:通常接到 mihomo 的 tunnel/规则,落地到 Bridge 所在内网。
+type Dispatcher interface {
+	// DialTarget 按 target 拨一条到本地目标的双工连接。
+	DialTarget(network TargetNetwork, addr Address, port uint16) (net.Conn, error)
+}
+
+// ServerWorker —— 在一条(VLESS-Rvs 隧道解出的)明文流上跑 Mux.cool 服务端。
+//
+// 角色反转:mihomo 主动拨号建隧道,但在 Mux.cool 里是服务端——被动读 Portal 开来的
+// New 帧、把子流落地、回写 Keep/End。永不主动开子流、永不回写控制心跳。
+type ServerWorker struct {
+	link       io.ReadWriteCloser
+	dispatcher Dispatcher
+	onControl  func(payload []byte) // 控制子流每个数据帧回调(解 Control 心跳);可 nil
+
+	writeMu  sync.Mutex // 串行化所有帧写(多个子流 goroutine 并发回写)
+	mu       sync.Mutex
+	sessions map[uint16]*serverSession
+}
+
+type serverSession struct {
+	id      uint16
+	control bool
+	udp     bool     // UDP 子流:每帧=一个数据报,直写 conn(不经 bufPipe,保数据报边界)
+	conn    net.Conn
+	inW     *bufPipe // 仅 TCP:reader loop 把上行数据写这里 → 由 goroutine 拷到 conn
+	once    sync.Once
+}
+
+// NewServerWorker 构造。onControl 可为 nil(此时控制子流数据被丢弃,仍正常 drain)。
+func NewServerWorker(link io.ReadWriteCloser, d Dispatcher, onControl func([]byte)) *ServerWorker {
+	return &ServerWorker{
+		link:       link,
+		dispatcher: d,
+		onControl:  onControl,
+		sessions:   make(map[uint16]*serverSession),
+	}
+}
+
+// Run 跑读环,直到 link 出错/关闭。返回时清理所有子流。
+func (w *ServerWorker) Run() error {
+	defer w.closeAll()
+	for {
+		m, data, err := ReadFrame(w.link)
+		if err != nil {
+			return err
+		}
+		switch m.Status {
+		case StatusNew:
+			w.handleNew(m, data)
+		case StatusKeep:
+			w.handleKeep(m, data)
+		case StatusEnd:
+			w.handleEnd(m)
+		case StatusKeepAlive:
+			// 纯心跳,丢弃(Xray 的 Writer 从不主动发,收到即忽略)。
+		}
+	}
+}
+
+// -------- 帧写(均加锁)--------
+
+func (w *ServerWorker) writeData(id uint16, data []byte) error {
+	w.writeMu.Lock()
+	defer w.writeMu.Unlock()
+	return WriteData(w.link, id, data)
+}
+
+func (w *ServerWorker) writeEnd(id uint16, hasErr bool) error {
+	w.writeMu.Lock()
+	defer w.writeMu.Unlock()
+	return WriteEnd(w.link, id, hasErr)
+}
+
+// writeUDPData 回写一个 UDP 数据报为 Keep 帧(带 network=UDP + 地址,对齐 Xray UDP 帧)。
+func (w *ServerWorker) writeUDPData(id uint16, addr Address, port uint16, data []byte) error {
+	w.writeMu.Lock()
+	defer w.writeMu.Unlock()
+	m := &FrameMetadata{SessionID: id, Status: StatusKeep, Network: NetworkUDP, Address: addr, Port: port, Option: OptionData}
+	return WriteFrame(w.link, m, data)
+}
+
+// -------- 会话表 --------
+
+func (w *ServerWorker) addSession(s *serverSession) {
+	w.mu.Lock()
+	w.sessions[s.id] = s
+	w.mu.Unlock()
+}
+
+func (w *ServerWorker) getSession(id uint16) *serverSession {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.sessions[id]
+}
+
+func (w *ServerWorker) removeSession(id uint16) {
+	w.mu.Lock()
+	delete(w.sessions, id)
+	w.mu.Unlock()
+}
+
+// finish 幂等收尾:从表移除、(可选)发 End、关 conn/pipe。
+// 两条路径都可能触发(Portal 发来 End / 本地目标读到 EOF),sync.Once 保证只做一次。
+func (w *ServerWorker) finish(s *serverSession, sendEnd bool) {
+	s.once.Do(func() {
+		w.removeSession(s.id)
+		if sendEnd {
+			w.writeEnd(s.id, false)
+		}
+		if s.inW != nil {
+			s.inW.Close()
+		}
+		if s.conn != nil {
+			s.conn.Close()
+		}
+	})
+}
+
+func (w *ServerWorker) closeAll() {
+	w.mu.Lock()
+	all := make([]*serverSession, 0, len(w.sessions))
+	for _, s := range w.sessions {
+		all = append(all, s)
+	}
+	w.mu.Unlock()
+	for _, s := range all {
+		w.finish(s, false)
+	}
+	w.link.Close()
+}
+
+// -------- 帧处理 --------
+
+func (w *ServerWorker) handleNew(m *FrameMetadata, data []byte) {
+	// 控制子流:target 域 == "reverse"(UDP, port 0)。不拨号,只消费。
+	if m.Address.IsDomain && m.Address.Domain == InternalDomain {
+		w.addSession(&serverSession{id: m.SessionID, control: true})
+		if len(data) > 0 && w.onControl != nil {
+			w.onControl(data)
+		}
+		return
+	}
+
+	conn, err := w.dispatcher.DialTarget(m.Network, m.Address, m.Port)
+	if err != nil {
+		// 落地失败:回一个带 error 的 End 通知 Portal 关会话。
+		w.writeEnd(m.SessionID, true)
+		return
+	}
+
+	// UDP 子流:数据报语义,不经 bufPipe(会丢边界)——每帧直写 conn、每读一个数据报回一 Keep。
+	if m.Network == NetworkUDP {
+		s := &serverSession{id: m.SessionID, udp: true, conn: conn}
+		w.addSession(s)
+		go func() {
+			buf := make([]byte, 64*1024)
+			for {
+				n, er := conn.Read(buf)
+				if n > 0 {
+					if we := w.writeUDPData(m.SessionID, m.Address, m.Port, buf[:n]); we != nil {
+						break
+					}
+				}
+				if er != nil {
+					break
+				}
+			}
+			w.finish(s, true)
+		}()
+		if len(data) > 0 {
+			conn.Write(data)
+		}
+		return
+	}
+
+	bp := newBufPipe(sessionBufLimit)
+	s := &serverSession{id: m.SessionID, conn: conn, inW: bp}
+	w.addSession(s)
+
+	// 上行:mux 收到的数据 → 本地目标。
+	go func() {
+		io.Copy(conn, bp)
+	}()
+
+	// 下行:本地目标响应 → mux(Keep 帧);EOF/出错则收尾并发 End。
+	go func() {
+		buf := make([]byte, StreamChunkSize)
+		for {
+			n, er := conn.Read(buf)
+			if n > 0 {
+				if we := w.writeData(m.SessionID, buf[:n]); we != nil {
+					break
+				}
+			}
+			if er != nil {
+				break
+			}
+		}
+		w.finish(s, true)
+	}()
+
+	// New 帧若带首包(Option&Data),先灌给本地目标。
+	if len(data) > 0 {
+		bp.Write(data)
+	}
+}
+
+func (w *ServerWorker) handleKeep(m *FrameMetadata, data []byte) {
+	s := w.getSession(m.SessionID)
+	if s == nil {
+		// 未知会话:回 End 通知对端关闭(对齐 Xray server.go:308-311)。
+		w.writeEnd(m.SessionID, false)
+		return
+	}
+	if s.control {
+		if len(data) > 0 && w.onControl != nil {
+			w.onControl(data)
+		}
+		return
+	}
+	if s.udp {
+		if len(data) > 0 && s.conn != nil {
+			s.conn.Write(data) // 每帧=一个数据报,直写 UDP conn
+		}
+		return
+	}
+	if len(data) > 0 && s.inW != nil {
+		// 注:io.Pipe 同步写,慢速本地目标会背压阻塞读环(HoL)。
+		// MVP 可接受;S5 再引入带缓冲/限额的 pipe(对齐 Xray 的 buf pipe 16KB)。
+		s.inW.Write(data)
+	}
+}
+
+func (w *ServerWorker) handleEnd(m *FrameMetadata) {
+	if s := w.getSession(m.SessionID); s != nil {
+		w.finish(s, false) // Portal 主动关,不回 End
+	}
+}

--- a/transport/muxcool/server_test.go
+++ b/transport/muxcool/server_test.go
@@ -1,0 +1,133 @@
+package muxcool
+
+import (
+	"net"
+	"testing"
+	"time"
+)
+
+type mockDisp struct {
+	conn    net.Conn
+	gotNet  TargetNetwork
+	gotAddr Address
+	gotPort uint16
+}
+
+func (d *mockDisp) DialTarget(n TargetNetwork, a Address, p uint16) (net.Conn, error) {
+	d.gotNet, d.gotAddr, d.gotPort = n, a, p
+	return d.conn, nil
+}
+
+func readFrameT(t *testing.T, c net.Conn) (*FrameMetadata, []byte) {
+	t.Helper()
+	_ = c.SetReadDeadline(time.Now().Add(3 * time.Second))
+	m, d, err := ReadFrame(c)
+	if err != nil {
+		t.Fatalf("ReadFrame: %v", err)
+	}
+	return m, d
+}
+
+// Portal 开一个 TCP 子流,数据落地到本地目标,响应回程为 Keep,关闭为 End。
+func TestServerWorker_NewTCP_Bidirectional(t *testing.T) {
+	portal, bridge := net.Pipe()      // mux 链路
+	service, dial := net.Pipe()       // 本地目标(service=测试持有,dial=worker 落地端)
+	disp := &mockDisp{conn: dial}
+
+	w := NewServerWorker(bridge, disp, nil)
+	go w.Run()
+	defer bridge.Close()
+
+	// service 端:收到 "ping" 就回 "pong",然后关闭。
+	go func() {
+		buf := make([]byte, 64)
+		_ = service.SetReadDeadline(time.Now().Add(3 * time.Second))
+		n, err := service.Read(buf)
+		if err == nil && string(buf[:n]) == "ping" {
+			service.Write([]byte("pong"))
+		}
+		time.Sleep(50 * time.Millisecond)
+		service.Close()
+	}()
+
+	// Portal 发 New(SID=1, TCP, 1.2.3.4:80, "ping")。
+	m := &FrameMetadata{SessionID: 1, Status: StatusNew, Network: NetworkTCP,
+		Address: Address{IP: net.IPv4(1, 2, 3, 4)}, Port: 80}
+	_ = portal.SetWriteDeadline(time.Now().Add(3 * time.Second))
+	if err := WriteFrame(portal, m, []byte("ping")); err != nil {
+		t.Fatal(err)
+	}
+
+	// 期望:Keep(SID=1, "pong")。
+	rm, rd := readFrameT(t, portal)
+	if rm.SessionID != 1 || rm.Status != StatusKeep || string(rd) != "pong" {
+		t.Fatalf("unexpected response: sid=%d status=%v data=%q", rm.SessionID, rm.Status, rd)
+	}
+
+	// 期望:End(SID=1)。
+	em, _ := readFrameT(t, portal)
+	if em.SessionID != 1 || em.Status != StatusEnd {
+		t.Fatalf("expected End(1), got sid=%d status=%v", em.SessionID, em.Status)
+	}
+
+	// dispatcher 收到的 target 正确。
+	if disp.gotNet != NetworkTCP || disp.gotPort != 80 || !disp.gotAddr.IP.Equal(net.IPv4(1, 2, 3, 4)) {
+		t.Fatalf("dispatcher got wrong target: %v %v :%d", disp.gotNet, disp.gotAddr, disp.gotPort)
+	}
+}
+
+// 控制子流(target 域 "reverse"):数据经 onControl 回调,不落地。
+func TestServerWorker_ControlSubstream(t *testing.T) {
+	portal, bridge := net.Pipe()
+	got := make(chan []byte, 4)
+	disp := &mockDisp{} // 控制流不该触发 dial
+	w := NewServerWorker(bridge, disp, func(p []byte) {
+		cp := make([]byte, len(p))
+		copy(cp, p)
+		got <- cp
+	})
+	go w.Run()
+	defer bridge.Close()
+
+	_ = portal.SetWriteDeadline(time.Now().Add(3 * time.Second))
+	// New(SID=2, UDP, "reverse":0)
+	newCtl := &FrameMetadata{SessionID: 2, Status: StatusNew, Network: NetworkUDP,
+		Address: Address{IsDomain: true, Domain: InternalDomain}, Port: 0}
+	if err := WriteFrame(portal, newCtl, nil); err != nil {
+		t.Fatal(err)
+	}
+	// 一条 DRAIN 心跳字节:08 01 9A 06 <len=2> AA BB
+	ctl := []byte{0x08, 0x01, 0x9A, 0x06, 0x02, 0xAA, 0xBB}
+	if err := WriteData(portal, 2, ctl); err != nil {
+		t.Fatal(err)
+	}
+
+	select {
+	case p := <-got:
+		if string(p) != string(ctl) {
+			t.Fatalf("control payload mismatch: %x", p)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("onControl not called")
+	}
+	if disp.conn != nil {
+		t.Fatal("control substream must not dial")
+	}
+}
+
+// Keep 到未知会话 → Bridge 回一个 End 通知对端关闭。
+func TestServerWorker_KeepUnknown_RepliesEnd(t *testing.T) {
+	portal, bridge := net.Pipe()
+	w := NewServerWorker(bridge, &mockDisp{}, nil)
+	go w.Run()
+	defer bridge.Close()
+
+	_ = portal.SetWriteDeadline(time.Now().Add(3 * time.Second))
+	if err := WriteData(portal, 99, []byte("orphan")); err != nil {
+		t.Fatal(err)
+	}
+	em, _ := readFrameT(t, portal)
+	if em.SessionID != 99 || em.Status != StatusEnd {
+		t.Fatalf("expected End(99), got sid=%d status=%v", em.SessionID, em.Status)
+	}
+}

--- a/transport/muxcool/udp.go
+++ b/transport/muxcool/udp.go
@@ -1,0 +1,140 @@
+package muxcool
+
+import (
+	"net"
+	"strconv"
+	"sync"
+	"time"
+)
+
+// udpPacket —— 一个入站 UDP 数据报(带 source,供 ReadFrom 回填)。
+type udpPacket struct {
+	src  net.Addr
+	data []byte
+}
+
+// NewPacketConn 返回一个反向 UDP 的 net.PacketConn(全锥):一个 PacketConn 内,
+// 每个不同 target 开一条独立 Mux.cool UDP 子流(与 Xray reverse 的 per-target 子流一致),
+// 所有子流的回程数据报汇聚到共享队列,ReadFrom 带回各自 source。
+func (w *ClientWorker) NewPacketConn() *muxPacketConn {
+	return &muxPacketConn{
+		w:        w,
+		recv:     make(chan udpPacket, 512),
+		sessions: make(map[string]*clientSession),
+		closed:   make(chan struct{}),
+	}
+}
+
+type muxPacketConn struct {
+	w    *ClientWorker
+	recv chan udpPacket // 所有子流的入站数据报汇聚于此
+
+	mu       sync.Mutex
+	sessions map[string]*clientSession // targetKey(addr.String())→ 子流
+	closed   chan struct{}
+	closeOn  sync.Once
+
+	dmu      sync.Mutex
+	deadline time.Time
+}
+
+// WriteTo 把 p 发到 addr:按 target 复用/新建 UDP 子流,数据报封成 UDP Keep 帧发出。
+func (c *muxPacketConn) WriteTo(p []byte, addr net.Addr) (int, error) {
+	a, port := netAddrToMux(addr)
+	key := addr.String()
+
+	c.mu.Lock()
+	cs := c.sessions[key]
+	newSession := cs == nil
+	if newSession {
+		id := c.w.allocID()
+		cs = &clientSession{id: id, udp: true, sink: c.recv, target: addr, closed: make(chan struct{})}
+		c.w.addSession(cs)
+		c.sessions[key] = cs
+	}
+	c.mu.Unlock()
+
+	if newSession {
+		// 新 target:先发一个 New(UDP, target) 注册子流。
+		nm := &FrameMetadata{SessionID: cs.id, Status: StatusNew, Network: NetworkUDP, Address: a, Port: port}
+		if err := c.w.writeFrame(nm, nil); err != nil {
+			return 0, err
+		}
+	}
+	// 数据报 → UDP Keep 帧(带 network=UDP + 地址)。
+	c.w.writeMu.Lock()
+	m := &FrameMetadata{SessionID: cs.id, Status: StatusKeep, Network: NetworkUDP, Address: a, Port: port, Option: OptionData}
+	err := WriteFrame(c.w.link, m, p)
+	c.w.writeMu.Unlock()
+	if err != nil {
+		return 0, err
+	}
+	return len(p), nil
+}
+
+// ReadFrom 从共享队列取一个回程数据报,返回其 source(对应子流的 target)。
+func (c *muxPacketConn) ReadFrom(p []byte) (int, net.Addr, error) {
+	c.dmu.Lock()
+	dl := c.deadline
+	c.dmu.Unlock()
+	var timer <-chan time.Time
+	if !dl.IsZero() {
+		t := time.NewTimer(time.Until(dl))
+		defer t.Stop()
+		timer = t.C
+	}
+	select {
+	case pkt := <-c.recv:
+		n := copy(p, pkt.data)
+		return n, pkt.src, nil
+	case <-c.closed:
+		return 0, nil, net.ErrClosed
+	case <-timer:
+		return 0, nil, timeoutErr{}
+	}
+}
+
+func (c *muxPacketConn) Close() error {
+	c.closeOn.Do(func() {
+		close(c.closed)
+		c.mu.Lock()
+		sessions := c.sessions
+		c.sessions = map[string]*clientSession{}
+		c.mu.Unlock()
+		for _, cs := range sessions {
+			c.w.writeEnd(cs.id, false)
+			c.w.finish(cs)
+		}
+	})
+	return nil
+}
+
+func (c *muxPacketConn) LocalAddr() net.Addr { return muxAddr{} }
+
+func (c *muxPacketConn) SetDeadline(t time.Time) error {
+	c.dmu.Lock()
+	c.deadline = t
+	c.dmu.Unlock()
+	return nil
+}
+func (c *muxPacketConn) SetReadDeadline(t time.Time) error  { return c.SetDeadline(t) }
+func (c *muxPacketConn) SetWriteDeadline(t time.Time) error { return nil }
+
+// netAddrToMux 把 net.Addr 转成 Mux.cool 地址+端口(IP 直用,否则按 host:port 解析,支持域名)。
+func netAddrToMux(addr net.Addr) (Address, uint16) {
+	if ua, ok := addr.(*net.UDPAddr); ok {
+		return Address{IP: ua.IP}, uint16(ua.Port)
+	}
+	host, portStr, err := net.SplitHostPort(addr.String())
+	if err != nil {
+		return Address{IsDomain: true, Domain: addr.String()}, 0
+	}
+	port, _ := strconv.Atoi(portStr)
+	return AddrFromString(host), uint16(port)
+}
+
+type timeoutErr struct{}
+
+func (timeoutErr) Error() string   { return "muxcool: i/o timeout" }
+func (timeoutErr) Timeout() bool   { return true }
+func (timeoutErr) Temporary() bool { return true }

--- a/transport/vless/conn.go
+++ b/transport/vless/conn.go
@@ -81,7 +81,7 @@ func (vc *Conn) sendRequest(p []byte) (err error) {
 	requestLen += 1  // addons length
 	requestLen += len(addonsBytes)
 	requestLen += 1 // command
-	if !vc.dst.Mux {
+	if !vc.dst.Mux && !vc.dst.Rvs {
 		requestLen += 2 // port
 		requestLen += 1 // addr type
 		requestLen += len(vc.dst.Addr)
@@ -98,7 +98,9 @@ func (vc *Conn) sendRequest(p []byte) (err error) {
 		buf.Error(buffer.Write(addonsBytes)),
 	)
 
-	if vc.dst.Mux {
+	if vc.dst.Rvs {
+		buf.Must(buffer.WriteByte(CommandRvs))
+	} else if vc.dst.Mux {
 		buf.Must(buffer.WriteByte(CommandMux))
 	} else {
 		if vc.dst.UDP {

--- a/transport/vless/vless.go
+++ b/transport/vless/vless.go
@@ -22,6 +22,7 @@ const (
 	CommandTCP byte = 1
 	CommandUDP byte = 2
 	CommandMux byte = 3
+	CommandRvs byte = 4
 )
 
 // Addr types
@@ -38,6 +39,7 @@ type DstAddr struct {
 	Addr     []byte
 	Port     uint16
 	Mux      bool // currently used for XUDP only
+	Rvs      bool // reverse proxy (Rvs command); no address written
 }
 
 // Client is vless connection generator


### PR DESCRIPTION

### Summary
Adds an **Xray-compatible reverse proxy** to mihomo — both roles: **bridge** (NAT side; dials out and lands traffic to its local network) and **portal** (public side; accepts reverse connections and serves user traffic), without an external tunnel. New listener types `reverse-bridge` / `reverse-portal` and a `reverse-portal` outbound. Supports **TCP / REALITY / Vision / UDP (full-cone)**.

Addresses #190 (currently `not_planned`) — opening for discussion.

### Why
mihomo can currently only be a *client* to Xray's reverse proxy via an external tunnel. This lets mihomo interoperate with Xray's reverse proxy **in both roles**, and run a pure mihomo↔mihomo reverse stack. Verified against Xray-core 26.7.28 in every role-swap combination (bridge ∈ {mihomo, Xray} × portal ∈ {mihomo, Xray}).

### Suggested commit structure
1. **`transport/muxcool`** — Xray Mux.cool wire protocol (frame codec + server/client workers + UDP full-cone + buffered pipe), stdlib-only, with unit tests. mihomo's sing-mux is a different, wire-incompatible protocol, so a real Mux.cool impl is required. Standalone package, no wiring.
2. **VLESS `Rvs` command + `DialReverse`** — `CommandRvs (0x04)` (address-less, like `Mux`) in the client encoder + `DstAddr.Rvs`; `DialReverse` outbound method that opens a VLESS-Rvs stream reusing the full transport chain (REALITY/TLS/ws/grpc/Vision). This is the capability a bridge uses to dial a portal.
3. **reverse bridge + portal + wiring** —
   - `listener/inbound/reverse_bridge.go`: `reverse-bridge` listener (no port); resolves a referenced VLESS outbound, `DialReverse` to the portal, runs a Mux.cool `ServerWorker`, feeds each substream into `tunnel.HandleTCPConn` (UDP lands via `dialer.DialContext`); reconnects on drop.
   - `listener/inbound/reverse_portal.go` (+ `reverse_portal_tls.go`): `reverse-portal` listener; accepts VLESS-Rvs (optional REALITY / plain TLS 1.3 / Vision auto-detected from client flow); runs a Mux.cool `ClientWorker` + heartbeat.
   - `listener/reverse/portal.go`: runtime registry (tag → active tunnels) with a round-robin, `IsActive`-filtered picker.
   - `adapter/outbound/reverse_portal.go`: `reverse-portal` outbound; routes user traffic to an active tunnel by tag (TCP `DialContext` + UDP `ListenPacketContext`).
   - `adapter/outbound/base.go`: expose the auto-close wrapper's inner adapter (so the bridge can get the concrete `*Vless`).
   - `listener/parse.go`, `adapter/parser.go`: register the two listener types + the outbound.

### Configuration reference

**`reverse-bridge` listener** (no port; dials out): `name`, `type: reverse-bridge`, `portal` (a `proxies:` VLESS outbound name used to dial the portal).

**`reverse-portal` listener** (accepts reverse connections): `name`, `type: reverse-portal`, `listen`/`port`, `uuid`, `tag` (links to the outbound), plus one security layer — `reality-config: {dest, private-key, short-id: [], server-names: []}` **or** `tls: true` (+ `certificate`/`private-key`, PEM path or inline; empty → self-signed) **or** none. Precedence: reality > tls > none. `flow` is auto-detected (empty or `xtls-rprx-vision`; Vision needs TLS/REALITY underneath).

**`reverse-portal` outbound**: `name`, `type: reverse-portal`, `tag` (matches the listener's tag).

```yaml
# ---- Portal (public) ----
mixed-port: 10800
allow-lan: true
proxies:
  - { name: rvout, type: reverse-portal, tag: rvpool }
listeners:
  - { name: rp, type: reverse-portal, listen: 0.0.0.0, port: 10000, uuid: <uuid>, tag: rvpool,
      reality-config: { dest: www.cloudflare.com:443, private-key: <priv>, short-id: ["01ab"], server-names: [www.cloudflare.com] } }
rules: [ MATCH, rvout ]

# ---- Bridge (intranet) ----
proxies:
  - { name: toportal, type: vless, server: <portal>, port: 10000, uuid: <uuid>, network: tcp,
      tls: true, servername: www.cloudflare.com, client-fingerprint: chrome,
      reality-opts: { public-key: <pub>, short-id: "01ab" } }
listeners: [ { name: rb, type: reverse-bridge, portal: toportal } ]
rules: [ MATCH, DIRECT ]
```

### Testing
End-to-end against real Xray-core 26.7.28 — all four quadrants for TCP and REALITY; UDP full-cone (single/multi-target) both directions; Vision (`xtls-rprx-vision`); plus `go test -race` for `transport/muxcool`.

### Notes for maintainers
Sizeable feature for a `not_planned` issue — happy to split (bridge-only first, or gate behind a build tag) or adjust the config surface. UDP lands via direct dial (no XUDP GlobalID; Xray's reverse path doesn't use it either). Reverse accounts require empty or Vision flow.

---

