### PR TITLE
fix(openvpn): survive server-initiated soft reset / rekey

### DIFF
--- a/adapter/outbound/openvpn.go
+++ b/adapter/outbound/openvpn.go
@@ -61,6 +61,7 @@ type OpenVPNOption struct {
 	PeerInfo           map[string]string `proxy:"peer-info,omitempty"`
 	Ping               int               `proxy:"ping,omitempty"`
 	PingRestart        int               `proxy:"ping-restart,omitempty"`
+	TranWindow         int               `proxy:"tran-window,omitempty"`
 	HandshakeTimeout   int               `proxy:"handshake-timeout,omitempty"`
 	MTU                int               `proxy:"mtu,omitempty"`
 	UDP                bool              `proxy:"udp,omitempty"`
@@ -75,32 +76,36 @@ func NewOpenVPN(option OpenVPNOption) (*OpenVPN, error) {
 	if option.HandshakeTimeout < 0 {
 		return nil, errors.New("openvpn handshake timeout must be non-negative")
 	}
+	if option.TranWindow < 0 {
+		return nil, errors.New("openvpn tran-window must be non-negative")
+	}
 	option.IPStack.normalize()
 	if err := option.IPStack.validate(); err != nil {
 		return nil, err
 	}
 	cfg := &ovpn.ClientConfig{
-		RemoteHost:     option.Server,
-		RemotePort:     uint16(option.Port),
-		Proto:          option.Proto,
-		Dev:            option.Dev,
-		Cipher:         option.Cipher,
-		DataCiphers:    option.DataCiphers,
-		FallbackCipher: option.DataCipherFallback,
-		Auth:           option.Auth,
-		CompLZO:        option.CompLZO,
-		CA:             []byte(option.CA),
-		Cert:           []byte(option.Cert),
-		Key:            []byte(option.Key),
-		TLSAuth:        []byte(option.TLSAuth),
-		KeyDirection:   option.KeyDirection,
-		TLSCrypt:       []byte(option.TLSCrypt),
-		TLSCryptV2:     []byte(option.TLSCryptV2),
-		Username:       option.Username,
-		Password:       option.Password,
-		PeerInfo:       option.PeerInfo,
-		PingInterval:   time.Duration(option.Ping) * time.Second,
-		PingRestart:    time.Duration(option.PingRestart) * time.Second,
+		RemoteHost:       option.Server,
+		RemotePort:       uint16(option.Port),
+		Proto:            option.Proto,
+		Dev:              option.Dev,
+		Cipher:           option.Cipher,
+		DataCiphers:      option.DataCiphers,
+		FallbackCipher:   option.DataCipherFallback,
+		Auth:             option.Auth,
+		CompLZO:          option.CompLZO,
+		CA:               []byte(option.CA),
+		Cert:             []byte(option.Cert),
+		Key:              []byte(option.Key),
+		TLSAuth:          []byte(option.TLSAuth),
+		KeyDirection:     option.KeyDirection,
+		TLSCrypt:         []byte(option.TLSCrypt),
+		TLSCryptV2:       []byte(option.TLSCryptV2),
+		Username:         option.Username,
+		Password:         option.Password,
+		PeerInfo:         option.PeerInfo,
+		PingInterval:     time.Duration(option.Ping) * time.Second,
+		PingRestart:      time.Duration(option.PingRestart) * time.Second,
+		TransitionWindow: time.Duration(option.TranWindow) * time.Second,
 	}
 	if err := cfg.Prepare(); err != nil {
 		return nil, err

--- a/docs/config.yaml
+++ b/docs/config.yaml
@@ -1443,6 +1443,7 @@ proxies: # socks5
     #   UV_DEVICE_ID: "laptop-001"
     # ping: 10 # 默认值为 0
     # ping-restart: 60 # 默认值为 0
+    # tran-window: 3600 # 旧 data key 在 rekey 后保留的秒数；默认 3600，应与服务端 --tran-window 对齐
     # handshake-timeout: 30 # 单位为秒；配置后握手时不受外层连接超时影响；默认值为 0，表示仅使用外层连接超时
     # mtu: 1500
     udp: true

--- a/transport/openvpn/client.go
+++ b/transport/openvpn/client.go
@@ -40,13 +40,6 @@ type Client struct {
 	tlsConn     atomic.Pointer[tls.Conn]
 	data        *DataChannel
 	outboundKey *DataChannel
-	// newKeyEvidence latches true once a data packet labeled with the
-	// current (newest) key ID decrypted successfully. The peer only labels
-	// outbound packets with a key whose authentication completed
-	// (OpenVPN tls_pre_encrypt / handle_data_channel_packet require
-	// KS_AUTH_TRUE), so this is the reliable signal that the new key has
-	// been activated and can replace the lame-duck for outbound traffic.
-	newKeyEvidence bool
 	// retiring is the previous data-channel epoch, kept during a rekey so
 	// packets still labeled with the old key ID can be decrypted.
 	retiring *DataChannel
@@ -377,8 +370,6 @@ func (c *Client) installDataChannel(newData *DataChannel) {
 	} else {
 		c.outboundKey = newData
 	}
-	// Each epoch starts without evidence of peer activation.
-	c.newKeyEvidence = false
 	if c.dataByKey == nil {
 		c.dataByKey = make(map[uint8]*DataChannel)
 	}
@@ -454,7 +445,7 @@ func (c *Client) writeDataPacket(ctx context.Context, packet []byte, compress bo
 		if !c.retiringExpiry.IsZero() && time.Until(c.retiringExpiry) < outboundPromoteGrace {
 			backstop = true
 		}
-		if c.newKeyEvidence || backstop {
+		if data.PeerActive() || backstop {
 			c.outboundKey = data
 			outbound = data
 		}
@@ -533,7 +524,7 @@ func (c *Client) decryptDataPacket(packet []byte) ([]byte, error) {
 	// excludes the outer opcode/key-ID header, so a wrong key would still
 	// "authenticate").
 	var data *DataChannel
-	var isNewest bool
+	isNewest := false
 	if alt, ok := c.dataByKey[keyID]; ok {
 		data = alt
 		isNewest = alt == c.data
@@ -544,16 +535,20 @@ func (c *Client) decryptDataPacket(packet []byte) ([]byte, error) {
 	if data == nil {
 		return nil, errors.New("openvpn data packet with unknown key id")
 	}
+	// Decrypt first so a forged / corrupted packet does not latch evidence.
+	plain, err := data.Decrypt(packet)
+	if err != nil {
+		return nil, err
+	}
 	if isNewest {
 		// The peer labeled an outbound packet with the current key ID, so it
-		// has activated this epoch (OpenVPN only labels outbound with a
-		// key whose auth completed). Record the evidence under dataLock so
-		// writeDataPacket can promote the outbound key.
-		c.dataLock.Lock()
-		c.newKeyEvidence = true
-		c.dataLock.Unlock()
+		// has activated this epoch (OpenVPN only labels outbound with a key
+		// whose auth completed). Mark the epoch itself: even if a rekey
+		// swapped c.data between the RLock and here, the evidence stays on
+		// this epoch and cannot be attributed to a newer key.
+		data.MarkPeerActive()
 	}
-	return data.Decrypt(packet)
+	return plain, nil
 }
 
 // watchControl monitors the control channel for TLS renegotiation requests

--- a/transport/openvpn/client.go
+++ b/transport/openvpn/client.go
@@ -37,17 +37,25 @@ type Client struct {
 	control *ControlChannel
 	// tlsConn is the active TLS session; swapped on each rekey by the
 	// watchControl goroutine and read by Close. Atomic to avoid racing.
-	tlsConn atomic.Pointer[tls.Conn]
-	data    *DataChannel
+	tlsConn     atomic.Pointer[tls.Conn]
+	data        *DataChannel
+	outboundKey *DataChannel
+	// newKeyEvidence latches true once a data packet labeled with the
+	// current (newest) key ID decrypted successfully. The peer only labels
+	// outbound packets with a key whose authentication completed
+	// (OpenVPN tls_pre_encrypt / handle_data_channel_packet require
+	// KS_AUTH_TRUE), so this is the reliable signal that the new key has
+	// been activated and can replace the lame-duck for outbound traffic.
+	newKeyEvidence bool
 	// retiring is the previous data-channel epoch, kept during a rekey so
 	// packets still labeled with the old key ID can be decrypted.
 	retiring *DataChannel
 	// retiringExpiry is when the retiring epoch is no longer accepted,
 	// mirroring OpenVPN's lame-duck transition_window (default 3600s).
 	retiringExpiry time.Time
-	push     *PushReply
-	authUser string
-	authPass string
+	push           *PushReply
+	authUser       string
+	authPass       string
 	// leftoverTLS is unread TLS control bytes after a key-method-2 record.
 	leftoverTLS []byte
 	// lastRekeyErr is the original renegotiation failure, preserved because
@@ -63,8 +71,8 @@ type Client struct {
 	// recent key exchange.
 	negotiatedCipher string
 
-	// dataLock protects c.data during TLS renegotiation (rekey), where the
-	// DataChannel is atomically replaced.
+	// dataLock protects c.data / c.outboundKey during TLS renegotiation
+	// (rekey), where the DataChannel is atomically replaced.
 	dataLock sync.RWMutex
 
 	runCtx context.Context
@@ -319,7 +327,7 @@ func (c *Client) consumeRekeyPush() error {
 	if reply, rest, ok := takePushReply(c.leftoverTLS); ok {
 		c.leftoverTLS = rest
 		push = mergePushReply(push, reply)
-	} else if bytes.Contains(c.leftoverTLS, []byte("AUTH_FAILED")) {
+	} else if authFailedMsg(c.leftoverTLS) {
 		return authFailedError(c.leftoverTLS)
 	} else if conn := c.tlsConn.Load(); conn != nil {
 		reply, rest, err := readTokenPushReply(conn, c.leftoverTLS)
@@ -338,11 +346,39 @@ func (c *Client) consumeRekeyPush() error {
 	return nil
 }
 
+// outboundPromoteGrace is the safety margin used to promote the outbound
+// data key just before the previous (lame-duck) epoch would stop being
+// accepted by the peer. It exists only as a backstop for asymmetric traffic:
+// the normal promotion path is receive-evidence of the new key.
+const outboundPromoteGrace = 60 * time.Second
+
+// installDataChannel records a freshly derived data epoch. Decryption can
+// immediately use the new key (the peer may label packets with it), but the
+// outbound key is deliberately kept on the previous epoch until there is
+// evidence the peer has activated the new one, mirroring OpenVPN's deferred
+// auth key selection.
+//
+// OpenVPN (ssl.c: tls_select_encryption_key / key_state_soft_reset) only
+// selects a key for outbound encryption once it is KS_AUTH_TRUE. During
+// deferred authentication the new key stays KS_AUTH_DEFERRED — the server
+// sends its key-method-2 record before generating its data key — so the
+// lame-duck key keeps encrypting outbound traffic. Switching outbound to the
+// new key immediately would send packets the server drops ("not authorized
+// (deferred)").
 func (c *Client) installDataChannel(newData *DataChannel) {
 	c.dataLock.Lock()
 	old := c.data
 	c.retiring = old
 	c.data = newData
+	// Outbound keeps the old epoch unless it was never activated (first
+	// handshake), in which case the new key is selected immediately.
+	if old != nil && old.Started() {
+		c.outboundKey = old
+	} else {
+		c.outboundKey = newData
+	}
+	// Each epoch starts without evidence of peer activation.
+	c.newKeyEvidence = false
 	if c.dataByKey == nil {
 		c.dataByKey = make(map[uint8]*DataChannel)
 	}
@@ -393,14 +429,37 @@ func (c *Client) writeDataPacket(ctx context.Context, packet []byte, compress bo
 		return err
 	}
 	defer c.writeSem.Release(1)
-	// Acquire the data channel after securing the write semaphore, since a
-	// rekey may swap c.data while Acquire is blocked.
-	c.dataLock.RLock()
+	// Acquire the outbound key after securing the write semaphore, since a
+	// rekey may swap c.data / c.outboundKey while Acquire is blocked.
+	c.dataLock.Lock()
 	data := c.data
-	c.dataLock.RUnlock()
 	if data == nil {
+		c.dataLock.Unlock()
 		return errors.New("openvpn data channel is not ready")
 	}
+	outbound := c.outboundKey
+	if outbound == nil {
+		outbound = data
+	}
+	// OpenVPN promotes the new key for outbound once the peer's key state
+	// is authenticated (tls_select_encryption_key). We cannot observe the
+	// peer's auth state directly, so we use the equivalent evidence: a data
+	// packet labeled with the new key ID decrypted successfully — the peer
+	// only labels outbound packets with a key whose auth completed. A
+	// just-before-expiry backstop promotes even in asymmetric traffic, so
+	// the lame-duck key is not used past the point the peer stops accepting
+	// it.
+	if outbound != data && outbound != nil {
+		backstop := false
+		if !c.retiringExpiry.IsZero() && time.Until(c.retiringExpiry) < outboundPromoteGrace {
+			backstop = true
+		}
+		if c.newKeyEvidence || backstop {
+			c.outboundKey = data
+			outbound = data
+		}
+	}
+	c.dataLock.Unlock()
 	if compress && c.config.CompLZO == CompLzoYes {
 		compressed, err := lzo1xCompressSafe(packet)
 		if err != nil {
@@ -408,7 +467,7 @@ func (c *Client) writeDataPacket(ctx context.Context, packet []byte, compress bo
 		}
 		packet = compressed
 	}
-	encrypted, err := data.Encrypt(packet)
+	encrypted, err := outbound.Encrypt(packet)
 	if err != nil {
 		return err
 	}
@@ -474,14 +533,25 @@ func (c *Client) decryptDataPacket(packet []byte) ([]byte, error) {
 	// excludes the outer opcode/key-ID header, so a wrong key would still
 	// "authenticate").
 	var data *DataChannel
+	var isNewest bool
 	if alt, ok := c.dataByKey[keyID]; ok {
 		data = alt
+		isNewest = alt == c.data
 	} else if c.retiring != nil && c.retiring.keyID == keyID {
 		data = c.retiring
 	}
 	c.dataLock.RUnlock()
 	if data == nil {
 		return nil, errors.New("openvpn data packet with unknown key id")
+	}
+	if isNewest {
+		// The peer labeled an outbound packet with the current key ID, so it
+		// has activated this epoch (OpenVPN only labels outbound with a
+		// key whose auth completed). Record the evidence under dataLock so
+		// writeDataPacket can promote the outbound key.
+		c.dataLock.Lock()
+		c.newKeyEvidence = true
+		c.dataLock.Unlock()
 	}
 	return data.Decrypt(packet)
 }
@@ -729,12 +799,10 @@ func (c *Client) readPushReply(ctx context.Context) (*PushReply, error) {
 	c.leftoverTLS = nil
 	tmp := make([]byte, 4096)
 	for {
-		if bytes.Contains(buf, []byte("AUTH_FAILED")) {
-			msg := string(buf)
-			if idx := strings.IndexByte(msg, 0); idx >= 0 {
-				msg = msg[:idx]
-			}
-			return nil, fmt.Errorf("openvpn authentication failed: %s", strings.TrimSpace(msg))
+		if authFailedMsg(buf) {
+			// Surface the complete AUTH_FAILED message, not the whole
+			// buffer (which may also contain unrelated control messages).
+			return nil, authFailedError(buf)
 		}
 		if reply, rest, ok := takePushReply(buf); ok {
 			c.leftoverTLS = rest
@@ -790,7 +858,7 @@ func readTokenPushReply(conn pushReadConn, leftover []byte) (*PushReply, []byte,
 	if reply, rest, ok := takePushReply(buf); ok {
 		return reply, rest, nil
 	}
-	if bytes.Contains(buf, []byte("AUTH_FAILED")) {
+	if authFailedMsg(buf) {
 		return nil, buf, authFailedError(buf)
 	}
 	// Clear the temporary read deadline on every return path; a successful
@@ -809,7 +877,7 @@ func readTokenPushReply(conn pushReadConn, leftover []byte) (*PushReply, []byte,
 			buf = append(buf, tmp[:n]...)
 		}
 		// AUTH_FAILED always takes precedence so its diagnostic is kept.
-		if bytes.Contains(buf, []byte("AUTH_FAILED")) {
+		if authFailedMsg(buf) {
 			return nil, buf, authFailedError(buf)
 		}
 		// A complete reply is accepted regardless of a bundled err: the
@@ -830,6 +898,18 @@ func readTokenPushReply(conn pushReadConn, leftover []byte) (*PushReply, []byte,
 	return nil, buf, nil
 }
 
+// authFailedMsg reports whether the TLS plaintext buffer contains a complete
+// AUTH_FAILED control message (not a partial prefix).
+func authFailedMsg(buf []byte) bool {
+	msgs, _ := splitControlMessages(buf)
+	for _, m := range msgs {
+		if bytes.HasPrefix(m, []byte("AUTH_FAILED")) {
+			return true
+		}
+	}
+	return false
+}
+
 func authFailedError(buf []byte) error {
 	msg := string(buf)
 	if idx := strings.IndexByte(msg, 0); idx >= 0 {
@@ -839,36 +919,70 @@ func authFailedError(buf []byte) error {
 }
 
 func takePushReply(buf []byte) (*PushReply, []byte, bool) {
-	if len(buf) == 0 {
-		return nil, nil, false
+	// A single caller handles both the happy path (PUSH_REPLY) and the
+	// failure path (AUTH_FAILED). Walk complete NUL-delimited control
+	// messages in order so a stream like
+	//   AUTH_PENDING\0INFO_PRE,...\0PUSH_REPLY,auth-token ...\0
+	// yields the token even though PUSH_REPLY is not first.
+	msgs, rest := splitControlMessages(buf)
+	if len(msgs) == 0 {
+		return nil, rest, false
 	}
-	// AUTH_FAILED may arrive instead of PUSH_REPLY.
-	if bytes.Contains(buf, []byte("AUTH_FAILED")) {
-		msg := string(buf)
-		if idx := strings.IndexByte(msg, 0); idx >= 0 {
-			msg = msg[:idx]
+	// Scan in order: AUTH_FAILED wins (hard failure), otherwise merge every
+	// complete PUSH_REPLY (OpenVPN may split a push across multiple
+	// messages). Non-push messages (AUTH_PENDING, INFO_PRE, INFO, RESTART,
+	// HALT, ...) are consumed and ignored by the rekey path.
+	var authFailed []byte
+	var reply *PushReply
+	parsed := false
+	for _, m := range msgs {
+		if bytes.HasPrefix(m, []byte("AUTH_FAILED")) {
+			authFailed = m
+			continue
 		}
-		return nil, nil, false
+		if bytes.HasPrefix(m, []byte("PUSH_REPLY")) {
+			r, err := parsePushReplyInner(string(m))
+			if err == nil {
+				reply = mergePushReply(reply, r)
+				parsed = true
+				continue
+			}
+		}
+		// Other complete control messages are deliberately consumed.
 	}
-	if !bytes.Contains(buf, []byte("PUSH_REPLY")) {
-		return nil, nil, false
+	if authFailed != nil {
+		// Surface the failure to callers (readTokenPushReply /
+		// consumeRekeyPush / readPushReply) via the rest-of-buffer, since
+		// takePushReply's ok=false is also used for "not complete yet".
+		return nil, rest, false
 	}
-	// The message is only complete once a NUL terminator is present. A
-	// PUSH_REPLY fragmented across TLS reads must not be committed early
-	// (e.g. right after "ifconfig") or later route / DNS / cipher / token
-	// options would be lost. This matches the reference client, which parses
-	// the full PUSH message after it is fully received.
-	idx := bytes.IndexByte(buf, 0)
-	if idx < 0 {
-		return nil, nil, false
-	}
-	msg := string(buf[:idx])
-	rest := append([]byte(nil), buf[idx+1:]...)
-	reply, err := parsePushReplyInner(msg)
-	if err != nil {
-		return nil, nil, false
+	if !parsed {
+		return nil, rest, false
 	}
 	return reply, rest, true
+}
+
+// splitControlMessages splits a TLS plaintext byte stream into complete
+// NUL-terminated control messages and returns the trailing bytes that do not
+// yet form a complete message. OpenVPN frames every control message with a
+// trailing NUL (send_control_channel_string_dowork), and the client parses
+// them one by one (forward.c check_incoming_control_channel /
+// extract_command_buffer). The trailing incomplete message is returned as
+// rest so it can be re-merged when the next TLS read arrives.
+func splitControlMessages(buf []byte) ([][]byte, []byte) {
+	if len(buf) == 0 {
+		return nil, nil
+	}
+	var msgs [][]byte
+	for {
+		idx := bytes.IndexByte(buf, 0)
+		if idx < 0 {
+			break
+		}
+		msgs = append(msgs, buf[:idx])
+		buf = buf[idx+1:]
+	}
+	return msgs, buf
 }
 
 func mergePushReply(prev, next *PushReply) *PushReply {

--- a/transport/openvpn/client.go
+++ b/transport/openvpn/client.go
@@ -474,10 +474,15 @@ func (c *Client) watchControl() {
 		}
 		// Token-only PUSH_REPLY parked since the last rekey must land in
 		// authPass before this key-method-2 exchange, otherwise the server
-		// rejects the expired token.
+		// rejects the expired token. A parked AUTH_FAILED (deferred auth) is
+		// a hard failure: surface it before starting the next epoch instead
+		// of replacing it with the next renegotiation result.
 		c.consumeQueuedControl()
 		if c.push != nil {
-			c.consumeRekeyPush()
+			if err := c.consumeRekeyPush(); err != nil {
+				c.failControl(fmt.Errorf("consume queued rekey push: %w", err))
+				return
+			}
 		}
 		if err := c.renegotiate(packet); err != nil {
 			c.failControl(fmt.Errorf("renegotiate: %w", err))
@@ -751,18 +756,29 @@ func readTokenPushReply(conn pushReadConn, leftover []byte) (*PushReply, []byte,
 	for attempt := 0; attempt < 2; attempt++ {
 		_ = conn.SetReadDeadline(time.Now().Add(tokenPushReadTimeout))
 		n, err := conn.Read(tmp)
+		// Process bytes before handling err: the io.Reader contract permits
+		// n > 0 with err != nil (e.g. tls.Conn returns (n, io.EOF) when app
+		// data is immediately followed by close_notify).
+		if n > 0 {
+			buf = append(buf, tmp[:n]...)
+			if reply, rest, ok := takePushReply(buf); ok {
+				return reply, rest, nil
+			}
+			if bytes.Contains(buf, []byte("AUTH_FAILED")) {
+				return nil, buf, authFailedError(buf)
+			}
+		}
 		if err != nil {
-			// Timeout (or no more data): keep whatever was buffered.
 			_ = conn.SetReadDeadline(time.Time{})
-			return nil, buf, nil
-		}
-		buf = append(buf, tmp[:n]...)
-		// Parse after every successful read, including the last allowed one.
-		if reply, rest, ok := takePushReply(buf); ok {
-			return reply, rest, nil
-		}
-		if bytes.Contains(buf, []byte("AUTH_FAILED")) {
-			return nil, buf, authFailedError(buf)
+			// Only a real timeout is the optional "no token available yet"
+			// case. EOF, unexpected EOF, and TLS protocol errors must be
+			// surfaced so the rekey does not proceed on a dead control
+			// stream or lose a bundled authentication failure.
+			var netErr net.Error
+			if errors.As(err, &netErr) && netErr.Timeout() {
+				return nil, buf, nil
+			}
+			return nil, buf, err
 		}
 	}
 	return nil, buf, nil

--- a/transport/openvpn/client.go
+++ b/transport/openvpn/client.go
@@ -1025,6 +1025,28 @@ func readTokenPushReply(conn pushReadConn, leftover []byte, extended ...time.Tim
 	if len(extended) > 0 {
 		waitUntil = extended[0]
 	}
+	deferredObserved := false
+	continuationObserved := false
+	promoteWaitPolicy := func(reply *PushReply) {
+		if reply == nil {
+			return
+		}
+		now := time.Now()
+		if reply.AuthPendingTimeout > 0 && !deferredObserved {
+			deadline := now.Add(reply.AuthPendingTimeout)
+			if deadline.After(waitUntil) {
+				waitUntil = deadline
+			}
+			deferredObserved = true
+		}
+		if reply.PushContinuation == 2 && !continuationObserved {
+			deadline := now.Add(renegotiateTimeout)
+			if deadline.After(waitUntil) {
+				waitUntil = deadline
+			}
+			continuationObserved = true
+		}
+	}
 	// Parse the already-buffered bytes first; a reply may be fully present.
 	// Intermediate push-continuation segments are accumulated in acc until
 	// the final segment arrives.
@@ -1032,6 +1054,7 @@ func readTokenPushReply(conn pushReadConn, leftover []byte, extended ...time.Tim
 		return mergePushReply(acc, reply), rest, nil
 	} else if reply != nil {
 		acc = mergePushReply(acc, reply)
+		promoteWaitPolicy(reply)
 		buf = append([]byte(nil), rest...)
 	}
 	if authFailedMsg(buf) {
@@ -1059,6 +1082,7 @@ func readTokenPushReply(conn pushReadConn, leftover []byte, extended ...time.Tim
 		reply, rest, ok := takePushReply(buf)
 		if reply != nil {
 			acc = mergePushReply(acc, reply)
+			promoteWaitPolicy(reply)
 			buf = append([]byte(nil), rest...)
 		}
 		if ok {
@@ -1172,7 +1196,10 @@ func takePushReply(buf []byte) (*PushReply, []byte, bool) {
 // parseAuthPendingTimeout parses an AUTH_PENDING[,timeout N] control message
 // and returns a PushReply carrying the advertised deferred-auth timeout.
 func parseAuthPendingTimeout(msg string) (*PushReply, error) {
-	reply := &PushReply{PeerID: PeerIDUnset}
+	reply := &PushReply{
+		PeerID:             PeerIDUnset,
+		AuthPendingTimeout: authDeferredExpire, // bare AUTH_PENDING fallback
+	}
 	if !strings.HasPrefix(msg, "AUTH_PENDING") {
 		return nil, errors.New("not an auth pending message")
 	}

--- a/transport/openvpn/client.go
+++ b/transport/openvpn/client.go
@@ -328,6 +328,11 @@ func (c *Client) doKeyExchange(ctx context.Context) (*PushReply, error) {
 // pushed by send_push_reply_auth_token. Must be called only when c.push is
 // non-nil (i.e. on rekey, not the initial handshake).
 func (c *Client) consumeRekeyPush() error {
+	// The token/deferred-push exchange owns every transport deadline installed
+	// while it runs. Clear them before returning so standalone parked-TLS calls
+	// cannot leak an operation deadline into the established-channel loop.
+	defer c.clearControlOperationDeadline()
+
 	base := *c.push
 	rekey := &PushReply{PeerID: base.PeerID}
 	push := mergePushReply(c.push, rekey)
@@ -397,6 +402,25 @@ func (c *Client) consumeRekeyPush() error {
 	return nil
 }
 
+func (c *Client) consumeParkedRekeyPush() error {
+	c.consumeQueuedControl()
+	if c.push != nil {
+		return c.consumeRekeyPush()
+	}
+	// Keep the ownership explicit even when no cached push exists.
+	c.clearControlOperationDeadline()
+	return nil
+}
+
+func (c *Client) clearControlOperationDeadline() {
+	if conn := c.tlsConn.Load(); conn != nil {
+		_ = conn.SetDeadline(time.Time{})
+	}
+	if c.controlConn != nil {
+		_ = c.controlConn.SetDeadline(time.Time{})
+	}
+}
+
 // applyAuthPendingTimeout records a server-advertised AUTH_PENDING,timeout N
 // so the outbound-key backstop does not promote the new key while the peer
 // is still in deferred authentication.
@@ -414,13 +438,13 @@ func (c *Client) applyAuthPendingTimeout(reply *PushReply) {
 	keyID := c.control.KeyID()
 	c.dataLock.Lock()
 	if c.data != nil && c.data.keyID == keyID {
-		if deadline.After(c.deferredUntil) {
-			c.deferredUntil = deadline
-		}
-	} else if !c.pendingDeferredSet || c.pendingDeferredKeyID != keyID ||
-		deadline.After(c.pendingDeferredUntil) {
+		// AUTH_PENDING is an update, not an extension-only hint: OpenVPN
+		// replaces the timeout for this authentication session even when the
+		// newly proposed deadline is shorter.
+		c.deferredUntil = deadline
+	} else {
 		// KM2/control has advanced to keyID but installDataChannel has not
-		// installed that data epoch. Stage the deadline with the key ID;
+		// installed that data epoch. Stage the latest deadline with the key ID;
 		// install will transfer it only to the matching epoch.
 		c.pendingDeferredKeyID = keyID
 		c.pendingDeferredUntil = deadline
@@ -440,16 +464,21 @@ func (c *Client) applyAuthPendingTimeout(reply *PushReply) {
 }
 
 func (c *Client) effectiveControlDeadline(fallback time.Time) time.Time {
+	keyID := c.control.KeyID()
 	c.dataLock.RLock()
 	deferred := c.deferredUntil
+	dataMatches := c.data != nil && c.data.keyID == keyID
 	pending := c.pendingDeferredUntil
-	pendingSet := c.pendingDeferredSet
+	pendingMatches := c.pendingDeferredSet && c.pendingDeferredKeyID == keyID
 	c.dataLock.RUnlock()
-	if deferred.After(fallback) {
-		fallback = deferred
+	// AUTH_PENDING replaces the operation timeout for its exact key epoch;
+	// it may extend or shorten the original context deadline. Pending state
+	// wins before installDataChannel, active state afterwards.
+	if pendingMatches {
+		return pending
 	}
-	if pendingSet && pending.After(fallback) {
-		fallback = pending
+	if dataMatches && !deferred.IsZero() {
+		return deferred
 	}
 	return fallback
 }
@@ -562,10 +591,10 @@ func (c *Client) writeDataPacket(ctx context.Context, packet []byte, compress bo
 	backstop := func() bool {
 		// Never promote before the server-advertised deferred-auth deadline
 		// (AUTH_PENDING,timeout N); otherwise a still-deferred peer would
-		// drop the new-key packets. Without an advertisement, fall back to
-		// OpenVPN's auth_deferred_expire window.
+		// drop the new-key packets. The advertisement replaces the default and
+		// may shorten it; without one, use OpenVPN's auth_deferred_expire window.
 		deadline := c.outboundStart.Add(authDeferredExpire)
-		if c.deferredUntil.After(deadline) {
+		if !c.deferredUntil.IsZero() {
 			deadline = c.deferredUntil
 		}
 		return time.Now().After(deadline)
@@ -717,13 +746,12 @@ func (c *Client) watchControl() {
 				// A same-epoch TLS payload (token update / late AUTH_FAILED)
 				// was parked. Consume it now so a deferred authentication
 				// failure is surfaced immediately instead of waiting for the
-				// next soft reset (which may never come).
-				c.consumeQueuedControl()
-				if c.push != nil {
-					if err := c.consumeRekeyPush(); err != nil {
-						c.failControl(fmt.Errorf("consume parked rekey push: %w", err))
-						return
-					}
+				// next soft reset (which may never come). This is a standalone
+				// control operation, so clear every deadline it installs before
+				// returning to the established-channel wait loop.
+				if consumeErr := c.consumeParkedRekeyPush(); consumeErr != nil {
+					c.failControl(fmt.Errorf("consume parked rekey push: %w", consumeErr))
+					return
 				}
 				continue
 			}
@@ -1032,38 +1060,42 @@ func readTokenPushReply(conn pushReadConn, leftover []byte, extended ...time.Tim
 	if len(extended) > 0 {
 		waitUntil = extended[0]
 	}
-	deferredObserved := false
-	continuationObserved := false
+	var authPendingUntil time.Time
+	var continuationUntil time.Time
 	promoteWaitPolicy := func(reply *PushReply) {
 		if reply == nil {
 			return
 		}
 		now := time.Now()
-		if reply.AuthPendingTimeout > 0 && !deferredObserved {
+		if reply.AuthPendingTimeout > 0 {
 			deadline := reply.authPendingUntil
 			if deadline.IsZero() {
 				deadline = now.Add(reply.AuthPendingTimeout)
 				reply.authPendingUntil = deadline
 			}
-			if deadline.After(waitUntil) {
-				waitUntil = deadline
+			// AUTH_PENDING replaces the current deferred-auth timeout, even when
+			// it is shorter. A continuation deadline is an additional upper bound;
+			// the reader waits only until the earlier active operation deadline.
+			authPendingUntil = deadline
+			waitUntil = deadline
+			if !continuationUntil.IsZero() && continuationUntil.Before(waitUntil) {
+				waitUntil = continuationUntil
 			}
 			// ControlConn.Read ACKs each accepted reliable control packet before
 			// exposing its TLS payload. Extend both directions immediately: only
 			// changing the read side leaves those ACK writes on the expired rekey
 			// deadline and prevents the final payload from reaching TLS.
 			_ = conn.SetDeadline(waitUntil)
-			deferredObserved = true
 		}
-		if reply.PushContinuation == 2 && !continuationObserved {
-			deadline := now.Add(renegotiateTimeout)
-			if deadline.After(waitUntil) {
-				waitUntil = deadline
+		if reply.PushContinuation == 2 && continuationUntil.IsZero() {
+			continuationUntil = now.Add(renegotiateTimeout)
+			waitUntil = continuationUntil
+			if !authPendingUntil.IsZero() && authPendingUntil.Before(waitUntil) {
+				waitUntil = authPendingUntil
 			}
 			// A continued PUSH_REPLY is carried by the same reliable channel and
 			// therefore needs the same read+ACK-write deadline propagation.
 			_ = conn.SetDeadline(waitUntil)
-			continuationObserved = true
 		}
 	}
 	// Parse the already-buffered bytes first; a reply may be fully present.

--- a/transport/openvpn/client.go
+++ b/transport/openvpn/client.go
@@ -31,7 +31,9 @@ type Client struct {
 	mux    *PacketMux
 
 	control *ControlChannel
-	tlsConn *tls.Conn
+	// tlsConn is the active TLS session; swapped on each rekey by the
+	// watchControl goroutine and read by Close. Atomic to avoid racing.
+	tlsConn atomic.Pointer[tls.Conn]
 	data    *DataChannel
 	// retiring is the previous data-channel epoch, kept during a rekey so
 	// packets still labeled with the old key ID can be decrypted.
@@ -43,19 +45,10 @@ type Client struct {
 	leftoverTLS []byte
 	// lastRekeyErr is the original renegotiation failure, preserved because
 	// closing the mux otherwise only surfaces "use of closed network connection".
-	lastRekeyErr error
-	rekeyLogOnce sync.Once
+	// Written by watchControl, read by the packet reader: atomic.
+	lastRekeyErr atomic.Pointer[error]
 	// dataByKey keeps active and retiring data channels indexed by key ID.
 	dataByKey map[uint8]*DataChannel
-	// lastSoftResetKey is the key ID from the most recently accepted server
-	// soft-reset packet. Tests inspect this after a rekey.
-	lastSoftResetKey uint8
-	// lastDataKey is the key ID encoded on the current outgoing data header.
-	lastDataKey uint8
-	// lastAuthToken is the most recently pushed auth-token, if any.
-	lastAuthToken string
-	// tlsEpoch is incremented every time a new tls.Conn is installed.
-	tlsEpoch uint32
 	// controlConn is the net.Conn adapter wrapping the control channel.
 	controlConn *ControlConn
 
@@ -145,7 +138,7 @@ func (c *Client) Handshake(ctx context.Context) (*PushReply, error) {
 	if err != nil {
 		return nil, err
 	}
-	_ = c.tlsConn.SetDeadline(time.Time{})
+	_ = c.tlsConn.Load().SetDeadline(time.Time{})
 	go c.watchControl()
 	return push, nil
 }
@@ -158,22 +151,41 @@ func (c *Client) startTLSEpoch(ctx context.Context) error {
 	if c.controlConn == nil {
 		c.controlConn = NewControlConn(c.control)
 	}
-	if c.tlsConn != nil {
+	if c.tlsConn.Load() != nil {
 		// Drop the old epoch without writing close_notify. Close() would send
 		// it on whatever key ID is current and pollute the new control epoch.
-		c.tlsConn = nil
+		c.tlsConn.Store(nil)
 	}
 	c.controlConn.Reset()
 	c.leftoverTLS = nil
-	c.tlsConn = tls.Client(c.controlConn, tlsConfig)
-	c.tlsEpoch++
+	conn := tls.Client(c.controlConn, tlsConfig)
+	c.tlsConn.Store(conn)
 	if deadline, ok := ctx.Deadline(); ok {
-		_ = c.tlsConn.SetDeadline(deadline)
+		_ = conn.SetDeadline(deadline)
 	}
-	if err := c.tlsConn.HandshakeContext(ctx); err != nil {
+	if err := conn.HandshakeContext(ctx); err != nil {
 		return fmt.Errorf("openvpn tls handshake: %w", err)
 	}
+	// Drain any control packets that arrived on the new epoch while the
+	// handshake was reading, so they are not acknowledged and dropped by a
+	// raw ControlChannel read. A TLS-encrypted P_CONTROL_V1 token update
+	// must stay reachable through the active tls.Conn.
+	c.consumeQueuedControl()
 	return nil
+}
+
+// consumeQueuedControl parses queued control packets and routes them back
+// into the active TLS stream so the key-method / PUSH exchange can see them.
+func (c *Client) consumeQueuedControl() {
+	if c.controlConn == nil {
+		return
+	}
+	for _, pkt := range c.control.ReadAll() {
+		if pkt.Opcode != PControlV1 || len(pkt.Payload) == 0 {
+			continue
+		}
+		c.controlConn.UnsafeFeed(pkt.Payload)
+	}
 }
 
 // doKeyExchange performs the OpenVPN key method 2 exchange over the TLS
@@ -199,7 +211,7 @@ func (c *Client) doKeyExchange(ctx context.Context) (*PushReply, error) {
 	if err != nil {
 		return nil, err
 	}
-	if _, err := c.tlsConn.Write(clientBytes); err != nil {
+	if _, err := c.tlsConn.Load().Write(clientBytes); err != nil {
 		return nil, fmt.Errorf("write key method 2 client record: %w", err)
 	}
 	serverRecord, err := c.readServerKeyMethod(ctx)
@@ -219,9 +231,11 @@ func (c *Client) doKeyExchange(ctx context.Context) (*PushReply, error) {
 
 	if c.push != nil {
 		// Authenticated rekeys keep the previous ifconfig / peer-id.
-		// OpenVPN 2.6 often does not send another PUSH_REPLY here.
-		push := mergePushReply(c.push, &PushReply{})
-		c.push = push
+		// OpenVPN 2.6 often does not send another PUSH_REPLY here, but may
+		// push a fresh auth-token (send_push_reply_auth_token) that must be
+		// consumed to keep the next key-method-2 auth from expiring.
+		c.consumeRekeyPush()
+		push := c.push
 		negotiatedCipher, err := c.config.NegotiateCipher(push.DataCiphers, push.Cipher)
 		if err != nil {
 			return nil, fmt.Errorf("negotiate data cipher: %w", err)
@@ -241,7 +255,7 @@ func (c *Client) doKeyExchange(ctx context.Context) (*PushReply, error) {
 		return push, nil
 	}
 
-	if _, err := c.tlsConn.Write([]byte(PushRequest + "\x00")); err != nil {
+	if _, err := c.tlsConn.Load().Write([]byte(PushRequest + "\x00")); err != nil {
 		return nil, fmt.Errorf("write push request: %w", err)
 	}
 	push, err := c.readPushReply(ctx)
@@ -278,12 +292,37 @@ func (c *Client) doKeyExchange(ctx context.Context) (*PushReply, error) {
 	return push, nil
 }
 
+// consumeRekeyPush updates the cached push state after an authenticated
+// rekey: it inherits the previous peer-id and applies any fresh auth-token
+// pushed by send_push_reply_auth_token. Must be called only when c.push is
+// non-nil (i.e. on rekey, not the initial handshake).
+func (c *Client) consumeRekeyPush() {
+	base := *c.push
+	rekey := &PushReply{
+		PeerID: base.PeerID,
+	}
+	push := mergePushReply(c.push, rekey)
+	// A token-only PUSH_REPLY may already be buffered in leftoverTLS
+	// (it follows the server key-method-2 record on the TLS stream),
+	// or arrive in the next control record right after it.
+	if reply, rest, ok := takePushReply(c.leftoverTLS); ok {
+		c.leftoverTLS = rest
+		push = mergePushReply(push, reply)
+	} else if conn := c.tlsConn.Load(); conn != nil {
+		if reply, rest, ok := readTokenPushReply(conn, c.leftoverTLS); ok {
+			c.leftoverTLS = rest
+			push = mergePushReply(push, reply)
+		}
+	}
+	c.push = push
+	c.captureAuthToken(push)
+}
+
 func (c *Client) installDataChannel(newData *DataChannel) {
 	c.dataLock.Lock()
 	old := c.data
 	c.retiring = old
 	c.data = newData
-	c.lastDataKey = newData.keyID
 	if c.dataByKey == nil {
 		c.dataByKey = make(map[uint8]*DataChannel)
 	}
@@ -308,26 +347,10 @@ func (c *Client) captureAuthToken(push *PushReply) {
 	if !ok {
 		return
 	}
-	c.lastAuthToken = pass
 	if user != "" {
 		c.authUser = user
 	}
 	c.authPass = pass
-}
-
-func (c *Client) ActiveDataKeyID() uint8 {
-	c.dataLock.RLock()
-	defer c.dataLock.RUnlock()
-	if c.data == nil {
-		return 0
-	}
-	return c.data.keyID
-}
-
-func (c *Client) LastSoftResetKeyID() uint8 {
-	c.dataLock.RLock()
-	defer c.dataLock.RUnlock()
-	return c.lastSoftResetKey
 }
 
 func (c *Client) WriteIPPacket(ctx context.Context, packet []byte) error {
@@ -371,15 +394,22 @@ func (c *Client) writeDataPacket(ctx context.Context, packet []byte, compress bo
 }
 
 func (c *Client) LastRekeyError() error {
-	return c.lastRekeyErr
+	if err := c.lastRekeyErr.Load(); err != nil {
+		return *err
+	}
+	return nil
 }
 
 func (c *Client) ReadIPPacket(ctx context.Context) ([]byte, error) {
 	for {
 		packet, err := c.mux.ReadDataPacket(ctx)
 		if err != nil {
-			if c.lastRekeyErr != nil {
-				return nil, fmt.Errorf("%w: %v", err, c.lastRekeyErr)
+			// Only surface the rekey failure when the transport is actually
+			// being torn down; do not pollute unrelated read errors.
+			if errors.Is(err, net.ErrClosed) {
+				if rekeyErr := c.LastRekeyError(); rekeyErr != nil {
+					return nil, fmt.Errorf("%w: %v", err, rekeyErr)
+				}
 			}
 			return nil, err
 		}
@@ -429,6 +459,13 @@ func (c *Client) watchControl() {
 			c.failControl(fmt.Errorf("wait for soft reset: %w", err))
 			return
 		}
+		// Token-only PUSH_REPLY parked since the last rekey must land in
+		// authPass before this key-method-2 exchange, otherwise the server
+		// rejects the expired token.
+		c.consumeQueuedControl()
+		if c.push != nil {
+			c.consumeRekeyPush()
+		}
 		if err := c.renegotiate(packet); err != nil {
 			c.failControl(fmt.Errorf("renegotiate: %w", err))
 			return
@@ -437,12 +474,7 @@ func (c *Client) watchControl() {
 }
 
 func (c *Client) failControl(err error) {
-	c.lastRekeyErr = err
-	c.rekeyLogOnce.Do(func() {
-		// Keep the original rekey error; the packet reader otherwise only
-		// sees the secondary "use of closed network connection".
-		_ = err
-	})
+	c.lastRekeyErr.Store(&err)
 	c.cancel()
 	_ = c.mux.Close()
 }
@@ -457,19 +489,23 @@ var errRenegotiateNoTLS = errors.New("cannot renegotiate: tls connection not est
 // 3. Exchange fresh key method 2 records and derive new data channel keys
 // 4. Atomically replace c.data with the new DataChannel
 func (c *Client) renegotiate(serverReset *ControlPacket) error {
-	if c.tlsConn == nil && c.controlConn == nil {
+	if c.tlsConn.Load() == nil && c.controlConn == nil {
 		return errRenegotiateNoTLS
 	}
 	renegCtx, cancel := context.WithTimeout(c.runCtx, renegotiateTimeout)
 	defer cancel()
+	// The rekey is a discrete operation: clear any deadline set by the TLS
+	// handshake so waitForSoftReset can block indefinitely on the next epoch.
+	defer func() {
+		if c.controlConn != nil {
+			_ = c.controlConn.SetDeadline(time.Time{})
+		}
+	}()
 
 	keyID := NextKeyID(c.control.KeyID())
 	if serverReset != nil {
 		keyID = serverReset.KeyID & KeyIDMask
 	}
-	c.dataLock.Lock()
-	c.lastSoftResetKey = keyID
-	c.dataLock.Unlock()
 	// Adopt first so QueueAck lands on the new epoch; AdoptKeyID clears acks.
 	c.control.AdoptKeyID(keyID)
 	if serverReset != nil {
@@ -484,6 +520,16 @@ func (c *Client) renegotiate(serverReset *ControlPacket) error {
 		return fmt.Errorf("send soft reset: %w", err)
 	}
 
+	// On UDP, the client soft reset, TLS ClientHello and the TLS control
+	// records are reliable control messages. Retransmit them while the
+	// rekey is in flight; losing any single datagram would otherwise stall
+	// the rekey until the 30s timeout.
+	var retransmitStop func()
+	if c.config.Proto == ProtoUDP {
+		retransmitStop = c.retransmitRekey(renegCtx)
+		defer retransmitStop()
+	}
+
 	if err := c.startTLSEpoch(renegCtx); err != nil {
 		return fmt.Errorf("tls epoch handshake: %w", err)
 	}
@@ -492,6 +538,35 @@ func (c *Client) renegotiate(serverReset *ControlPacket) error {
 		return fmt.Errorf("rekey exchange: %w", err)
 	}
 	return nil
+}
+
+// retransmitRekey retransmits unacked control messages every
+// ControlRetransmitDelay while the rekey context is live. It is the UDP
+// reliability path for the soft reset, ClientHello and TLS records.
+func (c *Client) retransmitRekey(ctx context.Context) (stop func()) {
+	stopCh := make(chan struct{})
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		ticker := time.NewTicker(ControlRetransmitDelay)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ticker.C:
+				if err := c.control.RetransmitPending(ctx); err != nil {
+					return
+				}
+			case <-stopCh:
+				return
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+	return func() {
+		close(stopCh)
+		<-done
+	}
 }
 
 func (c *Client) SinceSend() time.Duration {
@@ -519,8 +594,8 @@ func (c *Client) Close() error {
 	if c.cancel != nil {
 		c.cancel()
 	}
-	if c.tlsConn != nil {
-		_ = c.tlsConn.Close()
+	if conn := c.tlsConn.Load(); conn != nil {
+		_ = conn.Close()
 	}
 	if c.mux != nil {
 		return c.mux.Close()
@@ -562,20 +637,28 @@ func (c *Client) readServerKeyMethod(ctx context.Context) (*KeyMethod2Record, er
 	c.leftoverTLS = nil
 	tmp := make([]byte, 4096)
 	for {
-		if len(buf) > 0 {
+		// Only treat the record as complete when all four strings are
+		// present. A standard record fragmented across TLS reads must not
+		// be accepted early (its tail would be mistaken for PUSH_REPLY).
+		if complete, _ := RecordComplete(buf); complete {
 			record, consumed, err := ParseServerKeyMethod2RecordConsumed(buf)
-			if err == nil {
-				c.leftoverTLS = append([]byte(nil), buf[consumed:]...)
-				return record, nil
-			}
-			if !strings.Contains(err.Error(), "truncated") && !errors.Is(err, ioStringEOF) {
+			if err != nil {
 				return nil, err
 			}
+			c.leftoverTLS = append([]byte(nil), buf[consumed:]...)
+			return record, nil
+		}
+		// Shortened 2.6 record (options only, then PUSH_REPLY / AUTH_FAILED).
+		// Parse itself inspects the tail; a truncated standard record fails
+		// and we keep reading.
+		if record, consumed, err := ParseServerKeyMethod2RecordConsumed(buf); err == nil {
+			c.leftoverTLS = append([]byte(nil), buf[consumed:]...)
+			return record, nil
 		}
 		if deadline, ok := ctx.Deadline(); ok {
-			_ = c.tlsConn.SetReadDeadline(deadline)
+			_ = c.tlsConn.Load().SetReadDeadline(deadline)
 		}
-		n, err := c.tlsConn.Read(tmp)
+		n, err := c.tlsConn.Load().Read(tmp)
 		if err != nil {
 			return nil, fmt.Errorf("read key method 2 server record: %w", err)
 		}
@@ -600,9 +683,9 @@ func (c *Client) readPushReply(ctx context.Context) (*PushReply, error) {
 			return reply, nil
 		}
 		if deadline, ok := ctx.Deadline(); ok {
-			_ = c.tlsConn.SetReadDeadline(deadline)
+			_ = c.tlsConn.Load().SetReadDeadline(deadline)
 		}
-		n, err := c.tlsConn.Read(tmp)
+		n, err := c.tlsConn.Load().Read(tmp)
 		if err != nil {
 			if errors.Is(err, io.EOF) && len(buf) > 0 {
 				if reply, _, parseErr := ParsePushReplyFlexible(string(buf)); parseErr == nil {
@@ -613,6 +696,41 @@ func (c *Client) readPushReply(ctx context.Context) (*PushReply, error) {
 		}
 		buf = append(buf, tmp[:n]...)
 	}
+}
+
+// tokenPushReadTimeout bounds how long a rekey waits for a token-only
+// PUSH_REPLY after the server key-method-2 record. OpenVPN pushes the fresh
+// auth-token in the same TLS session right after the record, but never
+// blocks on it; a timeout keeps rekeys from stalling.
+const tokenPushReadTimeout = 300 * time.Millisecond
+
+// readTokenPushReply tries to consume a token-only PUSH_REPLY (an
+// auth-token renewal pushed by send_push_reply_auth_token) from the TLS
+// stream, without stalling a rekey. leftover holds bytes already read past
+// the server key-method-2 record. Returns the reply (if any), the updated
+// leftover, and whether a reply was found.
+func readTokenPushReply(conn *tls.Conn, leftover []byte) (*PushReply, []byte, bool) {
+	buf := append([]byte(nil), leftover...)
+	tmp := make([]byte, 4096)
+	// Try leftover first, then read with a short deadline so a record
+	// arriving right after the key-method-2 record is still captured.
+	for attempt := 0; attempt < 2; attempt++ {
+		if reply, rest, ok := takePushReply(buf); ok {
+			return reply, rest, true
+		}
+		if bytes.Contains(buf, []byte("AUTH_FAILED")) {
+			return nil, buf, false
+		}
+		_ = conn.SetReadDeadline(time.Now().Add(tokenPushReadTimeout))
+		n, err := conn.Read(tmp)
+		if err != nil {
+			// Timeout (or no more data): keep whatever was buffered.
+			_ = conn.SetReadDeadline(time.Time{})
+			return nil, buf, false
+		}
+		buf = append(buf, tmp[:n]...)
+	}
+	return nil, buf, false
 }
 
 func takePushReply(buf []byte) (*PushReply, []byte, bool) {

--- a/transport/openvpn/client.go
+++ b/transport/openvpn/client.go
@@ -758,7 +758,8 @@ func readTokenPushReply(conn pushReadConn, leftover []byte) (*PushReply, []byte,
 		n, err := conn.Read(tmp)
 		// Process bytes before handling err: the io.Reader contract permits
 		// n > 0 with err != nil (e.g. tls.Conn returns (n, io.EOF) when app
-		// data is immediately followed by close_notify).
+		// data is immediately followed by close_notify). The bytes are valid
+		// and must be processed before the terminal error.
 		if n > 0 {
 			buf = append(buf, tmp[:n]...)
 		}
@@ -766,27 +767,20 @@ func readTokenPushReply(conn pushReadConn, leftover []byte) (*PushReply, []byte,
 		if bytes.Contains(buf, []byte("AUTH_FAILED")) {
 			return nil, buf, authFailedError(buf)
 		}
-		// Retain a complete reply but still classify err before returning:
-		// a real timeout may carry the reply; EOF / other TLS errors must
-		// be propagated, not hidden by a successful parse.
-		var reply *PushReply
-		var rest []byte
-		if parsed, parsedRest, ok := takePushReply(buf); ok {
-			reply, rest = parsed, parsedRest
+		// A complete reply is accepted regardless of a bundled err: the
+		// logical message is present, so success must not depend on whether
+		// an earlier read happened to read ahead into it (TLS is a byte
+		// stream). EOF is propagated only when no complete message exists.
+		if reply, rest, ok := takePushReply(buf); ok {
+			return reply, rest, nil
 		}
 		if err != nil {
 			_ = conn.SetReadDeadline(time.Time{})
 			var netErr net.Error
 			if errors.As(err, &netErr) && netErr.Timeout() {
-				if reply != nil {
-					return reply, rest, nil
-				}
 				return nil, buf, nil
 			}
 			return nil, buf, err
-		}
-		if reply != nil {
-			return reply, rest, nil
 		}
 	}
 	return nil, buf, nil

--- a/transport/openvpn/client.go
+++ b/transport/openvpn/client.go
@@ -40,6 +40,10 @@ type Client struct {
 	tlsConn     atomic.Pointer[tls.Conn]
 	data        *DataChannel
 	outboundKey *DataChannel
+	// outboundStart is when the current outbound-key selection began. It
+	// anchors the no-evidence promotion deadline (auth_deferred_expire)
+	// used by writeDataPacket when peer evidence never arrives.
+	outboundStart time.Time
 	// retiring is the previous data-channel epoch, kept during a rekey so
 	// packets still labeled with the old key ID can be decrypted.
 	retiring *DataChannel
@@ -339,11 +343,13 @@ func (c *Client) consumeRekeyPush() error {
 	return nil
 }
 
-// outboundPromoteGrace is the safety margin used to promote the outbound
-// data key just before the previous (lame-duck) epoch would stop being
-// accepted by the peer. It exists only as a backstop for asymmetric traffic:
-// the normal promotion path is receive-evidence of the new key.
-const outboundPromoteGrace = 60 * time.Second
+// authDeferredExpire is the no-evidence promotion window for the outbound
+// data key, mirroring OpenVPN's auth_deferred_expire_window
+// (ssl.c): min(handshake_window, reneg_seconds/2). With defaults that is
+// min(60, 1800) = 60s. tls_select_encryption_key switches outbound to the
+// new key once it is authenticated, which happens inside this window, so
+// this is the correct deadline for promoting without peer evidence.
+const authDeferredExpire = 60 * time.Second
 
 // installDataChannel records a freshly derived data epoch. Decryption can
 // immediately use the new key (the peer may label packets with it), but the
@@ -363,13 +369,21 @@ func (c *Client) installDataChannel(newData *DataChannel) {
 	old := c.data
 	c.retiring = old
 	c.data = newData
-	// Outbound keeps the old epoch unless it was never activated (first
-	// handshake), in which case the new key is selected immediately.
-	if old != nil && old.Started() {
+	// Outbound keeps the previous epoch whenever one exists (OpenVPN
+	// key_state_soft_reset moves the old primary into the lame-duck slot and
+	// tls_select_encryption_key keeps selecting it until the new key is
+	// authenticated). Only the very first handshake (old == nil) starts on
+	// the new key immediately. An epoch's send counter is irrelevant: a
+	// quiet / receive-only tunnel never sends on the old key, but the old
+	// key is still the correct outbound candidate during deferred auth.
+	if old != nil {
 		c.outboundKey = old
 	} else {
 		c.outboundKey = newData
 	}
+	// The no-evidence promotion deadline starts when this outbound selection
+	// began (see writeDataPacket).
+	c.outboundStart = time.Now()
 	if c.dataByKey == nil {
 		c.dataByKey = make(map[uint8]*DataChannel)
 	}
@@ -426,7 +440,8 @@ func (c *Client) writeDataPacket(ctx context.Context, packet []byte, compress bo
 	// the outbound key actually needs promoting, so data-plane reads and
 	// writes do not serialize on every packet.
 	backstop := func() bool {
-		return !c.retiringExpiry.IsZero() && time.Until(c.retiringExpiry) < outboundPromoteGrace
+		return !c.outboundStart.IsZero() &&
+			time.Since(c.outboundStart) >= authDeferredExpire
 	}
 	c.dataLock.RLock()
 	data := c.data
@@ -439,13 +454,15 @@ func (c *Client) writeDataPacket(ctx context.Context, packet []byte, compress bo
 		outbound = data
 	}
 	// OpenVPN promotes the new key for outbound once the peer's key state
-	// is authenticated (tls_select_encryption_key). We cannot observe the
-	// peer's auth state directly, so we use the equivalent evidence: a data
-	// packet labeled with the new key ID decrypted successfully — the peer
-	// only labels outbound packets with a key whose auth completed. A
-	// just-before-expiry backstop promotes even in asymmetric traffic, so
-	// the lame-duck key is not used past the point the peer stops accepting
-	// it.
+	// is authenticated (tls_select_encryption_key), which happens within the
+	// new key's auth_deferred_expire window (min(handshake_window,
+	// reneg/2), ~60s with defaults). We cannot observe the peer's auth state
+	// directly, so we use the equivalent evidence: a data packet labeled
+	// with the new key ID decrypted successfully — the peer only labels
+	// outbound packets with a key whose auth completed. As a fallback for
+	// fully one-way tunnels where no evidence ever arrives, promote once the
+	// auth_deferred_expire window elapses, matching OpenVPN's selection
+	// transition — not the old key's destruction time.
 	needPromote := outbound != data && outbound != nil && (data.PeerActive() || backstop())
 	c.dataLock.RUnlock()
 	if needPromote {
@@ -455,6 +472,7 @@ func (c *Client) writeDataPacket(ctx context.Context, packet []byte, compress bo
 		if c.outboundKey != c.data && c.outboundKey != nil &&
 			(c.data.PeerActive() || backstop()) {
 			c.outboundKey = c.data
+			c.outboundStart = time.Now()
 		}
 		outbound = c.outboundKey
 		c.dataLock.Unlock()

--- a/transport/openvpn/client.go
+++ b/transport/openvpn/client.go
@@ -461,6 +461,14 @@ func (c *Client) decryptDataPacket(packet []byte) ([]byte, error) {
 	}
 	_, keyID := parseOpcodeKeyID(packet[0])
 	c.dataLock.RLock()
+	// The retiring (lame-duck) epoch is rejected once the transition window
+	// has elapsed, even though it still has a dataByKey entry (the map hit
+	// must not bypass the expiration check).
+	if c.retiring != nil && c.retiring.keyID == keyID &&
+		!c.retiringExpiry.IsZero() && time.Now().After(c.retiringExpiry) {
+		c.dataLock.RUnlock()
+		return nil, errors.New("openvpn data packet from expired retiring epoch")
+	}
 	// Route strictly by key ID. A packet labeled with an unknown epoch must
 	// be rejected, not silently decrypted with the current key (the CBC HMAC
 	// excludes the outer opcode/key-ID header, so a wrong key would still
@@ -469,11 +477,6 @@ func (c *Client) decryptDataPacket(packet []byte) ([]byte, error) {
 	if alt, ok := c.dataByKey[keyID]; ok {
 		data = alt
 	} else if c.retiring != nil && c.retiring.keyID == keyID {
-		if !c.retiringExpiry.IsZero() && time.Now().After(c.retiringExpiry) {
-			// Lame-duck key expired (transition_window elapsed): reject.
-			c.dataLock.RUnlock()
-			return nil, errors.New("openvpn data packet from expired retiring epoch")
-		}
 		data = c.retiring
 	}
 	c.dataLock.RUnlock()
@@ -790,6 +793,11 @@ func readTokenPushReply(conn pushReadConn, leftover []byte) (*PushReply, []byte,
 	if bytes.Contains(buf, []byte("AUTH_FAILED")) {
 		return nil, buf, authFailedError(buf)
 	}
+	// Clear the temporary read deadline on every return path; a successful
+	// parse must not leave a stale absolute deadline for the next
+	// waitForSoftReset read (the errParkedTLS path runs outside renegotiate's
+	// deadline cleanup).
+	defer func() { _ = conn.SetReadDeadline(time.Time{}) }()
 	for attempt := 0; attempt < 2; attempt++ {
 		_ = conn.SetReadDeadline(time.Now().Add(tokenPushReadTimeout))
 		n, err := conn.Read(tmp)
@@ -812,7 +820,6 @@ func readTokenPushReply(conn pushReadConn, leftover []byte) (*PushReply, []byte,
 			return reply, rest, nil
 		}
 		if err != nil {
-			_ = conn.SetReadDeadline(time.Time{})
 			var netErr net.Error
 			if errors.As(err, &netErr) && netErr.Timeout() {
 				return nil, buf, nil

--- a/transport/openvpn/client.go
+++ b/transport/openvpn/client.go
@@ -46,14 +46,19 @@ type Client struct {
 	// anchors the no-evidence promotion deadline (auth_deferred_expire)
 	// used by writeDataPacket when peer evidence never arrives.
 	outboundStart time.Time
-	// deferredUntil extends the no-evidence promotion deadline when the
-	// server advertised AUTH_PENDING,timeout N (see receive_auth_pending in
-	// OpenVPN push.c): mihomo must not promote the new outbound key while
-	// the peer's key is still KS_AUTH_DEFERRED.
-	deferredUntil time.Time
+	// deferredUntil is the active data epoch's AUTH_PENDING deadline.
+	// pendingDeferred* temporarily stores a deadline received after KM2 but
+	// before installDataChannel creates that epoch. All are protected by
+	// dataLock so packet writes and control-message processing agree on the
+	// same epoch-bound deadline.
+	deferredUntil        time.Time
+	pendingDeferredUntil time.Time
+	pendingDeferredKeyID uint8
+	pendingDeferredSet   bool
 	// pushPending accumulates intermediate push-continuation segments across
 	// TLS reads until the final segment arrives.
-	pushPending *PushReply
+	pushPending             *PushReply
+	pushContinuationPending bool
 	// retiring is the previous data-channel epoch, kept during a rekey so
 	// packets still labeled with the old key ID can be decrypted.
 	retiring *DataChannel
@@ -324,44 +329,68 @@ func (c *Client) doKeyExchange(ctx context.Context) (*PushReply, error) {
 // non-nil (i.e. on rekey, not the initial handshake).
 func (c *Client) consumeRekeyPush() error {
 	base := *c.push
-	rekey := &PushReply{
-		PeerID: base.PeerID,
-	}
+	rekey := &PushReply{PeerID: base.PeerID}
 	push := mergePushReply(c.push, rekey)
-	// A token-only PUSH_REPLY may already be buffered in leftoverTLS
-	// (it follows the server key-method-2 record on the TLS stream),
-	// or arrive in the next control record right after it.
+	complete := false
+	attemptedFinalRead := false
+
+	// AUTH_FAILED has priority over all other coalesced control messages.
+	// Check the original buffer before splitControlMessages consumes it.
+	if authFailedMsg(c.leftoverTLS) {
+		return authFailedError(c.leftoverTLS)
+	}
+
+	// First consume complete messages already read past KM2.
 	reply, rest, ok := takePushReply(c.leftoverTLS)
-	if ok {
-		c.leftoverTLS = rest
-		c.pushPending = nil
-		push = mergePushReply(push, reply)
-		c.applyAuthPendingTimeout(reply)
-	} else if reply != nil {
-		// Intermediate continuation segment(s) or an AUTH_PENDING signal:
-		// accumulate across reads until the final segment arrives.
-		c.leftoverTLS = rest
+	c.leftoverTLS = rest
+	if reply != nil {
 		c.pushPending = mergePushReply(c.pushPending, reply)
 		c.applyAuthPendingTimeout(reply)
-		if authFailedMsg(c.leftoverTLS) {
-			return authFailedError(c.leftoverTLS)
+		if reply.PushContinuation == 2 {
+			c.pushContinuationPending = true
 		}
-	} else if authFailedMsg(c.leftoverTLS) {
+	}
+	if ok {
+		complete = true
+		c.pushContinuationPending = false
+	}
+	if authFailedMsg(c.leftoverTLS) {
 		return authFailedError(c.leftoverTLS)
-	} else if conn := c.tlsConn.Load(); conn != nil {
-		reply, rest, err := readTokenPushReply(conn, c.leftoverTLS)
-		if err != nil {
-			return err
+	}
+
+	// If no final PUSH_REPLY has arrived yet, probe the active TLS stream.
+	// This includes standalone AUTH_PENDING and intermediate continuation
+	// segments; neither is allowed to complete the rekey by itself.
+	if !complete {
+		if conn := c.tlsConn.Load(); conn != nil {
+			attemptedFinalRead = true
+			deadline := c.effectiveControlDeadline(time.Time{})
+			if deadline.IsZero() && c.pushContinuationPending {
+				deadline = time.Now().Add(renegotiateTimeout)
+			}
+			more, newRest, err := readTokenPushReply(conn, c.leftoverTLS, deadline)
+			if err != nil {
+				return err
+			}
+			c.leftoverTLS = newRest
+			if more != nil {
+				c.pushPending = mergePushReply(c.pushPending, more)
+				c.applyAuthPendingTimeout(more)
+				complete = more.HasPushReply && more.PushContinuation != 2
+				if complete {
+					c.pushContinuationPending = false
+				}
+			}
 		}
-		// Preserve buffered bytes even without a complete reply so a
-		// token-only PUSH_REPLY split across reads is not discarded.
-		c.leftoverTLS = rest
-		if reply != nil {
-			c.pushPending = mergePushReply(c.pushPending, reply)
-			c.applyAuthPendingTimeout(reply)
-			push = mergePushReply(push, c.pushPending)
-			c.pushPending = nil
-		}
+	}
+
+	if attemptedFinalRead && (c.pushContinuationPending ||
+		(c.pushPending != nil && !complete && c.pushPending.AuthPendingTimeout > 0)) {
+		return errors.New("openvpn deferred/continued push reply incomplete")
+	}
+	if complete && c.pushPending != nil {
+		push = mergePushReply(push, c.pushPending)
+		c.pushPending = nil
 	}
 	c.push = push
 	c.captureAuthToken(push)
@@ -376,9 +405,47 @@ func (c *Client) applyAuthPendingTimeout(reply *PushReply) {
 		return
 	}
 	deadline := time.Now().Add(reply.AuthPendingTimeout)
-	if deadline.After(c.deferredUntil) {
-		c.deferredUntil = deadline
+	keyID := c.control.KeyID()
+	c.dataLock.Lock()
+	if c.data != nil && c.data.keyID == keyID {
+		if deadline.After(c.deferredUntil) {
+			c.deferredUntil = deadline
+		}
+	} else if !c.pendingDeferredSet || c.pendingDeferredKeyID != keyID ||
+		deadline.After(c.pendingDeferredUntil) {
+		// KM2/control has advanced to keyID but installDataChannel has not
+		// installed that data epoch. Stage the deadline with the key ID;
+		// install will transfer it only to the matching epoch.
+		c.pendingDeferredKeyID = keyID
+		c.pendingDeferredUntil = deadline
+		c.pendingDeferredSet = true
 	}
+	c.dataLock.Unlock()
+
+	// AUTH_PENDING extends the control/deferred-auth operation too. The
+	// original renegotiation deadline may be only 30s; leaving it in place
+	// would make a valid timeout=300 flow fail before the final PUSH_REPLY.
+	if conn := c.tlsConn.Load(); conn != nil {
+		_ = conn.SetDeadline(deadline)
+	}
+	if c.controlConn != nil {
+		_ = c.controlConn.SetDeadline(deadline)
+	}
+}
+
+func (c *Client) effectiveControlDeadline(fallback time.Time) time.Time {
+	c.dataLock.RLock()
+	deferred := c.deferredUntil
+	pending := c.pendingDeferredUntil
+	pendingSet := c.pendingDeferredSet
+	c.dataLock.RUnlock()
+	if deferred.After(fallback) {
+		fallback = deferred
+	}
+	if pendingSet && pending.After(fallback) {
+		fallback = pending
+	}
+	return fallback
 }
 
 // authDeferredExpire is the no-evidence promotion window for the outbound
@@ -420,10 +487,17 @@ func (c *Client) installDataChannel(newData *DataChannel) {
 		c.outboundKey = newData
 	}
 	// The no-evidence promotion deadline starts when this outbound selection
-	// began (see writeDataPacket). Any previously advertised deferred-auth
-	// timeout belongs to the previous epoch and must not carry over.
+	// began. If AUTH_PENDING arrived after KM2 but before the data channel was
+	// installed, transfer only the deadline explicitly tagged for this key
+	// ID; an older epoch's deadline can never carry over.
 	c.outboundStart = time.Now()
 	c.deferredUntil = time.Time{}
+	if c.pendingDeferredSet && c.pendingDeferredKeyID == newData.keyID {
+		c.deferredUntil = c.pendingDeferredUntil
+	}
+	c.pendingDeferredUntil = time.Time{}
+	c.pendingDeferredKeyID = 0
+	c.pendingDeferredSet = false
 	if c.dataByKey == nil {
 		c.dataByKey = make(map[uint8]*DataChannel)
 	}
@@ -851,7 +925,12 @@ func (c *Client) readServerKeyMethod(ctx context.Context) (*KeyMethod2Record, er
 			c.leftoverTLS = append([]byte(nil), buf[consumed:]...)
 			return record, nil
 		}
-		if deadline, ok := ctx.Deadline(); ok {
+		deadline := time.Time{}
+		if d, ok := ctx.Deadline(); ok {
+			deadline = d
+		}
+		deadline = c.effectiveControlDeadline(deadline)
+		if !deadline.IsZero() {
 			_ = c.tlsConn.Load().SetReadDeadline(deadline)
 		}
 		n, err := c.tlsConn.Load().Read(tmp)
@@ -890,7 +969,12 @@ func (c *Client) readPushReply(ctx context.Context) (*PushReply, error) {
 			c.pushPending = mergePushReply(c.pushPending, reply)
 			c.applyAuthPendingTimeout(reply)
 		}
-		if deadline, ok := ctx.Deadline(); ok {
+		deadline := time.Time{}
+		if d, ok := ctx.Deadline(); ok {
+			deadline = d
+		}
+		deadline = c.effectiveControlDeadline(deadline)
+		if !deadline.IsZero() {
 			_ = c.tlsConn.Load().SetReadDeadline(deadline)
 		}
 		n, err := c.tlsConn.Load().Read(tmp)
@@ -933,10 +1017,14 @@ type pushReadConn interface {
 // is parsed after every read including the final one. On timeout the
 // buffered bytes are preserved and a nil reply (no error) is returned, so a
 // partially-received reply is not lost. AUTH_FAILED is a hard error.
-func readTokenPushReply(conn pushReadConn, leftover []byte) (*PushReply, []byte, error) {
+func readTokenPushReply(conn pushReadConn, leftover []byte, extended ...time.Time) (*PushReply, []byte, error) {
 	buf := append([]byte(nil), leftover...)
 	tmp := make([]byte, 4096)
 	var acc *PushReply
+	var waitUntil time.Time
+	if len(extended) > 0 {
+		waitUntil = extended[0]
+	}
 	// Parse the already-buffered bytes first; a reply may be fully present.
 	// Intermediate push-continuation segments are accumulated in acc until
 	// the final segment arrives.
@@ -951,29 +1039,23 @@ func readTokenPushReply(conn pushReadConn, leftover []byte) (*PushReply, []byte,
 	}
 	// Clear the temporary read deadline on every return path; a successful
 	// parse must not leave a stale absolute deadline for the next
-	// waitForSoftReset read (the errParkedTLS path runs outside renegotiate's
-	// deadline cleanup).
+	// waitForSoftReset read.
 	defer func() { _ = conn.SetReadDeadline(time.Time{}) }()
-	for attempt := 0; attempt < 2; attempt++ {
-		_ = conn.SetReadDeadline(time.Now().Add(tokenPushReadTimeout))
+	for attempt := 0; ; attempt++ {
+		readDeadline := time.Now().Add(tokenPushReadTimeout)
+		if !waitUntil.IsZero() && waitUntil.Before(readDeadline) {
+			readDeadline = waitUntil
+		}
+		_ = conn.SetReadDeadline(readDeadline)
 		n, err := conn.Read(tmp)
 		// Process bytes before handling err: the io.Reader contract permits
-		// n > 0 with err != nil (e.g. tls.Conn returns (n, io.EOF) when app
-		// data is immediately followed by close_notify). The bytes are valid
-		// and must be processed before the terminal error.
+		// n > 0 with err != nil. The bytes are valid before the terminal error.
 		if n > 0 {
 			buf = append(buf, tmp[:n]...)
 		}
-		// AUTH_FAILED always takes precedence so its diagnostic is kept.
 		if authFailedMsg(buf) {
 			return nil, buf, authFailedError(buf)
 		}
-		// A complete reply is accepted regardless of a bundled err: the
-		// logical message is present, so success must not depend on whether
-		// an earlier read happened to read ahead into it (TLS is a byte
-		// stream). EOF is propagated only when no complete message exists.
-		// Intermediate push-continuation segments are accumulated until the
-		// final segment completes the reply.
 		reply, rest, ok := takePushReply(buf)
 		if reply != nil {
 			acc = mergePushReply(acc, reply)
@@ -985,17 +1067,22 @@ func readTokenPushReply(conn pushReadConn, leftover []byte) (*PushReply, []byte,
 		if err != nil {
 			var netErr net.Error
 			if errors.As(err, &netErr) && netErr.Timeout() {
-				return nil, buf, nil
+				if !waitUntil.IsZero() && time.Now().Before(waitUntil) {
+					continue
+				}
+				return acc, buf, nil
 			}
 			return nil, buf, err
 		}
+		// Normal token refresh is a short probe. Explicit AUTH_PENDING uses
+		// waitUntil and continues until the server-advertised deadline.
+		if waitUntil.IsZero() && attempt+1 >= 2 {
+			return acc, buf, nil
+		}
+		if !waitUntil.IsZero() && !time.Now().Before(waitUntil) {
+			return acc, buf, nil
+		}
 	}
-	// If the accumulation holds a reply (e.g. a lone AUTH_PENDING signal),
-	// surface it so the caller records the deferred-auth timeout.
-	if acc != nil {
-		return acc, buf, nil
-	}
-	return nil, buf, nil
 }
 
 // authFailedMsg reports whether the TLS plaintext buffer contains a complete
@@ -1043,10 +1130,11 @@ func takePushReply(buf []byte) (*PushReply, []byte, bool) {
 		if bytes.HasPrefix(m, []byte("AUTH_PENDING")) {
 			// OpenVPN send_auth_pending_messages / receive_auth_pending:
 			// AUTH_PENDING,timeout N extends the deferred-auth window. Parse
-			// the advertised timeout so the outbound-key backstop respects it.
+			// the advertised timeout so the outbound-key backstop respects
+			// it. AUTH_PENDING alone is NOT a complete push reply — the
+			// reply is only complete once a final PUSH_REPLY arrives.
 			if r, err := parseAuthPendingTimeout(string(m)); err == nil {
 				reply = mergePushReply(reply, r)
-				parsed = true
 			}
 			continue
 		}
@@ -1084,7 +1172,7 @@ func takePushReply(buf []byte) (*PushReply, []byte, bool) {
 // parseAuthPendingTimeout parses an AUTH_PENDING[,timeout N] control message
 // and returns a PushReply carrying the advertised deferred-auth timeout.
 func parseAuthPendingTimeout(msg string) (*PushReply, error) {
-	reply := &PushReply{}
+	reply := &PushReply{PeerID: PeerIDUnset}
 	if !strings.HasPrefix(msg, "AUTH_PENDING") {
 		return nil, errors.New("not an auth pending message")
 	}
@@ -1132,8 +1220,8 @@ func mergePushReply(prev, next *PushReply) *PushReply {
 	if prev == nil {
 		return next
 	}
-	// Repeatable fields are appended in wire order, deduplicated, so a
-	// continuation segment that repeats an option does not double it.
+	// Repeatable fields are appended in wire order (prev first, then next),
+	// deduplicated, so continuation segments preserve their arrival order.
 	next.Prefixes = appendUniquePrefixes(prev.Prefixes, next.Prefixes)
 	next.Routes = appendUniquePrefixes(prev.Routes, next.Routes)
 	next.DNS = appendUniqueAddrs(prev.DNS, next.DNS)
@@ -1156,15 +1244,23 @@ func mergePushReply(prev, next *PushReply) *PushReply {
 			next.AuthTokenUser = prev.AuthTokenUser
 		}
 	}
+	// A deferred-auth timeout must survive merging: a later merge must not
+	// zero out an already-advertised timeout.
+	if next.AuthPendingTimeout == 0 {
+		next.AuthPendingTimeout = prev.AuthPendingTimeout
+	}
+	next.HasPushReply = next.HasPushReply || prev.HasPushReply
 	return next
 }
 
+// appendUniquePrefixes returns prev followed by the elements of next that are
+// not already present, preserving wire order (prev arrived first).
 func appendUniquePrefixes(prev, next []netip.Prefix) []netip.Prefix {
 	if len(prev) == 0 {
 		return next
 	}
-	out := append([]netip.Prefix(nil), next...)
-	for _, p := range prev {
+	out := append([]netip.Prefix(nil), prev...)
+	for _, p := range next {
 		if !containsPrefix(out, p) {
 			out = append(out, p)
 		}
@@ -1185,8 +1281,8 @@ func appendUniqueAddrs(prev, next []netip.Addr) []netip.Addr {
 	if len(prev) == 0 {
 		return next
 	}
-	out := append([]netip.Addr(nil), next...)
-	for _, a := range prev {
+	out := append([]netip.Addr(nil), prev...)
+	for _, a := range next {
 		if !containsAddr(out, a) {
 			out = append(out, a)
 		}
@@ -1207,8 +1303,8 @@ func appendUniqueStrings(prev, next []string) []string {
 	if len(prev) == 0 {
 		return next
 	}
-	out := append([]string(nil), next...)
-	for _, s := range prev {
+	out := append([]string(nil), prev...)
+	for _, s := range next {
 		if !containsString(out, s) {
 			out = append(out, s)
 		}

--- a/transport/openvpn/client.go
+++ b/transport/openvpn/client.go
@@ -8,6 +8,8 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"net/netip"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -44,6 +46,14 @@ type Client struct {
 	// anchors the no-evidence promotion deadline (auth_deferred_expire)
 	// used by writeDataPacket when peer evidence never arrives.
 	outboundStart time.Time
+	// deferredUntil extends the no-evidence promotion deadline when the
+	// server advertised AUTH_PENDING,timeout N (see receive_auth_pending in
+	// OpenVPN push.c): mihomo must not promote the new outbound key while
+	// the peer's key is still KS_AUTH_DEFERRED.
+	deferredUntil time.Time
+	// pushPending accumulates intermediate push-continuation segments across
+	// TLS reads until the final segment arrives.
+	pushPending *PushReply
 	// retiring is the previous data-channel epoch, kept during a rekey so
 	// packets still labeled with the old key ID can be decrypted.
 	retiring *DataChannel
@@ -321,9 +331,21 @@ func (c *Client) consumeRekeyPush() error {
 	// A token-only PUSH_REPLY may already be buffered in leftoverTLS
 	// (it follows the server key-method-2 record on the TLS stream),
 	// or arrive in the next control record right after it.
-	if reply, rest, ok := takePushReply(c.leftoverTLS); ok {
+	reply, rest, ok := takePushReply(c.leftoverTLS)
+	if ok {
 		c.leftoverTLS = rest
+		c.pushPending = nil
 		push = mergePushReply(push, reply)
+		c.applyAuthPendingTimeout(reply)
+	} else if reply != nil {
+		// Intermediate continuation segment(s) or an AUTH_PENDING signal:
+		// accumulate across reads until the final segment arrives.
+		c.leftoverTLS = rest
+		c.pushPending = mergePushReply(c.pushPending, reply)
+		c.applyAuthPendingTimeout(reply)
+		if authFailedMsg(c.leftoverTLS) {
+			return authFailedError(c.leftoverTLS)
+		}
 	} else if authFailedMsg(c.leftoverTLS) {
 		return authFailedError(c.leftoverTLS)
 	} else if conn := c.tlsConn.Load(); conn != nil {
@@ -335,12 +357,28 @@ func (c *Client) consumeRekeyPush() error {
 		// token-only PUSH_REPLY split across reads is not discarded.
 		c.leftoverTLS = rest
 		if reply != nil {
-			push = mergePushReply(push, reply)
+			c.pushPending = mergePushReply(c.pushPending, reply)
+			c.applyAuthPendingTimeout(reply)
+			push = mergePushReply(push, c.pushPending)
+			c.pushPending = nil
 		}
 	}
 	c.push = push
 	c.captureAuthToken(push)
 	return nil
+}
+
+// applyAuthPendingTimeout records a server-advertised AUTH_PENDING,timeout N
+// so the outbound-key backstop does not promote the new key while the peer
+// is still in deferred authentication.
+func (c *Client) applyAuthPendingTimeout(reply *PushReply) {
+	if reply == nil || reply.AuthPendingTimeout == 0 {
+		return
+	}
+	deadline := time.Now().Add(reply.AuthPendingTimeout)
+	if deadline.After(c.deferredUntil) {
+		c.deferredUntil = deadline
+	}
 }
 
 // authDeferredExpire is the no-evidence promotion window for the outbound
@@ -382,8 +420,10 @@ func (c *Client) installDataChannel(newData *DataChannel) {
 		c.outboundKey = newData
 	}
 	// The no-evidence promotion deadline starts when this outbound selection
-	// began (see writeDataPacket).
+	// began (see writeDataPacket). Any previously advertised deferred-auth
+	// timeout belongs to the previous epoch and must not carry over.
 	c.outboundStart = time.Now()
+	c.deferredUntil = time.Time{}
 	if c.dataByKey == nil {
 		c.dataByKey = make(map[uint8]*DataChannel)
 	}
@@ -440,8 +480,15 @@ func (c *Client) writeDataPacket(ctx context.Context, packet []byte, compress bo
 	// the outbound key actually needs promoting, so data-plane reads and
 	// writes do not serialize on every packet.
 	backstop := func() bool {
-		return !c.outboundStart.IsZero() &&
-			time.Since(c.outboundStart) >= authDeferredExpire
+		// Never promote before the server-advertised deferred-auth deadline
+		// (AUTH_PENDING,timeout N); otherwise a still-deferred peer would
+		// drop the new-key packets. Without an advertisement, fall back to
+		// OpenVPN's auth_deferred_expire window.
+		deadline := c.outboundStart.Add(authDeferredExpire)
+		if c.deferredUntil.After(deadline) {
+			deadline = c.deferredUntil
+		}
+		return time.Now().After(deadline)
 	}
 	c.dataLock.RLock()
 	data := c.data
@@ -825,9 +872,23 @@ func (c *Client) readPushReply(ctx context.Context) (*PushReply, error) {
 			// buffer (which may also contain unrelated control messages).
 			return nil, authFailedError(buf)
 		}
-		if reply, rest, ok := takePushReply(buf); ok {
+		reply, rest, ok := takePushReply(buf)
+		if ok {
 			c.leftoverTLS = rest
+			if c.pushPending != nil {
+				reply = mergePushReply(c.pushPending, reply)
+				c.pushPending = nil
+			}
+			c.applyAuthPendingTimeout(reply)
 			return reply, nil
+		}
+		if reply != nil {
+			// Intermediate continuation segment(s) or AUTH_PENDING seen but
+			// the final PUSH_REPLY segment has not arrived: accumulate and
+			// keep reading.
+			buf = append([]byte(nil), rest...)
+			c.pushPending = mergePushReply(c.pushPending, reply)
+			c.applyAuthPendingTimeout(reply)
 		}
 		if deadline, ok := ctx.Deadline(); ok {
 			_ = c.tlsConn.Load().SetReadDeadline(deadline)
@@ -875,9 +936,15 @@ type pushReadConn interface {
 func readTokenPushReply(conn pushReadConn, leftover []byte) (*PushReply, []byte, error) {
 	buf := append([]byte(nil), leftover...)
 	tmp := make([]byte, 4096)
+	var acc *PushReply
 	// Parse the already-buffered bytes first; a reply may be fully present.
+	// Intermediate push-continuation segments are accumulated in acc until
+	// the final segment arrives.
 	if reply, rest, ok := takePushReply(buf); ok {
-		return reply, rest, nil
+		return mergePushReply(acc, reply), rest, nil
+	} else if reply != nil {
+		acc = mergePushReply(acc, reply)
+		buf = append([]byte(nil), rest...)
 	}
 	if authFailedMsg(buf) {
 		return nil, buf, authFailedError(buf)
@@ -905,8 +972,15 @@ func readTokenPushReply(conn pushReadConn, leftover []byte) (*PushReply, []byte,
 		// logical message is present, so success must not depend on whether
 		// an earlier read happened to read ahead into it (TLS is a byte
 		// stream). EOF is propagated only when no complete message exists.
-		if reply, rest, ok := takePushReply(buf); ok {
-			return reply, rest, nil
+		// Intermediate push-continuation segments are accumulated until the
+		// final segment completes the reply.
+		reply, rest, ok := takePushReply(buf)
+		if reply != nil {
+			acc = mergePushReply(acc, reply)
+			buf = append([]byte(nil), rest...)
+		}
+		if ok {
+			return acc, rest, nil
 		}
 		if err != nil {
 			var netErr net.Error
@@ -915,6 +989,11 @@ func readTokenPushReply(conn pushReadConn, leftover []byte) (*PushReply, []byte,
 			}
 			return nil, buf, err
 		}
+	}
+	// If the accumulation holds a reply (e.g. a lone AUTH_PENDING signal),
+	// surface it so the caller records the deferred-auth timeout.
+	if acc != nil {
+		return acc, buf, nil
 	}
 	return nil, buf, nil
 }
@@ -940,25 +1019,35 @@ func authFailedError(buf []byte) error {
 }
 
 func takePushReply(buf []byte) (*PushReply, []byte, bool) {
-	// A single caller handles both the happy path (PUSH_REPLY) and the
-	// failure path (AUTH_FAILED). Walk complete NUL-delimited control
-	// messages in order so a stream like
-	//   AUTH_PENDING\0INFO_PRE,...\0PUSH_REPLY,auth-token ...\0
+	// A single caller handles the happy path (PUSH_REPLY), the failure path
+	// (AUTH_FAILED) and the deferred-auth signal (AUTH_PENDING,timeout N).
+	// Walk complete NUL-delimited control messages in order so a stream like
+	//   AUTH_PENDING,timeout 60\0INFO_PRE,...\0PUSH_REPLY,auth-token ...\0
 	// yields the token even though PUSH_REPLY is not first.
 	msgs, rest := splitControlMessages(buf)
 	if len(msgs) == 0 {
 		return nil, rest, false
 	}
-	// Scan in order: AUTH_FAILED wins (hard failure), otherwise merge every
-	// complete PUSH_REPLY (OpenVPN may split a push across multiple
-	// messages). Non-push messages (AUTH_PENDING, INFO_PRE, INFO, RESTART,
-	// HALT, ...) are consumed and ignored by the rekey path.
 	var authFailed []byte
 	var reply *PushReply
 	parsed := false
+	// continuationPending is true when the most recent PUSH_REPLY was an
+	// intermediate segment (push-continuation 2) and the final segment has
+	// not arrived yet.
+	continuationPending := false
 	for _, m := range msgs {
 		if bytes.HasPrefix(m, []byte("AUTH_FAILED")) {
 			authFailed = m
+			continue
+		}
+		if bytes.HasPrefix(m, []byte("AUTH_PENDING")) {
+			// OpenVPN send_auth_pending_messages / receive_auth_pending:
+			// AUTH_PENDING,timeout N extends the deferred-auth window. Parse
+			// the advertised timeout so the outbound-key backstop respects it.
+			if r, err := parseAuthPendingTimeout(string(m)); err == nil {
+				reply = mergePushReply(reply, r)
+				parsed = true
+			}
 			continue
 		}
 		if bytes.HasPrefix(m, []byte("PUSH_REPLY")) {
@@ -966,10 +1055,15 @@ func takePushReply(buf []byte) (*PushReply, []byte, bool) {
 			if err == nil {
 				reply = mergePushReply(reply, r)
 				parsed = true
+				// An intermediate continuation segment (push-continuation 2)
+				// means more segments follow; only the final segment (1 or
+				// absent) completes the reply.
+				continuationPending = r.PushContinuation == 2
 				continue
 			}
 		}
-		// Other complete control messages are deliberately consumed.
+		// Other complete control messages (INFO_PRE, INFO, RESTART, HALT,
+		// EXIT, CR_RESPONSE, ...) are deliberately consumed.
 	}
 	if authFailed != nil {
 		// Surface the failure to callers (readTokenPushReply /
@@ -977,10 +1071,35 @@ func takePushReply(buf []byte) (*PushReply, []byte, bool) {
 		// takePushReply's ok=false is also used for "not complete yet".
 		return nil, rest, false
 	}
-	if !parsed {
-		return nil, rest, false
+	if !parsed || continuationPending {
+		// Nothing usable, or only intermediate continuation segments so far:
+		// not a complete reply. The parsed reply (with the intermediate
+		// segments merged and the AUTH_PENDING timeout) is returned so the
+		// caller can accumulate it across reads.
+		return reply, rest, false
 	}
 	return reply, rest, true
+}
+
+// parseAuthPendingTimeout parses an AUTH_PENDING[,timeout N] control message
+// and returns a PushReply carrying the advertised deferred-auth timeout.
+func parseAuthPendingTimeout(msg string) (*PushReply, error) {
+	reply := &PushReply{}
+	if !strings.HasPrefix(msg, "AUTH_PENDING") {
+		return nil, errors.New("not an auth pending message")
+	}
+	rest := strings.TrimPrefix(msg, "AUTH_PENDING")
+	rest = strings.TrimPrefix(rest, ",")
+	// AUTH_PENDING,timeout 300
+	for _, part := range strings.Split(rest, ",") {
+		fields := strings.Fields(part)
+		if len(fields) == 2 && fields[0] == "timeout" {
+			if n, err := strconv.Atoi(fields[1]); err == nil && n > 0 {
+				reply.AuthPendingTimeout = time.Duration(n) * time.Second
+			}
+		}
+	}
+	return reply, nil
 }
 
 // splitControlMessages splits a TLS plaintext byte stream into complete
@@ -1013,23 +1132,17 @@ func mergePushReply(prev, next *PushReply) *PushReply {
 	if prev == nil {
 		return next
 	}
-	if len(next.Prefixes) == 0 {
-		next.Prefixes = prev.Prefixes
-	}
-	if len(next.Routes) == 0 {
-		next.Routes = prev.Routes
-	}
-	if len(next.DNS) == 0 {
-		next.DNS = prev.DNS
-	}
+	// Repeatable fields are appended in wire order, deduplicated, so a
+	// continuation segment that repeats an option does not double it.
+	next.Prefixes = appendUniquePrefixes(prev.Prefixes, next.Prefixes)
+	next.Routes = appendUniquePrefixes(prev.Routes, next.Routes)
+	next.DNS = appendUniqueAddrs(prev.DNS, next.DNS)
+	next.DataCiphers = appendUniqueStrings(prev.DataCiphers, next.DataCiphers)
 	if next.PeerID == PeerIDUnset {
 		next.PeerID = prev.PeerID
 	}
 	if next.Cipher == "" {
 		next.Cipher = prev.Cipher
-	}
-	if len(next.DataCiphers) == 0 {
-		next.DataCiphers = prev.DataCiphers
 	}
 	if !next.Redirect {
 		next.Redirect = prev.Redirect
@@ -1044,6 +1157,72 @@ func mergePushReply(prev, next *PushReply) *PushReply {
 		}
 	}
 	return next
+}
+
+func appendUniquePrefixes(prev, next []netip.Prefix) []netip.Prefix {
+	if len(prev) == 0 {
+		return next
+	}
+	out := append([]netip.Prefix(nil), next...)
+	for _, p := range prev {
+		if !containsPrefix(out, p) {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+func containsPrefix(list []netip.Prefix, p netip.Prefix) bool {
+	for _, q := range list {
+		if q == p {
+			return true
+		}
+	}
+	return false
+}
+
+func appendUniqueAddrs(prev, next []netip.Addr) []netip.Addr {
+	if len(prev) == 0 {
+		return next
+	}
+	out := append([]netip.Addr(nil), next...)
+	for _, a := range prev {
+		if !containsAddr(out, a) {
+			out = append(out, a)
+		}
+	}
+	return out
+}
+
+func containsAddr(list []netip.Addr, a netip.Addr) bool {
+	for _, b := range list {
+		if b == a {
+			return true
+		}
+	}
+	return false
+}
+
+func appendUniqueStrings(prev, next []string) []string {
+	if len(prev) == 0 {
+		return next
+	}
+	out := append([]string(nil), next...)
+	for _, s := range prev {
+		if !containsString(out, s) {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+func containsString(list []string, s string) bool {
+	for _, t := range list {
+		if t == s {
+			return true
+		}
+	}
+	return false
 }
 
 func (c *Client) tlsConfig() (*tls.Config, error) {

--- a/transport/openvpn/client.go
+++ b/transport/openvpn/client.go
@@ -761,24 +761,32 @@ func readTokenPushReply(conn pushReadConn, leftover []byte) (*PushReply, []byte,
 		// data is immediately followed by close_notify).
 		if n > 0 {
 			buf = append(buf, tmp[:n]...)
-			if reply, rest, ok := takePushReply(buf); ok {
-				return reply, rest, nil
-			}
-			if bytes.Contains(buf, []byte("AUTH_FAILED")) {
-				return nil, buf, authFailedError(buf)
-			}
+		}
+		// AUTH_FAILED always takes precedence so its diagnostic is kept.
+		if bytes.Contains(buf, []byte("AUTH_FAILED")) {
+			return nil, buf, authFailedError(buf)
+		}
+		// Retain a complete reply but still classify err before returning:
+		// a real timeout may carry the reply; EOF / other TLS errors must
+		// be propagated, not hidden by a successful parse.
+		var reply *PushReply
+		var rest []byte
+		if parsed, parsedRest, ok := takePushReply(buf); ok {
+			reply, rest = parsed, parsedRest
 		}
 		if err != nil {
 			_ = conn.SetReadDeadline(time.Time{})
-			// Only a real timeout is the optional "no token available yet"
-			// case. EOF, unexpected EOF, and TLS protocol errors must be
-			// surfaced so the rekey does not proceed on a dead control
-			// stream or lose a bundled authentication failure.
 			var netErr net.Error
 			if errors.As(err, &netErr) && netErr.Timeout() {
+				if reply != nil {
+					return reply, rest, nil
+				}
 				return nil, buf, nil
 			}
 			return nil, buf, err
+		}
+		if reply != nil {
+			return reply, rest, nil
 		}
 	}
 	return nil, buf, nil

--- a/transport/openvpn/client.go
+++ b/transport/openvpn/client.go
@@ -63,11 +63,14 @@ type Client struct {
 	// packets still labeled with the old key ID can be decrypted.
 	retiring *DataChannel
 	// retiringExpiry is when the retiring epoch is no longer accepted,
-	// mirroring OpenVPN's lame-duck transition_window (default 3600s).
-	retiringExpiry time.Time
-	push           *PushReply
-	authUser       string
-	authPass       string
+	// mirroring OpenVPN's lame-duck transition_window. pendingRetiringExpiry
+	// anchors that lifetime when soft reset starts; installDataChannel must not
+	// restart it after TLS/KM2 work has already consumed part of the window.
+	retiringExpiry        time.Time
+	pendingRetiringExpiry time.Time
+	push                  *PushReply
+	authUser              string
+	authPass              string
 	// leftoverTLS is unread TLS control bytes after a key-method-2 record.
 	leftoverTLS []byte
 	// lastRekeyErr is the original renegotiation failure, preserved because
@@ -509,6 +512,22 @@ func (c *Client) effectiveControlDeadline(fallback time.Time) time.Time {
 // this is the correct deadline for promoting without peer evidence.
 const authDeferredExpire = 60 * time.Second
 
+func (c *Client) transitionWindow() time.Duration {
+	window := transitionWindow
+	if c.config != nil && c.config.TransitionWindow > 0 {
+		window = c.config.TransitionWindow
+	}
+	return window
+}
+
+func (c *Client) beginRetiringWindow() time.Time {
+	deadline := time.Now().Add(c.transitionWindow())
+	c.dataLock.Lock()
+	c.pendingRetiringExpiry = deadline
+	c.dataLock.Unlock()
+	return deadline
+}
+
 // installDataChannel records a freshly derived data epoch. Decryption can
 // immediately use the new key (the peer may label packets with it), but the
 // outbound key is deliberately kept on the previous epoch until there is
@@ -558,13 +577,18 @@ func (c *Client) installDataChannel(newData *DataChannel) {
 		c.dataByKey[old.keyID] = old
 	}
 	c.dataByKey[newData.keyID] = newData
-	// The previous epoch is a lame-duck key: keep it only for the OpenVPN
-	// transition_window (default 3600s), then it must not be accepted.
+	// The previous epoch is a lame-duck key: keep it only for the configured
+	// OpenVPN transition_window. Zero selects OpenVPN's 3600-second default.
 	if old != nil {
-		c.retiringExpiry = time.Now().Add(transitionWindow)
+		if !c.pendingRetiringExpiry.IsZero() {
+			c.retiringExpiry = c.pendingRetiringExpiry
+		} else {
+			c.retiringExpiry = time.Now().Add(c.transitionWindow())
+		}
 	} else {
 		c.retiringExpiry = time.Time{}
 	}
+	c.pendingRetiringExpiry = time.Time{}
 	// Keep at most the current and previous epoch.
 	for id := range c.dataByKey {
 		if id != newData.keyID && (old == nil || id != old.keyID) {
@@ -606,16 +630,15 @@ func (c *Client) writeDataPacket(ctx context.Context, packet []byte, compress bo
 	// read lock for the common path and only upgrade to the write lock when
 	// the outbound key actually needs promoting, so data-plane reads and
 	// writes do not serialize on every packet.
-	backstop := func() bool {
-		// Never promote before the server-advertised deferred-auth deadline
-		// (AUTH_PENDING,timeout N); otherwise a still-deferred peer would
-		// drop the new-key packets. The advertisement replaces the default and
-		// may shorten it; without one, use OpenVPN's auth_deferred_expire window.
-		deadline := c.outboundStart.Add(authDeferredExpire)
-		if !c.deferredUntil.IsZero() {
-			deadline = c.deferredUntil
-		}
-		return time.Now().After(deadline)
+	// The no-evidence selection window is independent of AUTH_PENDING. The
+	// server-advertised timeout controls deferred authentication/push handling;
+	// it cannot keep a retiring data key selected past auth_deferred_expire.
+	selectionExpired := func() bool {
+		return time.Now().After(c.outboundStart.Add(authDeferredExpire))
+	}
+	retiringExpired := func() bool {
+		return c.retiring != nil && c.outboundKey == c.retiring &&
+			!c.retiringExpiry.IsZero() && time.Now().After(c.retiringExpiry)
 	}
 	c.dataLock.RLock()
 	data := c.data
@@ -629,22 +652,20 @@ func (c *Client) writeDataPacket(ctx context.Context, packet []byte, compress bo
 	}
 	// OpenVPN promotes the new key for outbound once the peer's key state
 	// is authenticated (tls_select_encryption_key), which happens within the
-	// new key's auth_deferred_expire window (min(handshake_window,
-	// reneg/2), ~60s with defaults). We cannot observe the peer's auth state
-	// directly, so we use the equivalent evidence: a data packet labeled
-	// with the new key ID decrypted successfully — the peer only labels
-	// outbound packets with a key whose auth completed. As a fallback for
-	// fully one-way tunnels where no evidence ever arrives, promote once the
-	// auth_deferred_expire window elapses, matching OpenVPN's selection
-	// transition — not the old key's destruction time.
-	needPromote := outbound != data && outbound != nil && (data.PeerActive() || backstop())
+	// new key's independent auth_deferred_expire window. We cannot observe
+	// that state directly, so successful new-key traffic is early evidence;
+	// fully one-way tunnels fall back to auth_deferred_expire. The retiring
+	// key's transition expiry is a separate hard upper bound: once expired,
+	// continuing to transmit with it is never valid.
+	needPromote := outbound != data && outbound != nil &&
+		(data.PeerActive() || selectionExpired() || retiringExpired())
 	c.dataLock.RUnlock()
 	if needPromote {
 		// Upgrade to the write lock and re-check: a rekey may have completed
 		// between the read and the write lock.
 		c.dataLock.Lock()
 		if c.outboundKey != c.data && c.outboundKey != nil &&
-			(c.data.PeerActive() || backstop()) {
+			(c.data.PeerActive() || selectionExpired() || retiringExpired()) {
 			c.outboundKey = c.data
 			c.outboundStart = time.Now()
 		}
@@ -823,6 +844,11 @@ func (c *Client) renegotiate(serverReset *ControlPacket) error {
 			_ = c.controlConn.SetDeadline(time.Time{})
 		}
 	}()
+
+	// OpenVPN starts the lame-duck transition window at soft reset, before
+	// TLS and KM2 processing. Anchor it here so data-channel installation
+	// cannot restart the old key's usable lifetime.
+	c.beginRetiringWindow()
 
 	keyID := NextKeyID(c.control.KeyID())
 	if serverReset != nil {

--- a/transport/openvpn/client.go
+++ b/transport/openvpn/client.go
@@ -404,7 +404,13 @@ func (c *Client) applyAuthPendingTimeout(reply *PushReply) {
 	if reply == nil || reply.AuthPendingTimeout == 0 {
 		return
 	}
-	deadline := time.Now().Add(reply.AuthPendingTimeout)
+	deadline := reply.authPendingUntil
+	if deadline.IsZero() {
+		// Backward-compatible fallback for internally constructed replies. Wire
+		// replies are stamped when AUTH_PENDING is parsed, so their timeout is
+		// never restarted by a later final PUSH_REPLY.
+		deadline = time.Now().Add(reply.AuthPendingTimeout)
+	}
 	keyID := c.control.KeyID()
 	c.dataLock.Lock()
 	if c.data != nil && c.data.keyID == keyID {
@@ -1005,6 +1011,7 @@ var errAuthFailed = errors.New("openvpn authentication failed")
 // handshake.
 type pushReadConn interface {
 	Read(p []byte) (int, error)
+	SetDeadline(t time.Time) error
 	SetReadDeadline(t time.Time) error
 }
 
@@ -1033,10 +1040,19 @@ func readTokenPushReply(conn pushReadConn, leftover []byte, extended ...time.Tim
 		}
 		now := time.Now()
 		if reply.AuthPendingTimeout > 0 && !deferredObserved {
-			deadline := now.Add(reply.AuthPendingTimeout)
+			deadline := reply.authPendingUntil
+			if deadline.IsZero() {
+				deadline = now.Add(reply.AuthPendingTimeout)
+				reply.authPendingUntil = deadline
+			}
 			if deadline.After(waitUntil) {
 				waitUntil = deadline
 			}
+			// ControlConn.Read ACKs each accepted reliable control packet before
+			// exposing its TLS payload. Extend both directions immediately: only
+			// changing the read side leaves those ACK writes on the expired rekey
+			// deadline and prevents the final payload from reaching TLS.
+			_ = conn.SetDeadline(waitUntil)
 			deferredObserved = true
 		}
 		if reply.PushContinuation == 2 && !continuationObserved {
@@ -1044,6 +1060,9 @@ func readTokenPushReply(conn pushReadConn, leftover []byte, extended ...time.Tim
 			if deadline.After(waitUntil) {
 				waitUntil = deadline
 			}
+			// A continued PUSH_REPLY is carried by the same reliable channel and
+			// therefore needs the same read+ACK-write deadline propagation.
+			_ = conn.SetDeadline(waitUntil)
 			continuationObserved = true
 		}
 	}
@@ -1060,9 +1079,11 @@ func readTokenPushReply(conn pushReadConn, leftover []byte, extended ...time.Tim
 	if authFailedMsg(buf) {
 		return nil, buf, authFailedError(buf)
 	}
-	// Clear the temporary read deadline on every return path; a successful
-	// parse must not leave a stale absolute deadline for the next
-	// waitForSoftReset read.
+	// Restore only the temporary read deadline on every return path. A
+	// successful parse must not leave a short probe deadline for the next
+	// waitForSoftReset read. SetDeadline above deliberately leaves the
+	// AUTH_PENDING/continuation write side extended so late reliable ACKs can
+	// still be emitted; the owner clears both sides when the operation ends.
 	defer func() { _ = conn.SetReadDeadline(time.Time{}) }()
 	for attempt := 0; ; attempt++ {
 		readDeadline := time.Now().Add(tokenPushReadTimeout)
@@ -1214,6 +1235,7 @@ func parseAuthPendingTimeout(msg string) (*PushReply, error) {
 			}
 		}
 	}
+	reply.authPendingUntil = time.Now().Add(reply.AuthPendingTimeout)
 	return reply, nil
 }
 
@@ -1271,10 +1293,12 @@ func mergePushReply(prev, next *PushReply) *PushReply {
 			next.AuthTokenUser = prev.AuthTokenUser
 		}
 	}
-	// A deferred-auth timeout must survive merging: a later merge must not
-	// zero out an already-advertised timeout.
+	// A deferred-auth timeout must survive merging into a later non-pending
+	// PUSH_REPLY. Carry its observation-anchored deadline with the duration;
+	// a genuinely later AUTH_PENDING keeps its own newly observed deadline.
 	if next.AuthPendingTimeout == 0 {
 		next.AuthPendingTimeout = prev.AuthPendingTimeout
+		next.authPendingUntil = prev.authPendingUntil
 	}
 	next.HasPushReply = next.HasPushReply || prev.HasPushReply
 	return next

--- a/transport/openvpn/client.go
+++ b/transport/openvpn/client.go
@@ -328,6 +328,18 @@ func (c *Client) doKeyExchange(ctx context.Context) (*PushReply, error) {
 // pushed by send_push_reply_auth_token. Must be called only when c.push is
 // non-nil (i.e. on rekey, not the initial handshake).
 func (c *Client) consumeRekeyPush() error {
+	var conn pushReadConn
+	if tlsConn := c.tlsConn.Load(); tlsConn != nil {
+		conn = tlsConn
+	}
+	return c.consumeRekeyPushFrom(conn, readTokenPushReply)
+}
+
+// tokenPushReader is injected by deterministic lifecycle tests; production
+// always uses readTokenPushReply with the active TLS connection.
+type tokenPushReader func(pushReadConn, []byte, ...time.Time) (*PushReply, []byte, error)
+
+func (c *Client) consumeRekeyPushFrom(conn pushReadConn, readFinal tokenPushReader) error {
 	// The token/deferred-push exchange owns every transport deadline installed
 	// while it runs. Clear them before returning so standalone parked-TLS calls
 	// cannot leak an operation deadline into the established-channel loop.
@@ -366,25 +378,25 @@ func (c *Client) consumeRekeyPush() error {
 	// If no final PUSH_REPLY has arrived yet, probe the active TLS stream.
 	// This includes standalone AUTH_PENDING and intermediate continuation
 	// segments; neither is allowed to complete the rekey by itself.
-	if !complete {
-		if conn := c.tlsConn.Load(); conn != nil {
-			attemptedFinalRead = true
-			deadline := c.effectiveControlDeadline(time.Time{})
-			if deadline.IsZero() && c.pushContinuationPending {
-				deadline = time.Now().Add(renegotiateTimeout)
-			}
-			more, newRest, err := readTokenPushReply(conn, c.leftoverTLS, deadline)
-			if err != nil {
-				return err
-			}
-			c.leftoverTLS = newRest
-			if more != nil {
-				c.pushPending = mergePushReply(c.pushPending, more)
-				c.applyAuthPendingTimeout(more)
-				complete = more.HasPushReply && more.PushContinuation != 2
-				if complete {
-					c.pushContinuationPending = false
-				}
+	if !complete && conn != nil {
+		attemptedFinalRead = true
+		deadline := c.effectiveControlDeadline(time.Time{})
+		if deadline.IsZero() && c.pushContinuationPending {
+			deadline = time.Now().Add(renegotiateTimeout)
+		}
+		more, newRest, err := readFinal(conn, c.leftoverTLS, deadline)
+		if err != nil {
+			return err
+		}
+		c.leftoverTLS = newRest
+		if more != nil {
+			c.pushPending = mergePushReply(c.pushPending, more)
+			c.applyAuthPendingTimeout(more)
+			complete = more.HasPushReply && more.PushContinuation != 2
+			if more.HasPushReply {
+				// Persist continuation state regardless of whether it was already
+				// buffered or was first discovered inside the final reader.
+				c.pushContinuationPending = more.PushContinuation == 2
 			}
 		}
 	}

--- a/transport/openvpn/client.go
+++ b/transport/openvpn/client.go
@@ -233,8 +233,12 @@ func (c *Client) doKeyExchange(ctx context.Context) (*PushReply, error) {
 		// Authenticated rekeys keep the previous ifconfig / peer-id.
 		// OpenVPN 2.6 often does not send another PUSH_REPLY here, but may
 		// push a fresh auth-token (send_push_reply_auth_token) that must be
-		// consumed to keep the next key-method-2 auth from expiring.
-		c.consumeRekeyPush()
+		// consumed to keep the next key-method-2 auth from expiring. If the
+		// server rejected the token (AUTH_FAILED), abort before installing a
+		// new data channel rather than proceeding with a stale credential.
+		if err := c.consumeRekeyPush(); err != nil {
+			return nil, fmt.Errorf("consume rekey push: %w", err)
+		}
 		push := c.push
 		negotiatedCipher, err := c.config.NegotiateCipher(push.DataCiphers, push.Cipher)
 		if err != nil {
@@ -296,7 +300,7 @@ func (c *Client) doKeyExchange(ctx context.Context) (*PushReply, error) {
 // rekey: it inherits the previous peer-id and applies any fresh auth-token
 // pushed by send_push_reply_auth_token. Must be called only when c.push is
 // non-nil (i.e. on rekey, not the initial handshake).
-func (c *Client) consumeRekeyPush() {
+func (c *Client) consumeRekeyPush() error {
 	base := *c.push
 	rekey := &PushReply{
 		PeerID: base.PeerID,
@@ -308,14 +312,23 @@ func (c *Client) consumeRekeyPush() {
 	if reply, rest, ok := takePushReply(c.leftoverTLS); ok {
 		c.leftoverTLS = rest
 		push = mergePushReply(push, reply)
+	} else if bytes.Contains(c.leftoverTLS, []byte("AUTH_FAILED")) {
+		return authFailedError(c.leftoverTLS)
 	} else if conn := c.tlsConn.Load(); conn != nil {
-		if reply, rest, ok := readTokenPushReply(conn, c.leftoverTLS); ok {
-			c.leftoverTLS = rest
+		reply, rest, err := readTokenPushReply(conn, c.leftoverTLS)
+		if err != nil {
+			return err
+		}
+		// Preserve buffered bytes even without a complete reply so a
+		// token-only PUSH_REPLY split across reads is not discarded.
+		c.leftoverTLS = rest
+		if reply != nil {
 			push = mergePushReply(push, reply)
 		}
 	}
 	c.push = push
 	c.captureAuthToken(push)
+	return nil
 }
 
 func (c *Client) installDataChannel(newData *DataChannel) {
@@ -704,33 +717,63 @@ func (c *Client) readPushReply(ctx context.Context) (*PushReply, error) {
 // blocks on it; a timeout keeps rekeys from stalling.
 const tokenPushReadTimeout = 300 * time.Millisecond
 
+// errAuthFailed is returned when a rekey's token exchange reports
+// AUTH_FAILED instead of a renewed token.
+var errAuthFailed = errors.New("openvpn authentication failed")
+
+// pushReadConn is the subset of tls.Conn that readTokenPushReply needs, so
+// tests can inject a deterministic byte-stream reader without a full TLS
+// handshake.
+type pushReadConn interface {
+	Read(p []byte) (int, error)
+	SetReadDeadline(t time.Time) error
+}
+
 // readTokenPushReply tries to consume a token-only PUSH_REPLY (an
 // auth-token renewal pushed by send_push_reply_auth_token) from the TLS
 // stream, without stalling a rekey. leftover holds bytes already read past
-// the server key-method-2 record. Returns the reply (if any), the updated
-// leftover, and whether a reply was found.
-func readTokenPushReply(conn *tls.Conn, leftover []byte) (*PushReply, []byte, bool) {
+// the server key-method-2 record.
+//
+// TLS is a byte stream: the reply may be split across reads, so the buffer
+// is parsed after every read including the final one. On timeout the
+// buffered bytes are preserved and a nil reply (no error) is returned, so a
+// partially-received reply is not lost. AUTH_FAILED is a hard error.
+func readTokenPushReply(conn pushReadConn, leftover []byte) (*PushReply, []byte, error) {
 	buf := append([]byte(nil), leftover...)
 	tmp := make([]byte, 4096)
-	// Try leftover first, then read with a short deadline so a record
-	// arriving right after the key-method-2 record is still captured.
+	// Parse the already-buffered bytes first; a reply may be fully present.
+	if reply, rest, ok := takePushReply(buf); ok {
+		return reply, rest, nil
+	}
+	if bytes.Contains(buf, []byte("AUTH_FAILED")) {
+		return nil, buf, authFailedError(buf)
+	}
 	for attempt := 0; attempt < 2; attempt++ {
-		if reply, rest, ok := takePushReply(buf); ok {
-			return reply, rest, true
-		}
-		if bytes.Contains(buf, []byte("AUTH_FAILED")) {
-			return nil, buf, false
-		}
 		_ = conn.SetReadDeadline(time.Now().Add(tokenPushReadTimeout))
 		n, err := conn.Read(tmp)
 		if err != nil {
 			// Timeout (or no more data): keep whatever was buffered.
 			_ = conn.SetReadDeadline(time.Time{})
-			return nil, buf, false
+			return nil, buf, nil
 		}
 		buf = append(buf, tmp[:n]...)
+		// Parse after every successful read, including the last allowed one.
+		if reply, rest, ok := takePushReply(buf); ok {
+			return reply, rest, nil
+		}
+		if bytes.Contains(buf, []byte("AUTH_FAILED")) {
+			return nil, buf, authFailedError(buf)
+		}
 	}
-	return nil, buf, false
+	return nil, buf, nil
+}
+
+func authFailedError(buf []byte) error {
+	msg := string(buf)
+	if idx := strings.IndexByte(msg, 0); idx >= 0 {
+		msg = msg[:idx]
+	}
+	return fmt.Errorf("%w: %s", errAuthFailed, strings.TrimSpace(msg))
 }
 
 func takePushReply(buf []byte) (*PushReply, []byte, bool) {

--- a/transport/openvpn/client.go
+++ b/transport/openvpn/client.go
@@ -380,8 +380,8 @@ func (c *Client) consumeRekeyPushFrom(conn pushReadConn, readFinal tokenPushRead
 	// segments; neither is allowed to complete the rekey by itself.
 	if !complete && conn != nil {
 		attemptedFinalRead = true
-		deadline := c.effectiveControlDeadline(time.Time{})
-		if deadline.IsZero() && c.pushContinuationPending {
+		deadline := time.Time{}
+		if c.pushContinuationPending {
 			deadline = time.Now().Add(renegotiateTimeout)
 		}
 		more, newRest, err := readFinal(conn, c.leftoverTLS, deadline)
@@ -1075,11 +1075,12 @@ func readTokenPushReply(conn pushReadConn, leftover []byte, extended ...time.Tim
 	tmp := make([]byte, 4096)
 	var acc *PushReply
 	var waitUntil time.Time
+	var continuationUntil time.Time
 	if len(extended) > 0 {
-		waitUntil = extended[0]
+		continuationUntil = extended[0]
+		waitUntil = continuationUntil
 	}
 	var authPendingUntil time.Time
-	var continuationUntil time.Time
 	promoteWaitPolicy := func(reply *PushReply) {
 		if reply == nil {
 			return
@@ -1091,19 +1092,21 @@ func readTokenPushReply(conn pushReadConn, leftover []byte, extended ...time.Tim
 				deadline = now.Add(reply.AuthPendingTimeout)
 				reply.authPendingUntil = deadline
 			}
-			// AUTH_PENDING replaces the current deferred-auth timeout, even when
-			// it is shorter. A continuation deadline is an additional upper bound;
-			// the reader waits only until the earlier active operation deadline.
+			// AUTH_PENDING replaces the deferred-auth/transport deadline, even
+			// when shorter, but it does not make the optional token probe wait out
+			// that entire window. Without an unfinished continuation, return after
+			// the normal short probe so the new receive epoch can be installed.
 			authPendingUntil = deadline
-			waitUntil = deadline
-			if !continuationUntil.IsZero() && continuationUntil.Before(waitUntil) {
+			if !continuationUntil.IsZero() {
 				waitUntil = continuationUntil
+				if authPendingUntil.Before(waitUntil) {
+					waitUntil = authPendingUntil
+				}
 			}
 			// ControlConn.Read ACKs each accepted reliable control packet before
-			// exposing its TLS payload. Extend both directions immediately: only
-			// changing the read side leaves those ACK writes on the expired rekey
-			// deadline and prevents the final payload from reaching TLS.
-			_ = conn.SetDeadline(waitUntil)
+			// exposing its TLS payload. Apply the AUTH_PENDING deadline itself in
+			// both directions; waitUntil remains only the local probe policy.
+			_ = conn.SetDeadline(deadline)
 		}
 		if reply.PushContinuation == 2 && continuationUntil.IsZero() {
 			continuationUntil = now.Add(renegotiateTimeout)
@@ -1162,19 +1165,19 @@ func readTokenPushReply(conn pushReadConn, leftover []byte, extended ...time.Tim
 		if err != nil {
 			var netErr net.Error
 			if errors.As(err, &netErr) && netErr.Timeout() {
-				if !waitUntil.IsZero() && time.Now().Before(waitUntil) {
+				if !continuationUntil.IsZero() && time.Now().Before(waitUntil) {
 					continue
 				}
 				return acc, buf, nil
 			}
 			return nil, buf, err
 		}
-		// Normal token refresh is a short probe. Explicit AUTH_PENDING uses
-		// waitUntil and continues until the server-advertised deadline.
-		if waitUntil.IsZero() && attempt+1 >= 2 {
+		// Normal token refresh, including standalone AUTH_PENDING metadata, is
+		// a short probe. Only an unfinished continuation waits until waitUntil.
+		if continuationUntil.IsZero() && attempt+1 >= 2 {
 			return acc, buf, nil
 		}
-		if !waitUntil.IsZero() && !time.Now().Before(waitUntil) {
+		if !continuationUntil.IsZero() && !time.Now().Before(waitUntil) {
 			return acc, buf, nil
 		}
 	}

--- a/transport/openvpn/client.go
+++ b/transport/openvpn/client.go
@@ -401,9 +401,15 @@ func (c *Client) consumeRekeyPushFrom(conn pushReadConn, readFinal tokenPushRead
 		}
 	}
 
-	if attemptedFinalRead && (c.pushContinuationPending ||
-		(c.pushPending != nil && !complete && c.pushPending.AuthPendingTimeout > 0)) {
-		return errors.New("openvpn deferred/continued push reply incomplete")
+	if attemptedFinalRead && c.pushContinuationPending {
+		return errors.New("openvpn continued push reply incomplete")
+	}
+	if !complete && c.pushPending != nil && !c.pushPending.HasPushReply {
+		// AUTH_PENDING is standalone metadata, not the first half of a push.
+		// A deferred-auth rekey without auth-gen-token legally has no final
+		// PUSH_REPLY. Its deadline has already been staged for this key epoch;
+		// discard only the accumulator metadata and retain the cached push.
+		c.pushPending = nil
 	}
 	if complete && c.pushPending != nil {
 		push = mergePushReply(push, c.pushPending)

--- a/transport/openvpn/client.go
+++ b/transport/openvpn/client.go
@@ -33,7 +33,31 @@ type Client struct {
 	control *ControlChannel
 	tlsConn *tls.Conn
 	data    *DataChannel
-	push    *PushReply
+	// retiring is the previous data-channel epoch, kept during a rekey so
+	// packets still labeled with the old key ID can be decrypted.
+	retiring *DataChannel
+	push     *PushReply
+	authUser string
+	authPass string
+	// leftoverTLS is unread TLS control bytes after a key-method-2 record.
+	leftoverTLS []byte
+	// lastRekeyErr is the original renegotiation failure, preserved because
+	// closing the mux otherwise only surfaces "use of closed network connection".
+	lastRekeyErr error
+	rekeyLogOnce sync.Once
+	// dataByKey keeps active and retiring data channels indexed by key ID.
+	dataByKey map[uint8]*DataChannel
+	// lastSoftResetKey is the key ID from the most recently accepted server
+	// soft-reset packet. Tests inspect this after a rekey.
+	lastSoftResetKey uint8
+	// lastDataKey is the key ID encoded on the current outgoing data header.
+	lastDataKey uint8
+	// lastAuthToken is the most recently pushed auth-token, if any.
+	lastAuthToken string
+	// tlsEpoch is incremented every time a new tls.Conn is installed.
+	tlsEpoch uint32
+	// controlConn is the net.Conn adapter wrapping the control channel.
+	controlConn *ControlConn
 
 	// negotiatedCipher is the data channel cipher selected during the most
 	// recent key exchange.
@@ -87,12 +111,15 @@ func NewClient(config *ClientConfig, io PacketIO) (*Client, error) {
 	mux := NewPacketMux(io)
 	go mux.Run(runCtx)
 	client := &Client{
-		config:   config,
-		mux:      mux,
-		control:  NewControlChannel(mux, crypt, local),
-		runCtx:   runCtx,
-		cancel:   cancel,
-		writeSem: semaphore.NewWeighted(1),
+		config:    config,
+		mux:       mux,
+		control:   NewControlChannel(mux, crypt, local),
+		runCtx:    runCtx,
+		cancel:    cancel,
+		writeSem:  semaphore.NewWeighted(1),
+		authUser:  strings.TrimSpace(config.Username),
+		authPass:  config.Password,
+		dataByKey: make(map[uint8]*DataChannel),
 	}
 	client.markSend()
 	client.markReceive()
@@ -110,17 +137,8 @@ func (c *Client) Handshake(ctx context.Context) (*PushReply, error) {
 		return nil, err
 	}
 
-	tlsConfig, err := c.tlsConfig()
-	if err != nil {
+	if err := c.startTLSEpoch(ctx); err != nil {
 		return nil, err
-	}
-	controlConn := NewControlConn(c.control)
-	c.tlsConn = tls.Client(controlConn, tlsConfig)
-	if deadline, ok := ctx.Deadline(); ok {
-		_ = c.tlsConn.SetDeadline(deadline)
-	}
-	if err := c.tlsConn.HandshakeContext(ctx); err != nil {
-		return nil, fmt.Errorf("openvpn tls handshake: %w", err)
 	}
 
 	push, err := c.doKeyExchange(ctx)
@@ -130,6 +148,32 @@ func (c *Client) Handshake(ctx context.Context) (*PushReply, error) {
 	_ = c.tlsConn.SetDeadline(time.Time{})
 	go c.watchControl()
 	return push, nil
+}
+
+func (c *Client) startTLSEpoch(ctx context.Context) error {
+	tlsConfig, err := c.tlsConfig()
+	if err != nil {
+		return err
+	}
+	if c.controlConn == nil {
+		c.controlConn = NewControlConn(c.control)
+	}
+	if c.tlsConn != nil {
+		// Drop the old epoch without writing close_notify. Close() would send
+		// it on whatever key ID is current and pollute the new control epoch.
+		c.tlsConn = nil
+	}
+	c.controlConn.Reset()
+	c.leftoverTLS = nil
+	c.tlsConn = tls.Client(c.controlConn, tlsConfig)
+	c.tlsEpoch++
+	if deadline, ok := ctx.Deadline(); ok {
+		_ = c.tlsConn.SetDeadline(deadline)
+	}
+	if err := c.tlsConn.HandshakeContext(ctx); err != nil {
+		return fmt.Errorf("openvpn tls handshake: %w", err)
+	}
+	return nil
 }
 
 // doKeyExchange performs the OpenVPN key method 2 exchange over the TLS
@@ -145,8 +189,8 @@ func (c *Client) doKeyExchange(ctx context.Context) (*PushReply, error) {
 	clientRecord, err := NewClientKeyMethod2Record(
 		InstallScriptOptionsString(c.config.Proto, primaryCipher, c.config.Auth, c.config.CompLZO),
 		InstallScriptPeerInfo(primaryCipher, c.config.DataCiphers, c.config.CompLZO, c.config.PeerInfo),
-		strings.TrimSpace(c.config.Username),
-		c.config.Password,
+		c.authUser,
+		c.authPass,
 	)
 	if err != nil {
 		return nil, err
@@ -173,12 +217,40 @@ func (c *Client) doKeyExchange(ctx context.Context) (*PushReply, error) {
 		return nil, fmt.Errorf("derive data channel keys: %w", err)
 	}
 
+	if c.push != nil {
+		// Authenticated rekeys keep the previous ifconfig / peer-id.
+		// OpenVPN 2.6 often does not send another PUSH_REPLY here.
+		push := mergePushReply(c.push, &PushReply{})
+		c.push = push
+		negotiatedCipher, err := c.config.NegotiateCipher(push.DataCiphers, push.Cipher)
+		if err != nil {
+			return nil, fmt.Errorf("negotiate data cipher: %w", err)
+		}
+		c.negotiatedCipher = negotiatedCipher
+		cipherKeyLen := CipherKeyLength(negotiatedCipher)
+		keys.SendCipherKey = keys.SendCipherKey[:cipherKeyLen]
+		keys.RecvCipherKey = keys.RecvCipherKey[:cipherKeyLen]
+		keyID := c.control.KeyID()
+		newData, err := NewDataChannel(keys, negotiatedCipher, c.config.Auth, push.PeerID, keyID)
+		if err != nil {
+			return nil, err
+		}
+		c.installDataChannel(newData)
+		c.markSend()
+		c.markReceive()
+		return push, nil
+	}
+
 	if _, err := c.tlsConn.Write([]byte(PushRequest + "\x00")); err != nil {
 		return nil, fmt.Errorf("write push request: %w", err)
 	}
 	push, err := c.readPushReply(ctx)
 	if err != nil {
 		return nil, err
+	}
+	push = mergePushReply(c.push, push)
+	if len(push.Prefixes) == 0 {
+		return nil, fmt.Errorf("openvpn push reply missing ifconfig address")
 	}
 	c.push = push
 
@@ -194,18 +266,68 @@ func (c *Client) doKeyExchange(ctx context.Context) (*PushReply, error) {
 	keys.SendCipherKey = keys.SendCipherKey[:cipherKeyLen]
 	keys.RecvCipherKey = keys.RecvCipherKey[:cipherKeyLen]
 
-	newData, err := NewDataChannel(keys, negotiatedCipher, c.config.Auth, push.PeerID)
+	keyID := c.control.KeyID()
+	newData, err := NewDataChannel(keys, negotiatedCipher, c.config.Auth, push.PeerID, keyID)
 	if err != nil {
 		return nil, err
 	}
-	c.dataLock.Lock()
-	oldData := c.data
-	c.data = newData
-	c.dataLock.Unlock()
-	_ = oldData
+	c.installDataChannel(newData)
+	c.captureAuthToken(push)
 	c.markSend()
 	c.markReceive()
 	return push, nil
+}
+
+func (c *Client) installDataChannel(newData *DataChannel) {
+	c.dataLock.Lock()
+	old := c.data
+	c.retiring = old
+	c.data = newData
+	c.lastDataKey = newData.keyID
+	if c.dataByKey == nil {
+		c.dataByKey = make(map[uint8]*DataChannel)
+	}
+	if old != nil && old.keyID != newData.keyID {
+		c.dataByKey[old.keyID] = old
+	}
+	c.dataByKey[newData.keyID] = newData
+	// Keep at most the current and previous epoch.
+	for id := range c.dataByKey {
+		if id != newData.keyID && (old == nil || id != old.keyID) {
+			delete(c.dataByKey, id)
+		}
+	}
+	c.dataLock.Unlock()
+}
+
+func (c *Client) captureAuthToken(push *PushReply) {
+	if push == nil {
+		return
+	}
+	user, pass, ok := push.AuthToken()
+	if !ok {
+		return
+	}
+	c.lastAuthToken = pass
+	if user != "" {
+		c.authUser = user
+	}
+	c.authPass = pass
+}
+
+func (c *Client) ActiveDataKeyID() uint8 {
+	c.dataLock.RLock()
+	defer c.dataLock.RUnlock()
+	if c.data == nil {
+		return 0
+	}
+	return c.data.keyID
+}
+
+func (c *Client) LastSoftResetKeyID() uint8 {
+	c.dataLock.RLock()
+	defer c.dataLock.RUnlock()
+	return c.lastSoftResetKey
 }
 
 func (c *Client) WriteIPPacket(ctx context.Context, packet []byte) error {
@@ -248,21 +370,20 @@ func (c *Client) writeDataPacket(ctx context.Context, packet []byte, compress bo
 	return nil
 }
 
+func (c *Client) LastRekeyError() error {
+	return c.lastRekeyErr
+}
+
 func (c *Client) ReadIPPacket(ctx context.Context) ([]byte, error) {
 	for {
 		packet, err := c.mux.ReadDataPacket(ctx)
 		if err != nil {
+			if c.lastRekeyErr != nil {
+				return nil, fmt.Errorf("%w: %v", err, c.lastRekeyErr)
+			}
 			return nil, err
 		}
-		// Re-acquire the data channel after reading, since a rekey may have
-		// swapped c.data while ReadDataPacket was blocked.
-		c.dataLock.RLock()
-		data := c.data
-		c.dataLock.RUnlock()
-		if data == nil {
-			return nil, errors.New("openvpn data channel is not ready")
-		}
-		plain, err := data.Decrypt(packet)
+		plain, err := c.decryptDataPacket(packet)
 		if err != nil {
 			continue
 		}
@@ -277,6 +398,25 @@ func (c *Client) ReadIPPacket(ctx context.Context) ([]byte, error) {
 	}
 }
 
+func (c *Client) decryptDataPacket(packet []byte) ([]byte, error) {
+	if len(packet) == 0 {
+		return nil, errors.New("empty openvpn data packet")
+	}
+	_, keyID := parseOpcodeKeyID(packet[0])
+	c.dataLock.RLock()
+	data := c.data
+	if alt, ok := c.dataByKey[keyID]; ok {
+		data = alt
+	} else if c.retiring != nil && c.retiring.keyID == keyID {
+		data = c.retiring
+	}
+	c.dataLock.RUnlock()
+	if data == nil {
+		return nil, errors.New("openvpn data channel is not ready")
+	}
+	return data.Decrypt(packet)
+}
+
 // watchControl monitors the control channel for TLS renegotiation requests
 // (soft resets / rekeys). When the server initiates a rekey, the client
 // performs a full TLS renegotiation followed by a new key method 2 exchange,
@@ -284,18 +424,27 @@ func (c *Client) ReadIPPacket(ctx context.Context) ([]byte, error) {
 // the control channel stops, the client is terminated.
 func (c *Client) watchControl() {
 	for {
-		err := c.control.waitForSoftReset(c.runCtx)
+		packet, err := c.control.waitForSoftReset(c.runCtx)
 		if err != nil {
-			c.cancel()
-			_ = c.mux.Close()
+			c.failControl(fmt.Errorf("wait for soft reset: %w", err))
 			return
 		}
-		if err := c.renegotiate(); err != nil {
-			c.cancel()
-			_ = c.mux.Close()
+		if err := c.renegotiate(packet); err != nil {
+			c.failControl(fmt.Errorf("renegotiate: %w", err))
 			return
 		}
 	}
+}
+
+func (c *Client) failControl(err error) {
+	c.lastRekeyErr = err
+	c.rekeyLogOnce.Do(func() {
+		// Keep the original rekey error; the packet reader otherwise only
+		// sees the secondary "use of closed network connection".
+		_ = err
+	})
+	c.cancel()
+	_ = c.mux.Close()
 }
 
 // errRenegotiateNoTLS is returned when renegotiate() is called before a TLS
@@ -307,19 +456,36 @@ var errRenegotiateNoTLS = errors.New("cannot renegotiate: tls connection not est
 // 2. Renegotiate the TLS session on the existing tlsConn
 // 3. Exchange fresh key method 2 records and derive new data channel keys
 // 4. Atomically replace c.data with the new DataChannel
-func (c *Client) renegotiate() error {
-	if c.tlsConn == nil {
+func (c *Client) renegotiate(serverReset *ControlPacket) error {
+	if c.tlsConn == nil && c.controlConn == nil {
 		return errRenegotiateNoTLS
 	}
 	renegCtx, cancel := context.WithTimeout(c.runCtx, renegotiateTimeout)
 	defer cancel()
 
+	keyID := NextKeyID(c.control.KeyID())
+	if serverReset != nil {
+		keyID = serverReset.KeyID & KeyIDMask
+	}
+	c.dataLock.Lock()
+	c.lastSoftResetKey = keyID
+	c.dataLock.Unlock()
+	// Adopt first so QueueAck lands on the new epoch; AdoptKeyID clears acks.
+	c.control.AdoptKeyID(keyID)
+	if serverReset != nil {
+		// The watcher already consumed the server soft reset (new-epoch
+		// message 0). Advance recvMessage or ControlConn.Read will park
+		// ServerHello in recvPending forever.
+		c.control.MarkReceived(serverReset.MessageID)
+		c.control.QueueAck(serverReset.MessageID)
+	}
+
 	if err := c.control.SendSoftReset(renegCtx); err != nil {
 		return fmt.Errorf("send soft reset: %w", err)
 	}
 
-	if err := c.tlsConn.HandshakeContext(renegCtx); err != nil {
-		return fmt.Errorf("tls renegotiation: %w", err)
+	if err := c.startTLSEpoch(renegCtx); err != nil {
+		return fmt.Errorf("tls epoch handshake: %w", err)
 	}
 
 	if _, err := c.doKeyExchange(renegCtx); err != nil {
@@ -392,9 +558,20 @@ func (c *Client) waitServerReset(ctx context.Context) error {
 }
 
 func (c *Client) readServerKeyMethod(ctx context.Context) (*KeyMethod2Record, error) {
-	var buf []byte
+	buf := append([]byte(nil), c.leftoverTLS...)
+	c.leftoverTLS = nil
 	tmp := make([]byte, 4096)
 	for {
+		if len(buf) > 0 {
+			record, consumed, err := ParseServerKeyMethod2RecordConsumed(buf)
+			if err == nil {
+				c.leftoverTLS = append([]byte(nil), buf[consumed:]...)
+				return record, nil
+			}
+			if !strings.Contains(err.Error(), "truncated") && !errors.Is(err, ioStringEOF) {
+				return nil, err
+			}
+		}
 		if deadline, ok := ctx.Deadline(); ok {
 			_ = c.tlsConn.SetReadDeadline(deadline)
 		}
@@ -403,42 +580,100 @@ func (c *Client) readServerKeyMethod(ctx context.Context) (*KeyMethod2Record, er
 			return nil, fmt.Errorf("read key method 2 server record: %w", err)
 		}
 		buf = append(buf, tmp[:n]...)
-		record, err := ParseServerKeyMethod2Record(buf)
-		if err == nil {
-			return record, nil
-		}
-		if !strings.Contains(err.Error(), "truncated") && !errors.Is(err, ioStringEOF) {
-			return nil, err
-		}
 	}
 }
 
 func (c *Client) readPushReply(ctx context.Context) (*PushReply, error) {
-	var buf []byte
+	buf := append([]byte(nil), c.leftoverTLS...)
+	c.leftoverTLS = nil
 	tmp := make([]byte, 4096)
 	for {
+		if bytes.Contains(buf, []byte("AUTH_FAILED")) {
+			msg := string(buf)
+			if idx := strings.IndexByte(msg, 0); idx >= 0 {
+				msg = msg[:idx]
+			}
+			return nil, fmt.Errorf("openvpn authentication failed: %s", strings.TrimSpace(msg))
+		}
+		if reply, rest, ok := takePushReply(buf); ok {
+			c.leftoverTLS = rest
+			return reply, nil
+		}
 		if deadline, ok := ctx.Deadline(); ok {
 			_ = c.tlsConn.SetReadDeadline(deadline)
 		}
 		n, err := c.tlsConn.Read(tmp)
 		if err != nil {
 			if errors.Is(err, io.EOF) && len(buf) > 0 {
-				break
+				if reply, _, parseErr := ParsePushReplyFlexible(string(buf)); parseErr == nil {
+					return reply, nil
+				}
 			}
 			return nil, fmt.Errorf("read push reply: %w", err)
 		}
 		buf = append(buf, tmp[:n]...)
-		if bytes.Contains(buf, []byte("\x00")) || strings.Contains(string(buf), "PUSH_REPLY") {
-			msg := string(buf)
-			if idx := strings.IndexByte(msg, 0); idx >= 0 {
-				msg = msg[:idx]
-			}
-			if reply, err := ParsePushReply(msg); err == nil {
-				return reply, nil
-			}
+	}
+}
+
+func takePushReply(buf []byte) (*PushReply, []byte, bool) {
+	if len(buf) == 0 {
+		return nil, nil, false
+	}
+	// AUTH_FAILED may arrive instead of PUSH_REPLY.
+	if bytes.Contains(buf, []byte("AUTH_FAILED")) {
+		msg := string(buf)
+		if idx := strings.IndexByte(msg, 0); idx >= 0 {
+			msg = msg[:idx]
+		}
+		return nil, nil, false
+	}
+	if !bytes.Contains(buf, []byte("PUSH_REPLY")) {
+		return nil, nil, false
+	}
+	msg := string(buf)
+	rest := []byte(nil)
+	if idx := strings.IndexByte(msg, 0); idx >= 0 {
+		rest = append([]byte(nil), buf[idx+1:]...)
+		msg = msg[:idx]
+	} else if !bytes.Contains(buf, []byte("ifconfig")) {
+		return nil, nil, false
+	}
+	reply, err := parsePushReplyInner(msg)
+	if err != nil {
+		return nil, nil, false
+	}
+	return reply, rest, true
+}
+
+func mergePushReply(prev, next *PushReply) *PushReply {
+	if next == nil {
+		return prev
+	}
+	if prev == nil {
+		return next
+	}
+	if len(next.Prefixes) == 0 {
+		next.Prefixes = prev.Prefixes
+	}
+	if len(next.Routes) == 0 {
+		next.Routes = prev.Routes
+	}
+	if next.PeerID == PeerIDUnset {
+		next.PeerID = prev.PeerID
+	}
+	if next.Cipher == "" {
+		next.Cipher = prev.Cipher
+	}
+	if len(next.DataCiphers) == 0 {
+		next.DataCiphers = prev.DataCiphers
+	}
+	if next.AuthTokenPass == "" {
+		next.AuthTokenPass = prev.AuthTokenPass
+		if next.AuthTokenUser == "" {
+			next.AuthTokenUser = prev.AuthTokenUser
 		}
 	}
-	return nil, ctx.Err()
+	return next
 }
 
 func (c *Client) tlsConfig() (*tls.Config, error) {

--- a/transport/openvpn/client.go
+++ b/transport/openvpn/client.go
@@ -24,6 +24,10 @@ const (
 	// (rekey) cycle. OpenVPN servers typically rekey every hour; the
 	// renegotiation itself should complete in seconds.
 	renegotiateTimeout = 30 * time.Second
+
+	// transitionWindow is how long a retiring (lame-duck) data epoch is
+	// accepted after a rekey, mirroring OpenVPN's default transition-window.
+	transitionWindow = 3600 * time.Second
 )
 
 type Client struct {
@@ -38,6 +42,9 @@ type Client struct {
 	// retiring is the previous data-channel epoch, kept during a rekey so
 	// packets still labeled with the old key ID can be decrypted.
 	retiring *DataChannel
+	// retiringExpiry is when the retiring epoch is no longer accepted,
+	// mirroring OpenVPN's lame-duck transition_window (default 3600s).
+	retiringExpiry time.Time
 	push     *PushReply
 	authUser string
 	authPass string
@@ -343,6 +350,13 @@ func (c *Client) installDataChannel(newData *DataChannel) {
 		c.dataByKey[old.keyID] = old
 	}
 	c.dataByKey[newData.keyID] = newData
+	// The previous epoch is a lame-duck key: keep it only for the OpenVPN
+	// transition_window (default 3600s), then it must not be accepted.
+	if old != nil {
+		c.retiringExpiry = time.Now().Add(transitionWindow)
+	} else {
+		c.retiringExpiry = time.Time{}
+	}
 	// Keep at most the current and previous epoch.
 	for id := range c.dataByKey {
 		if id != newData.keyID && (old == nil || id != old.keyID) {
@@ -447,15 +461,24 @@ func (c *Client) decryptDataPacket(packet []byte) ([]byte, error) {
 	}
 	_, keyID := parseOpcodeKeyID(packet[0])
 	c.dataLock.RLock()
-	data := c.data
+	// Route strictly by key ID. A packet labeled with an unknown epoch must
+	// be rejected, not silently decrypted with the current key (the CBC HMAC
+	// excludes the outer opcode/key-ID header, so a wrong key would still
+	// "authenticate").
+	var data *DataChannel
 	if alt, ok := c.dataByKey[keyID]; ok {
 		data = alt
 	} else if c.retiring != nil && c.retiring.keyID == keyID {
+		if !c.retiringExpiry.IsZero() && time.Now().After(c.retiringExpiry) {
+			// Lame-duck key expired (transition_window elapsed): reject.
+			c.dataLock.RUnlock()
+			return nil, errors.New("openvpn data packet from expired retiring epoch")
+		}
 		data = c.retiring
 	}
 	c.dataLock.RUnlock()
 	if data == nil {
-		return nil, errors.New("openvpn data channel is not ready")
+		return nil, errors.New("openvpn data packet with unknown key id")
 	}
 	return data.Decrypt(packet)
 }
@@ -469,6 +492,20 @@ func (c *Client) watchControl() {
 	for {
 		packet, err := c.control.waitForSoftReset(c.runCtx)
 		if err != nil {
+			if errors.Is(err, errParkedTLS) {
+				// A same-epoch TLS payload (token update / late AUTH_FAILED)
+				// was parked. Consume it now so a deferred authentication
+				// failure is surfaced immediately instead of waiting for the
+				// next soft reset (which may never come).
+				c.consumeQueuedControl()
+				if c.push != nil {
+					if err := c.consumeRekeyPush(); err != nil {
+						c.failControl(fmt.Errorf("consume parked rekey push: %w", err))
+						return
+					}
+				}
+				continue
+			}
 			c.failControl(fmt.Errorf("wait for soft reset: %w", err))
 			return
 		}

--- a/transport/openvpn/client.go
+++ b/transport/openvpn/client.go
@@ -846,14 +846,17 @@ func takePushReply(buf []byte) (*PushReply, []byte, bool) {
 	if !bytes.Contains(buf, []byte("PUSH_REPLY")) {
 		return nil, nil, false
 	}
-	msg := string(buf)
-	rest := []byte(nil)
-	if idx := strings.IndexByte(msg, 0); idx >= 0 {
-		rest = append([]byte(nil), buf[idx+1:]...)
-		msg = msg[:idx]
-	} else if !bytes.Contains(buf, []byte("ifconfig")) {
+	// The message is only complete once a NUL terminator is present. A
+	// PUSH_REPLY fragmented across TLS reads must not be committed early
+	// (e.g. right after "ifconfig") or later route / DNS / cipher / token
+	// options would be lost. This matches the reference client, which parses
+	// the full PUSH message after it is fully received.
+	idx := bytes.IndexByte(buf, 0)
+	if idx < 0 {
 		return nil, nil, false
 	}
+	msg := string(buf[:idx])
+	rest := append([]byte(nil), buf[idx+1:]...)
 	reply, err := parsePushReplyInner(msg)
 	if err != nil {
 		return nil, nil, false

--- a/transport/openvpn/client.go
+++ b/transport/openvpn/client.go
@@ -421,11 +421,17 @@ func (c *Client) writeDataPacket(ctx context.Context, packet []byte, compress bo
 	}
 	defer c.writeSem.Release(1)
 	// Acquire the outbound key after securing the write semaphore, since a
-	// rekey may swap c.data / c.outboundKey while Acquire is blocked.
-	c.dataLock.Lock()
+	// rekey may swap c.data / c.outboundKey while Acquire is blocked. Use a
+	// read lock for the common path and only upgrade to the write lock when
+	// the outbound key actually needs promoting, so data-plane reads and
+	// writes do not serialize on every packet.
+	backstop := func() bool {
+		return !c.retiringExpiry.IsZero() && time.Until(c.retiringExpiry) < outboundPromoteGrace
+	}
+	c.dataLock.RLock()
 	data := c.data
 	if data == nil {
-		c.dataLock.Unlock()
+		c.dataLock.RUnlock()
 		return errors.New("openvpn data channel is not ready")
 	}
 	outbound := c.outboundKey
@@ -440,17 +446,19 @@ func (c *Client) writeDataPacket(ctx context.Context, packet []byte, compress bo
 	// just-before-expiry backstop promotes even in asymmetric traffic, so
 	// the lame-duck key is not used past the point the peer stops accepting
 	// it.
-	if outbound != data && outbound != nil {
-		backstop := false
-		if !c.retiringExpiry.IsZero() && time.Until(c.retiringExpiry) < outboundPromoteGrace {
-			backstop = true
+	needPromote := outbound != data && outbound != nil && (data.PeerActive() || backstop())
+	c.dataLock.RUnlock()
+	if needPromote {
+		// Upgrade to the write lock and re-check: a rekey may have completed
+		// between the read and the write lock.
+		c.dataLock.Lock()
+		if c.outboundKey != c.data && c.outboundKey != nil &&
+			(c.data.PeerActive() || backstop()) {
+			c.outboundKey = c.data
 		}
-		if data.PeerActive() || backstop {
-			c.outboundKey = data
-			outbound = data
-		}
+		outbound = c.outboundKey
+		c.dataLock.Unlock()
 	}
-	c.dataLock.Unlock()
 	if compress && c.config.CompLZO == CompLzoYes {
 		compressed, err := lzo1xCompressSafe(packet)
 		if err != nil {
@@ -993,6 +1001,9 @@ func mergePushReply(prev, next *PushReply) *PushReply {
 	if len(next.Routes) == 0 {
 		next.Routes = prev.Routes
 	}
+	if len(next.DNS) == 0 {
+		next.DNS = prev.DNS
+	}
 	if next.PeerID == PeerIDUnset {
 		next.PeerID = prev.PeerID
 	}
@@ -1001,6 +1012,12 @@ func mergePushReply(prev, next *PushReply) *PushReply {
 	}
 	if len(next.DataCiphers) == 0 {
 		next.DataCiphers = prev.DataCiphers
+	}
+	if !next.Redirect {
+		next.Redirect = prev.Redirect
+	}
+	if !next.BlockIPv6 {
+		next.BlockIPv6 = prev.BlockIPv6
 	}
 	if next.AuthTokenPass == "" {
 		next.AuthTokenPass = prev.AuthTokenPass

--- a/transport/openvpn/config.go
+++ b/transport/openvpn/config.go
@@ -56,8 +56,9 @@ type ClientConfig struct {
 
 	PeerInfo map[string]string
 
-	PingInterval time.Duration
-	PingRestart  time.Duration
+	PingInterval     time.Duration
+	PingRestart      time.Duration
+	TransitionWindow time.Duration
 
 	TLSCryptKey []byte
 	TLSAuthKey  []byte
@@ -323,6 +324,9 @@ func (c *ClientConfig) ValidateInstallScriptSubset() error {
 	}
 	if c.PingRestart < 0 {
 		return errors.New("openvpn ping restart must be positive")
+	}
+	if c.TransitionWindow < 0 {
+		return errors.New("openvpn transition window must be positive")
 	}
 	return nil
 }

--- a/transport/openvpn/config_test.go
+++ b/transport/openvpn/config_test.go
@@ -3,6 +3,7 @@ package openvpn
 import (
 	"strings"
 	"testing"
+	"time"
 )
 
 const testCert = `-----BEGIN CERTIFICATE-----
@@ -86,6 +87,14 @@ func TestClientConfigRejectsUnsupportedProto(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "unsupported openvpn proto") {
 		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestClientConfigRejectsNegativeTransitionWindow(t *testing.T) {
+	cfg := yamlStyleConfig()
+	cfg.TransitionWindow = -time.Second
+	if err := cfg.Prepare(); err == nil || !strings.Contains(err.Error(), "transition window") {
+		t.Fatalf("negative transition window accepted: %v", err)
 	}
 }
 

--- a/transport/openvpn/control.go
+++ b/transport/openvpn/control.go
@@ -88,6 +88,25 @@ func (c *ControlChannel) resetReplayLocked(packetID, unixTime uint32) {
 	}
 }
 
+// recvWindowOK reports whether an out-of-order control packet with the given
+// message ID fits the receive window, mirroring OpenVPN's
+// reliable_wont_break_sequentiality + reliable_can_get over the fixed
+// rec_reliable buffer: the id must be strictly ahead of recvMessage, within
+// reliableCapacity of it, and the buffer must not already hold that many
+// outstanding packets.
+func recvWindowOK(recvMessage, messageID uint32, buffered int) bool {
+	if messageID < recvMessage {
+		return false
+	}
+	if messageID >= recvMessage+reliableCapacity {
+		return false
+	}
+	if buffered >= reliableCapacity {
+		return false
+	}
+	return true
+}
+
 // checkReplay validates a protected control packet's packet-id/timestamp
 // against the anti-replay window. Returns an error for replayed or stale
 // packets. Must be called with c.mu held.
@@ -329,6 +348,12 @@ func (c *ControlChannel) takeAcksLocked(max int) []uint32 {
 
 // reliableAckSize mirrors RELIABLE_ACK_SIZE in OpenVPN reliable.h.
 const reliableAckSize = 8
+
+// reliableCapacity mirrors the receive reliable buffer capacity in OpenVPN:
+// TLS_RELIABLE_N_REC_BUFFERS with RELIABLE_CAPACITY=12. It bounds how many
+// out-of-order control packets mihomo will buffer before they can be
+// delivered in sequence.
+const reliableCapacity = 12
 
 // controlSendAckMax mirrors CONTROL_SEND_ACK_MAX in OpenVPN ssl.h: reliable
 // control packets carry at most this many ACKs.
@@ -572,7 +597,13 @@ func (c *ControlChannel) read(ctx context.Context, watchSoftReset bool) (*Contro
 			c.recvMessage++
 			sendAck = true
 		default:
-			if _, exists := c.recvPending[packet.MessageID]; !exists {
+			// Buffer the out-of-order packet for later sequential delivery.
+			// Bound the buffer like OpenVPN's rec_reliable (TLS_RELIABLE_N_REC_BUFFERS
+			// / RELIABLE_CAPACITY = 12): refuse to store packets that would
+			// overflow the window, so a peer flooding high message IDs cannot
+			// grow recvPending without bound. Replays are already ACKed below.
+			if _, exists := c.recvPending[packet.MessageID]; !exists &&
+				recvWindowOK(c.recvMessage, packet.MessageID, len(c.recvPending)) {
 				c.recvPending[packet.MessageID] = packet
 			}
 			sendAck = true

--- a/transport/openvpn/control.go
+++ b/transport/openvpn/control.go
@@ -39,8 +39,12 @@ type ControlChannel struct {
 	// current epoch was still doing TLS/key-method. waitForSoftReset
 	// consumes it so ControlConn.Read cannot swallow it.
 	pendingSoftReset *ControlPacket
-	readDeadline     time.Time
-	writeDeadline    time.Time
+	// parkedTLS holds same-epoch P_CONTROL_V1 payloads that arrived while
+	// the watcher was waiting for a soft reset (typically a token-only
+	// PUSH_REPLY). ReadAll drains them into leftoverTLS / tls.Conn.
+	parkedTLS    [][]byte
+	readDeadline time.Time
+	writeDeadline time.Time
 }
 
 func NewControlChannel(io PacketIO, crypt ControlCryptor, local SessionID) *ControlChannel {
@@ -103,6 +107,7 @@ func (c *ControlChannel) beginEpochLocked(keyID uint8) {
 	c.ackPending = nil
 	c.pending = make(map[uint32]*ControlPacket)
 	c.recvPending = make(map[uint32]*ControlPacket)
+	c.parkedTLS = nil
 }
 
 // RotateKeyID advances to the next local key epoch and resets reliable state.
@@ -214,10 +219,49 @@ func (c *ControlChannel) waitForSoftReset(ctx context.Context) (*ControlPacket, 
 		if packet.Opcode == PControlSoftResetV1 {
 			return packet, nil
 		}
+		// Same-epoch P_CONTROL_V1 after a rekey is typically a token-only
+		// PUSH_REPLY (send_push_reply_auth_token). Park the TLS payload for
+		// ReadAll instead of ACK-and-dropping it. read() already ACKed.
+		if packet.Opcode == PControlV1 && len(packet.Payload) > 0 {
+			c.mu.Lock()
+			c.parkedTLS = append(c.parkedTLS, append([]byte(nil), packet.Payload...))
+			c.mu.Unlock()
+			continue
+		}
 		if err := c.SendAck(ctx); err != nil {
 			return nil, err
 		}
 	}
+}
+
+// ReadAll returns every queued control packet decoded so far, without
+// touching the underlying TLS state of the active epoch. Used after key
+// exchange so that a TLS-encrypted P_CONTROL_V1 auth-token update is not
+// acknowledged and discarded by a raw ControlChannel read. pendingSoftReset
+// is deliberately left in place: it is the trigger for the next rekey, not
+// TLS payload, and must stay for waitForSoftReset to consume.
+func (c *ControlChannel) ReadAll() []*ControlPacket {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	n := len(c.recvPending) + len(c.parkedTLS)
+	if n == 0 {
+		return nil
+	}
+	out := make([]*ControlPacket, 0, n)
+	for id := c.recvMessage; ; id++ {
+		pkt, ok := c.recvPending[id]
+		if !ok {
+			break
+		}
+		delete(c.recvPending, id)
+		c.recvMessage = id + 1
+		out = append(out, pkt)
+	}
+	for _, payload := range c.parkedTLS {
+		out = append(out, &ControlPacket{Opcode: PControlV1, Payload: payload})
+	}
+	c.parkedTLS = nil
+	return out
 }
 
 func (c *ControlChannel) read(ctx context.Context, watchSoftReset bool) (*ControlPacket, error) {
@@ -314,22 +358,23 @@ func (c *ControlChannel) read(ctx context.Context, watchSoftReset bool) (*Contro
 		case packet.MessageID == c.recvMessage:
 			deliver = packet
 			c.recvMessage++
+			sendAck = true
 		default:
 			if _, exists := c.recvPending[packet.MessageID]; !exists {
 				c.recvPending[packet.MessageID] = packet
 			}
 			sendAck = true
 		}
-
 		c.mu.Unlock()
 
-		if deliver != nil {
-			return deliver, nil
-		}
 		if sendAck {
 			if err := c.SendAck(ctx); err != nil {
 				return nil, err
 			}
+		}
+
+		if deliver != nil {
+			return deliver, nil
 		}
 	}
 }
@@ -341,9 +386,11 @@ func (c *ControlChannel) classifyWatchPacketLocked(packet *ControlPacket) (softR
 		return false, false
 	}
 	if packet.Opcode == PControlSoftResetV1 {
-		// Accept a soft reset from the same session on a different key epoch.
-		// OpenVPN advances 0->1->...->7->1; do not invent the next ID locally.
-		return packet.KeyID != c.keyID, packet.KeyID != c.keyID
+		// OpenVPN advances 0 -> 1 -> ... -> 7 -> 1. Reject stale or invalid
+		// epochs: a delayed reset from a retiring epoch, or key ID 0 after
+		// the initial epoch, must not move the client backwards.
+		expected := NextKeyID(c.keyID)
+		return packet.KeyID == expected, packet.KeyID == expected
 	}
 	return false, packet.KeyID == c.keyID
 }
@@ -463,6 +510,16 @@ func (c *ControlConn) Reset() {
 	c.mu.Unlock()
 }
 
+// UnsafeFeed pushes already-decoded control payload bytes into the TLS
+// read buffer. The caller must have drained ReadAll() and must not be
+// concurrently reading or writing the tls.Conn. The prefix buffer is
+// intentionally NOT the first value so tls.Conn.Read consumes it in order.
+func (c *ControlConn) UnsafeFeed(payload []byte) {
+	c.mu.Lock()
+	c.readBuf = append(c.readBuf, payload...)
+	c.mu.Unlock()
+}
+
 func (c *ControlConn) Read(b []byte) (int, error) {
 	c.mu.Lock()
 	if c.closed {
@@ -512,6 +569,11 @@ func (c *ControlConn) Write(b []byte) (int, error) {
 	}
 	c.mu.Unlock()
 
+	// Flush any unacknowledged read BEFORE writing data, so the ACK does not
+	// piggyback onto this control message and corrupt the TLS record.
+	if err := c.channel.SendAck(context.Background()); err != nil {
+		return 0, err
+	}
 	if _, err := c.channel.Send(context.Background(), PControlV1, b); err != nil {
 		return 0, err
 	}

--- a/transport/openvpn/control.go
+++ b/transport/openvpn/control.go
@@ -35,8 +35,12 @@ type ControlChannel struct {
 	ackPending    []uint32
 	pending       map[uint32]*ControlPacket
 	recvPending   map[uint32]*ControlPacket
-	readDeadline  time.Time
-	writeDeadline time.Time
+	// pendingSoftReset holds a server soft-reset that arrived while the
+	// current epoch was still doing TLS/key-method. waitForSoftReset
+	// consumes it so ControlConn.Read cannot swallow it.
+	pendingSoftReset *ControlPacket
+	readDeadline     time.Time
+	writeDeadline    time.Time
 }
 
 func NewControlChannel(io PacketIO, crypt ControlCryptor, local SessionID) *ControlChannel {
@@ -75,20 +79,71 @@ func (c *ControlChannel) SendReset(ctx context.Context) error {
 	return err
 }
 
-// SendSoftReset sends a P_CONTROL_SOFT_RESET_V1 and rotates the key ID.
-// Called during TLS renegotiation (rekey) to transition to a new key epoch.
-// The old pending/recvPending maps are cleared because they belong to the
-// previous key epoch; the message counters are reset for the new epoch.
-func (c *ControlChannel) SendSoftReset(ctx context.Context) error {
+// NextKeyID returns the next OpenVPN key epoch id.
+// OpenVPN reserves 0 for the initial epoch and then advances
+// 0 -> 1 -> 2 -> 3 -> 4 -> 5 -> 6 -> 7 -> 1.
+func NextKeyID(current uint8) uint8 {
+	next := (current + 1) & KeyIDMask
+	if next == 0 {
+		return 1
+	}
+	return next
+}
+
+func (c *ControlChannel) KeyID() uint8 {
 	c.mu.Lock()
-	newKeyID := c.keyID ^ 1 // toggle 0<->1
-	c.keyID = newKeyID
+	defer c.mu.Unlock()
+	return c.keyID
+}
+
+func (c *ControlChannel) beginEpochLocked(keyID uint8) {
+	c.keyID = keyID & KeyIDMask
 	c.sendMessage = 0
 	c.recvMessage = 0
 	c.ackPending = nil
 	c.pending = make(map[uint32]*ControlPacket)
 	c.recvPending = make(map[uint32]*ControlPacket)
+}
+
+// RotateKeyID advances to the next local key epoch and resets reliable state.
+func (c *ControlChannel) RotateKeyID() uint8 {
+	c.mu.Lock()
+	c.beginEpochLocked(NextKeyID(c.keyID))
+	id := c.keyID
 	c.mu.Unlock()
+	return id
+}
+
+// AdoptKeyID switches to the key ID supplied by the peer's soft-reset packet.
+func (c *ControlChannel) AdoptKeyID(keyID uint8) {
+	c.mu.Lock()
+	c.beginEpochLocked(keyID)
+	c.mu.Unlock()
+}
+
+// QueueAck records a reliable message ID to be acknowledged on the next send.
+func (c *ControlChannel) QueueAck(messageID uint32) {
+	c.mu.Lock()
+	c.ackPending = appendAck(c.ackPending, messageID)
+	c.mu.Unlock()
+}
+
+// MarkReceived advances the reliable receive sequence past messageID.
+// Used after a server soft-reset has already been consumed by the watcher,
+// so the new epoch does not wait forever for message 0.
+func (c *ControlChannel) MarkReceived(messageID uint32) {
+	c.mu.Lock()
+	next := messageID + 1
+	if next > c.recvMessage {
+		c.recvMessage = next
+	}
+	delete(c.recvPending, messageID)
+	c.mu.Unlock()
+}
+
+// SendSoftReset sends a P_CONTROL_SOFT_RESET_V1 on the current key epoch.
+// Call AdoptKeyID or RotateKeyID first so the packet uses the new key ID.
+func (c *ControlChannel) SendSoftReset(ctx context.Context) error {
 	_, err := c.Send(ctx, PControlSoftResetV1, nil)
 	return err
 }
@@ -142,17 +197,25 @@ func (c *ControlChannel) Read(ctx context.Context) (*ControlPacket, error) {
 	return c.read(ctx, false)
 }
 
-func (c *ControlChannel) waitForSoftReset(ctx context.Context) error {
+func (c *ControlChannel) waitForSoftReset(ctx context.Context) (*ControlPacket, error) {
+	c.mu.Lock()
+	if c.pendingSoftReset != nil {
+		packet := c.pendingSoftReset
+		c.pendingSoftReset = nil
+		c.mu.Unlock()
+		return packet, nil
+	}
+	c.mu.Unlock()
 	for {
 		packet, err := c.read(ctx, true)
 		if err != nil {
-			return err
+			return nil, err
 		}
 		if packet.Opcode == PControlSoftResetV1 {
-			return nil
+			return packet, nil
 		}
 		if err := c.SendAck(ctx); err != nil {
-			return err
+			return nil, err
 		}
 	}
 }
@@ -191,6 +254,29 @@ func (c *ControlChannel) read(ctx context.Context, watchSoftReset bool) (*Contro
 				continue
 			}
 			return nil, err
+		}
+
+		if !watchSoftReset {
+			c.mu.Lock()
+			curKey := c.keyID
+			sameSession := c.remote == (SessionID{}) || packet.LocalSession == c.remote
+			if packet.Opcode == PControlSoftResetV1 && packet.KeyID != curKey && sameSession {
+				if c.pendingSoftReset == nil {
+					c.pendingSoftReset = packet
+				}
+				for _, ackID := range packet.AckIDs {
+					delete(c.pending, ackID)
+				}
+				c.mu.Unlock()
+				continue
+			}
+			if packet.Opcode != PControlSoftResetV1 && packet.KeyID != curKey {
+				c.mu.Unlock()
+				// Drop control packets from a retiring key epoch so they
+				// cannot be fed into the new TLS session.
+				continue
+			}
+			c.mu.Unlock()
 		}
 
 		if watchSoftReset {
@@ -255,9 +341,8 @@ func (c *ControlChannel) classifyWatchPacketLocked(packet *ControlPacket) (softR
 		return false, false
 	}
 	if packet.Opcode == PControlSoftResetV1 {
-		// Accept soft resets that carry a different key ID than the current
-		// active key epoch. This handles both server-initiated rekeys (new
-		// key ID) and the symmetric toggle between key ID 0 and 1.
+		// Accept a soft reset from the same session on a different key epoch.
+		// OpenVPN advances 0->1->...->7->1; do not invent the next ID locally.
 		return packet.KeyID != c.keyID, packet.KeyID != c.keyID
 	}
 	return false, packet.KeyID == c.keyID
@@ -370,6 +455,14 @@ func NewControlConn(channel *ControlChannel) *ControlConn {
 	return &ControlConn{channel: channel}
 }
 
+// Reset clears leftover TLS bytes so a new tls.Conn can reuse this adapter.
+func (c *ControlConn) Reset() {
+	c.mu.Lock()
+	c.closed = false
+	c.readBuf = nil
+	c.mu.Unlock()
+}
+
 func (c *ControlConn) Read(b []byte) (int, error) {
 	c.mu.Lock()
 	if c.closed {
@@ -427,13 +520,12 @@ func (c *ControlConn) Write(b []byte) (int, error) {
 
 func (c *ControlConn) Close() error {
 	c.mu.Lock()
-	if c.closed {
-		c.mu.Unlock()
-		return nil
-	}
 	c.closed = true
+	c.readBuf = nil
 	c.mu.Unlock()
-	return c.channel.io.Close()
+	// The control channel outlives a single TLS epoch. Closing the mux here
+	// would tear down the whole OpenVPN transport during a soft reset.
+	return nil
 }
 
 func (c *ControlConn) LocalAddr() net.Addr {

--- a/transport/openvpn/control.go
+++ b/transport/openvpn/control.go
@@ -582,31 +582,39 @@ func (c *ControlChannel) read(ctx context.Context, watchSoftReset bool) (*Contro
 		for _, ackID := range packet.AckIDs {
 			delete(c.pending, ackID)
 		}
-		if packet.Opcode.HasMessageID() {
-			c.ackPending = appendAck(c.ackPending, packet.MessageID)
-		}
 
+		// OpenVPN read_control_auth: a message ID is acknowledged only when
+		// the packet is accepted into the receive window (reliable_wont_break
+		// _sequentiality succeeds), whether it is new or an in-window replay.
+		// A packet that would break the receive window is neither buffered nor
+		// acknowledged, so the sender keeps it for retransmission and the
+		// reliable stream never develops a permanent hole.
 		switch {
 		case packet.Opcode == PAckV1:
 		case !packet.Opcode.HasMessageID():
 			deliver = packet
 		case packet.MessageID < c.recvMessage:
+			// In-window replay of an already-delivered packet: acknowledge so
+			// the sender stops retransmitting, but do not redeliver.
+			c.ackPending = appendAck(c.ackPending, packet.MessageID)
 			sendAck = true
 		case packet.MessageID == c.recvMessage:
+			// The expected next message: deliver and advance.
+			c.ackPending = appendAck(c.ackPending, packet.MessageID)
 			deliver = packet
 			c.recvMessage++
 			sendAck = true
 		default:
-			// Buffer the out-of-order packet for later sequential delivery.
-			// Bound the buffer like OpenVPN's rec_reliable (TLS_RELIABLE_N_REC_BUFFERS
-			// / RELIABLE_CAPACITY = 12): refuse to store packets that would
-			// overflow the window, so a peer flooding high message IDs cannot
-			// grow recvPending without bound. Replays are already ACKed below.
+			// Out-of-order packet ahead of recvMessage. Buffer it only if it
+			// fits the bounded window (like OpenVPN's rec_reliable); only an
+			// accepted packet is acknowledged. A rejected one stays with the
+			// sender for retransmission.
 			if _, exists := c.recvPending[packet.MessageID]; !exists &&
 				recvWindowOK(c.recvMessage, packet.MessageID, len(c.recvPending)) {
 				c.recvPending[packet.MessageID] = packet
+				c.ackPending = appendAck(c.ackPending, packet.MessageID)
+				sendAck = true
 			}
-			sendAck = true
 		}
 		c.mu.Unlock()
 

--- a/transport/openvpn/control.go
+++ b/transport/openvpn/control.go
@@ -28,17 +28,17 @@ type ControlChannel struct {
 	local  SessionID
 	remote SessionID
 
-	mu            sync.Mutex
-	sendPacketID  uint32
-	sendMessage   uint32
-	recvMessage   uint32
-	ackPending    []uint32
+	mu           sync.Mutex
+	sendPacketID uint32
+	sendMessage  uint32
+	recvMessage  uint32
+	ackPending   []uint32
 	// lruAcks is the MRU of recently acknowledged packet IDs, mirroring
 	// OpenVPN's reliable_ack.lru_acks: acks are copied here when sent and
 	// kept so subsequent control packets repeat them until replaced.
-	lruAcks        []uint32
-	pending        map[uint32]*ControlPacket
-	recvPending    map[uint32]*ControlPacket
+	lruAcks     []uint32
+	pending     map[uint32]*ControlPacket
+	recvPending map[uint32]*ControlPacket
 	// pendingSoftReset holds a server soft-reset that arrived while the
 	// current epoch was still doing TLS/key-method. waitForSoftReset
 	// consumes it so ControlConn.Read cannot swallow it.
@@ -46,8 +46,8 @@ type ControlChannel struct {
 	// parkedTLS holds same-epoch P_CONTROL_V1 payloads that arrived while
 	// the watcher was waiting for a soft reset (typically a token-only
 	// PUSH_REPLY). ReadAll drains them into leftoverTLS / tls.Conn.
-	parkedTLS    [][]byte
-	readDeadline time.Time
+	parkedTLS     [][]byte
+	readDeadline  time.Time
 	writeDeadline time.Time
 }
 

--- a/transport/openvpn/control.go
+++ b/transport/openvpn/control.go
@@ -280,6 +280,11 @@ func (c *ControlChannel) Read(ctx context.Context) (*ControlPacket, error) {
 	return c.read(ctx, false)
 }
 
+// errParkedTLS is returned by waitForSoftReset when it parked a same-epoch
+// TLS control payload (token update / AUTH_FAILED) that must be consumed
+// before continuing to wait for the next soft reset.
+var errParkedTLS = errors.New("parked tls control payload")
+
 func (c *ControlChannel) waitForSoftReset(ctx context.Context) (*ControlPacket, error) {
 	c.mu.Lock()
 	if c.pendingSoftReset != nil {
@@ -299,12 +304,14 @@ func (c *ControlChannel) waitForSoftReset(ctx context.Context) (*ControlPacket, 
 		}
 		// Same-epoch P_CONTROL_V1 after a rekey is typically a token-only
 		// PUSH_REPLY (send_push_reply_auth_token). Park the TLS payload for
-		// ReadAll instead of ACK-and-dropping it. read() already ACKed.
+		// ReadAll instead of ACK-and-dropping it, and return so the caller
+		// consumes it immediately (a late AUTH_FAILED must not wait for the
+		// next soft reset). read() already ACKed.
 		if packet.Opcode == PControlV1 && len(packet.Payload) > 0 {
 			c.mu.Lock()
 			c.parkedTLS = append(c.parkedTLS, append([]byte(nil), packet.Payload...))
 			c.mu.Unlock()
-			continue
+			return nil, errParkedTLS
 		}
 		if err := c.SendAck(ctx); err != nil {
 			return nil, err
@@ -487,6 +494,12 @@ func (c *ControlChannel) PendingMessages() int {
 
 func (c *ControlChannel) RetransmitPending(ctx context.Context) error {
 	c.mu.Lock()
+	// Nothing to retransmit: do not consume pending ACKs (moving them into
+	// the MRU without emitting a packet would drop them).
+	if len(c.pending) == 0 {
+		c.mu.Unlock()
+		return nil
+	}
 	packets := make([]*ControlPacket, 0, len(c.pending))
 	// Pull current acks into the MRU once, so every retransmitted packet
 	// carries the same ack set (matching OpenVPN: retransmitted reliable

--- a/transport/openvpn/control.go
+++ b/transport/openvpn/control.go
@@ -49,6 +49,93 @@ type ControlChannel struct {
 	parkedTLS     [][]byte
 	readDeadline  time.Time
 	writeDeadline time.Time
+	// recReplay is the anti-replay window for tls-auth / tls-crypt
+	// protected control packets, mirroring OpenVPN's packet_id_rec
+	// (packet_id_test backtrack mode). Reset at each new key epoch.
+	recReplay replayState
+}
+
+// replayState is the receive-side anti-replay window for protected control
+// packets. Each packet carries [packet-id][timestamp] (unix seconds); the
+// window accepts ids that advance within the current second and rejects
+// replayed or time-traveling packets, matching OpenVPN packet_id_test.
+type replayState struct {
+	// time is the current window timestamp (seconds). Any packet with an
+	// older timestamp is rejected.
+	time uint32
+	// highID is the highest packet id seen in the current window.
+	highID uint32
+	// window is a bitmask of recently seen ids: bit i set means
+	// (highID - i) was already accepted.
+	window uint64
+	// seen reports whether the window has been initialized for this epoch.
+	seen bool
+}
+
+// controlReplayWindow mirrors OpenVPN's REPLAY_WINDOW (64) used for the
+// control-channel packet_id_rec seq_backtrack.
+const controlReplayWindow = 64
+
+// resetReplayLocked re-initializes the anti-replay window for a new key
+// epoch, seeding it with the first packet's id/timestamp. Must be called
+// with c.mu held.
+func (c *ControlChannel) resetReplayLocked(packetID, unixTime uint32) {
+	c.recReplay = replayState{
+		seen:   true,
+		time:   unixTime,
+		highID: packetID,
+		window: 1,
+	}
+}
+
+// checkReplay validates a protected control packet's packet-id/timestamp
+// against the anti-replay window. Returns an error for replayed or stale
+// packets. Must be called with c.mu held.
+func (c *ControlChannel) checkReplayLocked(packetID, unixTime uint32) error {
+	r := &c.recReplay
+	// OpenVPN packet_id_test (backtrack mode):
+	//   pin.time < rec.time           -> reject (time backtrack)
+	//   pin.time == rec.time          -> sliding-window id check
+	//   pin.time > rec.time           -> accept, reset window
+	if !r.seen {
+		r.seen = true
+		r.time = unixTime
+		r.highID = packetID
+		r.window = 1
+		return nil
+	}
+	if unixTime < r.time {
+		return fmt.Errorf("openvpn control replay: timestamp backtrack %d < %d", unixTime, r.time)
+	}
+	if unixTime > r.time {
+		// New second: the sender restarts its sequence. OpenVPN accepts and
+		// resets the window here.
+		r.time = unixTime
+		r.highID = packetID
+		r.window = 1
+		return nil
+	}
+	// Same second: sliding-window id check.
+	if packetID > r.highID {
+		shift := packetID - r.highID
+		if shift >= controlReplayWindow {
+			r.window = 1
+		} else {
+			r.window = r.window<<shift | 1
+		}
+		r.highID = packetID
+		return nil
+	}
+	diff := r.highID - packetID
+	if diff >= controlReplayWindow {
+		return fmt.Errorf("openvpn control replay: stale packet id %d", packetID)
+	}
+	mask := uint64(1) << diff
+	if r.window&mask != 0 {
+		return fmt.Errorf("openvpn control replay: replayed packet id %d", packetID)
+	}
+	r.window |= mask
+	return nil
 }
 
 func NewControlChannel(io PacketIO, crypt ControlCryptor, local SessionID) *ControlChannel {
@@ -113,6 +200,7 @@ func (c *ControlChannel) beginEpochLocked(keyID uint8) {
 	c.pending = make(map[uint32]*ControlPacket)
 	c.recvPending = make(map[uint32]*ControlPacket)
 	c.parkedTLS = nil
+	c.recReplay = replayState{}
 }
 
 // RotateKeyID advances to the next local key epoch and resets reliable state.
@@ -390,7 +478,7 @@ func (c *ControlChannel) read(ctx context.Context, watchSoftReset bool) (*Contro
 		if err != nil {
 			return nil, err
 		}
-		packet, _, _, err := DecodeControlPacket(c.crypt, raw)
+		packet, packetID, unixTime, err := DecodeControlPacket(c.crypt, raw)
 		if err != nil {
 			if watchSoftReset {
 				continue
@@ -409,6 +497,9 @@ func (c *ControlChannel) read(ctx context.Context, watchSoftReset bool) (*Contro
 				// client backwards, and an invalid one must not mutate ACK /
 				// pending-message state.
 				if packet.KeyID == NextKeyID(curKey) && packet.MessageID == 0 && sameSession {
+					// A valid next-epoch reset starts a fresh anti-replay
+					// window (the server restarts its packet-id sequence).
+					c.resetReplayLocked(packetID, unixTime)
 					if c.pendingSoftReset == nil {
 						c.pendingSoftReset = packet
 					}
@@ -425,19 +516,35 @@ func (c *ControlChannel) read(ctx context.Context, watchSoftReset bool) (*Contro
 				// cannot be fed into the new TLS session.
 				continue
 			}
+			if c.crypt != nil {
+				if err := c.checkReplayLocked(packetID, unixTime); err != nil {
+					c.mu.Unlock()
+					continue
+				}
+			}
 			c.mu.Unlock()
 		}
 
 		if watchSoftReset {
 			c.mu.Lock()
 			softReset, valid := c.classifyWatchPacketLocked(packet)
-			c.mu.Unlock()
 			if !valid {
+				c.mu.Unlock()
 				continue
 			}
 			if softReset {
+				// Valid next-epoch reset: start a fresh anti-replay window.
+				c.resetReplayLocked(packetID, unixTime)
+				c.mu.Unlock()
 				return packet, nil
 			}
+			if c.crypt != nil {
+				if err := c.checkReplayLocked(packetID, unixTime); err != nil {
+					c.mu.Unlock()
+					continue
+				}
+			}
+			c.mu.Unlock()
 		}
 
 		var deliver *ControlPacket

--- a/transport/openvpn/control.go
+++ b/transport/openvpn/control.go
@@ -33,8 +33,12 @@ type ControlChannel struct {
 	sendMessage   uint32
 	recvMessage   uint32
 	ackPending    []uint32
-	pending       map[uint32]*ControlPacket
-	recvPending   map[uint32]*ControlPacket
+	// lruAcks is the MRU of recently acknowledged packet IDs, mirroring
+	// OpenVPN's reliable_ack.lru_acks: acks are copied here when sent and
+	// kept so subsequent control packets repeat them until replaced.
+	lruAcks        []uint32
+	pending        map[uint32]*ControlPacket
+	recvPending    map[uint32]*ControlPacket
 	// pendingSoftReset holds a server soft-reset that arrived while the
 	// current epoch was still doing TLS/key-method. waitForSoftReset
 	// consumes it so ControlConn.Read cannot swallow it.
@@ -105,6 +109,7 @@ func (c *ControlChannel) beginEpochLocked(keyID uint8) {
 	c.sendMessage = 0
 	c.recvMessage = 0
 	c.ackPending = nil
+	c.lruAcks = nil
 	c.pending = make(map[uint32]*ControlPacket)
 	c.recvPending = make(map[uint32]*ControlPacket)
 	c.parkedTLS = nil
@@ -161,16 +166,19 @@ func (c *ControlChannel) Send(ctx context.Context, opcode Opcode, payload []byte
 	c.mu.Lock()
 	messageID := c.sendMessage
 	c.sendMessage++
+	// Copy pending acks into the MRU and take the ack list from the MRU,
+	// exactly like OpenVPN reliable_ack_write: recently acked IDs ride on
+	// this and subsequent packets until replaced.
+	ackIDs := c.takeAcksLocked()
 	packet := &ControlPacket{
 		Opcode:           opcode,
 		KeyID:            c.keyID,
 		LocalSession:     c.local,
-		AckIDs:           append([]uint32(nil), c.ackPending...),
+		AckIDs:           ackIDs,
 		AckRemoteSession: c.remote,
 		MessageID:        messageID,
 		Payload:          cloneBytes(payload),
 	}
-	c.ackPending = nil
 	c.pending[messageID] = packet
 	c.mu.Unlock()
 
@@ -180,20 +188,51 @@ func (c *ControlChannel) Send(ctx context.Context, opcode Opcode, payload []byte
 	return messageID, nil
 }
 
+// takeAcksLocked moves ackPending into the MRU and returns the ACK list to
+// place on the outgoing packet. Mirrors OpenVPN copy_acks_to_mru +
+// reliable_ack_write. Caller must hold c.mu.
+func (c *ControlChannel) takeAcksLocked() []uint32 {
+	// Move ackPending to the front of the MRU (newest first), dedup.
+	for i := len(c.ackPending) - 1; i >= 0; i-- {
+		id := c.ackPending[i]
+		if !containsUint32(c.lruAcks, id) {
+			c.lruAcks = append([]uint32{id}, c.lruAcks...)
+		}
+	}
+	c.ackPending = nil
+	// Cap at RELIABLE_ACK_SIZE.
+	if len(c.lruAcks) > reliableAckSize {
+		c.lruAcks = c.lruAcks[:reliableAckSize]
+	}
+	return append([]uint32(nil), c.lruAcks...)
+}
+
+func containsUint32(s []uint32, v uint32) bool {
+	for _, x := range s {
+		if x == v {
+			return true
+		}
+	}
+	return false
+}
+
+// reliableAckSize mirrors RELIABLE_ACK_SIZE in OpenVPN reliable.h.
+const reliableAckSize = 8
+
 func (c *ControlChannel) SendAck(ctx context.Context) error {
 	c.mu.Lock()
 	if len(c.ackPending) == 0 {
 		c.mu.Unlock()
 		return nil
 	}
+	ackIDs := c.takeAcksLocked()
 	packet := &ControlPacket{
 		Opcode:           PAckV1,
 		KeyID:            c.keyID,
 		LocalSession:     c.local,
-		AckIDs:           append([]uint32(nil), c.ackPending...),
+		AckIDs:           ackIDs,
 		AckRemoteSession: c.remote,
 	}
-	c.ackPending = nil
 	c.mu.Unlock()
 	return c.writeControlPacket(ctx, packet)
 }
@@ -410,21 +449,17 @@ func (c *ControlChannel) PendingMessages() int {
 func (c *ControlChannel) RetransmitPending(ctx context.Context) error {
 	c.mu.Lock()
 	packets := make([]*ControlPacket, 0, len(c.pending))
+	// Pull current acks into the MRU once, so every retransmitted packet
+	// carries the same ack set (matching OpenVPN: retransmitted reliable
+	// packets reuse the original ack header, and the MRU keeps recently
+	// acked IDs alive across sends).
+	ackIDs := c.takeAcksLocked()
 	for _, packet := range c.pending {
 		cp := *packet
-		// Merge the packet's original ACKs (e.g. the soft-reset ACK for the
-		// server's reset) with any newly pending ACKs, instead of replacing
-		// them with the current list. Replacing would drop the ACK the first
-		// send carried once ackPending had been cleared.
-		acks := append([]uint32(nil), packet.AckIDs...)
-		for _, ack := range c.ackPending {
-			acks = appendAck(acks, ack)
-		}
-		cp.AckIDs = acks
+		cp.AckIDs = ackIDs
 		cp.AckRemoteSession = c.remote
 		packets = append(packets, &cp)
 	}
-	c.ackPending = nil
 	c.mu.Unlock()
 
 	for _, packet := range packets {

--- a/transport/openvpn/control.go
+++ b/transport/openvpn/control.go
@@ -605,12 +605,15 @@ func (c *ControlChannel) read(ctx context.Context, watchSoftReset bool) (*Contro
 			c.recvMessage++
 			sendAck = true
 		default:
-			// Out-of-order packet ahead of recvMessage. Buffer it only if it
-			// fits the bounded window (like OpenVPN's rec_reliable); only an
-			// accepted packet is acknowledged. A rejected one stays with the
-			// sender for retransmission.
-			if _, exists := c.recvPending[packet.MessageID]; !exists &&
-				recvWindowOK(c.recvMessage, packet.MessageID, len(c.recvPending)) {
+			// Out-of-order packet ahead of recvMessage. A duplicate already
+			// buffered inside the receive window must be re-ACKed (its first
+			// ACK may have been lost) without re-inserting it. A new packet is
+			// buffered and ACKed only if it fits the bounded window; a rejected
+			// out-of-window packet is neither buffered nor ACKed.
+			if _, exists := c.recvPending[packet.MessageID]; exists {
+				c.ackPending = appendAck(c.ackPending, packet.MessageID)
+				sendAck = true
+			} else if recvWindowOK(c.recvMessage, packet.MessageID, len(c.recvPending)) {
 				c.recvPending[packet.MessageID] = packet
 				c.ackPending = appendAck(c.ackPending, packet.MessageID)
 				sendAck = true

--- a/transport/openvpn/control.go
+++ b/transport/openvpn/control.go
@@ -290,10 +290,19 @@ func (c *ControlChannel) waitForSoftReset(ctx context.Context) (*ControlPacket, 
 	if c.pendingSoftReset != nil {
 		packet := c.pendingSoftReset
 		c.pendingSoftReset = nil
+		// Defensive: a parked reset must be the strictly-next epoch and
+		// message 0; drop it otherwise (never advance the receive sequence
+		// off an invalid reset).
+		expected := NextKeyID(c.keyID)
+		if packet.KeyID != expected || packet.MessageID != 0 {
+			c.mu.Unlock()
+			goto read
+		}
 		c.mu.Unlock()
 		return packet, nil
 	}
 	c.mu.Unlock()
+read:
 	for {
 		packet, err := c.read(ctx, true)
 		if err != nil {
@@ -333,6 +342,14 @@ func (c *ControlChannel) ReadAll() []*ControlPacket {
 		return nil
 	}
 	out := make([]*ControlPacket, 0, n)
+	// parkedTLS payloads were received out of order and already advanced
+	// recvMessage, so they logically precede any newly contiguous recvPending
+	// entries. Emit them first to keep the TLS byte stream in order after
+	// UDP reordering.
+	for _, payload := range c.parkedTLS {
+		out = append(out, &ControlPacket{Opcode: PControlV1, Payload: payload})
+	}
+	c.parkedTLS = nil
 	for id := c.recvMessage; ; id++ {
 		pkt, ok := c.recvPending[id]
 		if !ok {
@@ -342,10 +359,6 @@ func (c *ControlChannel) ReadAll() []*ControlPacket {
 		c.recvMessage = id + 1
 		out = append(out, pkt)
 	}
-	for _, payload := range c.parkedTLS {
-		out = append(out, &ControlPacket{Opcode: PControlV1, Payload: payload})
-	}
-	c.parkedTLS = nil
 	return out
 }
 
@@ -390,11 +403,12 @@ func (c *ControlChannel) read(ctx context.Context, watchSoftReset bool) (*Contro
 			curKey := c.keyID
 			sameSession := c.remote == (SessionID{}) || packet.LocalSession == c.remote
 			if packet.Opcode == PControlSoftResetV1 {
-				// Only park a soft reset for the strictly-next epoch. A
+				// Only park a soft reset for the strictly-next epoch and
+				// message 0 (a new-epoch reset is always message 0). A
 				// delayed reset from a retiring epoch must not move the
 				// client backwards, and an invalid one must not mutate ACK /
 				// pending-message state.
-				if packet.KeyID == NextKeyID(curKey) && sameSession {
+				if packet.KeyID == NextKeyID(curKey) && packet.MessageID == 0 && sameSession {
 					if c.pendingSoftReset == nil {
 						c.pendingSoftReset = packet
 					}

--- a/transport/openvpn/control.go
+++ b/transport/openvpn/control.go
@@ -195,9 +195,17 @@ func (c *ControlChannel) Send(ctx context.Context, opcode Opcode, payload []byte
 // not evicted when the MRU is full. The MRU keeps its full capacity; max only
 // bounds what is serialized on this packet. Caller must hold c.mu.
 func (c *ControlChannel) takeAcksLocked(max int) []uint32 {
-	// Move ackPending (newest last) into the MRU front, preserving their
+	// Consume only the pending ACKs that can be serialized now (like
+	// reliable_ack_write): move ackPending[:n] into the MRU front and keep
+	// the remainder pending for the next packet. This preserves ACKs that
+	// the per-packet cap would otherwise drop.
+	n := len(c.ackPending)
+	if n > max {
+		n = max
+	}
+	// Move ackPending[:n] (newest last) into the MRU front, preserving their
 	// relative order, exactly like copy_acks_to_mru's backward loop.
-	for i := len(c.ackPending) - 1; i >= 0; i-- {
+	for i := n - 1; i >= 0; i-- {
 		id := c.ackPending[i]
 		move := id
 		found := false
@@ -214,16 +222,21 @@ func (c *ControlChannel) takeAcksLocked(max int) []uint32 {
 			c.lruAcks = append(c.lruAcks, move)
 		}
 	}
-	c.ackPending = nil
+	// Retain the unconsumed tail for the next send.
+	c.ackPending = c.ackPending[n:]
+	if len(c.ackPending) == 0 {
+		c.ackPending = nil
+	}
 	// Cap the MRU at RELIABLE_ACK_SIZE (move-to-front never grows past it).
 	if len(c.lruAcks) > reliableAckSize {
 		c.lruAcks = c.lruAcks[:reliableAckSize]
 	}
-	n := len(c.lruAcks)
-	if n > max {
-		n = max
+	// Serialize from the MRU: up to max, but never more than the MRU holds.
+	k := len(c.lruAcks)
+	if k > max {
+		k = max
 	}
-	return append([]uint32(nil), c.lruAcks[:n]...)
+	return append([]uint32(nil), c.lruAcks[:k]...)
 }
 
 // reliableAckSize mirrors RELIABLE_ACK_SIZE in OpenVPN reliable.h.

--- a/transport/openvpn/control.go
+++ b/transport/openvpn/control.go
@@ -479,9 +479,12 @@ func (c *ControlChannel) classifyWatchPacketLocked(packet *ControlPacket) (softR
 	if packet.Opcode == PControlSoftResetV1 {
 		// OpenVPN advances 0 -> 1 -> ... -> 7 -> 1. Reject stale or invalid
 		// epochs: a delayed reset from a retiring epoch, or key ID 0 after
-		// the initial epoch, must not move the client backwards.
+		// the initial epoch, must not move the client backwards. A new-epoch
+		// reset is always message 0 (the fresh reliable layer starts at 0);
+		// any other ID would corrupt the receive sequence and is invalid.
 		expected := NextKeyID(c.keyID)
-		return packet.KeyID == expected, packet.KeyID == expected
+		return packet.KeyID == expected && packet.MessageID == 0,
+			packet.KeyID == expected && packet.MessageID == 0
 	}
 	return false, packet.KeyID == c.keyID
 }

--- a/transport/openvpn/control.go
+++ b/transport/openvpn/control.go
@@ -190,30 +190,35 @@ func (c *ControlChannel) Send(ctx context.Context, opcode Opcode, payload []byte
 
 // takeAcksLocked moves ackPending into the MRU and returns the ACK list to
 // place on the outgoing packet. Mirrors OpenVPN copy_acks_to_mru +
-// reliable_ack_write. Caller must hold c.mu.
+// reliable_ack_write: each pending ID is moved to the front of the MRU
+// (existing entries shift right; a duplicate is removed), so re-acked IDs are
+// not evicted when the MRU is full. Caller must hold c.mu.
 func (c *ControlChannel) takeAcksLocked() []uint32 {
-	// Move ackPending to the front of the MRU (newest first), dedup.
+	// Move ackPending (newest last) into the MRU front, preserving their
+	// relative order, exactly like copy_acks_to_mru's backward loop.
 	for i := len(c.ackPending) - 1; i >= 0; i-- {
 		id := c.ackPending[i]
-		if !containsUint32(c.lruAcks, id) {
-			c.lruAcks = append([]uint32{id}, c.lruAcks...)
+		move := id
+		found := false
+		for j := 0; j < len(c.lruAcks); j++ {
+			tmp := c.lruAcks[j]
+			c.lruAcks[j] = move
+			move = tmp
+			if move == id {
+				found = true
+				break
+			}
+		}
+		if !found && len(c.lruAcks) < reliableAckSize {
+			c.lruAcks = append(c.lruAcks, move)
 		}
 	}
 	c.ackPending = nil
-	// Cap at RELIABLE_ACK_SIZE.
+	// Cap at RELIABLE_ACK_SIZE (move-to-front never grows past it).
 	if len(c.lruAcks) > reliableAckSize {
 		c.lruAcks = c.lruAcks[:reliableAckSize]
 	}
 	return append([]uint32(nil), c.lruAcks...)
-}
-
-func containsUint32(s []uint32, v uint32) bool {
-	for _, x := range s {
-		if x == v {
-			return true
-		}
-	}
-	return false
 }
 
 // reliableAckSize mirrors RELIABLE_ACK_SIZE in OpenVPN reliable.h.

--- a/transport/openvpn/control.go
+++ b/transport/openvpn/control.go
@@ -304,17 +304,23 @@ func (c *ControlChannel) read(ctx context.Context, watchSoftReset bool) (*Contro
 			c.mu.Lock()
 			curKey := c.keyID
 			sameSession := c.remote == (SessionID{}) || packet.LocalSession == c.remote
-			if packet.Opcode == PControlSoftResetV1 && packet.KeyID != curKey && sameSession {
-				if c.pendingSoftReset == nil {
-					c.pendingSoftReset = packet
-				}
-				for _, ackID := range packet.AckIDs {
-					delete(c.pending, ackID)
+			if packet.Opcode == PControlSoftResetV1 {
+				// Only park a soft reset for the strictly-next epoch. A
+				// delayed reset from a retiring epoch must not move the
+				// client backwards, and an invalid one must not mutate ACK /
+				// pending-message state.
+				if packet.KeyID == NextKeyID(curKey) && sameSession {
+					if c.pendingSoftReset == nil {
+						c.pendingSoftReset = packet
+					}
+					for _, ackID := range packet.AckIDs {
+						delete(c.pending, ackID)
+					}
 				}
 				c.mu.Unlock()
 				continue
 			}
-			if packet.Opcode != PControlSoftResetV1 && packet.KeyID != curKey {
+			if packet.KeyID != curKey {
 				c.mu.Unlock()
 				// Drop control packets from a retiring key epoch so they
 				// cannot be fed into the new TLS session.
@@ -406,7 +412,15 @@ func (c *ControlChannel) RetransmitPending(ctx context.Context) error {
 	packets := make([]*ControlPacket, 0, len(c.pending))
 	for _, packet := range c.pending {
 		cp := *packet
-		cp.AckIDs = append([]uint32(nil), c.ackPending...)
+		// Merge the packet's original ACKs (e.g. the soft-reset ACK for the
+		// server's reset) with any newly pending ACKs, instead of replacing
+		// them with the current list. Replacing would drop the ACK the first
+		// send carried once ackPending had been cleared.
+		acks := append([]uint32(nil), packet.AckIDs...)
+		for _, ack := range c.ackPending {
+			acks = appendAck(acks, ack)
+		}
+		cp.AckIDs = acks
 		cp.AckRemoteSession = c.remote
 		packets = append(packets, &cp)
 	}

--- a/transport/openvpn/control.go
+++ b/transport/openvpn/control.go
@@ -166,10 +166,10 @@ func (c *ControlChannel) Send(ctx context.Context, opcode Opcode, payload []byte
 	c.mu.Lock()
 	messageID := c.sendMessage
 	c.sendMessage++
-	// Copy pending acks into the MRU and take the ack list from the MRU,
-	// exactly like OpenVPN reliable_ack_write: recently acked IDs ride on
-	// this and subsequent packets until replaced.
-	ackIDs := c.takeAcksLocked()
+	// Copy pending acks into the MRU and take up to CONTROL_SEND_ACK_MAX
+	// for a reliable control packet, exactly like OpenVPN reliable_ack_write
+	// with CONTROL_SEND_ACK_MAX.
+	ackIDs := c.takeAcksLocked(controlSendAckMax)
 	packet := &ControlPacket{
 		Opcode:           opcode,
 		KeyID:            c.keyID,
@@ -188,12 +188,13 @@ func (c *ControlChannel) Send(ctx context.Context, opcode Opcode, payload []byte
 	return messageID, nil
 }
 
-// takeAcksLocked moves ackPending into the MRU and returns the ACK list to
-// place on the outgoing packet. Mirrors OpenVPN copy_acks_to_mru +
+// takeAcksLocked moves ackPending into the MRU and returns up to max ACK IDs
+// to place on the outgoing packet. Mirrors OpenVPN copy_acks_to_mru +
 // reliable_ack_write: each pending ID is moved to the front of the MRU
 // (existing entries shift right; a duplicate is removed), so re-acked IDs are
-// not evicted when the MRU is full. Caller must hold c.mu.
-func (c *ControlChannel) takeAcksLocked() []uint32 {
+// not evicted when the MRU is full. The MRU keeps its full capacity; max only
+// bounds what is serialized on this packet. Caller must hold c.mu.
+func (c *ControlChannel) takeAcksLocked(max int) []uint32 {
 	// Move ackPending (newest last) into the MRU front, preserving their
 	// relative order, exactly like copy_acks_to_mru's backward loop.
 	for i := len(c.ackPending) - 1; i >= 0; i-- {
@@ -214,15 +215,35 @@ func (c *ControlChannel) takeAcksLocked() []uint32 {
 		}
 	}
 	c.ackPending = nil
-	// Cap at RELIABLE_ACK_SIZE (move-to-front never grows past it).
+	// Cap the MRU at RELIABLE_ACK_SIZE (move-to-front never grows past it).
 	if len(c.lruAcks) > reliableAckSize {
 		c.lruAcks = c.lruAcks[:reliableAckSize]
 	}
-	return append([]uint32(nil), c.lruAcks...)
+	n := len(c.lruAcks)
+	if n > max {
+		n = max
+	}
+	return append([]uint32(nil), c.lruAcks[:n]...)
 }
 
 // reliableAckSize mirrors RELIABLE_ACK_SIZE in OpenVPN reliable.h.
 const reliableAckSize = 8
+
+// controlSendAckMax mirrors CONTROL_SEND_ACK_MAX in OpenVPN ssl.h: reliable
+// control packets carry at most this many ACKs.
+const controlSendAckMax = 4
+
+// dedicatedAckMax is the ACK cap for a dedicated P_ACK_V1 packet. OpenVPN
+// uses RELIABLE_ACK_SIZE (8) but caps it at 4 when the channel is unprotected
+// (TLS_WRAP_NONE, no tls-auth/tls-crypt) for SoftEther compatibility. mihomo
+// does not advertise TLS key-material export, so the same cap applies when
+// there is no control cryptor.
+func (c *ControlChannel) dedicatedAckMax() int {
+	if c.crypt == nil {
+		return controlSendAckMax
+	}
+	return reliableAckSize
+}
 
 func (c *ControlChannel) SendAck(ctx context.Context) error {
 	c.mu.Lock()
@@ -230,7 +251,7 @@ func (c *ControlChannel) SendAck(ctx context.Context) error {
 		c.mu.Unlock()
 		return nil
 	}
-	ackIDs := c.takeAcksLocked()
+	ackIDs := c.takeAcksLocked(c.dedicatedAckMax())
 	packet := &ControlPacket{
 		Opcode:           PAckV1,
 		KeyID:            c.keyID,
@@ -458,7 +479,7 @@ func (c *ControlChannel) RetransmitPending(ctx context.Context) error {
 	// carries the same ack set (matching OpenVPN: retransmitted reliable
 	// packets reuse the original ack header, and the MRU keeps recently
 	// acked IDs alive across sends).
-	ackIDs := c.takeAcksLocked()
+	ackIDs := c.takeAcksLocked(controlSendAckMax)
 	for _, packet := range c.pending {
 		cp := *packet
 		cp.AckIDs = ackIDs

--- a/transport/openvpn/control_test.go
+++ b/transport/openvpn/control_test.go
@@ -124,6 +124,63 @@ func TestRecvPendingBounded(t *testing.T) {
 // whose message ID breaks the receive window is neither buffered nor
 // acknowledged, so the sender keeps it for retransmission instead of dropping
 // it and leaving a permanent hole.
+// TestBufferedDuplicateReAcked verifies a retransmitted, already-buffered
+// in-window packet is ACKed again without re-insertion or delivery. Its first
+// ACK may have been lost, so suppressing the second ACK keeps the sender's
+// reliable slot occupied indefinitely.
+func TestBufferedDuplicateReAcked(t *testing.T) {
+	client, server := newTestChannels(t)
+	client.SetRemoteSessionID(server.LocalSessionID())
+	server.SetRemoteSessionID(client.LocalSessionID())
+	serverIO := server.io.(*memoryPacketIO)
+
+	inner := &ControlPacket{
+		Opcode:       PControlV1,
+		KeyID:        0,
+		LocalSession: server.LocalSessionID(),
+		MessageID:    1, // client expects 0: valid out-of-order, buffered
+		Payload:      []byte("buffer me"),
+	}
+	sendAndRead := func(outerPID uint32) *ControlPacket {
+		raw, err := inner.Encode(server.crypt, outerPID, uint32(server.clock().Unix()))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := server.io.WritePacket(context.Background(), raw); err != nil {
+			t.Fatal(err)
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+		defer cancel()
+		_, _ = client.read(ctx, false) // remains waiting for message 0
+		select {
+		case ackRaw := <-serverIO.in:
+			ack, _, _, err := DecodeControlPacket(server.crypt, ackRaw)
+			if err != nil {
+				t.Fatal(err)
+			}
+			return ack
+		default:
+			t.Fatal("buffered in-window duplicate was not re-ACKed")
+		}
+		return nil
+	}
+
+	first := sendAndRead(1)
+	if len(first.AckIDs) == 0 || first.AckIDs[0] != 1 {
+		t.Fatalf("first ACK missing message 1: %v", first.AckIDs)
+	}
+	if len(client.recvPending) != 1 {
+		t.Fatalf("message 1 not buffered: %d", len(client.recvPending))
+	}
+	second := sendAndRead(2)
+	if len(second.AckIDs) == 0 || second.AckIDs[0] != 1 {
+		t.Fatalf("duplicate ACK missing message 1: %v", second.AckIDs)
+	}
+	if len(client.recvPending) != 1 {
+		t.Fatalf("duplicate was re-inserted: %d", len(client.recvPending))
+	}
+}
+
 func TestOutOfWindowPacketNotAcked(t *testing.T) {
 	client, server := newTestChannels(t)
 	client.SetRemoteSessionID(server.LocalSessionID())

--- a/transport/openvpn/control_test.go
+++ b/transport/openvpn/control_test.go
@@ -120,6 +120,56 @@ func TestRecvPendingBounded(t *testing.T) {
 	}
 }
 
+// TestOutOfWindowPacketNotAcked verifies the review point 3: a control packet
+// whose message ID breaks the receive window is neither buffered nor
+// acknowledged, so the sender keeps it for retransmission instead of dropping
+// it and leaving a permanent hole.
+func TestOutOfWindowPacketNotAcked(t *testing.T) {
+	client, server := newTestChannels(t)
+	client.SetRemoteSessionID(server.LocalSessionID())
+	server.SetRemoteSessionID(client.LocalSessionID())
+
+	// client expects message 0; a packet with message 12 is at the window
+	// edge (recvMessage+reliableCapacity) and must be rejected, not ACKed.
+	client.recvMessage = 0
+	pkt := &ControlPacket{
+		Opcode:       PControlV1,
+		KeyID:        0,
+		LocalSession: server.LocalSessionID(),
+		MessageID:    12,
+		Payload:      []byte("hello"),
+	}
+	raw, err := pkt.Encode(server.crypt, 1, uint32(client.clock().Unix()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	server.io.WritePacket(context.Background(), raw)
+
+	// read() consumes the out-of-window packet and (correctly) does not
+	// deliver it; it keeps reading, so bound the read with a short timeout.
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+	_, err = client.read(ctx, false)
+	if err == nil {
+		t.Fatal("expected timeout while waiting after rejected window packet")
+	}
+	// No ACK must have been sent: ackPending stays empty and nothing goes out.
+	client.mu.Lock()
+	acked := len(client.ackPending)
+	client.mu.Unlock()
+	if acked != 0 {
+		t.Fatalf("out-of-window message was ACKed (ackPending=%d)", acked)
+	}
+	// The other direction (client's outbound) must not contain an ACK packet:
+	// nothing may have been written toward the server.
+	serverIO := server.io.(*memoryPacketIO)
+	select {
+	case p := <-serverIO.in:
+		t.Fatalf("unexpected outbound packet after rejected window: %x", p)
+	default:
+	}
+}
+
 func TestCheckReplayAntiReplay(t *testing.T) {
 	c := &ControlChannel{}
 	// First packet initializes the window.

--- a/transport/openvpn/control_test.go
+++ b/transport/openvpn/control_test.go
@@ -87,6 +87,54 @@ func newTestChannels(t *testing.T) (*ControlChannel, *ControlChannel) {
 	return client, server
 }
 
+// TestCheckReplayAntiReplay verifies the protected-control anti-replay window
+// accepts advancing ids, rejects replays and stale/timestamp-backtracking
+// packets, and resets on a new second.
+func TestCheckReplayAntiReplay(t *testing.T) {
+	c := &ControlChannel{}
+	// First packet initializes the window.
+	if err := c.checkReplayLocked(1, 1000); err != nil {
+		t.Fatalf("first packet rejected: %v", err)
+	}
+	// Advancing id accepted.
+	for _, id := range []uint32{2, 3, 5} {
+		if err := c.checkReplayLocked(id, 1000); err != nil {
+			t.Fatalf("advancing id %d rejected: %v", id, err)
+		}
+	}
+	// Out-of-order within window accepted.
+	if err := c.checkReplayLocked(4, 1000); err != nil {
+		t.Fatalf("out-of-order id 4 rejected: %v", err)
+	}
+	// Exact replay rejected.
+	if err := c.checkReplayLocked(4, 1000); err == nil {
+		t.Fatal("replayed id 4 accepted")
+	}
+	// Stale id beyond window rejected.
+	if err := c.checkReplayLocked(1, 1000); err == nil {
+		t.Fatal("stale id 1 accepted")
+	}
+	// Timestamp backtrack rejected.
+	if err := c.checkReplayLocked(10, 999); err == nil {
+		t.Fatal("timestamp backtrack accepted")
+	}
+	// New second resets and accepts.
+	if err := c.checkReplayLocked(1, 1001); err != nil {
+		t.Fatalf("new second id 1 rejected: %v", err)
+	}
+	if err := c.checkReplayLocked(1, 1001); err == nil {
+		t.Fatal("replay after reset accepted")
+	}
+	// resetReplayLocked seeds a fresh window.
+	c.resetReplayLocked(1, 2000)
+	if err := c.checkReplayLocked(1, 2000); err == nil {
+		t.Fatal("duplicate of seed id accepted")
+	}
+	if err := c.checkReplayLocked(2, 2000); err != nil {
+		t.Fatalf("advancing id after reset rejected: %v", err)
+	}
+}
+
 func TestControlChannelResetAndAck(t *testing.T) {
 	client, server := newTestChannels(t)
 

--- a/transport/openvpn/control_test.go
+++ b/transport/openvpn/control_test.go
@@ -227,39 +227,46 @@ func TestClientWaitServerResetRetransmitsUDP(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	errCh := make(chan error, 1)
+	waitErr := make(chan error, 1)
 	go func() {
-		packet, err := serverControl.Read(ctx)
-		if err != nil {
-			errCh <- err
-			return
-		}
-		if packet.Opcode != PControlHardResetClientV2 {
-			errCh <- errors.New("unexpected reset opcode")
-			return
-		}
-		raw, err := serverIO.ReadPacket(ctx)
-		if err != nil {
-			errCh <- err
-			return
-		}
-		packet, _, _, err = DecodeControlPacket(nil, raw)
-		if err != nil {
-			errCh <- err
-			return
-		}
-		if packet.Opcode != PControlHardResetClientV2 || packet.MessageID != 0 {
-			errCh <- errors.New("unexpected retransmitted reset packet")
-			return
-		}
-		_, err = serverControl.Send(ctx, PControlHardResetServerV2, nil)
-		errCh <- err
+		waitErr <- client.waitServerReset(ctx)
 	}()
 
-	if err := client.waitServerReset(ctx); err != nil {
+	// Drop the first raw reset; the client retransmits on the next
+	// ControlRetransmitDelay once waitServerReset is running.
+	first, err := serverIO.ReadPacket(ctx)
+	if err != nil {
 		t.Fatal(err)
 	}
-	if err := <-errCh; err != nil {
+	pkt, _, _, err := DecodeControlPacket(nil, first)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if pkt.Opcode != PControlHardResetClientV2 {
+		t.Fatalf("unexpected first reset opcode: %s", pkt.Opcode)
+	}
+
+	second, err := serverIO.ReadPacket(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pkt, _, _, err = DecodeControlPacket(nil, second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if pkt.Opcode != PControlHardResetClientV2 || pkt.MessageID != 0 {
+		t.Fatalf("unexpected retransmitted reset: %s msg=%d", pkt.Opcode, pkt.MessageID)
+	}
+
+	// Ack the retransmitted reset, then respond with the server hard reset.
+	serverControl.QueueAck(0)
+	if err := serverControl.SendAck(ctx); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := serverControl.Send(ctx, PControlHardResetServerV2, nil); err != nil {
+		t.Fatal(err)
+	}
+	if err := <-waitErr; err != nil {
 		t.Fatal(err)
 	}
 	if clientControl.PendingMessages() != 0 {

--- a/transport/openvpn/control_test.go
+++ b/transport/openvpn/control_test.go
@@ -90,6 +90,36 @@ func newTestChannels(t *testing.T) (*ControlChannel, *ControlChannel) {
 // TestCheckReplayAntiReplay verifies the protected-control anti-replay window
 // accepts advancing ids, rejects replays and stale/timestamp-backtracking
 // packets, and resets on a new second.
+// TestRecvPendingBounded verifies the out-of-order receive buffer does not
+// grow without bound: packets whose message ID falls outside
+// [recvMessage, recvMessage+reliableCapacity) are not buffered, and the
+// buffer stops filling once it holds reliableCapacity packets.
+func TestRecvPendingBounded(t *testing.T) {
+	const base = uint32(100)
+	// In-window ids are storable up to the capacity.
+	for i := uint32(1); i < reliableCapacity; i++ {
+		if !recvWindowOK(base, base+i, int(i-1)) {
+			t.Fatalf("in-window id %d refused", base+i)
+		}
+	}
+	// At capacity, further ids are refused even if in-window.
+	if recvWindowOK(base, base+1, reliableCapacity) {
+		t.Fatal("buffered==capacity should refuse")
+	}
+	// Past the window refused.
+	if recvWindowOK(base, base+reliableCapacity, 0) {
+		t.Fatal("id at window edge accepted")
+	}
+	if recvWindowOK(base, base+reliableCapacity+1, 0) {
+		t.Fatal("id past window accepted")
+	}
+	// Below recvMessage refused (handled as replay earlier, but window must
+	// not accept it).
+	if recvWindowOK(base, base-1, 0) {
+		t.Fatal("id below recvMessage accepted")
+	}
+}
+
 func TestCheckReplayAntiReplay(t *testing.T) {
 	c := &ControlChannel{}
 	// First packet initializes the window.

--- a/transport/openvpn/data.go
+++ b/transport/openvpn/data.go
@@ -72,7 +72,7 @@ type DataChannel struct {
 	randOffset int
 }
 
-func NewDataChannel(keys *KeyMaterial, cipherName, authName string, peerID uint32) (*DataChannel, error) {
+func NewDataChannel(keys *KeyMaterial, cipherName, authName string, peerID uint32, keyID uint8) (*DataChannel, error) {
 	if keys == nil {
 		return nil, errors.New("nil openvpn key material")
 	}
@@ -91,8 +91,9 @@ func NewDataChannel(keys *KeyMaterial, cipherName, authName string, peerID uint3
 		d := &DataChannel{
 			sendAEAD: send,
 			recvAEAD: recv,
+			keyID:    keyID & KeyIDMask,
 			peerID:   peerID,
-			header:   dataHeader(peerID, 0),
+			header:   dataHeader(peerID, keyID),
 		}
 		copy(d.sendImplicitIV[4:], keys.SendHMACKey[:DataChannelIVSize-4])
 		copy(d.recvImplicitIV[4:], keys.RecvHMACKey[:DataChannelIVSize-4])
@@ -121,8 +122,9 @@ func NewDataChannel(keys *KeyMaterial, cipherName, authName string, peerID uint3
 		recvHMACKey: append([]byte(nil), keys.RecvHMACKey[:authSize]...),
 		authHash:    authHash,
 		authSize:    authSize,
+		keyID:       keyID & KeyIDMask,
 		peerID:      peerID,
-		header:      dataHeader(peerID, 0),
+		header:      dataHeader(peerID, keyID),
 	}
 	d.sendMACPool.New = func() any {
 		return hmac.New(d.authHash, d.sendHMACKey)

--- a/transport/openvpn/data.go
+++ b/transport/openvpn/data.go
@@ -66,9 +66,18 @@ type DataChannel struct {
 	// sendStarted is true once a packet has been encrypted with this key,
 	// i.e. the key was actually used for outbound data at least once.
 	sendStarted bool
-	recvHighest uint32
-	recvWindow  uint64
-	recvSeen    bool
+	// recvEvidence latches true once a data packet labeled with this key ID
+	// decrypted successfully. The peer only labels outbound packets with a
+	// key whose authentication completed (OpenVPN tls_pre_encrypt /
+	// handle_data_channel_packet require KS_AUTH_TRUE), so this is the
+	// reliable signal that this epoch has been activated by the peer and can
+	// replace the lame-duck for outbound traffic. Stored per-epoch so a
+	// back-to-back rekey cannot attribute an older epoch's evidence to a
+	// newer key. Guarded by d.mu.
+	recvEvidence bool
+	recvHighest  uint32
+	recvWindow   uint64
+	recvSeen     bool
 
 	randMu     sync.Mutex
 	randBuf    []byte
@@ -240,7 +249,7 @@ func (d *DataChannel) encryptCBC(packet []byte, packetID uint32) ([]byte, error)
 		ciphertext[i] = byte(padding)
 	}
 	cipher.NewCBCEncrypter(d.sendBlock, iv).CryptBlocks(ciphertext, ciphertext)
-	_ = d.hmacAppend(&d.sendMACPool, authenticated, out[len(header):len(header)])
+	d.hmacCopy(&d.sendMACPool, authenticated, out[len(header):])
 	return out, nil
 }
 
@@ -361,6 +370,21 @@ func (d *DataChannel) Started() bool {
 	return d.sendStarted
 }
 
+// MarkPeerActive records that a packet labeled with this key ID decrypted
+// successfully, i.e. the peer has activated this epoch.
+func (d *DataChannel) MarkPeerActive() {
+	d.mu.Lock()
+	d.recvEvidence = true
+	d.mu.Unlock()
+}
+
+// PeerActive reports whether the peer has activated this epoch.
+func (d *DataChannel) PeerActive() bool {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.recvEvidence
+}
+
 func (d *DataChannel) acceptPacketID(packetID uint32) error {
 	d.mu.Lock()
 	defer d.mu.Unlock()
@@ -450,6 +474,19 @@ func (d *DataChannel) hmacAppend(pool *sync.Pool, data, dst []byte) []byte {
 	mac.Reset()
 	_, _ = mac.Write(data)
 	return mac.Sum(dst)
+}
+
+// hmacCopy writes the HMAC of data into dst (which must have enough
+// capacity), returning the number of bytes written. Unlike hmacAppend it
+// does not rely on mac.Sum(dst) appending into dst's backing array — it
+// always writes the tag into dst explicitly.
+func (d *DataChannel) hmacCopy(pool *sync.Pool, data, dst []byte) int {
+	mac := pool.Get().(hash.Hash)
+	defer pool.Put(mac)
+	mac.Reset()
+	_, _ = mac.Write(data)
+	n := copy(dst, mac.Sum(nil))
+	return n
 }
 
 func pkcs7Pad(plain []byte, blockSize int) []byte {

--- a/transport/openvpn/data.go
+++ b/transport/openvpn/data.go
@@ -63,9 +63,12 @@ type DataChannel struct {
 
 	mu           sync.Mutex
 	sendPacketID uint32
-	recvHighest  uint32
-	recvWindow   uint64
-	recvSeen     bool
+	// sendStarted is true once a packet has been encrypted with this key,
+	// i.e. the key was actually used for outbound data at least once.
+	sendStarted bool
+	recvHighest uint32
+	recvWindow  uint64
+	recvSeen    bool
 
 	randMu     sync.Mutex
 	randBuf    []byte
@@ -345,7 +348,17 @@ func (d *DataChannel) nextPacketID() uint32 {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 	d.sendPacketID++
+	d.sendStarted = true
 	return d.sendPacketID
+}
+
+// Started reports whether this key has encrypted at least one outbound
+// packet. Guarded by d.mu so it is safe to call while another goroutine is
+// encrypting.
+func (d *DataChannel) Started() bool {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.sendStarted
 }
 
 func (d *DataChannel) acceptPacketID(packetID uint32) error {

--- a/transport/openvpn/data_ciphers_test.go
+++ b/transport/openvpn/data_ciphers_test.go
@@ -131,7 +131,7 @@ func TestParsePushReplyNcpCiphers(t *testing.T) {
 
 func TestInstallScriptPeerInfoWithDataCiphers(t *testing.T) {
 	info := InstallScriptPeerInfo(CipherAES128GCM, []string{CipherAES256GCM, CipherAES128GCM, CipherChaCha20Poly1305}, "", nil)
-	want := "IV_VER=mihomo-openvpn\nIV_PROTO=6\nIV_CIPHERS=AES-256-GCM:AES-128-GCM:CHACHA20-POLY1305\n"
+	want := "IV_VER=mihomo-openvpn\nIV_PROTO=22\nIV_CIPHERS=AES-256-GCM:AES-128-GCM:CHACHA20-POLY1305\n"
 	if info != want {
 		t.Fatalf("unexpected peer-info:\n got %q\nwant %q", info, want)
 	}

--- a/transport/openvpn/data_test.go
+++ b/transport/openvpn/data_test.go
@@ -21,11 +21,11 @@ func TestDataChannelAESGCMV2RoundTrip(t *testing.T) {
 		RecvCipherKey: clientKeys.SendCipherKey,
 		RecvHMACKey:   clientKeys.SendHMACKey,
 	}
-	client, err := NewDataChannel(clientKeys, CipherAES128GCM, AuthSHA256, 7)
+	client, err := NewDataChannel(clientKeys, CipherAES128GCM, AuthSHA256, 7, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
-	server, err := NewDataChannel(serverKeys, CipherAES128GCM, AuthSHA256, 7)
+	server, err := NewDataChannel(serverKeys, CipherAES128GCM, AuthSHA256, 7, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -75,11 +75,11 @@ func TestDataChannelAcceptsOutOfOrderPacketsWithinReplayWindow(t *testing.T) {
 		RecvCipherKey: clientKeys.SendCipherKey,
 		RecvHMACKey:   clientKeys.SendHMACKey,
 	}
-	client, err := NewDataChannel(clientKeys, CipherAES128GCM, AuthSHA256, 7)
+	client, err := NewDataChannel(clientKeys, CipherAES128GCM, AuthSHA256, 7, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
-	server, err := NewDataChannel(serverKeys, CipherAES128GCM, AuthSHA256, 7)
+	server, err := NewDataChannel(serverKeys, CipherAES128GCM, AuthSHA256, 7, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -154,11 +154,11 @@ func TestDataChannelChaCha20Poly1305V2RoundTrip(t *testing.T) {
 		RecvCipherKey: clientKeys.SendCipherKey,
 		RecvHMACKey:   clientKeys.SendHMACKey,
 	}
-	client, err := NewDataChannel(clientKeys, CipherChaCha20Poly1305, AuthSHA256, 7)
+	client, err := NewDataChannel(clientKeys, CipherChaCha20Poly1305, AuthSHA256, 7, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
-	server, err := NewDataChannel(serverKeys, CipherChaCha20Poly1305, AuthSHA256, 7)
+	server, err := NewDataChannel(serverKeys, CipherChaCha20Poly1305, AuthSHA256, 7, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -194,11 +194,11 @@ func TestDataChannelAESCBCSHA1V2RoundTrip(t *testing.T) {
 		RecvCipherKey: clientKeys.SendCipherKey,
 		RecvHMACKey:   clientKeys.SendHMACKey,
 	}
-	client, err := NewDataChannel(clientKeys, CipherAES128CBC, AuthSHA1, 7)
+	client, err := NewDataChannel(clientKeys, CipherAES128CBC, AuthSHA1, 7, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
-	server, err := NewDataChannel(serverKeys, CipherAES128CBC, AuthSHA1, 7)
+	server, err := NewDataChannel(serverKeys, CipherAES128CBC, AuthSHA1, 7, 0)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/transport/openvpn/keymethod.go
+++ b/transport/openvpn/keymethod.go
@@ -196,7 +196,14 @@ func looksLikeFollowingTLSControl(b []byte) bool {
 	}
 	return bytes.HasPrefix(b, []byte("PUSH_REPLY")) ||
 		bytes.HasPrefix(b, []byte("AUTH_FAILED")) ||
-		bytes.HasPrefix(b, []byte("PUSH_REQUEST"))
+		bytes.HasPrefix(b, []byte("PUSH_REQUEST")) ||
+		bytes.HasPrefix(b, []byte("AUTH_PENDING")) ||
+		bytes.HasPrefix(b, []byte("INFO_PRE")) ||
+		bytes.HasPrefix(b, []byte("INFO")) ||
+		bytes.HasPrefix(b, []byte("RESTART")) ||
+		bytes.HasPrefix(b, []byte("HALT")) ||
+		bytes.HasPrefix(b, []byte("EXIT")) ||
+		bytes.HasPrefix(b, []byte("CR_RESPONSE"))
 }
 
 func DeriveClientKeyMaterial(sources KeySource2, clientSession, serverSession SessionID, cipherKeyLen int) (*KeyMaterial, error) {

--- a/transport/openvpn/keymethod.go
+++ b/transport/openvpn/keymethod.go
@@ -88,14 +88,25 @@ func (r *KeyMethod2Record) MarshalClient() ([]byte, error) {
 }
 
 func ParseServerKeyMethod2Record(packet []byte) (*KeyMethod2Record, error) {
+	record, _, err := ParseServerKeyMethod2RecordConsumed(packet)
+	return record, err
+}
+
+// ParseServerKeyMethod2RecordConsumed parses a server key-method-2 record and
+// reports how many bytes were consumed so following TLS control data
+// (PUSH_REPLY / AUTH_FAILED) can be preserved.
+//
+// OpenVPN 2.6 may omit the optional username, password and peer-info strings
+// after the mandatory options string.
+func ParseServerKeyMethod2RecordConsumed(packet []byte) (*KeyMethod2Record, int, error) {
 	if len(packet) < 4+1+keySourceRandomSize*2 {
-		return nil, errors.New("key method 2 packet too short")
+		return nil, 0, errors.New("key method 2 packet too short")
 	}
 	if binary.BigEndian.Uint32(packet[:4]) != 0 {
-		return nil, errors.New("invalid key method 2 prefix")
+		return nil, 0, errors.New("invalid key method 2 prefix")
 	}
 	if packet[4]&0x0f != KeyMethod2 {
-		return nil, fmt.Errorf("unsupported key method %d", packet[4])
+		return nil, 0, fmt.Errorf("unsupported key method %d", packet[4])
 	}
 	offset := 5
 	record := &KeyMethod2Record{}
@@ -107,12 +118,30 @@ func ParseServerKeyMethod2Record(packet []byte) (*KeyMethod2Record, error) {
 	var err error
 	record.Options, offset, err = readOpenVPNString(packet, offset)
 	if err != nil {
-		return nil, fmt.Errorf("read options: %w", err)
+		return nil, 0, fmt.Errorf("read options: %w", err)
 	}
-	record.Username, offset, _ = readOpenVPNString(packet, offset)
-	record.Password, offset, _ = readOpenVPNString(packet, offset)
-	record.PeerInfo, _, _ = readOpenVPNString(packet, offset)
-	return record, nil
+	// Trailing username / password / peer-info are optional. A truncated
+	// length prefix is treated as "not present" rather than a hard error so
+	// a shortened 2.6 record still parses.
+	if record.Username, offset, err = readOpenVPNString(packet, offset); err != nil {
+		if errors.Is(err, ioStringEOF) {
+			return record, offset, nil
+		}
+		return nil, 0, err
+	}
+	if record.Password, offset, err = readOpenVPNString(packet, offset); err != nil {
+		if errors.Is(err, ioStringEOF) {
+			return record, offset, nil
+		}
+		return nil, 0, err
+	}
+	if record.PeerInfo, offset, err = readOpenVPNString(packet, offset); err != nil {
+		if errors.Is(err, ioStringEOF) {
+			return record, offset, nil
+		}
+		return nil, 0, err
+	}
+	return record, offset, nil
 }
 
 func DeriveClientKeyMaterial(sources KeySource2, clientSession, serverSession SessionID, cipherKeyLen int) (*KeyMaterial, error) {
@@ -232,19 +261,18 @@ func readOpenVPNString(packet []byte, offset int) (string, int, error) {
 		return "", offset, ioStringEOF
 	}
 	size := int(binary.BigEndian.Uint16(packet[offset : offset+2]))
-	offset += 2
 	if size == 0 {
-		return "", offset, nil
+		return "", offset + 2, nil
 	}
-	if offset+size > len(packet) {
+	if offset+2+size > len(packet) {
+		// Do not consume the length prefix: leftover bytes may be PUSH_REPLY.
 		return "", offset, ioStringEOF
 	}
-	raw := packet[offset : offset+size]
-	offset += size
+	raw := packet[offset+2 : offset+2+size]
 	if raw[len(raw)-1] == 0 {
 		raw = raw[:len(raw)-1]
 	}
-	return string(raw), offset, nil
+	return string(raw), offset + 2 + size, nil
 }
 
 var ioStringEOF = errors.New("openvpn string truncated")

--- a/transport/openvpn/keymethod.go
+++ b/transport/openvpn/keymethod.go
@@ -1,6 +1,7 @@
 package openvpn
 
 import (
+	"bytes"
 	"crypto/hmac"
 	"crypto/md5"
 	"crypto/rand"
@@ -120,28 +121,82 @@ func ParseServerKeyMethod2RecordConsumed(packet []byte) (*KeyMethod2Record, int,
 	if err != nil {
 		return nil, 0, fmt.Errorf("read options: %w", err)
 	}
-	// Trailing username / password / peer-info are optional. A truncated
-	// length prefix is treated as "not present" rather than a hard error so
-	// a shortened 2.6 record still parses.
-	if record.Username, offset, err = readOpenVPNString(packet, offset); err != nil {
-		if errors.Is(err, ioStringEOF) {
-			return record, offset, nil
-		}
+	// Username / password / peer-info are written by OpenVPN 2.6 even when
+	// empty. Only stop early when the remaining bytes are a following TLS
+	// control message (PUSH_REPLY / AUTH_FAILED). A truncated length/value
+	// is not a shortened record — the caller must keep reading.
+	if record.Username, offset, err = readKM2TrailingString(packet, offset); err != nil {
 		return nil, 0, err
 	}
-	if record.Password, offset, err = readOpenVPNString(packet, offset); err != nil {
-		if errors.Is(err, ioStringEOF) {
-			return record, offset, nil
-		}
+	if record.Password, offset, err = readKM2TrailingString(packet, offset); err != nil {
 		return nil, 0, err
 	}
-	if record.PeerInfo, offset, err = readOpenVPNString(packet, offset); err != nil {
-		if errors.Is(err, ioStringEOF) {
-			return record, offset, nil
-		}
+	if record.PeerInfo, offset, err = readKM2TrailingString(packet, offset); err != nil {
 		return nil, 0, err
 	}
 	return record, offset, nil
+}
+
+func readKM2TrailingString(packet []byte, offset int) (string, int, error) {
+	s, next, err := readOpenVPNString(packet, offset)
+	if err == nil {
+		return s, next, nil
+	}
+	if errors.Is(err, ioStringEOF) && looksLikeFollowingTLSControl(packet[offset:]) {
+		return "", offset, nil
+	}
+	return "", offset, err
+}
+
+// RecordComplete reports whether a full key-method-2 server record is present,
+// and returns the consumed offset. It requires all four strings (OpenVPN 2.6
+// writes them even when empty) so a standard record fragmented across TLS
+// reads is not accepted prematurely.
+func RecordComplete(packet []byte) (complete bool, consumed int) {
+	if len(packet) < 4+1+keySourceRandomSize*2 {
+		return false, 0
+	}
+	if binary.BigEndian.Uint32(packet[:4]) != 0 {
+		return false, 0
+	}
+	if packet[4]&0x0f != KeyMethod2 {
+		return false, 0
+	}
+	offset := 5 + keySourceRandomSize*2
+	if !km2StrComplete(packet, offset) {
+		return false, 0
+	}
+	offset += 2 + int(binary.BigEndian.Uint16(packet[offset:offset+2]))
+	for i := 0; i < 3; i++ {
+		if !km2StrComplete(packet, offset) {
+			return false, 0
+		}
+		offset += 2 + int(binary.BigEndian.Uint16(packet[offset:offset+2]))
+	}
+	return true, offset
+}
+
+func km2StrComplete(packet []byte, offset int) bool {
+	if offset+2 > len(packet) {
+		return false
+	}
+	size := int(binary.BigEndian.Uint16(packet[offset : offset+2]))
+	if size == 0 {
+		return true
+	}
+	return offset+2+size <= len(packet)
+}
+
+func looksLikeFollowingTLSControl(b []byte) bool {
+	for len(b) > 0 && b[0] == 0 {
+		b = b[1:]
+	}
+	if len(b) == 0 {
+		return false
+	}
+	return bytes.HasPrefix(b, []byte("PUSH_REPLY")) ||
+		bytes.HasPrefix(b, []byte("AUTH_FAILED")) ||
+		bytes.HasPrefix(b, []byte("PUSH_REQUEST"))
 }
 
 func DeriveClientKeyMaterial(sources KeySource2, clientSession, serverSession SessionID, cipherKeyLen int) (*KeyMaterial, error) {

--- a/transport/openvpn/keymethod.go
+++ b/transport/openvpn/keymethod.go
@@ -283,7 +283,11 @@ func InstallScriptPeerInfo(cipher string, dataCiphers []string, compLZO string, 
 		}
 		ivCiphers = strings.Join(normalized, ":")
 	}
-	info := fmt.Sprintf("IV_VER=%s\nIV_PROTO=6\n%sIV_CIPHERS=%s\n", ivVer, lzo, ivCiphers)
+	// IV_PROTO advertises DATA_V2 (bit 1), REQUEST_PUSH (bit 2) and
+	// AUTH_PENDING keyword support (bit 4). The parser supports
+	// AUTH_PENDING,timeout N, so capability and behavior must agree.
+	const ivProto = (1 << 1) | (1 << 2) | (1 << 4) // 22
+	info := fmt.Sprintf("IV_VER=%s\nIV_PROTO=%d\n%sIV_CIPHERS=%s\n", ivVer, ivProto, lzo, ivCiphers)
 	// Append user-defined peer-info entries (e.g. IV_HWADDR, UV_*) after the
 	// built-in fields. Keys are sorted so the output is deterministic.
 	keys := make([]string, 0, len(peerInfo))

--- a/transport/openvpn/keymethod_test.go
+++ b/transport/openvpn/keymethod_test.go
@@ -144,3 +144,28 @@ func TestParseServerKeyMethod2Record(t *testing.T) {
 		t.Fatalf("unexpected server randoms")
 	}
 }
+
+func TestParseServerKeyMethod2RecordShortenedPreservesTail(t *testing.T) {
+	var packet []byte
+	packet = binary.BigEndian.AppendUint32(packet, 0)
+	packet = append(packet, KeyMethod2)
+	packet = append(packet, bytes.Repeat([]byte{1}, keySourceRandomSize)...)
+	packet = append(packet, bytes.Repeat([]byte{2}, keySourceRandomSize)...)
+	packet = appendOpenVPNString(packet, "server-options")
+	packet = append(packet, []byte("PUSH_REPLY,ifconfig 10.8.0.2 255.255.255.0\x00")...)
+
+	record, consumed, err := ParseServerKeyMethod2RecordConsumed(packet)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if record.Options != "server-options" {
+		t.Fatalf("options = %q", record.Options)
+	}
+	if record.Username != "" || record.Password != "" || record.PeerInfo != "" {
+		t.Fatalf("optional strings should be empty: %#v", record)
+	}
+	tail := packet[consumed:]
+	if !bytes.HasPrefix(tail, []byte("PUSH_REPLY")) {
+		t.Fatalf("expected leftover PUSH_REPLY, got %q", tail)
+	}
+}

--- a/transport/openvpn/keymethod_test.go
+++ b/transport/openvpn/keymethod_test.go
@@ -94,7 +94,7 @@ func TestInstallScriptOptionsCBCSHA1(t *testing.T) {
 func TestInstallScriptPeerInfo(t *testing.T) {
 	// Without user-defined peer-info the output is unchanged (backward compatible).
 	base := InstallScriptPeerInfo(CipherAES128GCM, nil, "", nil)
-	if base != "IV_VER=mihomo-openvpn\nIV_PROTO=6\nIV_CIPHERS=AES-128-GCM\n" {
+	if base != "IV_VER=mihomo-openvpn\nIV_PROTO=22\nIV_CIPHERS=AES-128-GCM\n" {
 		t.Fatalf("unexpected default peer-info: %q", base)
 	}
 
@@ -116,7 +116,7 @@ func TestInstallScriptPeerInfo(t *testing.T) {
 		"IV_LZO":     "0",
 		"IV_CIPHERS": "AES-256-CBC",
 	})
-	want = "IV_VER=custom-client/1.0\nIV_PROTO=6\nIV_LZO=1\nIV_CIPHERS=AES-128-GCM\n"
+	want = "IV_VER=custom-client/1.0\nIV_PROTO=22\nIV_LZO=1\nIV_CIPHERS=AES-128-GCM\n"
 	if overridden != want {
 		t.Fatalf("unexpected overridden peer-info:\n got %q\nwant %q", overridden, want)
 	}

--- a/transport/openvpn/push.go
+++ b/transport/openvpn/push.go
@@ -6,6 +6,7 @@ import (
 	"net/netip"
 	"strconv"
 	"strings"
+	"time"
 )
 
 const PushRequest = "PUSH_REQUEST"
@@ -31,6 +32,15 @@ type PushReply struct {
 	// pair. Empty when the server does not rotate credentials.
 	AuthTokenUser string
 	AuthTokenPass string
+
+	// PushContinuation mirrors OpenVPN's "push-continuation N": 2 marks an
+	// intermediate multi-segment PUSH_REPLY, 1 marks the final segment, 0
+	// means a single segment.
+	PushContinuation int
+
+	// AuthPendingTimeout is the deferred-auth window advertised by
+	// AUTH_PENDING,timeout N. Zero when no AUTH_PENDING was seen.
+	AuthPendingTimeout time.Duration
 }
 
 func ParsePushReply(message string) (*PushReply, error) {
@@ -139,6 +149,12 @@ func parsePushReplyInner(message string) (*PushReply, error) {
 		case "auth-token-user":
 			if len(fields) >= 2 {
 				reply.AuthTokenUser = decodeAuthTokenUser(fields[1])
+			}
+		case "push-continuation":
+			if len(fields) >= 2 {
+				if n, err := strconv.Atoi(fields[1]); err == nil {
+					reply.PushContinuation = n
+				}
 			}
 		}
 	}

--- a/transport/openvpn/push.go
+++ b/transport/openvpn/push.go
@@ -44,6 +44,10 @@ type PushReply struct {
 	// AuthPendingTimeout is the deferred-auth window advertised by
 	// AUTH_PENDING,timeout N. Zero when no AUTH_PENDING was seen.
 	AuthPendingTimeout time.Duration
+	// authPendingUntil anchors that window to the instant AUTH_PENDING was
+	// processed. Keeping the absolute deadline prevents a later final
+	// PUSH_REPLY from restarting the server-advertised interval.
+	authPendingUntil time.Time
 }
 
 func ParsePushReply(message string) (*PushReply, error) {

--- a/transport/openvpn/push.go
+++ b/transport/openvpn/push.go
@@ -1,6 +1,7 @@
 package openvpn
 
 import (
+	"encoding/base64"
 	"fmt"
 	"net/netip"
 	"strconv"
@@ -25,9 +26,35 @@ type PushReply struct {
 	// Cipher is the single cipher pushed by the server via the "cipher"
 	// option (legacy or fallback).
 	Cipher string
+
+	// AuthToken is the most recently pushed auth-token / auth-token-user
+	// pair. Empty when the server does not rotate credentials.
+	AuthTokenUser string
+	AuthTokenPass string
 }
 
 func ParsePushReply(message string) (*PushReply, error) {
+	reply, err := parsePushReplyInner(message)
+	if err != nil {
+		return nil, err
+	}
+	if len(reply.Prefixes) == 0 {
+		return nil, fmt.Errorf("openvpn push reply missing ifconfig address")
+	}
+	return reply, nil
+}
+
+// ParsePushReplyFlexible accepts a PUSH_REPLY that may omit ifconfig, which
+// happens on some authenticated rekeys that only refresh auth-token.
+func ParsePushReplyFlexible(message string) (*PushReply, []byte, error) {
+	reply, err := parsePushReplyInner(message)
+	if err != nil {
+		return nil, nil, err
+	}
+	return reply, nil, nil
+}
+
+func parsePushReplyInner(message string) (*PushReply, error) {
 	message = strings.TrimRight(message, "\x00")
 	if !strings.HasPrefix(message, "PUSH_REPLY") {
 		return nil, fmt.Errorf("unexpected openvpn push message %q", message)
@@ -93,8 +120,6 @@ func ParsePushReply(message string) (*PushReply, error) {
 		case "block-ipv6":
 			reply.BlockIPv6 = true
 		case "data-ciphers", "ncp-ciphers":
-			// "data-ciphers" (OpenVPN 2.5+) or "ncp-ciphers" (2.4 legacy name).
-			// Value is a colon-separated list of cipher names.
 			if len(fields) >= 2 {
 				for _, c := range strings.Split(fields[1], ":") {
 					c = strings.TrimSpace(c)
@@ -104,16 +129,46 @@ func ParsePushReply(message string) (*PushReply, error) {
 				}
 			}
 		case "cipher":
-			// Legacy single cipher push, or fallback cipher.
 			if len(fields) >= 2 {
 				reply.Cipher = strings.TrimSpace(fields[1])
 			}
+		case "auth-token":
+			if len(fields) >= 2 {
+				reply.AuthTokenPass = strings.TrimSpace(fields[1])
+			}
+		case "auth-token-user":
+			if len(fields) >= 2 {
+				reply.AuthTokenUser = decodeAuthTokenUser(fields[1])
+			}
 		}
 	}
-	if len(reply.Prefixes) == 0 {
-		return nil, fmt.Errorf("openvpn push reply missing ifconfig address")
-	}
 	return reply, nil
+}
+
+func (p *PushReply) AuthToken() (user, pass string, ok bool) {
+	if p == nil || p.AuthTokenPass == "" {
+		return "", "", false
+	}
+	return p.AuthTokenUser, p.AuthTokenPass, true
+}
+
+func decodeAuthTokenUser(raw string) string {
+	raw = strings.TrimSpace(raw)
+	if decoded, err := decodeBase64Auth(raw); err == nil && decoded != "" {
+		return decoded
+	}
+	return raw
+}
+
+func decodeBase64Auth(raw string) (string, error) {
+	data, err := base64.StdEncoding.DecodeString(raw)
+	if err != nil {
+		data, err = base64.RawStdEncoding.DecodeString(raw)
+		if err != nil {
+			return "", err
+		}
+	}
+	return string(data), nil
 }
 
 func splitPushOptions(message string) []string {

--- a/transport/openvpn/push.go
+++ b/transport/openvpn/push.go
@@ -37,6 +37,9 @@ type PushReply struct {
 	// intermediate multi-segment PUSH_REPLY, 1 marks the final segment, 0
 	// means a single segment.
 	PushContinuation int
+	// HasPushReply distinguishes a parsed PUSH_REPLY from standalone control
+	// metadata such as AUTH_PENDING carried in the same accumulator.
+	HasPushReply bool
 
 	// AuthPendingTimeout is the deferred-auth window advertised by
 	// AUTH_PENDING,timeout N. Zero when no AUTH_PENDING was seen.
@@ -70,8 +73,9 @@ func parsePushReplyInner(message string) (*PushReply, error) {
 		return nil, fmt.Errorf("unexpected openvpn push message %q", message)
 	}
 	reply := &PushReply{
-		Raw:    message,
-		PeerID: PeerIDUnset,
+		Raw:          message,
+		PeerID:       PeerIDUnset,
+		HasPushReply: true,
 	}
 	for _, option := range splitPushOptions(message) {
 		fields := strings.Fields(option)

--- a/transport/openvpn/rekey_test.go
+++ b/transport/openvpn/rekey_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"io"
+	"net/netip"
 	"os"
 	"strings"
 	"testing"
@@ -308,6 +309,38 @@ func TestOutboundKeyStaysLameDuckUntilPeerEvidence(t *testing.T) {
 	}
 	if _, keyID := parseOpcodeKeyID(pkt[0]); keyID != 1 {
 		t.Fatalf("outbound key ID after evidence = %d; want 1", keyID)
+	}
+}
+
+// TestMergePushReplyContinuation verifies multi-segment PUSH_REPLY
+// (push-continuation) merging carries every field across segments.
+func TestMergePushReplyContinuation(t *testing.T) {
+	seg1 := &PushReply{
+		DNS:    []netip.Addr{netip.MustParseAddr("8.8.8.8")},
+		PeerID: 7,
+		Cipher: "AES-128-GCM",
+	}
+	seg2 := &PushReply{
+		PeerID:   PeerIDUnset,
+		Prefixes: []netip.Prefix{netip.MustParsePrefix("10.8.0.2/24")},
+		Routes:   []netip.Prefix{netip.MustParsePrefix("0.0.0.0/1")},
+		Redirect: true,
+	}
+	merged := mergePushReply(seg1, seg2)
+	if len(merged.DNS) != 1 || merged.DNS[0] != seg1.DNS[0] {
+		t.Fatalf("DNS not inherited: %v", merged.DNS)
+	}
+	if merged.PeerID != 7 {
+		t.Fatalf("PeerID not inherited: %d", merged.PeerID)
+	}
+	if merged.Cipher != "AES-128-GCM" {
+		t.Fatalf("Cipher not inherited: %q", merged.Cipher)
+	}
+	if len(merged.Prefixes) != 1 || len(merged.Routes) != 1 {
+		t.Fatalf("seg2 fields missing: prefixes=%v routes=%v", merged.Prefixes, merged.Routes)
+	}
+	if !merged.Redirect {
+		t.Fatal("Redirect not inherited")
 	}
 }
 

--- a/transport/openvpn/rekey_test.go
+++ b/transport/openvpn/rekey_test.go
@@ -773,7 +773,7 @@ func TestConsumeRekeyPushRejectsContinuationDiscoveredByReader(t *testing.T) {
 	}
 
 	err = client.consumeRekeyPushFrom(conn, reader)
-	if err == nil || !strings.Contains(err.Error(), "deferred/continued push reply incomplete") {
+	if err == nil || !strings.Contains(err.Error(), "continued push reply incomplete") {
 		t.Fatalf("reader-discovered continuation returned success: %v", err)
 	}
 	if !client.pushContinuationPending {
@@ -785,6 +785,100 @@ func TestConsumeRekeyPushRejectsContinuationDiscoveredByReader(t *testing.T) {
 	}
 	if client.push.AuthTokenPass != "SESS_ID_old" || len(client.push.Routes) != 0 {
 		t.Fatalf("partial continuation was committed to active push: %#v", client.push)
+	}
+}
+
+// TestConsumeRekeyPushAllowsAuthPendingWithoutFinalPush verifies deferred
+// authentication does not require the optional token-only PUSH_REPLY. A server
+// without auth-gen-token can send AUTH_PENDING, authenticate the new key, and
+// generate data keys without sending any further push message.
+func TestConsumeRekeyPushAllowsAuthPendingWithoutFinalPush(t *testing.T) {
+	clientIO, _ := newMemoryPacketPair()
+	client, err := NewClient(&ClientConfig{}, clientIO)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer client.Close()
+	mk := func(fill byte) *KeyMaterial {
+		k := &KeyMaterial{
+			SendCipherKey: make([]byte, 16),
+			SendHMACKey:   make([]byte, maxHMACKeyLength),
+			RecvCipherKey: make([]byte, 16),
+			RecvHMACKey:   make([]byte, maxHMACKeyLength),
+		}
+		for i := range k.SendCipherKey {
+			k.SendCipherKey[i] = fill
+		}
+		copy(k.RecvCipherKey, k.SendCipherKey)
+		for i := range k.SendHMACKey {
+			k.SendHMACKey[i] = fill + 1
+		}
+		copy(k.RecvHMACKey, k.SendHMACKey)
+		return k
+	}
+	initial, err := NewDataChannel(mk(0x11), CipherAES128GCM, AuthSHA256, 7, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rekeyed, err := NewDataChannel(mk(0x22), CipherAES128GCM, AuthSHA256, 7, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	client.installDataChannel(initial)
+	client.control.AdoptKeyID(1)
+	client.push = &PushReply{
+		PeerID:        7,
+		Cipher:        CipherAES128GCM,
+		AuthTokenPass: "",
+		Routes:        []netip.Prefix{netip.MustParsePrefix("10.8.0.0/24")},
+	}
+	conn := &chunkConn{}
+	pending, err := parseAuthPendingTimeout("AUTH_PENDING,timeout 1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	reader := func(got pushReadConn, leftover []byte, _ ...time.Time) (*PushReply, []byte, error) {
+		if got != conn {
+			t.Fatalf("reader received wrong connection: %T", got)
+		}
+		if len(leftover) != 0 {
+			t.Fatalf("unexpected initial leftover: %q", leftover)
+		}
+		return pending, nil, nil
+	}
+
+	if err := client.consumeRekeyPushFrom(conn, reader); err != nil {
+		t.Fatalf("standalone AUTH_PENDING required a final PUSH_REPLY: %v", err)
+	}
+	if client.push.PeerID != 7 || client.push.Cipher != CipherAES128GCM ||
+		len(client.push.Routes) != 1 || client.push.Routes[0].String() != "10.8.0.0/24" {
+		t.Fatalf("cached push changed without a final PUSH_REPLY: %#v", client.push)
+	}
+	if client.pushPending != nil || client.pushContinuationPending {
+		t.Fatalf("standalone AUTH_PENDING left incomplete push state: pending=%#v continuation=%v",
+			client.pushPending, client.pushContinuationPending)
+	}
+	client.dataLock.RLock()
+	staged := client.pendingDeferredUntil
+	stagedKey := client.pendingDeferredKeyID
+	stagedSet := client.pendingDeferredSet
+	client.dataLock.RUnlock()
+	if !stagedSet || stagedKey != client.control.KeyID() || !staged.Equal(pending.authPendingUntil) {
+		t.Fatalf("AUTH_PENDING epoch deadline not retained: set=%v key=%d deadline=%v want=%v",
+			stagedSet, stagedKey, staged, pending.authPendingUntil)
+	}
+	client.installDataChannel(rekeyed)
+	client.dataLock.RLock()
+	active := client.data
+	outbound := client.outboundKey
+	deferred := client.deferredUntil
+	client.dataLock.RUnlock()
+	if active != rekeyed || outbound != initial {
+		t.Fatalf("valid deferred epoch was not installable: active=%p outbound=%p", active, outbound)
+	}
+	if !deferred.Equal(pending.authPendingUntil) {
+		t.Fatalf("staged deferred deadline not transferred to installed epoch: got=%v want=%v",
+			deferred, pending.authPendingUntil)
 	}
 }
 

--- a/transport/openvpn/rekey_test.go
+++ b/transport/openvpn/rekey_test.go
@@ -229,6 +229,185 @@ func TestSoftResetAdvancesOpenVPNKeyID(t *testing.T) {
 // packets keep using the old (lame-duck) key until a packet labeled with the
 // new key ID decrypts successfully — the OpenVPN-equivalent signal that the
 // peer has activated the new key.
+// TestRekeyKeepsOldOutboundEvenIfNeverSent reproduces the review point 2: a
+// rekey on a quiet / receive-only tunnel (the old epoch never sent a packet)
+// must still keep the old key for outbound, because only the very first
+// handshake (old == nil) starts on the new key. The old key's send counter
+// is irrelevant.
+func TestRekeyKeepsOldOutboundEvenIfNeverSent(t *testing.T) {
+	clientIO, serverIO := newMemoryPacketPair()
+	client, err := NewClient(&ClientConfig{Username: "u", Password: "p"}, clientIO)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer client.Close()
+
+	mk := func() *KeyMaterial {
+		k := &KeyMaterial{
+			SendCipherKey: make([]byte, 16),
+			SendHMACKey:   make([]byte, maxHMACKeyLength),
+			RecvCipherKey: make([]byte, 16),
+			RecvHMACKey:   make([]byte, maxHMACKeyLength),
+		}
+		for i := range k.SendCipherKey {
+			k.SendCipherKey[i] = 0x11
+		}
+		copy(k.RecvCipherKey, k.SendCipherKey)
+		for i := range k.SendHMACKey {
+			k.SendHMACKey[i] = 0x22
+		}
+		copy(k.RecvHMACKey, k.SendHMACKey)
+		return k
+	}
+	initial, err := NewDataChannel(mk(), CipherAES128GCM, AuthSHA256, 7, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rekeyed, err := NewDataChannel(mk(), CipherAES128GCM, AuthSHA256, 7, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Install initial, but NEVER send on it: the tunnel is quiet.
+	client.installDataChannel(initial)
+	client.installDataChannel(rekeyed)
+
+	// Outbound must still be the old key (id 0) — not the new key.
+	if err := client.writeDataPacket(context.Background(), []byte{0x45, 0, 0, 20}, false); err != nil {
+		t.Fatal(err)
+	}
+	pkt, err := serverIO.ReadPacket(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, keyID := parseOpcodeKeyID(pkt[0]); keyID != 0 {
+		t.Fatalf("outbound key ID after quiet rekey = %d; want 0 (old key kept)", keyID)
+	}
+}
+
+// TestFailedDecryptDoesNotPromote reproduces the review point 1: a packet
+// that fails decryption (malformed / forged) must not set peer evidence and
+// must not promote the new outbound key.
+func TestFailedDecryptDoesNotPromote(t *testing.T) {
+	clientIO, serverIO := newMemoryPacketPair()
+	client, err := NewClient(&ClientConfig{Username: "u", Password: "p"}, clientIO)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer client.Close()
+
+	mk := func() *KeyMaterial {
+		k := &KeyMaterial{
+			SendCipherKey: make([]byte, 16),
+			SendHMACKey:   make([]byte, maxHMACKeyLength),
+			RecvCipherKey: make([]byte, 16),
+			RecvHMACKey:   make([]byte, maxHMACKeyLength),
+		}
+		for i := range k.SendCipherKey {
+			k.SendCipherKey[i] = 0x11
+		}
+		copy(k.RecvCipherKey, k.SendCipherKey)
+		for i := range k.SendHMACKey {
+			k.SendHMACKey[i] = 0x22
+		}
+		copy(k.RecvHMACKey, k.SendHMACKey)
+		return k
+	}
+	initial, err := NewDataChannel(mk(), CipherAES128GCM, AuthSHA256, 7, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rekeyed, err := NewDataChannel(mk(), CipherAES128GCM, AuthSHA256, 7, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	client.installDataChannel(initial)
+	client.installDataChannel(rekeyed)
+
+	// A malformed packet labeled with the new key id must fail decryption and
+	// must NOT latch evidence (the review's in-memory regression: a one-byte
+	// P_DATA_V2 with the new key id).
+	bad := []byte{opcodeKeyID(PDataV2, 1)}
+	if _, err := client.decryptDataPacket(bad); err == nil {
+		t.Fatal("malformed new-key packet unexpectedly decrypted")
+	}
+	if rekeyed.PeerActive() {
+		t.Fatal("failed decryption latched peer evidence")
+	}
+
+	// Outbound stays on the old key after the failed decrypt.
+	if err := client.writeDataPacket(context.Background(), []byte{0x45, 0, 0, 20}, false); err != nil {
+		t.Fatal(err)
+	}
+	pkt, err := serverIO.ReadPacket(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, keyID := parseOpcodeKeyID(pkt[0]); keyID != 0 {
+		t.Fatalf("outbound key ID after failed decrypt = %d; want 0", keyID)
+	}
+}
+
+// TestOutboundPromotesAfterAuthDeferredExpire verifies the no-evidence
+// backstop mirrors OpenVPN's auth_deferred_expire window (~60s), not the old
+// key's destruction time: after the window elapses with no peer evidence, a
+// one-way tunnel still rotates outbound to the new key.
+func TestOutboundPromotesAfterAuthDeferredExpire(t *testing.T) {
+	clientIO, serverIO := newMemoryPacketPair()
+	client, err := NewClient(&ClientConfig{Username: "u", Password: "p"}, clientIO)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer client.Close()
+
+	mk := func() *KeyMaterial {
+		k := &KeyMaterial{
+			SendCipherKey: make([]byte, 16),
+			SendHMACKey:   make([]byte, maxHMACKeyLength),
+			RecvCipherKey: make([]byte, 16),
+			RecvHMACKey:   make([]byte, maxHMACKeyLength),
+		}
+		for i := range k.SendCipherKey {
+			k.SendCipherKey[i] = 0x11
+		}
+		copy(k.RecvCipherKey, k.SendCipherKey)
+		for i := range k.SendHMACKey {
+			k.SendHMACKey[i] = 0x22
+		}
+		copy(k.RecvHMACKey, k.SendHMACKey)
+		return k
+	}
+	initial, err := NewDataChannel(mk(), CipherAES128GCM, AuthSHA256, 7, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rekeyed, err := NewDataChannel(mk(), CipherAES128GCM, AuthSHA256, 7, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	client.installDataChannel(initial)
+	client.installDataChannel(rekeyed)
+
+	// Before the window elapses, outbound stays on the old key (no evidence).
+	if err := client.writeDataPacket(context.Background(), []byte{0x45, 0, 0, 20}, false); err != nil {
+		t.Fatal(err)
+	}
+	pkt, _ := serverIO.ReadPacket(context.Background())
+	if _, keyID := parseOpcodeKeyID(pkt[0]); keyID != 0 {
+		t.Fatalf("outbound before window = %d; want 0", keyID)
+	}
+
+	// Simulate the auth_deferred_expire window elapsing.
+	client.outboundStart = time.Now().Add(-authDeferredExpire - time.Second)
+
+	if err := client.writeDataPacket(context.Background(), []byte{0x45, 0, 0, 20}, false); err != nil {
+		t.Fatal(err)
+	}
+	pkt, _ = serverIO.ReadPacket(context.Background())
+	if _, keyID := parseOpcodeKeyID(pkt[0]); keyID != 1 {
+		t.Fatalf("outbound after window = %d; want 1", keyID)
+	}
+}
+
 func TestOutboundKeyStaysLameDuckUntilPeerEvidence(t *testing.T) {
 	clientIO, serverIO := newMemoryPacketPair()
 	client, err := NewClient(&ClientConfig{Username: "u", Password: "p"}, clientIO)

--- a/transport/openvpn/rekey_test.go
+++ b/transport/openvpn/rekey_test.go
@@ -864,7 +864,7 @@ func hasAck(acks []uint32, id uint32) bool {
 func TestMRUMoveToFrontMatchesReference(t *testing.T) {
 	c := &ControlChannel{lruAcks: []uint32{1, 2, 3, 4, 5, 6, 7, 8}}
 	c.ackPending = []uint32{8, 9}
-	got := c.takeAcksLocked()
+	got := c.takeAcksLocked(reliableAckSize)
 	want := []uint32{8, 9, 1, 2, 3, 4, 5, 6}
 	if len(got) != len(want) {
 		t.Fatalf("len=%d want %d: %v", len(got), len(want), got)
@@ -883,6 +883,164 @@ func TestMRUMoveToFrontMatchesReference(t *testing.T) {
 			t.Fatalf("mru got %v want %v", c.lruAcks, want)
 		}
 	}
+}
+
+// TestAckSerializationCaps verifies per-packet ACK caps match OpenVPN:
+// reliable control packets (incl. retransmits) carry <= CONTROL_SEND_ACK_MAX
+// (4); a dedicated ACK carries <= RELIABLE_ACK_SIZE (8), and <= 4 when the
+// channel is unprotected (SoftEther compat).
+func TestAckSerializationCaps(t *testing.T) {
+	cases := []struct {
+		name    string
+		crypt   ControlCryptor
+		path    func(ctx context.Context, c *ControlChannel) error
+		reads   int
+		wantMax int
+	}{
+		{
+			name:  "reliable-control-with-tls",
+			crypt: mustClientCrypt(t),
+			path: func(ctx context.Context, c *ControlChannel) error {
+				c.QueueAck(1)
+				c.QueueAck(2)
+				c.QueueAck(3)
+				c.QueueAck(4)
+				c.QueueAck(5)
+				_, err := c.Send(ctx, PControlV1, []byte("data"))
+				return err
+			},
+			wantMax: 4,
+		},
+		{
+			name:  "reliable-control-plain",
+			crypt: nil,
+			path: func(ctx context.Context, c *ControlChannel) error {
+				c.QueueAck(1)
+				c.QueueAck(2)
+				c.QueueAck(3)
+				c.QueueAck(4)
+				c.QueueAck(5)
+				_, err := c.Send(ctx, PControlV1, []byte("data"))
+				return err
+			},
+			wantMax: 4,
+		},
+		{
+			name:  "dedicated-ack-with-tls",
+			crypt: mustClientCrypt(t),
+			path: func(ctx context.Context, c *ControlChannel) error {
+				for i := 0; i < 5; i++ {
+					c.QueueAck(uint32(i))
+				}
+				return c.SendAck(ctx)
+			},
+			wantMax: 5,
+		},
+		{
+			name:  "dedicated-ack-plain",
+			crypt: nil,
+			path: func(ctx context.Context, c *ControlChannel) error {
+				for i := 0; i < 5; i++ {
+					c.QueueAck(uint32(i))
+				}
+				return c.SendAck(ctx)
+			},
+			wantMax: 4,
+		},
+		{
+			name:  "retransmit-with-tls",
+			crypt: mustClientCrypt(t),
+			path: func(ctx context.Context, c *ControlChannel) error {
+				// Prime a pending reliable message, queue 5 acks, then
+				// retransmit: the retransmitted reliable packet must carry
+				// at most CONTROL_SEND_ACK_MAX acks.
+				if _, err := c.Send(ctx, PControlV1, []byte("data")); err != nil {
+					return err
+				}
+				for i := 0; i < 5; i++ {
+					c.QueueAck(uint32(i))
+				}
+				return c.RetransmitPending(ctx)
+			},
+			reads:   2,
+			wantMax: 4,
+		},
+		{
+			name:  "retransmit-plain",
+			crypt: nil,
+			path: func(ctx context.Context, c *ControlChannel) error {
+				if _, err := c.Send(ctx, PControlV1, []byte("data")); err != nil {
+					return err
+				}
+				for i := 0; i < 5; i++ {
+					c.QueueAck(uint32(i))
+				}
+				return c.RetransmitPending(ctx)
+			},
+			reads:   2,
+			wantMax: 4,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			clientIO, serverIO := newMemoryPacketPair()
+			var clientID SessionID
+			copy(clientID[:], []byte("client01"))
+			var serverID SessionID
+			copy(serverID[:], []byte("server01"))
+			client := NewControlChannel(clientIO, tc.crypt, clientID)
+			client.SetRemoteSessionID(serverID)
+			client.clock = func() time.Time { return time.Unix(1714567890, 0) }
+
+			// The peer decodes client->server with the server-direction crypt.
+			var peerCrypt ControlCryptor
+			if tc.crypt != nil {
+				var err error
+				peerCrypt, err = NewTLSCrypt(testStaticKey(), false)
+				if err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+			defer cancel()
+
+			if err := tc.path(ctx, client); err != nil {
+				t.Fatal(err)
+			}
+			reads := tc.reads
+			if reads == 0 {
+				reads = 1
+			}
+			var pkt *ControlPacket
+			for i := 0; i < reads; i++ {
+				raw, err := serverIO.ReadPacket(ctx)
+				if err != nil {
+					t.Fatal(err)
+				}
+				pkt, _, _, err = DecodeControlPacket(peerCrypt, raw)
+				if err != nil {
+					t.Fatalf("decode: %v", err)
+				}
+			}
+			if len(pkt.AckIDs) > tc.wantMax {
+				t.Fatalf("serialized %d acks, want <= %d: %v", len(pkt.AckIDs), tc.wantMax, pkt.AckIDs)
+			}
+			if len(pkt.AckIDs) == 0 {
+				t.Fatal("expected at least one ack")
+			}
+		})
+	}
+}
+
+func mustClientCrypt(t *testing.T) ControlCryptor {
+	t.Helper()
+	c, err := NewTLSCrypt(testStaticKey(), true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return c
 }
 
 func TestMarkReceivedUnblocksNextEpochControl(t *testing.T) {

--- a/transport/openvpn/rekey_test.go
+++ b/transport/openvpn/rekey_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"io"
 	"os"
+	"strings"
 	"testing"
 	"time"
 )
@@ -219,6 +220,94 @@ func TestSoftResetAdvancesOpenVPNKeyID(t *testing.T) {
 	client.RotateKeyID()
 	if client.keyID != 2 {
 		t.Fatalf("second soft reset key ID = %d; want 2", client.keyID)
+	}
+}
+
+// TestOutboundKeyStaysLameDuckUntilPeerEvidence verifies the deferred-auth
+// outbound key selection: after a rekey installs a new data epoch, outbound
+// packets keep using the old (lame-duck) key until a packet labeled with the
+// new key ID decrypts successfully — the OpenVPN-equivalent signal that the
+// peer has activated the new key.
+func TestOutboundKeyStaysLameDuckUntilPeerEvidence(t *testing.T) {
+	clientIO, serverIO := newMemoryPacketPair()
+	client, err := NewClient(&ClientConfig{Username: "u", Password: "p"}, clientIO)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer client.Close()
+
+	mkKeys := func() *KeyMaterial {
+		k := &KeyMaterial{
+			SendCipherKey: make([]byte, 16),
+			SendHMACKey:   make([]byte, maxHMACKeyLength),
+			RecvCipherKey: make([]byte, 16),
+			RecvHMACKey:   make([]byte, maxHMACKeyLength),
+		}
+		for i := range k.SendCipherKey {
+			k.SendCipherKey[i] = 0x11
+		}
+		// Identical send/recv keys so a locally-encrypted packet decrypts
+		// through the peer path (the direction split is irrelevant here).
+		copy(k.RecvCipherKey, k.SendCipherKey)
+		for i := range k.SendHMACKey {
+			k.SendHMACKey[i] = 0x22
+		}
+		copy(k.RecvHMACKey, k.SendHMACKey)
+		return k
+	}
+
+	initial, err := NewDataChannel(mkKeys(), CipherAES128GCM, AuthSHA256, 7, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rekeyed, err := NewDataChannel(mkKeys(), CipherAES128GCM, AuthSHA256, 7, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	client.installDataChannel(initial)
+	// Activate the first epoch: outbound switches to it immediately.
+	if err := client.writeDataPacket(context.Background(), []byte{0x45, 0, 0, 20}, false); err != nil {
+		t.Fatal(err)
+	}
+	// Drain that first packet.
+	if _, err := serverIO.ReadPacket(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	client.installDataChannel(rekeyed)
+
+	// First outbound packet after the rekey must still use the old key ID 0
+	// (deferred auth: peer has not yet activated key ID 1).
+	if err := client.writeDataPacket(context.Background(), []byte{0x45, 0, 0, 20}, false); err != nil {
+		t.Fatal(err)
+	}
+	pkt, err := serverIO.ReadPacket(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, keyID := parseOpcodeKeyID(pkt[0]); keyID != 0 {
+		t.Fatalf("outbound key ID after rekey = %d; want 0 (lame duck)", keyID)
+	}
+
+	// Simulate the peer activating the new key: encrypt a data packet with the
+	// new key and decrypt it through the client, which latches newKeyEvidence.
+	peerPkt, err := rekeyed.Encrypt([]byte{0x45, 0, 0, 20})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := client.decryptDataPacket(peerPkt); err != nil {
+		t.Fatalf("decrypt new-key packet: %v", err)
+	}
+
+	// After evidence, outbound switches to key ID 1.
+	if err := client.writeDataPacket(context.Background(), []byte{0x45, 0, 0, 20}, false); err != nil {
+		t.Fatal(err)
+	}
+	pkt, err = serverIO.ReadPacket(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, keyID := parseOpcodeKeyID(pkt[0]); keyID != 1 {
+		t.Fatalf("outbound key ID after evidence = %d; want 1", keyID)
 	}
 }
 
@@ -443,7 +532,7 @@ func TestRekeyRetransmitsLostClientHello(t *testing.T) {
 	copy(serverID[:], []byte("server01"))
 
 	client, err := NewClient(&ClientConfig{
-		Proto:   ProtoUDP,
+		Proto:       ProtoUDP,
 		TLSCryptKey: testStaticKey(),
 	}, clientIO)
 	if err != nil {
@@ -699,6 +788,41 @@ func (c *chunkConn) SetReadDeadline(t time.Time) error {
 
 // TestReadTokenPushReplySplitAcrossReads verifies that a token-only PUSH_REPLY
 // split across two reads is parsed (TLS is a byte stream).
+// TestTakePushReplyAuthPendingBeforePush verifies the exact deferred-auth
+// stream from the review: AUTH_PENDING\0INFO_PRE,...\0PUSH_REPLY,...\0.
+// The token must be found even though PUSH_REPLY is not the first message.
+func TestTakePushReplyAuthPendingBeforePush(t *testing.T) {
+	stream := []byte("AUTH_PENDING,timeout 60\x00" +
+		"INFO_PRE,Auth-Message:OTAwODcxMjU5MTQ1MDExNjA3MjM=\x00" +
+		"PUSH_REPLY,auth-token SESS_ID_fresh\x00")
+	reply, rest, ok := takePushReply(stream)
+	if !ok {
+		t.Fatal("token PUSH_REPLY not found after AUTH_PENDING/INFO_PRE")
+	}
+	if reply == nil || reply.AuthTokenPass != "SESS_ID_fresh" {
+		t.Fatalf("token not parsed: %#v", reply)
+	}
+	if len(rest) != 0 {
+		t.Fatalf("unexpected leftover: %q", rest)
+	}
+}
+
+// TestReadTokenPushReplyDeferredAuth verifies the full reviewer scenario at
+// the readTokenPushReply level: AUTH_PENDING then token PUSH_REPLY in one
+// TLS read must yield the token.
+func TestReadTokenPushReplyDeferredAuth(t *testing.T) {
+	conn := &chunkConn{data: [][]byte{
+		[]byte("AUTH_PENDING,timeout 60\x00PUSH_REPLY,auth-token SESS_ID_deferred\x00"),
+	}}
+	reply, _, err := readTokenPushReply(conn, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if reply == nil || reply.AuthTokenPass != "SESS_ID_deferred" {
+		t.Fatalf("deferred-auth token not parsed: %#v", reply)
+	}
+}
+
 func TestReadTokenPushReplySplitAcrossReads(t *testing.T) {
 	conn := &chunkConn{data: [][]byte{
 		[]byte("PUSH_REPLY,auth-token "),
@@ -801,18 +925,31 @@ func TestWatchControlSurfacesParkedAUTHFailed(t *testing.T) {
 	}
 	defer client.Close()
 
-	// watcher loop consumes a valid next-epoch soft reset, then renegotiate
-	// fails (no TLS in this unit context) and the tunnel is failed.
+	// The watcher loop consumes a parked same-epoch P_CONTROL_V1
+	// (errParkedTLS) whose TLS payload is an AUTH_FAILED message — a
+	// deferred authentication that failed. consumeRekeyPush must surface it
+	// as a hard error, not swallow it or wait for the next soft reset.
 	var serverID SessionID
 	copy(serverID[:], []byte("server01"))
 	client.control.SetRemoteSessionID(serverID)
 	client.control.AdoptKeyID(1)
-	client.control.pendingSoftReset = &ControlPacket{
-		Opcode:       PControlSoftResetV1,
-		KeyID:        2,
+	// Simulate an established session with a cached push (so the rekey path
+	// is taken) and a deferred-auth failure already buffered in the TLS
+	// plaintext stream (arrives as a same-epoch P_CONTROL_V1 payload).
+	client.push = &PushReply{PeerID: 1, AuthTokenPass: "SESS_ID_old"}
+	client.leftoverTLS = []byte("AUTH_FAILED,SESSION: auth-token expired\x00")
+	// Park a same-epoch P_CONTROL_V1 so waitForSoftReset returns errParkedTLS.
+	// Its payload is the deferred-auth plaintext, which in production is fed
+	// through the TLS layer and lands in leftoverTLS (set above).
+	client.control.mu.Lock()
+	client.control.recvPending[0] = &ControlPacket{
+		Opcode:       PControlV1,
+		KeyID:        1,
 		MessageID:    0,
 		LocalSession: serverID,
+		Payload:      []byte("deferred auth status"),
 	}
+	client.control.mu.Unlock()
 
 	done := make(chan struct{})
 	go func() {
@@ -822,10 +959,12 @@ func TestWatchControlSurfacesParkedAUTHFailed(t *testing.T) {
 	select {
 	case <-done:
 	case <-time.After(2 * time.Second):
-		t.Fatal("watchControl did not exit after soft reset")
+		t.Fatal("watchControl did not exit after parked AUTH_FAILED")
 	}
 	if rekeyErr := client.LastRekeyError(); rekeyErr == nil {
-		t.Fatal("watchControl did not surface a rekey error")
+		t.Fatal("watchControl swallowed parked AUTH_FAILED")
+	} else if !strings.Contains(rekeyErr.Error(), "auth") {
+		t.Fatalf("unexpected rekey error: %v", rekeyErr)
 	}
 }
 
@@ -875,12 +1014,12 @@ func TestDecryptRejectsExpiredRetiringKey(t *testing.T) {
 	current := &DataChannel{keyID: 2}
 	retiring := &DataChannel{keyID: 1}
 	c := &Client{
-		data:          current,
-		retiring:      retiring,
+		data:           current,
+		retiring:       retiring,
 		retiringExpiry: time.Now().Add(-time.Second),
-		dataByKey:     map[uint8]*DataChannel{1: retiring, 2: current},
+		dataByKey:      map[uint8]*DataChannel{1: retiring, 2: current},
 	}
-	_, err := c.decryptDataPacket([]byte{byte(PDataV2 << OpcodeShift) | 1})
+	_, err := c.decryptDataPacket([]byte{byte(PDataV2<<OpcodeShift) | 1})
 	if err == nil {
 		t.Fatal("expired retiring key was accepted")
 	}
@@ -899,7 +1038,7 @@ func TestDecryptAcceptsRetiringKeyBeforeExpiry(t *testing.T) {
 	}
 	// Decryption will fail on the packet (no keys), but the key routing must
 	// NOT reject it as unknown/expired.
-	_, err := c.decryptDataPacket([]byte{byte(PDataV2 << OpcodeShift) | 1})
+	_, err := c.decryptDataPacket([]byte{byte(PDataV2<<OpcodeShift) | 1})
 	if err != nil && err.Error() == "openvpn data packet with unknown key id" {
 		t.Fatalf("retiring key rejected before expiry: %v", err)
 	}

--- a/transport/openvpn/rekey_test.go
+++ b/transport/openvpn/rekey_test.go
@@ -446,11 +446,19 @@ func TestAuthPendingTimeoutRespected(t *testing.T) {
 		t.Fatal(err)
 	}
 	client.installDataChannel(initial)
-	client.installDataChannel(rekeyed)
-	// Server advertises AUTH_PENDING,timeout 300 for the deferred epoch.
+	// Production order: the control epoch advances, AUTH_PENDING is parsed
+	// after KM2 but BEFORE the matching data channel is installed.
+	client.control.AdoptKeyID(1)
 	client.applyAuthPendingTimeout(&PushReply{AuthPendingTimeout: 300 * time.Second})
+	client.installDataChannel(rekeyed)
 	// Simulate the fixed authDeferredExpire window elapsing (61s).
+	client.dataLock.Lock()
 	client.outboundStart = time.Now().Add(-authDeferredExpire - time.Second)
+	deferred := client.deferredUntil
+	client.dataLock.Unlock()
+	if time.Until(deferred) < 290*time.Second {
+		t.Fatalf("epoch install discarded AUTH_PENDING deadline: %v", deferred)
+	}
 
 	// The advertised deadline (300s) has NOT elapsed, so outbound must stay
 	// on the old key.
@@ -469,6 +477,75 @@ func TestAuthPendingTimeoutRespected(t *testing.T) {
 // TestTakePushReplyContinuation verifies the review point 2: an intermediate
 // push-continuation 2 segment is not a complete reply, and the final segment
 // merges repeatable fields (routes / dns) across segments in wire order.
+// TestStandaloneAuthPendingDoesNotCompletePush verifies AUTH_PENDING updates
+// timeout state but does not complete PUSH parsing before a final PUSH_REPLY.
+func TestStandaloneAuthPendingDoesNotCompletePush(t *testing.T) {
+	pending := []byte("AUTH_PENDING,timeout 300\x00")
+	reply, rest, ok := takePushReply(pending)
+	if ok {
+		t.Fatal("AUTH_PENDING alone completed PUSH parsing")
+	}
+	if len(rest) != 0 {
+		t.Fatalf("unexpected rest: %q", rest)
+	}
+	if reply == nil || reply.AuthPendingTimeout != 300*time.Second {
+		t.Fatalf("AUTH_PENDING timeout not parsed: %#v", reply)
+	}
+
+	coalesced := []byte("AUTH_PENDING,timeout 300\x00" +
+		"PUSH_REPLY,ifconfig 10.8.0.2 255.255.255.0\x00")
+	reply, _, ok = takePushReply(coalesced)
+	if !ok {
+		t.Fatal("final PUSH_REPLY did not complete parsing")
+	}
+	if reply.AuthPendingTimeout != 300*time.Second {
+		t.Fatalf("AUTH_PENDING timeout lost during merge: got %v, want 5m", reply.AuthPendingTimeout)
+	}
+}
+
+// TestPushContinuationWireOrderAndCrossCall verifies repeatable fields retain
+// wire order and an intermediate segment survives until a final segment in a
+// later consumeRekeyPush call.
+func TestPushContinuationWireOrderAndCrossCall(t *testing.T) {
+	full := []byte("PUSH_REPLY,route 10.1.0.0 255.255.0.0,dhcp-option DNS 1.1.1.1,data-ciphers AES-256-GCM,push-continuation 2\x00" +
+		"PUSH_REPLY,route 10.2.0.0 255.255.0.0,dhcp-option DNS 8.8.8.8,data-ciphers AES-128-GCM\x00")
+	reply, _, ok := takePushReply(full)
+	if !ok {
+		t.Fatal("coalesced continuation did not complete")
+	}
+	if got := []string{reply.Routes[0].String(), reply.Routes[1].String()}; got[0] != "10.1.0.0/16" || got[1] != "10.2.0.0/16" {
+		t.Fatalf("route wire order changed: %v", got)
+	}
+	if got := []string{reply.DNS[0].String(), reply.DNS[1].String()}; got[0] != "1.1.1.1" || got[1] != "8.8.8.8" {
+		t.Fatalf("DNS wire order changed: %v", got)
+	}
+	if len(reply.DataCiphers) != 2 || reply.DataCiphers[0] != "AES-256-GCM" || reply.DataCiphers[1] != "AES-128-GCM" {
+		t.Fatalf("cipher wire order changed: %v", reply.DataCiphers)
+	}
+
+	clientIO, _ := newMemoryPacketPair()
+	client, err := NewClient(&ClientConfig{Username: "u", Password: "p"}, clientIO)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer client.Close()
+	client.push = &PushReply{PeerID: 7}
+	client.leftoverTLS = []byte("PUSH_REPLY,route 10.1.0.0 255.255.0.0,push-continuation 2\x00")
+	if err := client.consumeRekeyPush(); err != nil {
+		t.Fatal(err)
+	}
+	if client.pushPending == nil || len(client.pushPending.Routes) != 1 {
+		t.Fatalf("intermediate continuation not retained: %#v", client.pushPending)
+	}
+	client.leftoverTLS = []byte("PUSH_REPLY,route 10.2.0.0 255.255.0.0\x00")
+	if err := client.consumeRekeyPush(); err != nil {
+		t.Fatal(err)
+	}
+	if len(client.push.Routes) != 2 || client.push.Routes[0].String() != "10.1.0.0/16" || client.push.Routes[1].String() != "10.2.0.0/16" {
+		t.Fatalf("intermediate continuation discarded across calls: %v", client.push.Routes)
+	}
+}
+
 func TestTakePushReplyContinuation(t *testing.T) {
 	// Only an intermediate segment: not complete.
 	intermediate := []byte("PUSH_REPLY,route 10.2.0.0 255.255.0.0,push-continuation 2\x00")

--- a/transport/openvpn/rekey_test.go
+++ b/transport/openvpn/rekey_test.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"io"
 	"os"
-	"strings"
 	"testing"
 	"time"
 )
@@ -676,6 +675,8 @@ type chunkConn struct {
 	data [][]byte
 	errs []error
 	idx  int
+	// lastDeadline records the most recent SetReadDeadline value.
+	lastDeadline time.Time
 }
 
 func (c *chunkConn) Read(p []byte) (int, error) {
@@ -691,7 +692,10 @@ func (c *chunkConn) Read(p []byte) (int, error) {
 	return n, err
 }
 
-func (c *chunkConn) SetReadDeadline(t time.Time) error { return nil }
+func (c *chunkConn) SetReadDeadline(t time.Time) error {
+	c.lastDeadline = t
+	return nil
+}
 
 // TestReadTokenPushReplySplitAcrossReads verifies that a token-only PUSH_REPLY
 // split across two reads is parsed (TLS is a byte stream).
@@ -797,16 +801,16 @@ func TestWatchControlSurfacesParkedAUTHFailed(t *testing.T) {
 	}
 	defer client.Close()
 
-	// watcher loop consumes a soft reset, then must abort on AUTH_FAILED.
+	// watcher loop consumes a valid next-epoch soft reset, then renegotiate
+	// fails (no TLS in this unit context) and the tunnel is failed.
 	var serverID SessionID
 	copy(serverID[:], []byte("server01"))
 	client.control.SetRemoteSessionID(serverID)
-	client.push = &PushReply{PeerID: 1, AuthTokenPass: "SESS_ID_old"}
-	client.leftoverTLS = []byte("AUTH_FAILED,SESSION: auth-token expired\x00")
 	client.control.AdoptKeyID(1)
 	client.control.pendingSoftReset = &ControlPacket{
 		Opcode:       PControlSoftResetV1,
-		KeyID:        1,
+		KeyID:        2,
+		MessageID:    0,
 		LocalSession: serverID,
 	}
 
@@ -818,12 +822,10 @@ func TestWatchControlSurfacesParkedAUTHFailed(t *testing.T) {
 	select {
 	case <-done:
 	case <-time.After(2 * time.Second):
-		t.Fatal("watchControl did not exit after AUTH_FAILED")
+		t.Fatal("watchControl did not exit after soft reset")
 	}
 	if rekeyErr := client.LastRekeyError(); rekeyErr == nil {
-		t.Fatal("watchControl swallowed parked AUTH_FAILED")
-	} else if !strings.Contains(rekeyErr.Error(), "auth") {
-		t.Fatalf("unexpected rekey error: %v", rekeyErr)
+		t.Fatal("watchControl did not surface a rekey error")
 	}
 }
 
@@ -1239,6 +1241,86 @@ func mustClientCrypt(t *testing.T) ControlCryptor {
 		t.Fatal(err)
 	}
 	return c
+}
+
+// TestReadTokenPushReplyClearsDeadlineOnSuccess verifies a successful token
+// read clears the temporary 300 ms read deadline (the errParkedTLS path runs
+// outside renegotiate's deadline cleanup, so a stale deadline would tear down
+// the idle established connection).
+func TestReadTokenPushReplyClearsDeadlineOnSuccess(t *testing.T) {
+	conn := &chunkConn{
+		data: [][]byte{[]byte("PUSH_REPLY,auth-token SESS_ID_new\x00")},
+	}
+	reply, _, err := readTokenPushReply(conn, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if reply == nil {
+		t.Fatal("expected a reply")
+	}
+	if !conn.lastDeadline.IsZero() {
+		t.Fatalf("read deadline not cleared on success: %v", conn.lastDeadline)
+	}
+}
+
+// TestReadTokenPushReplyClearsDeadlineOnError verifies the deadline is cleared
+// when no reply is obtained (timeout path).
+func TestReadTokenPushReplyClearsDeadlineOnError(t *testing.T) {
+	conn := &chunkConn{data: [][]byte{}}
+	reply, _, err := readTokenPushReply(conn, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if reply != nil {
+		t.Fatalf("unexpected reply: %#v", reply)
+	}
+	if !conn.lastDeadline.IsZero() {
+		t.Fatalf("read deadline not cleared on no-data path: %v", conn.lastDeadline)
+	}
+}
+
+// TestReadAllEmitsParkedBeforeContiguous verifies out-of-order reliable
+// control payloads are fed to TLS in the order they were received: parkedTLS
+// (already advanced recvMessage) precedes subsequently contiguous recvPending.
+func TestReadAllEmitsParkedBeforeContiguous(t *testing.T) {
+	c := &ControlChannel{
+		recvPending: map[uint32]*ControlPacket{
+			2: {Opcode: PControlV1, MessageID: 2, Payload: []byte("later")},
+		},
+		recvMessage: 2,
+		parkedTLS:   [][]byte{[]byte("earlier")},
+	}
+	out := c.ReadAll()
+	if len(out) != 2 {
+		t.Fatalf("len = %d, want 2", len(out))
+	}
+	if string(out[0].Payload) != "earlier" || string(out[1].Payload) != "later" {
+		t.Fatalf("order wrong: %q then %q", out[0].Payload, out[1].Payload)
+	}
+}
+
+// TestWaitForSoftResetRejectsInvalidParkedReset verifies a parked soft reset
+// with a non-zero message ID is dropped on consume, never advancing the
+// receive sequence.
+func TestWaitForSoftResetRejectsInvalidParkedReset(t *testing.T) {
+	client, server := newTestChannels(t)
+	client.SetRemoteSessionID(server.LocalSessionID())
+	server.SetRemoteSessionID(client.LocalSessionID())
+	client.AdoptKeyID(1)
+	client.pendingSoftReset = &ControlPacket{
+		Opcode:       PControlSoftResetV1,
+		KeyID:        2,
+		MessageID:    5,
+		LocalSession: server.LocalSessionID(),
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 150*time.Millisecond)
+	defer cancel()
+	// The invalid parked reset must not be returned; the wait times out
+	// because no valid reset arrives.
+	if _, err := client.waitForSoftReset(ctx); err == nil {
+		t.Fatal("invalid parked reset was accepted")
+	}
 }
 
 func TestMarkReceivedUnblocksNextEpochControl(t *testing.T) {

--- a/transport/openvpn/rekey_test.go
+++ b/transport/openvpn/rekey_test.go
@@ -530,6 +530,80 @@ func TestReadTokenPushReplyPromotesDynamicWait(t *testing.T) {
 	})
 }
 
+// TestReadTokenPushReplyExtendsReliableACKDeadline reproduces the dynamic
+// AUTH_PENDING path on an in-memory reliable ControlConn. AUTH_PENDING is
+// already decoded when the original operation deadline expires; the final
+// reliable packet still needs an ACK write before its TLS payload can be
+// delivered. The helper must therefore extend both deadline directions as
+// soon as it processes AUTH_PENDING.
+func TestReadTokenPushReplyExtendsReliableACKDeadline(t *testing.T) {
+	clientControl, serverControl := newTestChannels(t)
+	clientControl.SetRemoteSessionID(serverControl.LocalSessionID())
+	serverControl.SetRemoteSessionID(clientControl.LocalSessionID())
+	conn := NewControlConn(clientControl)
+	// Put AUTH_PENDING directly in the TLS adapter's already-decoded buffer,
+	// then reproduce the stale deadline left by the 30-second rekey context.
+	// The next reliable packet still needs a write-side ACK before delivery.
+	conn.UnsafeFeed([]byte("AUTH_PENDING,timeout 1\x00"))
+	if err := conn.SetDeadline(time.Now().Add(-time.Second)); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := serverControl.Send(context.Background(), PControlV1,
+		[]byte("PUSH_REPLY,auth-token SESS_ID_after_deadline\x00")); err != nil {
+		t.Fatal(err)
+	}
+
+	reply, rest, err := readTokenPushReply(conn, nil)
+	if err != nil {
+		t.Fatalf("extended read could not deliver final reliable packet: %v", err)
+	}
+	if reply == nil || reply.AuthTokenPass != "SESS_ID_after_deadline" {
+		t.Fatalf("final PUSH_REPLY not delivered: %#v", reply)
+	}
+	if len(rest) != 0 {
+		t.Fatalf("unexpected rest: %q", rest)
+	}
+}
+
+// TestAuthPendingDeadlineAnchoredAtObservation verifies the final PUSH_REPLY
+// does not restart the full timeout interval. applyAuthPendingTimeout must use
+// the absolute deadline stamped when AUTH_PENDING was parsed.
+func TestAuthPendingDeadlineAnchoredAtObservation(t *testing.T) {
+	pending, _, ok := takePushReply([]byte("AUTH_PENDING,timeout 1\x00"))
+	if ok || pending == nil || pending.authPendingUntil.IsZero() {
+		t.Fatalf("AUTH_PENDING was not parsed as intermediate state: %#v", pending)
+	}
+	observedDeadline := pending.authPendingUntil
+
+	timer := time.NewTimer(150 * time.Millisecond)
+	<-timer.C
+	timer.Stop()
+	final, err := parsePushReplyInner("PUSH_REPLY,auth-token SESS_ID_anchored")
+	if err != nil {
+		t.Fatal(err)
+	}
+	merged := mergePushReply(pending, final)
+	if !merged.authPendingUntil.Equal(observedDeadline) {
+		t.Fatalf("AUTH_PENDING deadline moved during final merge: got %v, want %v",
+			merged.authPendingUntil, observedDeadline)
+	}
+
+	clientIO, _ := newMemoryPacketPair()
+	client, err := NewClient(&ClientConfig{}, clientIO)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer client.Close()
+	client.applyAuthPendingTimeout(merged)
+	client.dataLock.RLock()
+	staged := client.pendingDeferredUntil
+	client.dataLock.RUnlock()
+	if !staged.Equal(observedDeadline) {
+		t.Fatalf("AUTH_PENDING timeout restarted after final PUSH_REPLY: got %v, want %v",
+			staged, observedDeadline)
+	}
+}
+
 func TestStandaloneAuthPendingDoesNotCompletePush(t *testing.T) {
 	bareReply, _, bareOK := takePushReply([]byte("AUTH_PENDING\x00"))
 	if bareOK {
@@ -1201,8 +1275,10 @@ type chunkConn struct {
 	data [][]byte
 	errs []error
 	idx  int
-	// lastDeadline records the most recent SetReadDeadline value.
-	lastDeadline time.Time
+	// lastDeadline records the most recent read deadline. lastWriteDeadline
+	// tracks the write side changed by SetDeadline.
+	lastDeadline      time.Time
+	lastWriteDeadline time.Time
 }
 
 func (c *chunkConn) Read(p []byte) (int, error) {
@@ -1216,6 +1292,12 @@ func (c *chunkConn) Read(p []byte) (int, error) {
 	}
 	c.idx++
 	return n, err
+}
+
+func (c *chunkConn) SetDeadline(t time.Time) error {
+	c.lastDeadline = t
+	c.lastWriteDeadline = t
+	return nil
 }
 
 func (c *chunkConn) SetReadDeadline(t time.Time) error {

--- a/transport/openvpn/rekey_test.go
+++ b/transport/openvpn/rekey_test.go
@@ -735,6 +735,26 @@ func TestReadTokenPushReplyEOFPropagated(t *testing.T) {
 	}
 }
 
+// TestReadTokenPushReplyCompleteReplyWithEOF verifies that a complete token
+// reply returned together with io.EOF is still surfaced as an error: the TLS
+// stream has closed, so the rekey must not proceed.
+func TestReadTokenPushReplyCompleteReplyWithEOF(t *testing.T) {
+	conn := &chunkConn{
+		data: [][]byte{[]byte("PUSH_REPLY,auth-token SESS_ID_new\x00")},
+		errs: []error{io.EOF},
+	}
+	reply, _, err := readTokenPushReply(conn, nil)
+	if err == nil {
+		t.Fatal("complete reply with EOF was treated as success")
+	}
+	if errors.Is(err, errAuthFailed) {
+		t.Fatalf("unexpected errAuthFailed: %v", err)
+	}
+	if reply != nil {
+		t.Fatalf("unexpected reply: %#v", reply)
+	}
+}
+
 // TestWatchControlSurfacesParkedAUTHFailed verifies that a parked or deferred
 // AUTH_FAILED is surfaced (failControl) instead of being swallowed by the next
 // renegotiation.

--- a/transport/openvpn/rekey_test.go
+++ b/transport/openvpn/rekey_test.go
@@ -479,7 +479,66 @@ func TestAuthPendingTimeoutRespected(t *testing.T) {
 // merges repeatable fields (routes / dns) across segments in wire order.
 // TestStandaloneAuthPendingDoesNotCompletePush verifies AUTH_PENDING updates
 // timeout state but does not complete PUSH parsing before a final PUSH_REPLY.
+// TestReadTokenPushReplyPromotesDynamicWait verifies state discovered inside
+// the reader (not pre-buffered) upgrades the active wait policy across a
+// short timeout until the final PUSH_REPLY arrives.
+func TestReadTokenPushReplyPromotesDynamicWait(t *testing.T) {
+	t.Run("AUTH_PENDING", func(t *testing.T) {
+		conn := &chunkConn{
+			data: [][]byte{
+				[]byte("AUTH_PENDING,timeout 1\x00"),
+				nil,
+				[]byte("PUSH_REPLY,auth-token SESS_ID_dynamic\x00"),
+			},
+			errs: []error{nil, os.ErrDeadlineExceeded, nil},
+		}
+		reply, rest, err := readTokenPushReply(conn, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if conn.idx != 3 {
+			t.Fatalf("reader returned before final PUSH_REPLY: reads=%d", conn.idx)
+		}
+		if reply == nil || reply.AuthTokenPass != "SESS_ID_dynamic" || reply.AuthPendingTimeout != time.Second {
+			t.Fatalf("dynamic AUTH_PENDING/final state lost: %#v", reply)
+		}
+		if len(rest) != 0 {
+			t.Fatalf("unexpected rest: %q", rest)
+		}
+	})
+
+	t.Run("push-continuation", func(t *testing.T) {
+		conn := &chunkConn{
+			data: [][]byte{
+				[]byte("PUSH_REPLY,route 10.1.0.0 255.255.0.0,push-continuation 2\x00"),
+				nil,
+				[]byte("PUSH_REPLY,route 10.2.0.0 255.255.0.0\x00"),
+			},
+			errs: []error{nil, os.ErrDeadlineExceeded, nil},
+		}
+		reply, _, err := readTokenPushReply(conn, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if conn.idx != 3 {
+			t.Fatalf("reader returned before final continuation: reads=%d", conn.idx)
+		}
+		if reply == nil || len(reply.Routes) != 2 ||
+			reply.Routes[0].String() != "10.1.0.0/16" || reply.Routes[1].String() != "10.2.0.0/16" {
+			t.Fatalf("continuation state lost: %#v", reply)
+		}
+	})
+}
+
 func TestStandaloneAuthPendingDoesNotCompletePush(t *testing.T) {
+	bareReply, _, bareOK := takePushReply([]byte("AUTH_PENDING\x00"))
+	if bareOK {
+		t.Fatal("bare AUTH_PENDING alone completed PUSH parsing")
+	}
+	if bareReply == nil || bareReply.AuthPendingTimeout != authDeferredExpire {
+		t.Fatalf("bare AUTH_PENDING did not receive default timeout: %#v", bareReply)
+	}
+
 	pending := []byte("AUTH_PENDING,timeout 300\x00")
 	reply, rest, ok := takePushReply(pending)
 	if ok {

--- a/transport/openvpn/rekey_test.go
+++ b/transport/openvpn/rekey_test.go
@@ -604,6 +604,147 @@ func TestAuthPendingDeadlineAnchoredAtObservation(t *testing.T) {
 	}
 }
 
+// TestAuthPendingUpdateCanShortenDeadline verifies a later AUTH_PENDING for
+// the same key replaces, rather than monotonically extends, the staged and
+// active data-epoch deadline, effective control deadline, outbound-key
+// backstop, and token reader's active operation deadline.
+func TestAuthPendingUpdateCanShortenDeadline(t *testing.T) {
+	clientIO, serverIO := newMemoryPacketPair()
+	client, err := NewClient(&ClientConfig{}, clientIO)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer client.Close()
+	client.controlConn = NewControlConn(client.control)
+
+	long, err := parseAuthPendingTimeout("AUTH_PENDING,timeout 60")
+	if err != nil {
+		t.Fatal(err)
+	}
+	short, err := parseAuthPendingTimeout("AUTH_PENDING,timeout 1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	client.applyAuthPendingTimeout(long)
+	client.applyAuthPendingTimeout(short)
+	client.control.mu.Lock()
+	transportRead := client.control.readDeadline
+	transportWrite := client.control.writeDeadline
+	client.control.mu.Unlock()
+	if !transportRead.Equal(short.authPendingUntil) || !transportWrite.Equal(short.authPendingUntil) {
+		t.Fatalf("later AUTH_PENDING did not replace transport deadline: read=%v write=%v want=%v",
+			transportRead, transportWrite, short.authPendingUntil)
+	}
+	client.dataLock.RLock()
+	staged := client.pendingDeferredUntil
+	client.dataLock.RUnlock()
+	if !staged.Equal(short.authPendingUntil) {
+		t.Fatalf("later AUTH_PENDING did not shorten staged deadline: got=%v want=%v",
+			staged, short.authPendingUntil)
+	}
+	fallback := time.Now().Add(30 * time.Second)
+	if effective := client.effectiveControlDeadline(fallback); !effective.Equal(short.authPendingUntil) {
+		t.Fatalf("effective deadline retained longer fallback: got=%v want=%v",
+			effective, short.authPendingUntil)
+	}
+
+	// Install the matching epoch and verify the same replacement reaches the
+	// outbound-key fallback, not only the pre-install staging fields.
+	mk := func(fill byte) *KeyMaterial {
+		k := &KeyMaterial{
+			SendCipherKey: make([]byte, 16),
+			SendHMACKey:   make([]byte, maxHMACKeyLength),
+			RecvCipherKey: make([]byte, 16),
+			RecvHMACKey:   make([]byte, maxHMACKeyLength),
+		}
+		for i := range k.SendCipherKey {
+			k.SendCipherKey[i] = fill
+		}
+		copy(k.RecvCipherKey, k.SendCipherKey)
+		for i := range k.SendHMACKey {
+			k.SendHMACKey[i] = fill + 1
+		}
+		copy(k.RecvHMACKey, k.SendHMACKey)
+		return k
+	}
+	initial, err := NewDataChannel(mk(0x11), CipherAES128GCM, AuthSHA256, 7, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	active, err := NewDataChannel(mk(0x22), CipherAES128GCM, AuthSHA256, 7, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	client.installDataChannel(initial)
+	client.control.AdoptKeyID(1)
+	client.applyAuthPendingTimeout(long)
+	client.applyAuthPendingTimeout(&PushReply{
+		AuthPendingTimeout: time.Second,
+		authPendingUntil:   time.Now().Add(-time.Millisecond),
+	})
+	client.installDataChannel(active)
+	if err := client.writeDataPacket(context.Background(), []byte{0x45, 0, 0, 20}, false); err != nil {
+		t.Fatal(err)
+	}
+	packet, err := serverIO.ReadPacket(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, keyID := parseOpcodeKeyID(packet[0]); keyID != 1 {
+		t.Fatalf("expired shorter AUTH_PENDING did not promote outbound key: got=%d want=1", keyID)
+	}
+
+	conn := &chunkConn{
+		data: [][]byte{
+			[]byte("AUTH_PENDING,timeout 60\x00"),
+			[]byte("AUTH_PENDING,timeout 1\x00"),
+			[]byte("PUSH_REPLY,auth-token SESS_ID_short\x00"),
+		},
+	}
+	if _, _, err := readTokenPushReply(conn, nil); err != nil {
+		t.Fatal(err)
+	}
+	if len(conn.operationDeadlines) < 2 {
+		t.Fatalf("AUTH_PENDING updates not propagated: %v", conn.operationDeadlines)
+	}
+	first := conn.operationDeadlines[0]
+	second := conn.operationDeadlines[1]
+	if !second.Before(first) {
+		t.Fatalf("reader ignored shorter AUTH_PENDING: first=%v second=%v", first, second)
+	}
+}
+
+// TestConsumeParkedRekeyPushClearsDeadline verifies a successful standalone
+// parked push cannot leave its AUTH_PENDING operation deadline on the
+// established connection's next waitForSoftReset cycle.
+func TestConsumeParkedRekeyPushClearsDeadline(t *testing.T) {
+	clientIO, _ := newMemoryPacketPair()
+	client, err := NewClient(&ClientConfig{}, clientIO)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer client.Close()
+	client.push = &PushReply{PeerID: 7}
+	client.controlConn = NewControlConn(client.control)
+	client.leftoverTLS = []byte("AUTH_PENDING,timeout 1\x00" +
+		"PUSH_REPLY,auth-token SESS_ID_parked\x00")
+
+	if err := client.consumeParkedRekeyPush(); err != nil {
+		t.Fatal(err)
+	}
+	client.control.mu.Lock()
+	readDeadline := client.control.readDeadline
+	writeDeadline := client.control.writeDeadline
+	client.control.mu.Unlock()
+	if !readDeadline.IsZero() || !writeDeadline.IsZero() {
+		t.Fatalf("successful parked push consume leaked operation deadline: read=%v write=%v",
+			readDeadline, writeDeadline)
+	}
+	if client.authPass != "SESS_ID_parked" {
+		t.Fatalf("parked auth token was not consumed: %q", client.authPass)
+	}
+}
+
 func TestStandaloneAuthPendingDoesNotCompletePush(t *testing.T) {
 	bareReply, _, bareOK := takePushReply([]byte("AUTH_PENDING\x00"))
 	if bareOK {
@@ -1276,9 +1417,11 @@ type chunkConn struct {
 	errs []error
 	idx  int
 	// lastDeadline records the most recent read deadline. lastWriteDeadline
-	// tracks the write side changed by SetDeadline.
-	lastDeadline      time.Time
-	lastWriteDeadline time.Time
+	// tracks the write side changed by SetDeadline; operationDeadlines retains
+	// each two-sided update so tests can verify later AUTH_PENDING replacement.
+	lastDeadline       time.Time
+	lastWriteDeadline  time.Time
+	operationDeadlines []time.Time
 }
 
 func (c *chunkConn) Read(p []byte) (int, error) {
@@ -1297,6 +1440,7 @@ func (c *chunkConn) Read(p []byte) (int, error) {
 func (c *chunkConn) SetDeadline(t time.Time) error {
 	c.lastDeadline = t
 	c.lastWriteDeadline = t
+	c.operationDeadlines = append(c.operationDeadlines, t)
 	return nil
 }
 

--- a/transport/openvpn/rekey_test.go
+++ b/transport/openvpn/rekey_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/binary"
 	"errors"
+	"os"
 	"testing"
 	"time"
 )
@@ -450,10 +451,11 @@ func TestRekeyRetransmitsLostClientHello(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Drop the client-hello the first time it is sent; it must be
-	// retransmitted by the loop.
-	gotHello := false
-	for i := 0; i < 3; i++ {
+	// Drop the client-hello the first time it is sent; the retransmit loop
+	// must resend the same reliable message.
+	firstHello := uint32(^uint32(0))
+	gotRetransmit := false
+	for i := 0; i < 5 && !gotRetransmit; i++ {
 		raw, err := serverIO.ReadPacket(ctx)
 		if err != nil {
 			t.Fatal(err)
@@ -462,13 +464,227 @@ func TestRekeyRetransmitsLostClientHello(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if pkt.Opcode == PControlV1 && string(pkt.Payload) == "client-hello" {
-			gotHello = true
-			break
+		if pkt.Opcode != PControlV1 || string(pkt.Payload) != "client-hello" {
+			continue
+		}
+		if firstHello == ^uint32(0) {
+			// First copy: record its message ID and ignore it (the loss).
+			firstHello = pkt.MessageID
+			continue
+		}
+		// Second copy: same message ID (reliable retransmission), same payload.
+		if pkt.MessageID == firstHello {
+			gotRetransmit = true
 		}
 	}
-	if !gotHello {
-		t.Fatal("client-hello never retransmitted after loss")
+	if !gotRetransmit {
+		t.Fatal("client-hello was never retransmitted after loss")
+	}
+}
+
+// TestRekeyRetransmitKeepsResetACK verifies that a retransmitted client soft
+// reset still carries the ACK for the server's reset (merged, not replaced).
+func TestRekeyRetransmitKeepsResetACK(t *testing.T) {
+	clientIO, serverIO := newMemoryPacketPair()
+	clientCrypt, err := NewTLSCrypt(testStaticKey(), true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	serverCrypt, err := NewTLSCrypt(testStaticKey(), false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var clientID SessionID
+	copy(clientID[:], []byte("client01"))
+	var serverID SessionID
+	copy(serverID[:], []byte("server01"))
+
+	client := NewControlChannel(clientIO, clientCrypt, clientID)
+	client.SetRemoteSessionID(serverID)
+	server := NewControlChannel(serverIO, serverCrypt, serverID)
+	server.SetRemoteSessionID(clientID)
+	client.clock = func() time.Time { return time.Unix(1714567890, 0) }
+	server.clock = func() time.Time { return time.Unix(1714567891, 0) }
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	// Server starts epoch 1 with a soft reset (message 0). Client adopts the
+	// epoch, ACKs message 0, and replies with its own soft reset carrying that
+	// ACK.
+	server.AdoptKeyID(1)
+	if _, err := server.Send(ctx, PControlSoftResetV1, nil); err != nil {
+		t.Fatal(err)
+	}
+	soft, err := client.waitForSoftReset(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	client.AdoptKeyID(1)
+	client.MarkReceived(soft.MessageID)
+	client.QueueAck(soft.MessageID)
+	if err := client.SendSoftReset(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	// Read the first client soft reset; its ACK list must contain the server
+	// reset (message 0).
+	raw, err := serverIO.ReadPacket(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	first, _, _, err := DecodeControlPacket(serverCrypt, raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first.Opcode != PControlSoftResetV1 {
+		t.Fatalf("first packet opcode = %s", first.Opcode)
+	}
+	foundResetAck := false
+	for _, ack := range first.AckIDs {
+		if ack == 0 {
+			foundResetAck = true
+		}
+	}
+	if !foundResetAck {
+		t.Fatalf("first client soft reset missing reset ACK: %v", first.AckIDs)
+	}
+
+	// Retransmit the client's pending messages; the retransmitted soft reset
+	// must STILL carry the reset ACK.
+	if err := client.RetransmitPending(ctx); err != nil {
+		t.Fatal(err)
+	}
+	raw, err = serverIO.ReadPacket(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	re, _, _, err := DecodeControlPacket(serverCrypt, raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if re.Opcode != PControlSoftResetV1 {
+		t.Fatalf("retransmitted opcode = %s", re.Opcode)
+	}
+	foundResetAck = false
+	for _, ack := range re.AckIDs {
+		if ack == 0 {
+			foundResetAck = true
+		}
+	}
+	if !foundResetAck {
+		t.Fatalf("retransmitted soft reset lost the reset ACK: %v", re.AckIDs)
+	}
+}
+
+// TestStaleSoftResetNotParked verifies that an ordinary control read does not
+// park a delayed soft reset from a retiring epoch (only the strictly-next key
+// ID may be parked), and that it mutates no ACK / pending state.
+func TestStaleSoftResetNotParked(t *testing.T) {
+	client, server := newTestChannels(t)
+	client.SetRemoteSessionID(server.LocalSessionID())
+	server.SetRemoteSessionID(client.LocalSessionID())
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	// Client is on epoch 2. A delayed soft reset for the retiring epoch 1
+	// arrives while the client reads control packets (not the watcher).
+	client.AdoptKeyID(2)
+	server.AdoptKeyID(1)
+	if _, err := server.Send(ctx, PControlSoftResetV1, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	// An ordinary read must NOT park the stale reset.
+	readCtx, readCancel := context.WithTimeout(context.Background(), 80*time.Millisecond)
+	defer readCancel()
+	if pkt, err := client.Read(readCtx); err == nil {
+		t.Fatalf("Read delivered %s key=%d, want stale reset dropped", pkt.Opcode, pkt.KeyID)
+	}
+	if client.pendingSoftReset != nil {
+		t.Fatalf("stale soft reset was parked: key=%d", client.pendingSoftReset.KeyID)
+	}
+
+	// The watcher must not accept the stale epoch either; only the next one.
+	server.AdoptKeyID(3)
+	if _, err := server.Send(ctx, PControlSoftResetV1, nil); err != nil {
+		t.Fatal(err)
+	}
+	got, err := client.waitForSoftReset(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.KeyID != 3 {
+		t.Fatalf("watcher accepted stale epoch, got key=%d want 3", got.KeyID)
+	}
+}
+
+// TestConsumeRekeyPushAUTHFailed verifies that AUTH_FAILED during a rekey is a
+// hard error, not "no token".
+func TestConsumeRekeyPushAUTHFailed(t *testing.T) {
+	client := &Client{push: &PushReply{PeerID: 5, AuthTokenPass: "SESS_ID_old"}}
+	client.leftoverTLS = []byte("AUTH_FAILED,SESSION: auth-token expired\x00")
+	err := client.consumeRekeyPush()
+	if err == nil {
+		t.Fatal("consumeRekeyPush returned nil on AUTH_FAILED")
+	}
+	if !errors.Is(err, errAuthFailed) {
+		t.Fatalf("expected errAuthFailed, got %v", err)
+	}
+}
+
+// chunkConn serves a fixed byte stream one chunk per Read, then blocks
+// (returns a timeout-style error) once exhausted. Simulates TLS exposing a
+// byte stream whose boundaries do not match message boundaries.
+type chunkConn struct {
+	data [][]byte
+	idx  int
+}
+
+func (c *chunkConn) Read(p []byte) (int, error) {
+	if c.idx >= len(c.data) {
+		return 0, os.ErrDeadlineExceeded
+	}
+	n := copy(p, c.data[c.idx])
+	c.idx++
+	return n, nil
+}
+
+func (c *chunkConn) SetReadDeadline(t time.Time) error { return nil }
+
+// TestReadTokenPushReplySplitAcrossReads verifies that a token-only PUSH_REPLY
+// split across two reads is parsed (TLS is a byte stream).
+func TestReadTokenPushReplySplitAcrossReads(t *testing.T) {
+	conn := &chunkConn{data: [][]byte{
+		[]byte("PUSH_REPLY,auth-token "),
+		[]byte("SESS_ID_split\x00"),
+	}}
+	reply, rest, err := readTokenPushReply(conn, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if reply == nil || reply.AuthTokenPass != "SESS_ID_split" {
+		t.Fatalf("split token not parsed: %#v", reply)
+	}
+	if len(rest) != 0 {
+		t.Fatalf("unexpected leftover: %q", rest)
+	}
+}
+
+// TestReadTokenPushReplyPartialPreserved verifies that a partial reply is
+// preserved (not discarded) when the stream ends without a complete message.
+func TestReadTokenPushReplyPartialPreserved(t *testing.T) {
+	conn := &chunkConn{data: [][]byte{[]byte("PUSH_REPLY,auth-token ")}}
+	reply, rest, err := readTokenPushReply(conn, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if reply != nil {
+		t.Fatalf("unexpected reply for partial data: %#v", reply)
+	}
+	if string(rest) != "PUSH_REPLY,auth-token " {
+		t.Fatalf("partial bytes lost: %q", rest)
 	}
 }
 

--- a/transport/openvpn/rekey_test.go
+++ b/transport/openvpn/rekey_test.go
@@ -858,6 +858,33 @@ func hasAck(acks []uint32, id uint32) bool {
 	return false
 }
 
+// TestMRUMoveToFrontMatchesReference verifies the exact copy_acks_to_mru
+// behavior on a full MRU: an already-present ID that is re-acked is moved to
+// the front instead of being evicted. MRU [1..8], pending [8 9] -> [8 9 1 2 3 4 5 6].
+func TestMRUMoveToFrontMatchesReference(t *testing.T) {
+	c := &ControlChannel{lruAcks: []uint32{1, 2, 3, 4, 5, 6, 7, 8}}
+	c.ackPending = []uint32{8, 9}
+	got := c.takeAcksLocked()
+	want := []uint32{8, 9, 1, 2, 3, 4, 5, 6}
+	if len(got) != len(want) {
+		t.Fatalf("len=%d want %d: %v", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("got %v want %v", got, want)
+		}
+	}
+	// The MRU itself must hold the same move-to-front result.
+	if len(c.lruAcks) != len(want) {
+		t.Fatalf("mru len=%d want %d: %v", len(c.lruAcks), len(want), c.lruAcks)
+	}
+	for i := range want {
+		if c.lruAcks[i] != want[i] {
+			t.Fatalf("mru got %v want %v", c.lruAcks, want)
+		}
+	}
+}
+
 func TestMarkReceivedUnblocksNextEpochControl(t *testing.T) {
 	client, server := newTestChannels(t)
 	client.SetRemoteSessionID(server.LocalSessionID())

--- a/transport/openvpn/rekey_test.go
+++ b/transport/openvpn/rekey_test.go
@@ -797,6 +797,83 @@ func TestWatchControlSurfacesParkedAUTHFailed(t *testing.T) {
 
 // TestMRUCarriesAckOnSubsequentSends verifies the MRU behavior: an ACK queued
 // once rides on this packet and the next (OpenVPN lru_acks), not just once.
+// TestRetransmitPendingEmptyDoesNotConsumeAcks verifies that retransmitting
+// with no pending packets does not consume queued ACKs (they must survive for
+// the next real send).
+func TestRetransmitPendingEmptyDoesNotConsumeAcks(t *testing.T) {
+	clientIO, _ := newMemoryPacketPair()
+	var clientID SessionID
+	copy(clientID[:], []byte("client01"))
+	var serverID SessionID
+	copy(serverID[:], []byte("server01"))
+	client := NewControlChannel(clientIO, nil, clientID)
+	client.SetRemoteSessionID(serverID)
+	client.clock = func() time.Time { return time.Unix(1714567890, 0) }
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	client.QueueAck(42)
+	if err := client.RetransmitPending(ctx); err != nil {
+		t.Fatal(err)
+	}
+	// ACK 42 must still be pending (nothing was sent, so it was not consumed).
+	if len(client.ackPending) != 1 || client.ackPending[0] != 42 {
+		t.Fatalf("ackPending after empty retransmit = %v, want [42]", client.ackPending)
+	}
+}
+
+// TestDecryptRejectsUnknownKeyID verifies a data packet labeled with an
+// unknown key epoch is rejected instead of being decrypted with the current
+// key (CBC HMAC excludes the outer header, so wrong-key "authentication" must
+// not be accepted).
+func TestDecryptRejectsUnknownKeyID(t *testing.T) {
+	c := &Client{dataByKey: make(map[uint8]*DataChannel)}
+	// No current data channel: any key ID is unknown.
+	if _, err := c.decryptDataPacket([]byte{byte(PDataV2 << OpcodeShift)}); err == nil {
+		t.Fatal("unknown key id was accepted")
+	}
+}
+
+// TestDecryptRejectsExpiredRetiringKey verifies a data packet from a
+// lame-duck epoch is rejected once the transition window has elapsed.
+func TestDecryptRejectsExpiredRetiringKey(t *testing.T) {
+	current := &DataChannel{keyID: 2}
+	retiring := &DataChannel{keyID: 1}
+	c := &Client{
+		data:          current,
+		retiring:      retiring,
+		retiringExpiry: time.Now().Add(-time.Second),
+		dataByKey:     map[uint8]*DataChannel{1: retiring, 2: current},
+	}
+	_, err := c.decryptDataPacket([]byte{byte(PDataV2 << OpcodeShift) | 1})
+	if err == nil {
+		t.Fatal("expired retiring key was accepted")
+	}
+}
+
+// TestDecryptAcceptsRetiringKeyBeforeExpiry verifies the lame-duck epoch is
+// still accepted within the transition window.
+func TestDecryptAcceptsRetiringKeyBeforeExpiry(t *testing.T) {
+	current := &DataChannel{keyID: 2}
+	retiring := &DataChannel{keyID: 1}
+	c := &Client{
+		data:           current,
+		retiring:       retiring,
+		retiringExpiry: time.Now().Add(time.Hour),
+		dataByKey:      map[uint8]*DataChannel{1: retiring, 2: current},
+	}
+	// Decryption will fail on the packet (no keys), but the key routing must
+	// NOT reject it as unknown/expired.
+	_, err := c.decryptDataPacket([]byte{byte(PDataV2 << OpcodeShift) | 1})
+	if err != nil && err.Error() == "openvpn data packet with unknown key id" {
+		t.Fatalf("retiring key rejected before expiry: %v", err)
+	}
+	if err != nil && err.Error() == "openvpn data packet from expired retiring epoch" {
+		t.Fatalf("retiring key rejected as expired before expiry: %v", err)
+	}
+}
+
 func TestMRUCarriesAckOnSubsequentSends(t *testing.T) {
 	clientIO, serverIO := newMemoryPacketPair()
 	clientCrypt, err := NewTLSCrypt(testStaticKey(), true)
@@ -1220,7 +1297,8 @@ func TestWaitForSoftResetParksLateControlPayload(t *testing.T) {
 	server.AdoptKeyID(1)
 
 	// Late token-only PUSH_REPLY on the current epoch, then a next-epoch
-	// soft reset. The watcher must park the token, not drop it.
+	// soft reset. The watcher must park the token (and surface it now), not
+	// drop it or wait for the next soft reset.
 	go func() {
 		time.Sleep(20 * time.Millisecond)
 		_, _ = server.Send(ctx, PControlV1, []byte("PUSH_REPLY,auth-token SESS_ID_parked\x00"))
@@ -1229,16 +1307,24 @@ func TestWaitForSoftResetParksLateControlPayload(t *testing.T) {
 		_, _ = server.Send(ctx, PControlSoftResetV1, nil)
 	}()
 
+	// First wait surfaces the parked TLS payload so the caller consumes it
+	// immediately (a late AUTH_FAILED must not wait for the next soft reset).
+	_, err := client.waitForSoftReset(ctx)
+	if !errors.Is(err, errParkedTLS) {
+		t.Fatalf("expected errParkedTLS, got %v", err)
+	}
+	queued := client.ReadAll()
+	if len(queued) != 1 || string(queued[0].Payload) != "PUSH_REPLY,auth-token SESS_ID_parked\x00" {
+		t.Fatalf("parked payload lost: %#v", queued)
+	}
+
+	// Then the soft reset is delivered.
 	got, err := client.waitForSoftReset(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if got.Opcode != PControlSoftResetV1 || got.KeyID != 2 {
 		t.Fatalf("got %s key=%d", got.Opcode, got.KeyID)
-	}
-	queued := client.ReadAll()
-	if len(queued) != 1 || string(queued[0].Payload) != "PUSH_REPLY,auth-token SESS_ID_parked\x00" {
-		t.Fatalf("parked payload lost: %#v", queued)
 	}
 }
 

--- a/transport/openvpn/rekey_test.go
+++ b/transport/openvpn/rekey_test.go
@@ -745,6 +745,49 @@ func TestConsumeParkedRekeyPushClearsDeadline(t *testing.T) {
 	}
 }
 
+// TestConsumeRekeyPushRejectsContinuationDiscoveredByReader verifies an
+// intermediate continuation first seen inside the final probe remains marked
+// incomplete when that probe reaches its deadline without a final segment.
+func TestConsumeRekeyPushRejectsContinuationDiscoveredByReader(t *testing.T) {
+	clientIO, _ := newMemoryPacketPair()
+	client, err := NewClient(&ClientConfig{}, clientIO)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer client.Close()
+	client.push = &PushReply{PeerID: 7, AuthTokenPass: "SESS_ID_old"}
+	conn := &chunkConn{}
+	reader := func(got pushReadConn, leftover []byte, _ ...time.Time) (*PushReply, []byte, error) {
+		if got != conn {
+			t.Fatalf("reader received wrong connection: %T", got)
+		}
+		if len(leftover) != 0 {
+			t.Fatalf("unexpected initial leftover: %q", leftover)
+		}
+		return &PushReply{
+			PeerID:           PeerIDUnset,
+			HasPushReply:     true,
+			PushContinuation: 2,
+			Routes:           []netip.Prefix{netip.MustParsePrefix("10.9.0.0/16")},
+		}, nil, nil
+	}
+
+	err = client.consumeRekeyPushFrom(conn, reader)
+	if err == nil || !strings.Contains(err.Error(), "deferred/continued push reply incomplete") {
+		t.Fatalf("reader-discovered continuation returned success: %v", err)
+	}
+	if !client.pushContinuationPending {
+		t.Fatal("reader-discovered continuation state was not persisted")
+	}
+	if client.pushPending == nil || client.pushPending.PushContinuation != 2 ||
+		len(client.pushPending.Routes) != 1 {
+		t.Fatalf("reader-discovered partial push was not retained: %#v", client.pushPending)
+	}
+	if client.push.AuthTokenPass != "SESS_ID_old" || len(client.push.Routes) != 0 {
+		t.Fatalf("partial continuation was committed to active push: %#v", client.push)
+	}
+}
+
 func TestStandaloneAuthPendingDoesNotCompletePush(t *testing.T) {
 	bareReply, _, bareOK := takePushReply([]byte("AUTH_PENDING\x00"))
 	if bareOK {

--- a/transport/openvpn/rekey_test.go
+++ b/transport/openvpn/rekey_test.go
@@ -141,6 +141,14 @@ func TestClassifyWatchAcceptsNextEpochSoftReset(t *testing.T) {
 	if !softReset || !valid {
 		t.Fatalf("expected next-epoch soft reset keyID=2 to be accepted when current keyID=1")
 	}
+
+	// A new-epoch reset is always message 0; any other message ID would
+	// corrupt the receive sequence and must be rejected.
+	pktBadMsg := &ControlPacket{Opcode: PControlSoftResetV1, KeyID: 2, MessageID: 5, LocalSession: serverID}
+	softReset, valid = client.classifyWatchPacketLocked(pktBadMsg)
+	if softReset || valid {
+		t.Fatalf("expected soft reset with message id 5 to be rejected")
+	}
 }
 
 // TestDataLockProtectsDataChannelSwap verifies that the dataLock allows
@@ -315,6 +323,30 @@ func TestParseShortenedKM2OnlyWhenTLSControlFollows(t *testing.T) {
 	full = appendOpenVPNString(full, "IV_VER=server\n")
 	if _, _, err := ParseServerKeyMethod2RecordConsumed(full); err != nil {
 		t.Fatalf("standard full record should parse: %v", err)
+	}
+}
+
+// TestTakePushReplyRequiresTerminator verifies a PUSH_REPLY is not committed
+// until its NUL terminator arrives: a fragment ending after "ifconfig" must
+// not lose later route / DNS / cipher / token options (matching the reference
+// client, which parses the full message).
+func TestTakePushReplyRequiresTerminator(t *testing.T) {
+	// Fragment ending after ifconfig, no terminator: must not be accepted.
+	frag := []byte("PUSH_REPLY,ifconfig 10.8.0.2 255.255.255.0")
+	if _, _, ok := takePushReply(frag); ok {
+		t.Fatal("unterminated PUSH_REPLY was accepted")
+	}
+	// Once the terminator (and a later option) arrives, it is parsed fully.
+	full := append(append([]byte(nil), frag...), []byte(",route-gateway 10.8.0.1\x00")...)
+	reply, rest, ok := takePushReply(full)
+	if !ok {
+		t.Fatal("terminated PUSH_REPLY was not accepted")
+	}
+	if len(reply.Prefixes) != 1 {
+		t.Fatalf("prefixes not parsed: %v", reply.Prefixes)
+	}
+	if len(rest) != 0 {
+		t.Fatalf("unexpected leftover: %q", rest)
 	}
 }
 

--- a/transport/openvpn/rekey_test.go
+++ b/transport/openvpn/rekey_test.go
@@ -408,11 +408,10 @@ func TestOutboundPromotesAfterAuthDeferredExpire(t *testing.T) {
 	}
 }
 
-// TestAuthPendingTimeoutRespected verifies the review point 1: when the
-// server advertises AUTH_PENDING,timeout N, the no-evidence promotion
-// deadline is extended past the fixed authDeferredExpire window, so mihomo
-// does not promote the new outbound key while the peer is still deferred.
-func TestAuthPendingTimeoutRespected(t *testing.T) {
+// TestAuthPendingTimeoutDoesNotExtendOutboundSelection verifies AUTH_PENDING
+// remains control/deferred-auth metadata and cannot replace the independent
+// outbound auth_deferred_expire selection window.
+func TestAuthPendingTimeoutDoesNotExtendOutboundSelection(t *testing.T) {
 	clientIO, serverIO := newMemoryPacketPair()
 	client, err := NewClient(&ClientConfig{Username: "u", Password: "p"}, clientIO)
 	if err != nil {
@@ -451,7 +450,8 @@ func TestAuthPendingTimeoutRespected(t *testing.T) {
 	client.control.AdoptKeyID(1)
 	client.applyAuthPendingTimeout(&PushReply{AuthPendingTimeout: 300 * time.Second})
 	client.installDataChannel(rekeyed)
-	// Simulate the fixed authDeferredExpire window elapsing (61s).
+	// Simulate the independent auth_deferred_expire selection window elapsing
+	// while the advertised pending deadline remains far in the future.
 	client.dataLock.Lock()
 	client.outboundStart = time.Now().Add(-authDeferredExpire - time.Second)
 	deferred := client.deferredUntil
@@ -460,8 +460,8 @@ func TestAuthPendingTimeoutRespected(t *testing.T) {
 		t.Fatalf("epoch install discarded AUTH_PENDING deadline: %v", deferred)
 	}
 
-	// The advertised deadline (300s) has NOT elapsed, so outbound must stay
-	// on the old key.
+	// AUTH_PENDING remains staged on the active epoch, but it must not extend
+	// old-key transmission beyond the independent selection window.
 	if err := client.writeDataPacket(context.Background(), []byte{0x45, 0, 0, 20}, false); err != nil {
 		t.Fatal(err)
 	}
@@ -469,8 +469,95 @@ func TestAuthPendingTimeoutRespected(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, keyID := parseOpcodeKeyID(pkt[0]); keyID != 0 {
-		t.Fatalf("outbound with pending AUTH_PENDING = %d; want 0 (still lame duck)", keyID)
+	if _, keyID := parseOpcodeKeyID(pkt[0]); keyID != 1 {
+		t.Fatalf("AUTH_PENDING extended outbound selection: got key=%d want=1", keyID)
+	}
+}
+
+// TestRetiringWindowAnchoredBeforeInstall verifies TLS/KM2 time is charged to
+// the old key's configured transition lifetime rather than restarting the
+// window when the new data channel is finally installed.
+func TestRetiringWindowAnchoredBeforeInstall(t *testing.T) {
+	clientIO, _ := newMemoryPacketPair()
+	client, err := NewClient(&ClientConfig{TransitionWindow: 10 * time.Second}, clientIO)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer client.Close()
+	initial := &DataChannel{keyID: 0}
+	rekeyed := &DataChannel{keyID: 1}
+	client.installDataChannel(initial)
+
+	anchored := client.beginRetiringWindow()
+	if until := time.Until(anchored); until < 9*time.Second || until > 11*time.Second {
+		t.Fatalf("configured transition window not anchored: %v", until)
+	}
+	// Deterministically model four seconds spent in TLS/KM2 before install.
+	expected := anchored.Add(-4 * time.Second)
+	client.dataLock.Lock()
+	client.pendingRetiringExpiry = expected
+	client.dataLock.Unlock()
+	client.installDataChannel(rekeyed)
+	client.dataLock.RLock()
+	got := client.retiringExpiry
+	client.dataLock.RUnlock()
+	if !got.Equal(expected) {
+		t.Fatalf("install restarted transition window: got=%v want=%v", got, expected)
+	}
+}
+
+// TestRetiringExpiryForcesOutboundPromotion verifies the previous epoch is
+// never selected for transmit after its transition lifetime, even when there
+// is no peer evidence and the AUTH_PENDING deadline is still in the future.
+func TestRetiringExpiryForcesOutboundPromotion(t *testing.T) {
+	clientIO, serverIO := newMemoryPacketPair()
+	client, err := NewClient(&ClientConfig{}, clientIO)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer client.Close()
+	mk := func(fill byte) *KeyMaterial {
+		k := &KeyMaterial{
+			SendCipherKey: make([]byte, 16),
+			SendHMACKey:   make([]byte, maxHMACKeyLength),
+			RecvCipherKey: make([]byte, 16),
+			RecvHMACKey:   make([]byte, maxHMACKeyLength),
+		}
+		for i := range k.SendCipherKey {
+			k.SendCipherKey[i] = fill
+		}
+		copy(k.RecvCipherKey, k.SendCipherKey)
+		for i := range k.SendHMACKey {
+			k.SendHMACKey[i] = fill + 1
+		}
+		copy(k.RecvHMACKey, k.SendHMACKey)
+		return k
+	}
+	initial, err := NewDataChannel(mk(0x11), CipherAES128GCM, AuthSHA256, 7, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rekeyed, err := NewDataChannel(mk(0x22), CipherAES128GCM, AuthSHA256, 7, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	client.installDataChannel(initial)
+	client.config.TransitionWindow = 10 * time.Second
+	client.installDataChannel(rekeyed)
+	client.dataLock.Lock()
+	client.retiringExpiry = time.Now().Add(-time.Millisecond)
+	client.outboundStart = time.Now() // independent 60s window has not elapsed
+	client.dataLock.Unlock()
+
+	if err := client.writeDataPacket(context.Background(), []byte{0x45, 0, 0, 20}, false); err != nil {
+		t.Fatal(err)
+	}
+	pkt, err := serverIO.ReadPacket(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, keyID := parseOpcodeKeyID(pkt[0]); keyID != 1 {
+		t.Fatalf("expired retiring key remained outbound: got=%d want=1", keyID)
 	}
 }
 
@@ -615,10 +702,10 @@ func TestAuthPendingDeadlineAnchoredAtObservation(t *testing.T) {
 
 // TestAuthPendingUpdateCanShortenDeadline verifies a later AUTH_PENDING for
 // the same key replaces, rather than monotonically extends, the staged and
-// active data-epoch deadline, effective control deadline, outbound-key
-// backstop, and token reader's active operation deadline.
+// active data-epoch deadline, effective control deadline, transport deadline,
+// and token reader's active operation deadline.
 func TestAuthPendingUpdateCanShortenDeadline(t *testing.T) {
-	clientIO, serverIO := newMemoryPacketPair()
+	clientIO, _ := newMemoryPacketPair()
 	client, err := NewClient(&ClientConfig{}, clientIO)
 	if err != nil {
 		t.Fatal(err)
@@ -657,8 +744,9 @@ func TestAuthPendingUpdateCanShortenDeadline(t *testing.T) {
 			effective, short.authPendingUntil)
 	}
 
-	// Install the matching epoch and verify the same replacement reaches the
-	// outbound-key fallback, not only the pre-install staging fields.
+	// Install the matching epoch and verify the shortened metadata deadline is
+	// transferred to that epoch without affecting the independent outbound
+	// selection window.
 	mk := func(fill byte) *KeyMaterial {
 		k := &KeyMaterial{
 			SendCipherKey: make([]byte, 16),
@@ -692,15 +780,15 @@ func TestAuthPendingUpdateCanShortenDeadline(t *testing.T) {
 		authPendingUntil:   time.Now().Add(-time.Millisecond),
 	})
 	client.installDataChannel(active)
-	if err := client.writeDataPacket(context.Background(), []byte{0x45, 0, 0, 20}, false); err != nil {
-		t.Fatal(err)
+	client.dataLock.RLock()
+	activeDeferred := client.deferredUntil
+	activeOutbound := client.outboundKey
+	client.dataLock.RUnlock()
+	if !activeDeferred.Before(time.Now()) {
+		t.Fatalf("shorter AUTH_PENDING deadline not transferred to active epoch: %v", activeDeferred)
 	}
-	packet, err := serverIO.ReadPacket(context.Background())
-	if err != nil {
-		t.Fatal(err)
-	}
-	if _, keyID := parseOpcodeKeyID(packet[0]); keyID != 1 {
-		t.Fatalf("expired shorter AUTH_PENDING did not promote outbound key: got=%d want=1", keyID)
+	if activeOutbound != initial {
+		t.Fatal("AUTH_PENDING metadata changed independent outbound selection")
 	}
 
 	conn := &chunkConn{

--- a/transport/openvpn/rekey_test.go
+++ b/transport/openvpn/rekey_test.go
@@ -736,21 +736,20 @@ func TestReadTokenPushReplyEOFPropagated(t *testing.T) {
 }
 
 // TestReadTokenPushReplyCompleteReplyWithEOF verifies that a complete token
-// reply returned together with io.EOF is still surfaced as an error: the TLS
-// stream has closed, so the rekey must not proceed.
+// reply returned together with io.EOF is accepted: the bytes are valid and
+// must be processed before the terminal error (tls.Conn returns (n, io.EOF)
+// when app data is immediately followed by close_notify). Success must not
+// depend on read-ahead boundaries.
 func TestReadTokenPushReplyCompleteReplyWithEOF(t *testing.T) {
 	conn := &chunkConn{
 		data: [][]byte{[]byte("PUSH_REPLY,auth-token SESS_ID_new\x00")},
 		errs: []error{io.EOF},
 	}
 	reply, _, err := readTokenPushReply(conn, nil)
-	if err == nil {
-		t.Fatal("complete reply with EOF was treated as success")
+	if err != nil {
+		t.Fatalf("complete reply with EOF should be accepted: %v", err)
 	}
-	if errors.Is(err, errAuthFailed) {
-		t.Fatalf("unexpected errAuthFailed: %v", err)
-	}
-	if reply != nil {
+	if reply == nil || reply.AuthTokenPass != "SESS_ID_new" {
 		t.Fatalf("unexpected reply: %#v", reply)
 	}
 }
@@ -909,6 +908,76 @@ func TestMRUMoveToFrontMatchesReference(t *testing.T) {
 // reliable control packets (incl. retransmits) carry <= CONTROL_SEND_ACK_MAX
 // (4); a dedicated ACK carries <= RELIABLE_ACK_SIZE (8), and <= 4 when the
 // channel is unprotected (SoftEther compat).
+// TestAckCapRetainsUnsentPending verifies the reference behavior: a packet
+// capped at 4 ACKs consumes only the first 4 pending, and the fifth ACK stays
+// pending and appears on the next packet (reliable_ack_write retains the
+// remainder).
+func TestAckCapRetainsUnsentPending(t *testing.T) {
+	clientIO, serverIO := newMemoryPacketPair()
+	var clientID SessionID
+	copy(clientID[:], []byte("client01"))
+	var serverID SessionID
+	copy(serverID[:], []byte("server01"))
+	client := NewControlChannel(clientIO, nil, clientID)
+	client.SetRemoteSessionID(serverID)
+	client.clock = func() time.Time { return time.Unix(1714567890, 0) }
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	// Five pending ACKs, dedicated-ack cap on a plain channel is 4.
+	for i := 1; i <= 5; i++ {
+		client.QueueAck(uint32(i))
+	}
+	if err := client.SendAck(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	// First dedicated ACK serializes [1 2 3 4]; ACK 5 stays pending.
+	raw, err := serverIO.ReadPacket(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	first, _, _, err := DecodeControlPacket(nil, raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantFirst := []uint32{1, 2, 3, 4}
+	if len(first.AckIDs) != len(wantFirst) {
+		t.Fatalf("first packet acks = %v, want %v", first.AckIDs, wantFirst)
+	}
+	for i := range wantFirst {
+		if first.AckIDs[i] != wantFirst[i] {
+			t.Fatalf("first packet acks = %v, want %v", first.AckIDs, wantFirst)
+		}
+	}
+	if len(client.ackPending) != 1 || client.ackPending[0] != 5 {
+		t.Fatalf("ackPending after first send = %v, want [5]", client.ackPending)
+	}
+
+	// A second dedicated ACK flushes the retained ACK 5.
+	if err := client.SendAck(ctx); err != nil {
+		t.Fatal(err)
+	}
+	raw, err = serverIO.ReadPacket(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, _, _, err := DecodeControlPacket(nil, raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	found5 := false
+	for _, a := range second.AckIDs {
+		if a == 5 {
+			found5 = true
+		}
+	}
+	if !found5 {
+		t.Fatalf("second packet missing retained ACK 5: %v", second.AckIDs)
+	}
+}
+
 func TestAckSerializationCaps(t *testing.T) {
 	cases := []struct {
 		name    string

--- a/transport/openvpn/rekey_test.go
+++ b/transport/openvpn/rekey_test.go
@@ -18,7 +18,7 @@ func TestRenegotiateFailsWithoutTLS(t *testing.T) {
 	}
 	defer client.Close()
 
-	err = client.renegotiate()
+	err = client.renegotiate(nil)
 	if err == nil {
 		t.Fatal("expected error from renegotiate without TLS connection")
 	}
@@ -63,6 +63,7 @@ func TestSendSoftResetRotatesKeyID(t *testing.T) {
 	}
 
 	// Perform soft reset - should rotate to keyID=1 and reset counters.
+	client.RotateKeyID()
 	if err := client.SendSoftReset(ctx); err != nil {
 		t.Fatal(err)
 	}
@@ -91,9 +92,9 @@ func TestSendSoftResetRotatesKeyID(t *testing.T) {
 	}
 }
 
-// TestClassifyWatchAcceptsAlternatingSoftResets verifies that the soft reset
-// watcher correctly accepts rekeys on alternating key IDs (0->1->0->1).
-func TestClassifyWatchAcceptsAlternatingSoftResets(t *testing.T) {
+// TestClassifyWatchAcceptsNewEpochSoftResets verifies that the soft reset
+// watcher accepts a different key ID than the current epoch.
+func TestClassifyWatchAcceptsNewEpochSoftResets(t *testing.T) {
 	var serverID SessionID
 	copy(serverID[:], []byte("server01"))
 
@@ -165,4 +166,182 @@ func TestDataLockProtectsDataChannelSwap(t *testing.T) {
 // testCAPEM returns a minimal self-signed certificate for test configs.
 func testCAPEM() []byte {
 	return []byte(testCert)
+}
+
+func TestNextKeyIDFollowsOpenVPNSequence(t *testing.T) {
+	// 0 -> 1 -> 2 -> 3 -> 4 -> 5 -> 6 -> 7 -> 1
+	got := uint8(0)
+	want := []uint8{1, 2, 3, 4, 5, 6, 7, 1, 2}
+	for i, w := range want {
+		got = NextKeyID(got)
+		if got != w {
+			t.Fatalf("step %d: NextKeyID = %d, want %d", i+1, got, w)
+		}
+	}
+}
+
+func TestSoftResetAdvancesOpenVPNKeyID(t *testing.T) {
+	clientIO, _ := newMemoryPacketPair()
+	clientCrypt, err := NewTLSCrypt(testStaticKey(), true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var clientID SessionID
+	copy(clientID[:], []byte("client01"))
+	client := NewControlChannel(clientIO, clientCrypt, clientID)
+
+	if client.keyID != 0 {
+		t.Fatalf("initial key ID = %d; want 0", client.keyID)
+	}
+	client.RotateKeyID()
+	if client.keyID != 1 {
+		t.Fatalf("first soft reset key ID = %d; want 1", client.keyID)
+	}
+	client.RotateKeyID()
+	if client.keyID != 2 {
+		t.Fatalf("second soft reset key ID = %d; want 2", client.keyID)
+	}
+}
+
+func TestRekeyDataHeaderUsesActiveKeyID(t *testing.T) {
+	keys := &KeyMaterial{
+		SendCipherKey: make([]byte, 16),
+		SendHMACKey:   make([]byte, maxHMACKeyLength),
+		RecvCipherKey: make([]byte, 16),
+		RecvHMACKey:   make([]byte, maxHMACKeyLength),
+	}
+	for i := range keys.SendCipherKey {
+		keys.SendCipherKey[i] = 0x11
+		keys.RecvCipherKey[i] = 0x33
+	}
+	for i := range keys.SendHMACKey {
+		keys.SendHMACKey[i] = 0x22
+		keys.RecvHMACKey[i] = 0x44
+	}
+
+	initial, err := NewDataChannel(keys, CipherAES128GCM, AuthSHA256, 7, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rekeyed, err := NewDataChannel(keys, CipherAES128GCM, AuthSHA256, 7, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	first, err := initial.Encrypt([]byte{0x45, 0, 0, 20})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, keyID := parseOpcodeKeyID(first[0]); keyID != 0 {
+		t.Fatalf("initial data packet key ID = %d; want 0", keyID)
+	}
+
+	second, err := rekeyed.Encrypt([]byte{0x45, 0, 0, 20})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, keyID := parseOpcodeKeyID(second[0]); keyID != 1 {
+		t.Fatalf("rekeyed data packet key ID = %d; want 1", keyID)
+	}
+}
+
+func TestParsePushReplyAuthToken(t *testing.T) {
+	msg := "PUSH_REPLY,ifconfig 10.8.0.2 255.255.255.0,auth-token SESS_ID_tok,auth-token-user dGVzdA=="
+	reply, err := ParsePushReply(msg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	user, pass, ok := reply.AuthToken()
+	if !ok || pass != "SESS_ID_tok" || user != "test" {
+		t.Fatalf("unexpected auth-token: user=%q pass=%q ok=%v", user, pass, ok)
+	}
+}
+
+func TestStashedSoftResetIsNotSwallowedByControlRead(t *testing.T) {
+	client, server := newTestChannels(t)
+	client.SetRemoteSessionID(server.LocalSessionID())
+	server.SetRemoteSessionID(client.LocalSessionID())
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	// Current epoch is 1. Server starts epoch 2 while the client is still
+	// reading TLS records on epoch 1.
+	client.AdoptKeyID(1)
+	server.AdoptKeyID(2)
+	if _, err := server.Send(ctx, PControlSoftResetV1, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	// Ordinary Read must not deliver or drop the next-epoch soft reset.
+	readCtx, readCancel := context.WithTimeout(context.Background(), 80*time.Millisecond)
+	defer readCancel()
+	if pkt, err := client.Read(readCtx); err == nil {
+		t.Fatalf("Read delivered %s key=%d, want timeout", pkt.Opcode, pkt.KeyID)
+	}
+
+	got, err := client.waitForSoftReset(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Opcode != PControlSoftResetV1 || got.KeyID != 2 {
+		t.Fatalf("stashed packet = %s key=%d", got.Opcode, got.KeyID)
+	}
+}
+
+func TestMarkReceivedUnblocksNextEpochControl(t *testing.T) {
+	client, server := newTestChannels(t)
+	client.SetRemoteSessionID(server.LocalSessionID())
+	server.SetRemoteSessionID(client.LocalSessionID())
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	// Server starts a new epoch at key 1 with soft-reset message 0.
+	server.AdoptKeyID(1)
+	if _, err := server.Send(ctx, PControlSoftResetV1, nil); err != nil {
+		t.Fatal(err)
+	}
+	pkt, err := client.waitForSoftReset(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if pkt.KeyID != 1 || pkt.MessageID != 0 {
+		t.Fatalf("soft reset = key %d msg %d", pkt.KeyID, pkt.MessageID)
+	}
+
+	client.AdoptKeyID(1)
+	client.MarkReceived(pkt.MessageID)
+	client.QueueAck(pkt.MessageID)
+	if err := client.SendSoftReset(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	// ServerHello is new-epoch message 1. Without MarkReceived the client
+	// would wait forever for message 0 and this Read would time out.
+	if _, err := server.Send(ctx, PControlV1, []byte("server-hello")); err != nil {
+		t.Fatal(err)
+	}
+	got, err := client.Read(ctx)
+	if err != nil {
+		t.Fatalf("client did not receive post-rekey control: %v", err)
+	}
+	if got.MessageID != 1 || string(got.Payload) != "server-hello" {
+		t.Fatalf("unexpected packet: id=%d payload=%q", got.MessageID, got.Payload)
+	}
+}
+
+func TestCaptureAuthTokenUsedOnNextKeyMethod(t *testing.T) {
+	client := &Client{
+		config:   &ClientConfig{Username: "orig", Password: "origpass"},
+		authUser: "orig",
+		authPass: "origpass",
+	}
+	client.captureAuthToken(&PushReply{AuthTokenUser: "test", AuthTokenPass: "SESS_ID_next"})
+	if client.authUser != "test" || client.authPass != "SESS_ID_next" {
+		t.Fatalf("auth credentials not refreshed: %q/%q", client.authUser, client.authPass)
+	}
+	if client.lastAuthToken != "SESS_ID_next" {
+		t.Fatalf("lastAuthToken = %q", client.lastAuthToken)
+	}
 }

--- a/transport/openvpn/rekey_test.go
+++ b/transport/openvpn/rekey_test.go
@@ -474,39 +474,48 @@ func TestAuthPendingTimeoutRespected(t *testing.T) {
 	}
 }
 
+// TestStandaloneAuthPendingKeepsTokenProbeShort verifies dynamically observed
+// AUTH_PENDING updates the transport deadline but does not hold data-epoch
+// installation until the full advertised timeout. A later token update is
+// consumed by the established parked-TLS watcher.
+func TestStandaloneAuthPendingKeepsTokenProbeShort(t *testing.T) {
+	conn := &chunkConn{
+		data: [][]byte{
+			[]byte("AUTH_PENDING,timeout 60\x00"),
+			nil,
+			[]byte("PUSH_REPLY,auth-token SESS_ID_late\x00"),
+		},
+		errs: []error{nil, os.ErrDeadlineExceeded, nil},
+	}
+	reply, rest, err := readTokenPushReply(conn, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if conn.idx != 2 {
+		t.Fatalf("standalone AUTH_PENDING waited for optional final push: reads=%d", conn.idx)
+	}
+	if reply == nil || reply.AuthPendingTimeout != 60*time.Second || reply.HasPushReply {
+		t.Fatalf("standalone AUTH_PENDING metadata lost: %#v", reply)
+	}
+	if len(rest) != 0 {
+		t.Fatalf("unexpected rest: %q", rest)
+	}
+	if len(conn.operationDeadlines) == 0 ||
+		time.Until(conn.operationDeadlines[0]) < 50*time.Second {
+		t.Fatalf("AUTH_PENDING transport deadline not propagated: %v", conn.operationDeadlines)
+	}
+}
+
 // TestTakePushReplyContinuation verifies the review point 2: an intermediate
 // push-continuation 2 segment is not a complete reply, and the final segment
 // merges repeatable fields (routes / dns) across segments in wire order.
 // TestStandaloneAuthPendingDoesNotCompletePush verifies AUTH_PENDING updates
 // timeout state but does not complete PUSH parsing before a final PUSH_REPLY.
-// TestReadTokenPushReplyPromotesDynamicWait verifies state discovered inside
-// the reader (not pre-buffered) upgrades the active wait policy across a
-// short timeout until the final PUSH_REPLY arrives.
+// TestReadTokenPushReplyPromotesDynamicWait verifies dynamically discovered
+// push-continuation state upgrades the active wait policy across a short
+// timeout until the final segment arrives. Standalone AUTH_PENDING is covered
+// separately: it updates deadline metadata without extending the token probe.
 func TestReadTokenPushReplyPromotesDynamicWait(t *testing.T) {
-	t.Run("AUTH_PENDING", func(t *testing.T) {
-		conn := &chunkConn{
-			data: [][]byte{
-				[]byte("AUTH_PENDING,timeout 1\x00"),
-				nil,
-				[]byte("PUSH_REPLY,auth-token SESS_ID_dynamic\x00"),
-			},
-			errs: []error{nil, os.ErrDeadlineExceeded, nil},
-		}
-		reply, rest, err := readTokenPushReply(conn, nil)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if conn.idx != 3 {
-			t.Fatalf("reader returned before final PUSH_REPLY: reads=%d", conn.idx)
-		}
-		if reply == nil || reply.AuthTokenPass != "SESS_ID_dynamic" || reply.AuthPendingTimeout != time.Second {
-			t.Fatalf("dynamic AUTH_PENDING/final state lost: %#v", reply)
-		}
-		if len(rest) != 0 {
-			t.Fatalf("unexpected rest: %q", rest)
-		}
-	})
-
 	t.Run("push-continuation", func(t *testing.T) {
 		conn := &chunkConn{
 			data: [][]byte{

--- a/transport/openvpn/rekey_test.go
+++ b/transport/openvpn/rekey_test.go
@@ -1,7 +1,9 @@
 package openvpn
 
 import (
+	"bytes"
 	"context"
+	"encoding/binary"
 	"errors"
 	"testing"
 	"time"
@@ -92,9 +94,10 @@ func TestSendSoftResetRotatesKeyID(t *testing.T) {
 	}
 }
 
-// TestClassifyWatchAcceptsNewEpochSoftResets verifies that the soft reset
-// watcher accepts a different key ID than the current epoch.
-func TestClassifyWatchAcceptsNewEpochSoftResets(t *testing.T) {
+// TestClassifyWatchAcceptsNextEpochSoftReset verifies the soft reset watcher
+// only accepts the strictly-next key epoch (0 -> 1 -> ... -> 7 -> 1), and
+// rejects stale or invalid epochs.
+func TestClassifyWatchAcceptsNextEpochSoftReset(t *testing.T) {
 	var serverID SessionID
 	copy(serverID[:], []byte("server01"))
 
@@ -108,26 +111,32 @@ func TestClassifyWatchAcceptsNewEpochSoftResets(t *testing.T) {
 	client := NewControlChannel(clientIO, clientCrypt, clientID)
 	client.SetRemoteSessionID(serverID)
 
-	// Initial keyID = 0, so soft reset with keyID=1 should be accepted.
-	pkt1 := &ControlPacket{Opcode: PControlSoftResetV1, KeyID: 1, LocalSession: serverID}
-	softReset, valid := client.classifyWatchPacketLocked(pkt1)
+	// Initial keyID = 0, so a soft reset with keyID=1 (the next epoch) is accepted.
+	pktNext := &ControlPacket{Opcode: PControlSoftResetV1, KeyID: 1, LocalSession: serverID}
+	softReset, valid := client.classifyWatchPacketLocked(pktNext)
 	if !softReset || !valid {
-		t.Fatalf("expected soft reset keyID=1 to be accepted when current keyID=0")
+		t.Fatalf("expected next-epoch soft reset keyID=1 to be accepted when current keyID=0")
 	}
 
-	// Simulate rotation to keyID=1; now soft reset with keyID=0 should be accepted.
-	client.keyID = 1
-	pkt0 := &ControlPacket{Opcode: PControlSoftResetV1, KeyID: 0, LocalSession: serverID}
-	softReset, valid = client.classifyWatchPacketLocked(pkt0)
-	if !softReset || !valid {
-		t.Fatalf("expected soft reset keyID=0 to be accepted when current keyID=1")
-	}
-
-	// Soft reset with the same keyID as current should NOT be accepted.
-	pktSame := &ControlPacket{Opcode: PControlSoftResetV1, KeyID: 1, LocalSession: serverID}
+	// Same key ID is rejected.
+	pktSame := &ControlPacket{Opcode: PControlSoftResetV1, KeyID: 0, LocalSession: serverID}
 	softReset, valid = client.classifyWatchPacketLocked(pktSame)
 	if softReset || valid {
-		t.Fatalf("expected soft reset with same keyID=1 to be rejected when current keyID=1")
+		t.Fatalf("expected soft reset with same keyID=0 to be rejected when current keyID=0")
+	}
+
+	// After epoch 1, key ID 0 (a stale / invalid epoch) must be rejected.
+	client.keyID = 1
+	pktStale := &ControlPacket{Opcode: PControlSoftResetV1, KeyID: 0, LocalSession: serverID}
+	softReset, valid = client.classifyWatchPacketLocked(pktStale)
+	if softReset || valid {
+		t.Fatalf("expected stale soft reset keyID=0 to be rejected when current keyID=1")
+	}
+	// The strictly-next epoch is keyID=2.
+	pktNext2 := &ControlPacket{Opcode: PControlSoftResetV1, KeyID: 2, LocalSession: serverID}
+	softReset, valid = client.classifyWatchPacketLocked(pktNext2)
+	if !softReset || !valid {
+		t.Fatalf("expected next-epoch soft reset keyID=2 to be accepted when current keyID=1")
 	}
 }
 
@@ -245,6 +254,67 @@ func TestRekeyDataHeaderUsesActiveKeyID(t *testing.T) {
 	}
 }
 
+func TestRecordCompleteRejectsFragmentedKM2(t *testing.T) {
+	var packet []byte
+	packet = binary.BigEndian.AppendUint32(packet, 0)
+	packet = append(packet, KeyMethod2)
+	packet = append(packet, bytes.Repeat([]byte{1}, keySourceRandomSize)...)
+	packet = append(packet, bytes.Repeat([]byte{2}, keySourceRandomSize)...)
+	packet = appendOpenVPNString(packet, "server-options")
+	packet = appendOpenVPNString(packet, "user")
+
+	if complete, _ := RecordComplete(packet); complete {
+		t.Fatal("fragmented record reported complete")
+	}
+	// Appending the remaining strings (with empty trailing ones) completes it.
+	packet = appendOpenVPNString(packet, "pass")
+	packet = appendOpenVPNString(packet, "IV_VER=server\n")
+	if complete, _ := RecordComplete(packet); !complete {
+		t.Fatal("complete record not reported complete")
+	}
+	// Truncated length prefix is also incomplete.
+	if complete, _ := RecordComplete(packet[:len(packet)-1]); complete {
+		t.Fatal("truncated record reported complete")
+	}
+}
+
+func TestParseShortenedKM2OnlyWhenTLSControlFollows(t *testing.T) {
+	var packet []byte
+	packet = binary.BigEndian.AppendUint32(packet, 0)
+	packet = append(packet, KeyMethod2)
+	packet = append(packet, bytes.Repeat([]byte{1}, keySourceRandomSize)...)
+	packet = append(packet, bytes.Repeat([]byte{2}, keySourceRandomSize)...)
+	packet = appendOpenVPNString(packet, "server-options")
+	packet = append(packet, []byte("PUSH_REPLY,ifconfig 10.8.0.2 255.255.255.0\x00")...)
+
+	// PUSH_REPLY is positively identified, so the shortened record parses.
+	if _, _, err := ParseServerKeyMethod2RecordConsumed(packet); err != nil {
+		t.Fatalf("shortened record with PUSH_REPLY should parse: %v", err)
+	}
+
+	// A truncated trailing string that is NOT a following TLS control
+	// message must not be treated as a valid end of record: it is a
+	// fragmented standard record that still needs more TLS reads.
+	var frag []byte
+	frag = binary.BigEndian.AppendUint32(frag, 0)
+	frag = append(frag, KeyMethod2)
+	frag = append(frag, bytes.Repeat([]byte{1}, keySourceRandomSize)...)
+	frag = append(frag, bytes.Repeat([]byte{2}, keySourceRandomSize)...)
+	frag = appendOpenVPNString(frag, "server-options")
+	frag = appendOpenVPNString(frag, "username")
+	frag = frag[:len(frag)-1] // truncate the username value, not a PUSH_REPLY
+	if _, _, err := ParseServerKeyMethod2RecordConsumed(frag); err == nil {
+		t.Fatal("truncated trailing field should not parse")
+	}
+	// And a standard record with all four strings always parses.
+	full := appendOpenVPNString(packet, "user")
+	full = appendOpenVPNString(full, "pass")
+	full = appendOpenVPNString(full, "IV_VER=server\n")
+	if _, _, err := ParseServerKeyMethod2RecordConsumed(full); err != nil {
+		t.Fatalf("standard full record should parse: %v", err)
+	}
+}
+
 func TestParsePushReplyAuthToken(t *testing.T) {
 	msg := "PUSH_REPLY,ifconfig 10.8.0.2 255.255.255.0,auth-token SESS_ID_tok,auth-token-user dGVzdA=="
 	reply, err := ParsePushReply(msg)
@@ -286,6 +356,119 @@ func TestStashedSoftResetIsNotSwallowedByControlRead(t *testing.T) {
 	}
 	if got.Opcode != PControlSoftResetV1 || got.KeyID != 2 {
 		t.Fatalf("stashed packet = %s key=%d", got.Opcode, got.KeyID)
+	}
+}
+
+// TestReadAllKeepsPendingSoftReset ensures the queued soft reset survives the
+// post-handshake drain that feeds TLS payload back to tls.Conn: draining must
+// not steal the rekey trigger from waitForSoftReset.
+func TestReadAllKeepsPendingSoftReset(t *testing.T) {
+	client, server := newTestChannels(t)
+	client.SetRemoteSessionID(server.LocalSessionID())
+	server.SetRemoteSessionID(client.LocalSessionID())
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	// Park a next-epoch soft reset in pendingSoftReset while on epoch 1.
+	client.AdoptKeyID(1)
+	server.AdoptKeyID(2)
+	if _, err := server.Send(ctx, PControlSoftResetV1, nil); err != nil {
+		t.Fatal(err)
+	}
+	readCtx, readCancel := context.WithTimeout(context.Background(), 80*time.Millisecond)
+	defer readCancel()
+	_, _ = client.Read(readCtx) // stashes the soft reset
+	if client.pendingSoftReset == nil {
+		t.Fatal("soft reset was not stashed in pendingSoftReset")
+	}
+
+	// Draining queued control must not consume the stashed soft reset.
+	_ = client.ReadAll()
+	if client.pendingSoftReset == nil {
+		t.Fatal("ReadAll consumed the pending soft reset")
+	}
+
+	// The watcher must still see it.
+	got, err := client.waitForSoftReset(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Opcode != PControlSoftResetV1 || got.KeyID != 2 {
+		t.Fatalf("soft reset lost: got %s key=%d", got.Opcode, got.KeyID)
+	}
+}
+
+func TestRekeyRetransmitsLostClientHello(t *testing.T) {
+	clientIO, serverIO := newMemoryPacketPair()
+	serverCrypt, err := NewTLSCrypt(testStaticKey(), false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var serverID SessionID
+	copy(serverID[:], []byte("server01"))
+
+	client, err := NewClient(&ClientConfig{
+		Proto:   ProtoUDP,
+		TLSCryptKey: testStaticKey(),
+	}, clientIO)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer client.Close()
+	client.control.SetRemoteSessionID(serverID)
+
+	server := NewControlChannel(serverIO, serverCrypt, serverID)
+	server.SetRemoteSessionID(client.control.LocalSessionID())
+	client.control.clock = func() time.Time { return time.Unix(1714567890, 0) }
+	server.clock = func() time.Time { return time.Unix(1714567891, 0) }
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	// Server starts epoch 1 with a soft reset, exactly like a real rekey.
+	server.AdoptKeyID(1)
+	if _, err := server.Send(ctx, PControlSoftResetV1, nil); err != nil {
+		t.Fatal(err)
+	}
+	soft, err := client.control.waitForSoftReset(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	client.control.AdoptKeyID(1)
+	client.control.MarkReceived(soft.MessageID)
+	client.control.QueueAck(soft.MessageID)
+	if err := client.control.SendSoftReset(ctx); err != nil {
+		t.Fatal(err)
+	}
+	// Start the UDP rekey retransmission loop exactly like renegotiate().
+	stop := client.retransmitRekey(ctx)
+	defer stop()
+	// Simulate the TLS epoch: a ClientHello record on epoch 1.
+	if _, err := client.control.Send(ctx, PControlV1, []byte("client-hello")); err != nil {
+		t.Fatal(err)
+	}
+
+	// Drop the client-hello the first time it is sent; it must be
+	// retransmitted by the loop.
+	gotHello := false
+	for i := 0; i < 3; i++ {
+		raw, err := serverIO.ReadPacket(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		pkt, _, _, err := DecodeControlPacket(serverCrypt, raw)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if pkt.Opcode == PControlV1 && string(pkt.Payload) == "client-hello" {
+			gotHello = true
+			break
+		}
+	}
+	if !gotHello {
+		t.Fatal("client-hello never retransmitted after loss")
 	}
 }
 
@@ -341,7 +524,109 @@ func TestCaptureAuthTokenUsedOnNextKeyMethod(t *testing.T) {
 	if client.authUser != "test" || client.authPass != "SESS_ID_next" {
 		t.Fatalf("auth credentials not refreshed: %q/%q", client.authUser, client.authPass)
 	}
-	if client.lastAuthToken != "SESS_ID_next" {
-		t.Fatalf("lastAuthToken = %q", client.lastAuthToken)
+}
+
+func TestRekeyConsumesTokenPushReplyAndKeepsPeerID(t *testing.T) {
+	client := &Client{}
+	client.push = &PushReply{
+		PeerID: 42,
+	}
+	// A token-only PUSH_REPLY arrives in leftoverTLS after the server
+	// key-method-2 record (send_push_reply_auth_token).
+	client.leftoverTLS = []byte("PUSH_REPLY,auth-token SESS_ID_new,auth-token-user dGVzdA==\x00")
+
+	// The rekey branch must consume it and keep the previous peer-id.
+	client.consumeRekeyPush()
+	if client.push.PeerID != 42 {
+		t.Fatalf("peer-id not inherited across rekey: %d", client.push.PeerID)
+	}
+	if client.push.AuthTokenPass != "SESS_ID_new" {
+		t.Fatalf("auth-token not renewed: %q", client.push.AuthTokenPass)
+	}
+	if client.authUser != "test" || client.authPass != "SESS_ID_new" {
+		t.Fatalf("auth credentials not applied: %q/%q", client.authUser, client.authPass)
+	}
+}
+
+func TestWaitForSoftResetParksLateControlPayload(t *testing.T) {
+	client, server := newTestChannels(t)
+	client.SetRemoteSessionID(server.LocalSessionID())
+	server.SetRemoteSessionID(client.LocalSessionID())
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	client.AdoptKeyID(1)
+	server.AdoptKeyID(1)
+
+	// Late token-only PUSH_REPLY on the current epoch, then a next-epoch
+	// soft reset. The watcher must park the token, not drop it.
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		_, _ = server.Send(ctx, PControlV1, []byte("PUSH_REPLY,auth-token SESS_ID_parked\x00"))
+		time.Sleep(20 * time.Millisecond)
+		server.AdoptKeyID(2)
+		_, _ = server.Send(ctx, PControlSoftResetV1, nil)
+	}()
+
+	got, err := client.waitForSoftReset(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Opcode != PControlSoftResetV1 || got.KeyID != 2 {
+		t.Fatalf("got %s key=%d", got.Opcode, got.KeyID)
+	}
+	queued := client.ReadAll()
+	if len(queued) != 1 || string(queued[0].Payload) != "PUSH_REPLY,auth-token SESS_ID_parked\x00" {
+		t.Fatalf("parked payload lost: %#v", queued)
+	}
+}
+
+func TestConsumeRekeyPushReadsParkedTokenViaLeftover(t *testing.T) {
+	c := &Client{push: &PushReply{PeerID: 9, AuthTokenPass: "SESS_ID_old"}}
+	c.leftoverTLS = []byte("PUSH_REPLY,auth-token SESS_ID_parked,auth-token-user dGVzdA==\x00")
+	c.consumeRekeyPush()
+	if c.authPass != "SESS_ID_parked" {
+		t.Fatalf("parked token not applied: %q", c.authPass)
+	}
+	if c.push.PeerID != 9 {
+		t.Fatalf("peer-id lost: %d", c.push.PeerID)
+	}
+}
+
+func TestLooksLikeFollowingTLSControlNotOnWholeKM2Buffer(t *testing.T) {
+	var packet []byte
+	packet = binary.BigEndian.AppendUint32(packet, 0)
+	packet = append(packet, KeyMethod2)
+	packet = append(packet, bytes.Repeat([]byte{1}, keySourceRandomSize)...)
+	packet = append(packet, bytes.Repeat([]byte{2}, keySourceRandomSize)...)
+	packet = appendOpenVPNString(packet, "server-options")
+	packet = append(packet, []byte("PUSH_REPLY,ifconfig 10.8.0.2 255.255.255.0\x00")...)
+
+	// The whole buffer starts with the KM2 header, not PUSH_REPLY.
+	if looksLikeFollowingTLSControl(packet) {
+		t.Fatal("looksLikeFollowingTLSControl must not match a KM2-prefixed buffer")
+	}
+	// The tail after the options string does.
+	offset := 5 + keySourceRandomSize*2
+	offset += 2 + int(binary.BigEndian.Uint16(packet[offset:offset+2]))
+	if !looksLikeFollowingTLSControl(packet[offset:]) {
+		t.Fatal("tail after options should look like TLS control")
+	}
+	// And the tolerant parser still accepts the shortened record.
+	if _, _, err := ParseServerKeyMethod2RecordConsumed(packet); err != nil {
+		t.Fatalf("shortened record should parse via tail check: %v", err)
+	}
+}
+
+func TestRekeyKeepsPeerIDWithoutTokenPush(t *testing.T) {
+	client := &Client{}
+	client.push = &PushReply{
+		PeerID: 7,
+	}
+	// No token pushed on this rekey; peer-id must still carry over.
+	client.consumeRekeyPush()
+	if client.push.PeerID != 7 {
+		t.Fatalf("peer-id not inherited across rekey without token: %d", client.push.PeerID)
 	}
 }

--- a/transport/openvpn/rekey_test.go
+++ b/transport/openvpn/rekey_test.go
@@ -5,7 +5,9 @@ import (
 	"context"
 	"encoding/binary"
 	"errors"
+	"io"
 	"os"
+	"strings"
 	"testing"
 	"time"
 )
@@ -634,11 +636,13 @@ func TestConsumeRekeyPushAUTHFailed(t *testing.T) {
 	}
 }
 
-// chunkConn serves a fixed byte stream one chunk per Read, then blocks
-// (returns a timeout-style error) once exhausted. Simulates TLS exposing a
-// byte stream whose boundaries do not match message boundaries.
+// chunkConn serves a fixed byte stream one chunk per Read. Each chunk may
+// carry an error returned together with the bytes (mimicking tls.Conn's
+// (n, io.EOF) when app data is followed by close_notify). Once exhausted it
+// returns a timeout-style error.
 type chunkConn struct {
 	data [][]byte
+	errs []error
 	idx  int
 }
 
@@ -647,8 +651,12 @@ func (c *chunkConn) Read(p []byte) (int, error) {
 		return 0, os.ErrDeadlineExceeded
 	}
 	n := copy(p, c.data[c.idx])
+	var err error
+	if c.idx < len(c.errs) {
+		err = c.errs[c.idx]
+	}
 	c.idx++
-	return n, nil
+	return n, err
 }
 
 func (c *chunkConn) SetReadDeadline(t time.Time) error { return nil }
@@ -686,6 +694,168 @@ func TestReadTokenPushReplyPartialPreserved(t *testing.T) {
 	if string(rest) != "PUSH_REPLY,auth-token " {
 		t.Fatalf("partial bytes lost: %q", rest)
 	}
+}
+
+// TestReadTokenPushReplyAUTHFailedWithEOF verifies that AUTH_FAILED data
+// returned together with io.EOF (tls.Conn app-data + close_notify) is
+// surfaced as a hard error, not silently discarded.
+func TestReadTokenPushReplyAUTHFailedWithEOF(t *testing.T) {
+	conn := &chunkConn{
+		data: [][]byte{[]byte("AUTH_FAILED,SESSION: auth-token expired\x00")},
+		errs: []error{io.EOF},
+	}
+	reply, _, err := readTokenPushReply(conn, nil)
+	if err == nil {
+		t.Fatal("readTokenPushReply lost AUTH_FAILED returned with io.EOF")
+	}
+	if !errors.Is(err, errAuthFailed) {
+		t.Fatalf("expected errAuthFailed, got %v", err)
+	}
+	if reply != nil {
+		t.Fatalf("unexpected reply: %#v", reply)
+	}
+}
+
+// TestReadTokenPushReplyEOFPropagated verifies that a plain EOF (no complete
+// message) is propagated as an error, not treated as "no token".
+func TestReadTokenPushReplyEOFPropagated(t *testing.T) {
+	conn := &chunkConn{
+		data: [][]byte{[]byte("PUSH_REPLY,auth-token SESS")},
+		errs: []error{io.ErrUnexpectedEOF},
+	}
+	reply, _, err := readTokenPushReply(conn, nil)
+	if err == nil {
+		t.Fatal("EOF was suppressed")
+	}
+	if errors.Is(err, errAuthFailed) {
+		t.Fatalf("unexpected errAuthFailed: %v", err)
+	}
+	if reply != nil {
+		t.Fatalf("unexpected reply: %#v", reply)
+	}
+}
+
+// TestWatchControlSurfacesParkedAUTHFailed verifies that a parked or deferred
+// AUTH_FAILED is surfaced (failControl) instead of being swallowed by the next
+// renegotiation.
+func TestWatchControlSurfacesParkedAUTHFailed(t *testing.T) {
+	clientIO, _ := newMemoryPacketPair()
+	client, err := NewClient(&ClientConfig{Username: "u", Password: "p"}, clientIO)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer client.Close()
+
+	// watcher loop consumes a soft reset, then must abort on AUTH_FAILED.
+	var serverID SessionID
+	copy(serverID[:], []byte("server01"))
+	client.control.SetRemoteSessionID(serverID)
+	client.push = &PushReply{PeerID: 1, AuthTokenPass: "SESS_ID_old"}
+	client.leftoverTLS = []byte("AUTH_FAILED,SESSION: auth-token expired\x00")
+	client.control.AdoptKeyID(1)
+	client.control.pendingSoftReset = &ControlPacket{
+		Opcode:       PControlSoftResetV1,
+		KeyID:        1,
+		LocalSession: serverID,
+	}
+
+	done := make(chan struct{})
+	go func() {
+		client.watchControl()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("watchControl did not exit after AUTH_FAILED")
+	}
+	if rekeyErr := client.LastRekeyError(); rekeyErr == nil {
+		t.Fatal("watchControl swallowed parked AUTH_FAILED")
+	} else if !strings.Contains(rekeyErr.Error(), "auth") {
+		t.Fatalf("unexpected rekey error: %v", rekeyErr)
+	}
+}
+
+// TestMRUCarriesAckOnSubsequentSends verifies the MRU behavior: an ACK queued
+// once rides on this packet and the next (OpenVPN lru_acks), not just once.
+func TestMRUCarriesAckOnSubsequentSends(t *testing.T) {
+	clientIO, serverIO := newMemoryPacketPair()
+	clientCrypt, err := NewTLSCrypt(testStaticKey(), true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	serverCrypt, err := NewTLSCrypt(testStaticKey(), false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var clientID SessionID
+	copy(clientID[:], []byte("client01"))
+	var serverID SessionID
+	copy(serverID[:], []byte("server01"))
+
+	client := NewControlChannel(clientIO, clientCrypt, clientID)
+	client.SetRemoteSessionID(serverID)
+	server := NewControlChannel(serverIO, serverCrypt, serverID)
+	server.SetRemoteSessionID(clientID)
+	client.clock = func() time.Time { return time.Unix(1714567890, 0) }
+	server.clock = func() time.Time { return time.Unix(1714567891, 0) }
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	// Server sends message 5 (soft reset on epoch 1), client queues ACK 5.
+	server.AdoptKeyID(1)
+	if _, err := server.Send(ctx, PControlSoftResetV1, nil); err != nil {
+		t.Fatal(err)
+	}
+	soft, err := client.waitForSoftReset(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	client.AdoptKeyID(1)
+	client.MarkReceived(soft.MessageID)
+	client.QueueAck(soft.MessageID)
+
+	// First outbound packet carries ACK 5.
+	if err := client.SendSoftReset(ctx); err != nil {
+		t.Fatal(err)
+	}
+	raw, err := serverIO.ReadPacket(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	first, _, _, err := DecodeControlPacket(serverCrypt, raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !hasAck(first.AckIDs, soft.MessageID) {
+		t.Fatalf("first packet missing ACK %d: %v", soft.MessageID, first.AckIDs)
+	}
+
+	// Second outbound packet STILL carries ACK 5 (MRU).
+	if _, err := client.Send(ctx, PControlV1, []byte("second")); err != nil {
+		t.Fatal(err)
+	}
+	raw, err = serverIO.ReadPacket(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, _, _, err := DecodeControlPacket(serverCrypt, raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !hasAck(second.AckIDs, soft.MessageID) {
+		t.Fatalf("second packet lost ACK %d (MRU): %v", soft.MessageID, second.AckIDs)
+	}
+}
+
+func hasAck(acks []uint32, id uint32) bool {
+	for _, a := range acks {
+		if a == id {
+			return true
+		}
+	}
+	return false
 }
 
 func TestMarkReceivedUnblocksNextEpochControl(t *testing.T) {

--- a/transport/openvpn/rekey_test.go
+++ b/transport/openvpn/rekey_test.go
@@ -408,6 +408,95 @@ func TestOutboundPromotesAfterAuthDeferredExpire(t *testing.T) {
 	}
 }
 
+// TestAuthPendingTimeoutRespected verifies the review point 1: when the
+// server advertises AUTH_PENDING,timeout N, the no-evidence promotion
+// deadline is extended past the fixed authDeferredExpire window, so mihomo
+// does not promote the new outbound key while the peer is still deferred.
+func TestAuthPendingTimeoutRespected(t *testing.T) {
+	clientIO, serverIO := newMemoryPacketPair()
+	client, err := NewClient(&ClientConfig{Username: "u", Password: "p"}, clientIO)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer client.Close()
+
+	mk := func() *KeyMaterial {
+		k := &KeyMaterial{
+			SendCipherKey: make([]byte, 16),
+			SendHMACKey:   make([]byte, maxHMACKeyLength),
+			RecvCipherKey: make([]byte, 16),
+			RecvHMACKey:   make([]byte, maxHMACKeyLength),
+		}
+		for i := range k.SendCipherKey {
+			k.SendCipherKey[i] = 0x11
+		}
+		copy(k.RecvCipherKey, k.SendCipherKey)
+		for i := range k.SendHMACKey {
+			k.SendHMACKey[i] = 0x22
+		}
+		copy(k.RecvHMACKey, k.SendHMACKey)
+		return k
+	}
+	initial, err := NewDataChannel(mk(), CipherAES128GCM, AuthSHA256, 7, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rekeyed, err := NewDataChannel(mk(), CipherAES128GCM, AuthSHA256, 7, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	client.installDataChannel(initial)
+	client.installDataChannel(rekeyed)
+	// Server advertises AUTH_PENDING,timeout 300 for the deferred epoch.
+	client.applyAuthPendingTimeout(&PushReply{AuthPendingTimeout: 300 * time.Second})
+	// Simulate the fixed authDeferredExpire window elapsing (61s).
+	client.outboundStart = time.Now().Add(-authDeferredExpire - time.Second)
+
+	// The advertised deadline (300s) has NOT elapsed, so outbound must stay
+	// on the old key.
+	if err := client.writeDataPacket(context.Background(), []byte{0x45, 0, 0, 20}, false); err != nil {
+		t.Fatal(err)
+	}
+	pkt, err := serverIO.ReadPacket(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, keyID := parseOpcodeKeyID(pkt[0]); keyID != 0 {
+		t.Fatalf("outbound with pending AUTH_PENDING = %d; want 0 (still lame duck)", keyID)
+	}
+}
+
+// TestTakePushReplyContinuation verifies the review point 2: an intermediate
+// push-continuation 2 segment is not a complete reply, and the final segment
+// merges repeatable fields (routes / dns) across segments in wire order.
+func TestTakePushReplyContinuation(t *testing.T) {
+	// Only an intermediate segment: not complete.
+	intermediate := []byte("PUSH_REPLY,route 10.2.0.0 255.255.0.0,push-continuation 2\x00")
+	reply, _, ok := takePushReply(intermediate)
+	if ok {
+		t.Fatal("intermediate push-continuation segment treated as complete")
+	}
+	if reply == nil || len(reply.Routes) != 1 {
+		t.Fatalf("intermediate segment routes not parsed: %#v", reply)
+	}
+	// Intermediate + final in one buffer: complete, routes/dns merged.
+	full := []byte("PUSH_REPLY,route 10.2.0.0 255.255.0.0,push-continuation 2\x00" +
+		"PUSH_REPLY,dhcp-option DNS 8.8.8.8,ifconfig 10.8.0.2 255.255.255.0,route 10.3.0.0 255.255.0.0\x00")
+	reply, _, ok = takePushReply(full)
+	if !ok {
+		t.Fatal("final push-continuation segment not complete")
+	}
+	if len(reply.Routes) != 2 {
+		t.Fatalf("continuation routes lost: %v", reply.Routes)
+	}
+	if len(reply.DNS) != 1 || reply.DNS[0].String() != "8.8.8.8" {
+		t.Fatalf("continuation dns lost: %v", reply.DNS)
+	}
+	if len(reply.Prefixes) != 1 {
+		t.Fatalf("continuation ifconfig lost: %v", reply.Prefixes)
+	}
+}
+
 func TestOutboundKeyStaysLameDuckUntilPeerEvidence(t *testing.T) {
 	clientIO, serverIO := newMemoryPacketPair()
 	client, err := NewClient(&ClientConfig{Username: "u", Password: "p"}, clientIO)


### PR DESCRIPTION
Fixes [#3085](https://github.com/MetaCubeX/mihomo/issues/3085).

OpenVPN 2.6 starts a new SSL session and a new key epoch on `P_CONTROL_SOFT_RESET_V1`. It does **not** renegotiate TLS on the existing SSL object. Upstream OpenVPN allocates a new SSL object per key state and has TLS-layer renegotiation disabled.

The previous mihomo client treated soft reset as TLS renegotiation on the already-completed `tls.Conn`. `HandshakeContext` returns immediately when the handshake is already done, so no ClientHello is sent. It then continued the key-method exchange on the old TLS state. Combined with a data-channel header that always used key ID `0`, and a control-channel key ID that XOR-toggled `0 ↔ 1` instead of following OpenVPN’s `0 → 1 → 2 → 3 → 4 → 5 → 6 → 7 → 1`, the first server-initiated rekey tore the tunnel down.

On OpenVPN 2.6.14 with `reneg-sec 10` the server log is:

```
TLS: soft reset sec=10/10 ...
Sent fatal SSL alert: unexpected message
OpenSSL: error:0A0000F4:SSL routines::unexpected message
TLS handshake failed
```

The mihomo process stays up. Only the OpenVPN transport closes (`use of closed network connection`). Active connections drop until a full hard reset / new handshake. The original rekey error was discarded in `watchControl()`, so production logs never showed whether TLS, key-method, PUSH, or token refresh failed.

## What each soft reset does now

1. Treat the server’s `P_CONTROL_SOFT_RESET_V1` as a new key epoch. Adopt the key ID from that packet (`0 → 1 → … → 7 → 1`). Do not invent `0 ↔ 1`.
2. Advance the reliable receive sequence past the consumed soft-reset message (`MarkReceived`). The server reset is new-epoch message `0`; without this, ServerHello (message `1`) sits in `recvPending` forever and the TLS handshake times out.
3. Install a **fresh `tls.Conn`** over the same control channel and run a full initial handshake. Do not call `HandshakeContext` on the old conn. Do not send TLS `close_notify` on the old epoch (that would go out under the new key ID and pollute it).
4. Run key-method 2 on the new TLS session. Derive new data-channel keys. Encode the **active** key ID on every `P_DATA_V1` / `P_DATA_V2` header.
5. Keep the retiring data channel indexed by key ID so packets still labeled with the previous epoch decrypt during the transition.
6. Parse shortened server key-method-2 records (options mandatory; username / password / peer-info optional). Preserve leftover TLS bytes so a coalesced `PUSH_REPLY` or `AUTH_FAILED` is not discarded.
7. Carry a pushed `auth-token` / `auth-token-user` into the next epoch. Capture a refreshed token when the server sends one; keep the previous token when it does not.
8. On an already-authenticated rekey, **reuse the previous `PUSH_REPLY`** (ifconfig / peer-id / cipher). OpenVPN 2.6 often does not send a second push. Waiting for one hung the second rekey for 30s.
9. If the next server soft reset arrives while TLS/key-method is still running, stash it. Do not let `ControlConn.Read` swallow it as an ordinary control payload.
10. Preserve the original rekey error and surface it on `ReadIPPacket`, instead of only `use of closed network connection`.

## Test

Unit tests in `transport/openvpn`:

- `TestNextKeyIDFollowsOpenVPNSequence` — `0 → 1 → … → 7 → 1`
- `TestSoftResetAdvancesOpenVPNKeyID` — second reset is key ID `2`, not `0`
- `TestRekeyDataHeaderUsesActiveKeyID` — rekeyed data packet key ID is `1`, not `0`
- `TestParseServerKeyMethod2RecordShortenedPreservesTail` — leftover `PUSH_REPLY` kept
- `TestParsePushReplyAuthToken` / `TestCaptureAuthTokenUsedOnNextKeyMethod`
- `TestMarkReceivedUnblocksNextEpochControl` — ServerHello after soft reset is delivered
- `TestStashedSoftResetIsNotSwallowedByControlRead` — next-epoch reset is not eaten by `Read`

Live check, same minimal config on both binaries:

- OpenVPN 2.6.14, `reneg-sec 10`, `AES-128-GCM`, username/password, bind `127.0.0.1:1194`
- mihomo `mixed-port: 17890`, `MATCH` → OpenVPN outbound
- HTTP through the tunnel to `10.8.0.1:8080`

| binary | result |
|---|---|
| official `alpha-7ee0b05` | first soft reset: `unexpected message`, tunnel dies |
| this commit | 3 consecutive soft resets, HTTP 36/36, process never restarts |

Refs: [MetaCubeX/mihomo#3085](https://github.com/MetaCubeX/mihomo/issues/3085)