### PR TITLE
fix: initialize DNS before NTP

### DIFF
--- a/hub/executor/executor.go
+++ b/hub/executor/executor.go
@@ -102,9 +102,8 @@ func ApplyConfig(cfg *config.Config, force bool) {
 	updateSniffer(cfg.Sniffer)
 	updateHosts(cfg.Hosts)
 	updateGeneral(cfg.General, true)
-	// Initialize DNS before starting NTP because an NTP server may be a hostname.
 	updateDNS(cfg.DNS, cfg.General.IPv6)
-	updateNTP(cfg.NTP)
+	updateNTP(cfg.NTP) // initialize NTP after DNS because an NTP server may be a hostname.
 	updateListeners(cfg.General, cfg.Listeners, force)
 	updateTun(cfg.General) // tun should not care "force"
 	updateIPTables(cfg)

--- a/hub/executor/executor.go
+++ b/hub/executor/executor.go
@@ -102,8 +102,9 @@ func ApplyConfig(cfg *config.Config, force bool) {
 	updateSniffer(cfg.Sniffer)
 	updateHosts(cfg.Hosts)
 	updateGeneral(cfg.General, true)
-	updateNTP(cfg.NTP)
+	// Initialize DNS before starting NTP because an NTP server may be a hostname.
 	updateDNS(cfg.DNS, cfg.General.IPv6)
+	updateNTP(cfg.NTP)
 	updateListeners(cfg.General, cfg.Listeners, force)
 	updateTun(cfg.General) // tun should not care "force"
 	updateIPTables(cfg)


### PR DESCRIPTION
## Summary

Initialize Mihomo DNS before starting the NTP service.

`ntp.server` defaults to the hostname `time.apple.com`. `updateNTP` starts its first sync asynchronously immediately, but the existing startup order creates the DNS resolver only afterwards. On a cold start this makes the first NTP lookup race DNS initialization and can emit a misleading warning even when DNS becomes usable moments later.

## Reproduction

- Mihomo Alpha `e183c58` on OpenWrt, with DNS enabled and NTP enabled (default hostname server).
- On startup the log repeatedly contains:

```text
level=warning msg="Sync time failed: dns resolve failed: couldn't find ip"
```

- In the same startup, DNS is initialized immediately after `updateNTP`; shortly afterwards `pool.ntp.org` and `time.google.com` resolve normally through Mihomo DNS.

## Change

Move `updateDNS(cfg.DNS, cfg.General.IPv6)` before `updateNTP(cfg.NTP)` in `ApplyConfig`.

This keeps all settings and NTP retry behavior unchanged, but ensures the resolver exists before the NTP goroutine begins its initial hostname lookup.

## Validation

```text
gofmt -w hub/executor/executor.go
git diff --check
go test ./hub/executor ./ntp/ntp
```

All commands completed successfully.
