### PR TITLE
VLESS Vision: support non-RAW transports (e.g. XHTTP) in client

### DIFF
--- a/transport/vless/vision/conn.go
+++ b/transport/vless/vision/conn.go
@@ -171,8 +171,10 @@ func (vc *Conn) ReadBuffer(buffer *buf.Buffer) error {
 			}
 			if vc.input == nil && vc.rawInput == nil {
 				vc.readProcess = false
-				vc.ExtendedReader = N.NewExtendedReader(vc.netConn)
-				log.Debugln("XTLS Vision direct read start")
+				if vc.netConn != nil { // non-RAW transport: keep relaying on the existing stream
+					vc.ExtendedReader = N.NewExtendedReader(vc.netConn)
+					log.Debugln("XTLS Vision direct read start")
+				}
 			}
 			if needReturn {
 				return nil
@@ -228,8 +230,10 @@ func (vc *Conn) WriteBuffer(buffer *buf.Buffer) (err error) {
 				return
 			}
 			if command == commandPaddingDirect {
-				vc.ExtendedWriter = N.NewExtendedWriter(vc.netConn)
-				log.Debugln("XTLS Vision direct write start")
+				if vc.netConn != nil { // non-RAW transport: keep relaying on the existing stream
+					vc.ExtendedWriter = N.NewExtendedWriter(vc.netConn)
+					log.Debugln("XTLS Vision direct write start")
+				}
 				//time.Sleep(5 * time.Millisecond)
 			}
 		}
@@ -246,7 +250,7 @@ func (vc *Conn) FrontHeadroom() int {
 	if vc.readFilterUUID || vc.writeOnceUserUUID != nil {
 		fontHeadroom = PaddingHeaderLen
 	}
-	if vc.writeFilterApplicationData { // The writer may be replaced, add the required value for vc.netConn
+	if vc.writeFilterApplicationData && vc.netConn != nil { // The writer may be replaced, add the required value for vc.netConn
 		if abs := N.CalculateFrontHeadroom(vc.netConn) - N.CalculateFrontHeadroom(vc.Conn); abs > 0 {
 			fontHeadroom += abs
 		}
@@ -256,7 +260,7 @@ func (vc *Conn) FrontHeadroom() int {
 
 func (vc *Conn) RearHeadroom() int {
 	rearHeadroom := 500 + 900
-	if vc.writeFilterApplicationData { // The writer may be replaced, add the required value for vc.netConn
+	if vc.writeFilterApplicationData && vc.netConn != nil { // The writer may be replaced, add the required value for vc.netConn
 		if abs := N.CalculateRearHeadroom(vc.netConn) - N.CalculateRearHeadroom(vc.Conn); abs > 0 {
 			rearHeadroom += abs
 		}
@@ -273,8 +277,8 @@ func (vc *Conn) NeedAdditionalReadDeadline() bool {
 }
 
 func (vc *Conn) Upstream() any {
-	if vc.writeDirect ||
-		vc.readLastCommand == commandPaddingDirect {
+	if (vc.writeDirect ||
+		vc.readLastCommand == commandPaddingDirect) && vc.netConn != nil {
 		return vc.netConn
 	}
 	return vc.Conn
@@ -304,7 +308,7 @@ func (vc *Conn) WriterReplaceable() bool {
 }
 
 func (vc *Conn) Close() error {
-	if vc.ReaderReplaceable() || vc.WriterReplaceable() { // ignore send closeNotify alert in tls.Conn
+	if (vc.ReaderReplaceable() || vc.WriterReplaceable()) && vc.netConn != nil { // ignore send closeNotify alert in tls.Conn
 		return vc.netConn.Close()
 	}
 	return vc.Conn.Close()

--- a/transport/vless/vision/vision.go
+++ b/transport/vless/vision/vision.go
@@ -7,7 +7,6 @@ import (
 	"bytes"
 	gotls "crypto/tls"
 	"errors"
-	"fmt"
 	"net"
 	"reflect"
 	"unsafe"
@@ -91,8 +90,13 @@ func NewConn(conn net.Conn, tlsConn net.Conn, userUUID uuid.UUID) (*Conn, error)
 		}
 	}
 	if t == nil || p == nil {
-		log.Warnln("vision: not a valid supported TLS connection: %s", reflect.TypeOf(tlsConn))
-		return nil, fmt.Errorf(`failed to use vision, maybe "tls" is not enable and "encryption" is empty`)
+		// Non-RAW transports (XHTTP, WebSocket, gRPC, ...) do not expose the
+		// underlying TLS/REALITY conn internals, so XTLS penetration is not
+		// possible. Vision still works in padding-only mode: the traffic is
+		// padded/filtered as usual, and after the inner TLS handshake both
+		// sides keep relaying raw bytes over the existing stream.
+		log.Debugln("vision: transport is not RAW (no TLS/REALITY penetration), %s", reflect.TypeOf(tlsConn))
+		return c, nil
 	}
 
 	if err := checkTLSVersion(tlsConn); err != nil {


### PR DESCRIPTION
﻿## What does this PR do?

Allows the VLESS flow `xtls-rprx-vision` to be used on non-RAW transports (e.g. XHTTP) in the **client**, instead of failing with `"vision: not a valid supported TLS connection: *xhttp.Conn"`.

The server side was recently enabled in XTLS/Xray-core (see https://github.com/XTLS/Xray-core/pull/6629). This PR brings the same capability to mihomo clients so VLESS + XHTTP + REALITY + `flow: xtls-rprx-vision` works end-to-end.

## How it works

- `vision.NewConn` no longer errors when the connection chain does not expose a TLS/REALITY conn (XHTTP, WebSocket, gRPC, ...). XTLS penetration is impossible there, so Vision runs in padding-only mode: padding + filtering work as usual, and after the inner TLS handshake both sides keep relaying raw bytes over the existing stream.
- Nil guards added for `netConn`/`input`/`rawInput` in the direct-copy branches (`ReadBuffer`/`WriteBuffer`), headroom calculation, `Upstream()` and `Close()`.

## Tests

- End-to-end verified with mihomo built from this branch against Xray-core (26.7.28, with the server-side patch):
  - VLESS + XHTTP + REALITY + `flow: xtls-rprx-vision`: TCP (gen204, api.ipify.org), 10MB download (~2.2MB/s), and UDP (SOCKS5 UDP ASSOCIATE, DNS via 8.8.8.8:53) all work.
