### PR TITLE
feat: configure initial provider load concurrency

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -47,26 +47,27 @@ import (
 // General config
 type General struct {
 	Inbound
-	Mode              T.TunnelMode            `json:"mode"`
-	UnifiedDelay      bool                    `json:"unified-delay"`
-	LogLevel          log.LogLevel            `json:"log-level"`
-	IPv6              bool                    `json:"ipv6"`
-	Interface         string                  `json:"interface-name"`
-	RoutingMark       int                     `json:"routing-mark"`
-	GeoXUrl           GeoXUrl                 `json:"geox-url"`
-	GeoAutoUpdate     bool                    `json:"geo-auto-update"`
-	GeoUpdateInterval int                     `json:"geo-update-interval"`
-	GeodataMode       bool                    `json:"geodata-mode"`
-	GeodataLoader     string                  `json:"geodata-loader"`
-	GeositeMatcher    string                  `json:"geosite-matcher"`
-	TCPConcurrent     bool                    `json:"tcp-concurrent"`
-	FindProcessMode   process.FindProcessMode `json:"find-process-mode"`
-	Sniffing          bool                    `json:"sniffing"`
-	GlobalUA          string                  `json:"global-ua"`
-	ETagSupport       bool                    `json:"etag-support"`
-	KeepAliveIdle     int                     `json:"keep-alive-idle"`
-	KeepAliveInterval int                     `json:"keep-alive-interval"`
-	DisableKeepAlive  bool                    `json:"disable-keep-alive"`
+	Mode                    T.TunnelMode            `json:"mode"`
+	UnifiedDelay            bool                    `json:"unified-delay"`
+	LogLevel                log.LogLevel            `json:"log-level"`
+	IPv6                    bool                    `json:"ipv6"`
+	Interface               string                  `json:"interface-name"`
+	RoutingMark             int                     `json:"routing-mark"`
+	GeoXUrl                 GeoXUrl                 `json:"geox-url"`
+	GeoAutoUpdate           bool                    `json:"geo-auto-update"`
+	GeoUpdateInterval       int                     `json:"geo-update-interval"`
+	GeodataMode             bool                    `json:"geodata-mode"`
+	GeodataLoader           string                  `json:"geodata-loader"`
+	GeositeMatcher          string                  `json:"geosite-matcher"`
+	TCPConcurrent           bool                    `json:"tcp-concurrent"`
+	ProviderLoadConcurrency int                     `json:"provider-load-concurrency"`
+	FindProcessMode         process.FindProcessMode `json:"find-process-mode"`
+	Sniffing                bool                    `json:"sniffing"`
+	GlobalUA                string                  `json:"global-ua"`
+	ETagSupport             bool                    `json:"etag-support"`
+	KeepAliveIdle           int                     `json:"keep-alive-idle"`
+	KeepAliveInterval       int                     `json:"keep-alive-interval"`
+	DisableKeepAlive        bool                    `json:"disable-keep-alive"`
 }
 
 // Inbound config
@@ -436,6 +437,7 @@ type RawConfig struct {
 	GeodataLoader                 string                  `yaml:"geodata-loader" json:"geodata-loader"`
 	GeositeMatcher                string                  `yaml:"geosite-matcher" json:"geosite-matcher"`
 	TCPConcurrent                 bool                    `yaml:"tcp-concurrent" json:"tcp-concurrent"`
+	ProviderLoadConcurrency       int                     `yaml:"provider-load-concurrency" json:"provider-load-concurrency"`
 	FindProcessMode               process.FindProcessMode `yaml:"find-process-mode" json:"find-process-mode"`
 	GlobalClientFingerprint       string                  `yaml:"global-client-fingerprint" json:"global-client-fingerprint"`
 	GlobalUA                      string                  `yaml:"global-ua" json:"global-ua"`
@@ -785,18 +787,19 @@ func parseGeneral(cfg *RawConfig) (*General, error) {
 			ASN:     cfg.GeoXUrl.ASN,
 			GeoSite: cfg.GeoXUrl.GeoSite,
 		},
-		GeoAutoUpdate:     cfg.GeoAutoUpdate,
-		GeoUpdateInterval: cfg.GeoUpdateInterval,
-		GeodataMode:       cfg.GeodataMode,
-		GeodataLoader:     cfg.GeodataLoader,
-		GeositeMatcher:    cfg.GeositeMatcher,
-		TCPConcurrent:     cfg.TCPConcurrent,
-		FindProcessMode:   cfg.FindProcessMode,
-		GlobalUA:          cfg.GlobalUA,
-		ETagSupport:       cfg.ETagSupport,
-		KeepAliveIdle:     cfg.KeepAliveIdle,
-		KeepAliveInterval: cfg.KeepAliveInterval,
-		DisableKeepAlive:  cfg.DisableKeepAlive,
+		GeoAutoUpdate:           cfg.GeoAutoUpdate,
+		GeoUpdateInterval:       cfg.GeoUpdateInterval,
+		GeodataMode:             cfg.GeodataMode,
+		GeodataLoader:           cfg.GeodataLoader,
+		GeositeMatcher:          cfg.GeositeMatcher,
+		TCPConcurrent:           cfg.TCPConcurrent,
+		ProviderLoadConcurrency: cfg.ProviderLoadConcurrency,
+		FindProcessMode:         cfg.FindProcessMode,
+		GlobalUA:                cfg.GlobalUA,
+		ETagSupport:             cfg.ETagSupport,
+		KeepAliveIdle:           cfg.KeepAliveIdle,
+		KeepAliveInterval:       cfg.KeepAliveInterval,
+		DisableKeepAlive:        cfg.DisableKeepAlive,
 	}, nil
 }
 

--- a/hub/executor/executor.go
+++ b/hub/executor/executor.go
@@ -112,9 +112,10 @@ func ApplyConfig(cfg *config.Config, force bool) {
 	tunnel.OnInnerLoading()
 
 	initInnerTcp()
-	loadProvider(cfg.Providers)
+	providerLoadConcurrency := cfg.General.ProviderLoadConcurrency
+	loadProvider(cfg.Providers, providerLoadConcurrency)
 	updateProfile(cfg)
-	loadProvider(cfg.RuleProviders)
+	loadProvider(cfg.RuleProviders, providerLoadConcurrency)
 	runtime.GC()
 	tunnel.OnRunning()
 	updateUpdater(cfg)
@@ -315,7 +316,7 @@ func updateRules(rules []C.Rule, subRules map[string][]C.Rule, ruleProviders map
 	tunnel.UpdateRules(rules, subRules, ruleProviders)
 }
 
-func loadProvider[T P.Provider](providers map[string]T) {
+func loadProvider[T P.Provider](providers map[string]T, concurrency int) {
 	load := func(pv T) {
 		name := pv.Name()
 		if pv.VehicleType() == P.Compatible {
@@ -338,8 +339,14 @@ func loadProvider[T P.Provider](providers map[string]T) {
 		}
 	}
 
+	if concurrency <= 0 {
+		concurrency = concurrentCount
+	} else {
+		log.Infoln("Use provider load concurrency: %d", concurrency)
+	}
+
 	wg := sync.WaitGroup{}
-	ch := make(chan struct{}, concurrentCount)
+	ch := make(chan struct{}, concurrency)
 	for _, pv := range providers {
 		pv := pv
 		wg.Add(1)

--- a/hub/executor/provider_load_concurrency_test.go
+++ b/hub/executor/provider_load_concurrency_test.go
@@ -1,0 +1,19 @@
+package executor
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestProviderLoadConcurrencyConfig(t *testing.T) {
+	config, err := ParseWithBytes([]byte("provider-load-concurrency: 1\n"))
+	require.NoError(t, err)
+	require.Equal(t, 1, config.General.ProviderLoadConcurrency)
+}
+
+func TestProviderLoadConcurrencyDefaultsToArchitectureValue(t *testing.T) {
+	config, err := ParseWithBytes([]byte(""))
+	require.NoError(t, err)
+	require.Zero(t, config.General.ProviderLoadConcurrency)
+}


### PR DESCRIPTION
## Summary

Make initial provider loading concurrency configurable with the new top-level YAML option:

```yaml
provider-load-concurrency: 1
```

When omitted or set to a non-positive value, Mihomo preserves the current architecture-specific default unchanged:

- `amd64` / `arm64` / `386`: unlimited
- other supported architectures: 5
- `mips` / `mipsle`: 1

The configured value applies to both `proxy-providers` and `rule-providers` during initial configuration loading.

## Motivation

On memory-constrained routers, many large rule-providers loaded concurrently can create a large transient allocation peak. A 512 MiB ARM64 OpenWrt device with approximately 300k domain rules previously failed intermittently during startup under the unlimited ARM64 default. Using a local one-line serial cap (`1`) made repeated restart and stop/start tests reliable while preserving the YAML rules and routing behavior.

A config option avoids requiring a private rebuilt Core for this device class, while retaining the current parallel behavior by default for users who value startup speed.

## Semantics

```yaml
# Omitted / 0 / negative: use the existing architecture default.
provider-load-concurrency: 0

# Strictly serial initial provider loading.
provider-load-concurrency: 1

# Bounded parallel loading.
provider-load-concurrency: 2
```

## Validation

```text
gofmt -w config/config.go hub/executor/executor.go hub/executor/provider_load_concurrency_test.go
git diff --check
go test ./hub/executor -run TestProviderLoadConcurrency -count=1 -v
go test . ./hub/executor ./ntp/ntp
GOOS=linux GOARCH=arm64 CGO_ENABLED=0 go build -tags with_gvisor ...
```

All checks passed. The cross-compiled output was verified as a statically linked Linux ARM64 ELF.
