### PR TITLE
fix: keep Tailscale system packet listener local

### DIFF
--- a/adapter/outbound/tailscale.go
+++ b/adapter/outbound/tailscale.go
@@ -156,7 +156,7 @@ func NewTailscale(option TailscaleOption) (*Tailscale, error) {
 		},
 		SystemPacketListener: func(ctx context.Context, network, address string) (net.PacketConn, error) {
 			log.Debugln("[Tailscale](%s) SystemPacketListener: start listen %s %s", option.Name, network, address)
-			pc, err := outbound.dialer.ListenPacket(ctx, network, address, netip.AddrPort{})
+			pc, err := dialer.ListenPacket(ctx, network, address, netip.AddrPort{}, outbound.DialOptions()...)
 			log.Debugln("[Tailscale](%s) SystemPacketListener: finish listen %s %s, err: %v", option.Name, network, address, err)
 			return pc, err
 		},

--- a/adapter/outbound/tailscale_test.go
+++ b/adapter/outbound/tailscale_test.go
@@ -1,0 +1,32 @@
+//go:build with_gvisor && !no_tailscale
+
+package outbound
+
+import (
+	"context"
+	"testing"
+)
+
+func TestTailscaleSystemPacketListenerWithDialerProxy(t *testing.T) {
+	outbound, err := NewTailscale(TailscaleOption{
+		BasicOption: BasicOption{DialerProxy: "missing"},
+		Name:        "test",
+		StateDir:    "tailscale-test",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := outbound.Close(); err != nil {
+			t.Error(err)
+		}
+	})
+
+	packetConn, err := outbound.server.SystemPacketListener(context.Background(), "udp4", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := packetConn.Close(); err != nil {
+		t.Error(err)
+	}
+}


### PR DESCRIPTION
## Problem

When a Tailscale outbound has `dialer-proxy` configured, `tsnet` calls
`SystemPacketListener` with a local bind address such as `:0`. The current
implementation forwards that request to the named proxy dialer together with
an empty remote `AddrPort`.

The proxy dialer expects a valid remote destination, so Tailscale cannot start.
Depending on the selected dialer, this is reported as an invalid tunnel or as:

```text
can't resolve ip: couldn't find ip
```

## Change

- Open `SystemPacketListener` with Mihomo's local packet dialer.
- Preserve the outbound's interface, routing-mark, and IP preference options.
- Add a regression test covering a Tailscale outbound with `dialer-proxy`.

`SystemDialer` is unchanged, so Tailscale control and DERP TCP connections still
use `dialer-proxy`. Only the local UDP socket requested by `tsnet` bypasses the
named proxy dialer.

## Tests

```text
go test ./adapter/outbound -tags with_gvisor -count=1
```

The regression test fails before this change and passes after it.
