### PR TITLE
[Alpha] fix(wireguard): prefer mips over gVisor for outbound auto IP stack on Windows

### DIFF
--- a/adapter/outbound/wireguard.go
+++ b/adapter/outbound/wireguard.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"net/netip"
 	"os"
+	"runtime"
 	"strconv"
 	"strings"
 	"sync"
@@ -188,7 +189,9 @@ type ipStack interface {
 func newIPStack(option IPStackOption, localAddresses []netip.Prefix, mtu uint32) (ipStack, error) {
 	mode := option.Mode
 	if mode == ipStackAuto {
-		if features.WithGVisor {
+		if runtime.GOOS == "windows" {
+			mode = ipStackMips
+		} else if features.WithGVisor {
 			mode = ipStackGVisor
 		} else {
 			mode = ipStackMips


### PR DESCRIPTION
IPStackOption's "auto" mode picked ipStackGVisor whenever the binary was built with the with_gvisor tag (the default for official releases), regardless of OS. On Windows this measured roughly 3x lower WireGuard outbound upload throughput than ipStackMips on otherwise identical builds and network paths (~15 Mbps vs ~50 Mbps).

mips carries no build-tag requirement and is already the fallback for non-with_gvisor builds, so prefer it on Windows unconditionally and keep the existing gVisor-if-built behavior on other platforms, where this hasn't been observed to regress throughput.

Benchmark (Windows 11 x64, 50/50 Mbps WAN):
- with_gvisor build + mode: auto (gvisor): 15.09 Mbps Upload
- with_gvisor build + mode: mips (mips):   49.96 Mbps Upload
- clean build (without with_gvisor):       48.21 Mbps Upload