### PR TITLE
feat(api): add PUT /configs/file to persist config via external controller

### DIFF
--- a/hub/route/configs.go
+++ b/hub/route/configs.go
@@ -2,6 +2,7 @@ package route
 
 import (
 	"net/netip"
+	"os"
 	"path/filepath"
 
 	"github.com/metacubex/mihomo/adapter/inbound"
@@ -27,6 +28,7 @@ func configRouter() http.Handler {
 	r.Get("/", getConfigs)
 	if !embedMode { // disallow update/patch configs in embed mode
 		r.Put("/", updateConfigs)
+		r.Put("/file", updateConfigFile)
 		r.Post("/geo", updateGeoDatabases)
 		r.Patch("/", patchConfigs)
 	}
@@ -437,6 +439,77 @@ func updateConfigs(w http.ResponseWriter, r *http.Request) {
 
 	executor.ApplyConfig(cfg, force)
 	render.NoContent(w, r)
+}
+
+// updateConfigFile validates a full configuration given as inline payload,
+// persists it to the default config file (atomic write: temp file + rename,
+// preserving the existing file mode) and applies it to the running core.
+//
+// Unlike PUT /configs with a payload — which only applies the config in
+// memory — this endpoint makes the configuration survive a restart, which is
+// required for remote config management (e.g. web panels).
+func updateConfigFile(w http.ResponseWriter, r *http.Request) {
+	req := struct {
+		Payload string `json:"payload"`
+	}{}
+	if err := render.DecodeJSON(r.Body, &req); err != nil {
+		render.Status(r, http.StatusBadRequest)
+		render.JSON(w, r, ErrBadRequest)
+		return
+	}
+	if req.Payload == "" {
+		render.Status(r, http.StatusBadRequest)
+		render.JSON(w, r, newError("payload is required"))
+		return
+	}
+
+	// validate before touching the file on disk
+	cfg, err := executor.ParseWithBytes([]byte(req.Payload))
+	if err != nil {
+		render.Status(r, http.StatusBadRequest)
+		render.JSON(w, r, newError(err.Error()))
+		return
+	}
+
+	cfgPath := C.Path.Resolve(C.Path.Config())
+	if err := saveConfigFile(cfgPath, []byte(req.Payload)); err != nil {
+		log.Errorln("[CONFIG] persist config to %s failed: %v", cfgPath, err)
+		render.Status(r, http.StatusInternalServerError)
+		render.JSON(w, r, newError(err.Error()))
+		return
+	}
+
+	force := r.URL.Query().Get("force") == "true"
+	executor.ApplyConfig(cfg, force)
+	render.NoContent(w, r)
+}
+
+// saveConfigFile writes data to path atomically: a temp file in the same
+// directory is written and renamed over the target, so a crash mid-write can
+// never leave a truncated config behind.
+func saveConfigFile(path string, data []byte) error {
+	dir := filepath.Dir(path)
+	perm := os.FileMode(0o644)
+	if stat, err := os.Stat(path); err == nil {
+		perm = stat.Mode().Perm()
+	}
+	tmp, err := os.CreateTemp(dir, ".config-*")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	defer os.Remove(tmpName) // no-op after a successful rename
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	if err := os.Chmod(tmpName, perm); err != nil {
+		return err
+	}
+	return os.Rename(tmpName, path)
 }
 
 func updateGeoDatabases(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Summary

`PUT /configs` with an inline `payload` applies a configuration **in memory only** — after a restart the core falls back to the previous file on disk. This makes fully remote config management impossible over the external-controller API alone: every management UI (web panels, fleet managers) still needs SSH access or a companion agent on the box just to write `config.yaml`.

This PR adds `PUT /configs/file`:

- `{"payload": "<full config.yaml>"}` — required, must be a complete valid config
- the payload is **validated first** (`executor.ParseWithBytes`): an invalid config is rejected with 400 and the file on disk is left untouched
- then persisted to the default config file (`C.Path.Resolve(C.Path.Config())`) with an **atomic write** (temp file in the same dir + `os.Rename`), preserving the existing file mode
- then applied to the running core, honouring `?force=true` exactly like `PUT /configs` (`force=false` keeps the documented behaviour of not recreating inbound listeners; `force=true` recreates them)
- the payload is written **verbatim**, so YAML comments survive a round-trip (unlike `GET /configs`, which returns the parsed running config)
- gated behind the same `!embedMode` check as the other mutation endpoints

## Use case

Managing a fleet of gateway nodes (TUN + auto-route + auto-redirect) from a single panel: the panel holds the source of truth for configs (versioning, diffs, rollback) and pushes a complete config to each node over the existing authenticated REST API — no SSH credentials or extra daemons on the nodes.

## Security considerations

The endpoint is protected by the existing external-controller auth (Bearer secret), same as `PUT /configs` and `POST /restart`. It only writes the default config file — no arbitrary paths are accepted, so it cannot be used to write elsewhere on disk. If maintainers prefer, the endpoint can be gated behind an opt-in config flag (e.g. `external-controller-persist: true`).

## Testing

- `go vet ./hub/...` clean; binary builds
- E2E against a running core:
  - valid payload → `204`, file on disk updated verbatim (comments preserved), running config applied
  - `?force=true` + changed `mixed-port` → listener recreated, new port listening
  - invalid YAML → `400`, file on disk unchanged
  - full process restart → core boots from the persisted file

## Alternatives considered

- SSH/SFTP from the panel: works, but forces the panel to hold node SSH credentials
- A companion agent daemon (Remnawave-style): more moving parts on every node
- Extending `PUT /configs` with a `persist` flag: kept the new endpoint separate so the existing endpoint's semantics are unchanged
