### PR TITLE
chore: report short-lived connections in snapshots

### DIFF
--- a/hub/route/connections.go
+++ b/hub/route/connections.go
@@ -1,7 +1,6 @@
 package route
 
 import (
-	"bytes"
 	"encoding/json"
 	"strconv"
 	"time"
@@ -51,34 +50,50 @@ func getConnections(w http.ResponseWriter, r *http.Request) {
 	snapshotStream := statistic.DefaultManager.NewSnapshotStream()
 	defer snapshotStream.Close()
 
-	buf := &bytes.Buffer{}
 	sendSnapshot := func() error {
-		buf.Reset()
 		snapshot := snapshotStream.Snapshot()
-		if err := json.NewEncoder(buf).Encode(snapshot); err != nil {
+		data, err := json.Marshal(snapshot)
+		if err != nil {
 			return err
 		}
 		if err := conn.SetWriteDeadline(time.Now().Add(C.DefaultTCPTimeout)); err != nil {
 			return err
 		}
 
-		return wsWriteServerText(conn, buf.Bytes())
+		return wsWriteServerText(conn, data)
 	}
 
 	if err := sendSnapshot(); err != nil {
 		return
 	}
 
-	tick := time.NewTicker(interval)
-	defer tick.Stop()
+	nextSnapshot := time.Now().Add(interval)
+	timer := time.NewTimer(interval)
+	defer timer.Stop()
+	updates := snapshotStream.Updates()
 	for {
 		select {
-		case <-tick.C:
-		case <-snapshotStream.Updates():
+		case <-timer.C:
+		case <-updates:
+			updates = nil
+			if time.Until(nextSnapshot) > C.DefaultTCPTimeout {
+				if !timer.Stop() {
+					select {
+					case <-timer.C:
+					default:
+					}
+				}
+				timer.Reset(C.DefaultTCPTimeout)
+				nextSnapshot = time.Now().Add(C.DefaultTCPTimeout)
+			}
+			continue
 		}
 		if err := sendSnapshot(); err != nil {
 			break
 		}
+		timer.Reset(interval)
+		nextSnapshot = time.Now().Add(interval)
+		updates = snapshotStream.Updates()
 	}
 }
 

--- a/hub/route/connections.go
+++ b/hub/route/connections.go
@@ -32,6 +32,8 @@ func getConnections(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		return
 	}
+	snapshotStream := statistic.DefaultManager.NewSnapshotStream()
+	defer snapshotStream.Close()
 
 	intervalStr := r.URL.Query().Get("interval")
 	interval := 1000
@@ -49,7 +51,7 @@ func getConnections(w http.ResponseWriter, r *http.Request) {
 	buf := &bytes.Buffer{}
 	sendSnapshot := func() error {
 		buf.Reset()
-		snapshot := statistic.DefaultManager.Snapshot()
+		snapshot := snapshotStream.Snapshot()
 		if err := json.NewEncoder(buf).Encode(snapshot); err != nil {
 			return err
 		}

--- a/hub/route/connections.go
+++ b/hub/route/connections.go
@@ -30,16 +30,17 @@ func getConnections(w http.ResponseWriter, r *http.Request) {
 	}
 
 	intervalStr := r.URL.Query().Get("interval")
-	interval := 1000
+	interval := time.Second
 	if intervalStr != "" {
-		t, err := strconv.Atoi(intervalStr)
-		if err != nil || t <= 0 {
+		const maxIntervalMilliseconds = (1<<63 - 1) / int64(time.Millisecond)
+		milliseconds, err := strconv.ParseInt(intervalStr, 10, 64)
+		if err != nil || milliseconds <= 0 || milliseconds > maxIntervalMilliseconds {
 			render.Status(r, http.StatusBadRequest)
 			render.JSON(w, r, ErrBadRequest)
 			return
 		}
 
-		interval = t
+		interval = time.Duration(milliseconds) * time.Millisecond
 	}
 
 	conn, _, err := wsUpgrade(r, w)
@@ -68,9 +69,13 @@ func getConnections(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	tick := time.NewTicker(time.Millisecond * time.Duration(interval))
+	tick := time.NewTicker(interval)
 	defer tick.Stop()
-	for range tick.C {
+	for {
+		select {
+		case <-tick.C:
+		case <-snapshotStream.Updates():
+		}
 		if err := sendSnapshot(); err != nil {
 			break
 		}

--- a/hub/route/connections.go
+++ b/hub/route/connections.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 	"time"
 
+	C "github.com/metacubex/mihomo/constant"
 	"github.com/metacubex/mihomo/tunnel/statistic"
 
 	"github.com/metacubex/chi"
@@ -28,18 +29,11 @@ func getConnections(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	conn, _, err := wsUpgrade(r, w)
-	if err != nil {
-		return
-	}
-	snapshotStream := statistic.DefaultManager.NewSnapshotStream()
-	defer snapshotStream.Close()
-
 	intervalStr := r.URL.Query().Get("interval")
 	interval := 1000
 	if intervalStr != "" {
 		t, err := strconv.Atoi(intervalStr)
-		if err != nil {
+		if err != nil || t <= 0 {
 			render.Status(r, http.StatusBadRequest)
 			render.JSON(w, r, ErrBadRequest)
 			return
@@ -48,11 +42,22 @@ func getConnections(w http.ResponseWriter, r *http.Request) {
 		interval = t
 	}
 
+	conn, _, err := wsUpgrade(r, w)
+	if err != nil {
+		return
+	}
+	defer conn.Close()
+	snapshotStream := statistic.DefaultManager.NewSnapshotStream()
+	defer snapshotStream.Close()
+
 	buf := &bytes.Buffer{}
 	sendSnapshot := func() error {
 		buf.Reset()
 		snapshot := snapshotStream.Snapshot()
 		if err := json.NewEncoder(buf).Encode(snapshot); err != nil {
+			return err
+		}
+		if err := conn.SetWriteDeadline(time.Now().Add(C.DefaultTCPTimeout)); err != nil {
 			return err
 		}
 

--- a/tunnel/statistic/manager.go
+++ b/tunnel/statistic/manager.go
@@ -2,11 +2,14 @@ package statistic
 
 import (
 	"os"
+	"sync"
 	"time"
 
 	"github.com/metacubex/mihomo/common/atomic"
 	"github.com/metacubex/mihomo/common/xsync"
 	"github.com/metacubex/mihomo/component/memory"
+
+	"github.com/gofrs/uuid/v5"
 )
 
 var DefaultManager *Manager
@@ -35,6 +38,9 @@ type Manager struct {
 	downloadTotal atomic.Int64
 	pid           int32
 	memory        uint64
+
+	snapshotStreamsMu sync.RWMutex
+	snapshotStreams   map[*SnapshotStream]struct{}
 }
 
 func (m *Manager) Join(c Tracker) {
@@ -42,7 +48,17 @@ func (m *Manager) Join(c Tracker) {
 }
 
 func (m *Manager) Leave(c Tracker) {
-	m.connections.Delete(c.ID())
+	tracker, loaded := m.connections.LoadAndDelete(c.ID())
+	if !loaded {
+		return
+	}
+
+	info := tracker.Info()
+	m.snapshotStreamsMu.RLock()
+	defer m.snapshotStreamsMu.RUnlock()
+	for stream := range m.snapshotStreams {
+		stream.pushClosed(info)
+	}
 }
 
 func (m *Manager) Get(id string) (c Tracker) {
@@ -93,6 +109,60 @@ func (m *Manager) Snapshot() *Snapshot {
 		Connections:   connections,
 		Memory:        m.memory,
 	}
+}
+
+// SnapshotStream includes connections closed between snapshots in the next snapshot.
+type SnapshotStream struct {
+	manager *Manager
+	mu      sync.Mutex
+	pending []*TrackerInfo
+}
+
+func (m *Manager) NewSnapshotStream() *SnapshotStream {
+	stream := &SnapshotStream{manager: m}
+	m.snapshotStreamsMu.Lock()
+	if m.snapshotStreams == nil {
+		m.snapshotStreams = map[*SnapshotStream]struct{}{}
+	}
+	m.snapshotStreams[stream] = struct{}{}
+	m.snapshotStreamsMu.Unlock()
+	return stream
+}
+
+func (s *SnapshotStream) Snapshot() *Snapshot {
+	snapshot := s.manager.Snapshot()
+
+	s.mu.Lock()
+	if len(s.pending) == 0 {
+		s.mu.Unlock()
+		return snapshot
+	}
+	closedConnections := s.pending
+	s.pending = nil
+	s.mu.Unlock()
+
+	activeConnections := make(map[uuid.UUID]struct{}, len(snapshot.Connections))
+	for _, connection := range snapshot.Connections {
+		activeConnections[connection.UUID] = struct{}{}
+	}
+	for _, connection := range closedConnections {
+		if _, exists := activeConnections[connection.UUID]; !exists {
+			snapshot.Connections = append(snapshot.Connections, connection)
+		}
+	}
+	return snapshot
+}
+
+func (s *SnapshotStream) Close() {
+	s.manager.snapshotStreamsMu.Lock()
+	delete(s.manager.snapshotStreams, s)
+	s.manager.snapshotStreamsMu.Unlock()
+}
+
+func (s *SnapshotStream) pushClosed(connection *TrackerInfo) {
+	s.mu.Lock()
+	s.pending = append(s.pending, connection)
+	s.mu.Unlock()
 }
 
 func (m *Manager) updateMemory() {

--- a/tunnel/statistic/manager.go
+++ b/tunnel/statistic/manager.go
@@ -58,6 +58,12 @@ func (m *Manager) Leave(c Tracker) {
 	m.snapshotMu.Lock()
 	if len(m.snapshotStreams) != 0 {
 		m.closedConnections.PushBack(tracker.Info())
+		for stream := range m.snapshotStreams {
+			select {
+			case stream.updates <- struct{}{}:
+			default:
+			}
+		}
 	}
 	m.snapshotMu.Unlock()
 }
@@ -116,6 +122,7 @@ func (m *Manager) Snapshot() *Snapshot {
 type SnapshotStream struct {
 	manager *Manager
 	cursor  int
+	updates chan struct{}
 }
 
 func (m *Manager) NewSnapshotStream() *SnapshotStream {
@@ -125,6 +132,7 @@ func (m *Manager) NewSnapshotStream() *SnapshotStream {
 	stream := &SnapshotStream{
 		manager: m,
 		cursor:  m.closedConnections.Len(),
+		updates: make(chan struct{}, 1),
 	}
 	if m.snapshotStreams == nil {
 		m.snapshotStreams = map[*SnapshotStream]struct{}{}
@@ -139,6 +147,10 @@ func (s *SnapshotStream) Snapshot() *Snapshot {
 	m.snapshotMu.Lock()
 
 	closedCount := m.closedConnections.Len()
+	select {
+	case <-s.updates:
+	default:
+	}
 	if s.cursor == closedCount {
 		m.snapshotMu.Unlock()
 		return snapshot
@@ -162,6 +174,11 @@ func (s *SnapshotStream) Snapshot() *Snapshot {
 		}
 	}
 	return snapshot
+}
+
+// Updates reports when closed connections are ready for the next snapshot.
+func (s *SnapshotStream) Updates() <-chan struct{} {
+	return s.updates
 }
 
 func (s *SnapshotStream) Close() {

--- a/tunnel/statistic/manager.go
+++ b/tunnel/statistic/manager.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/metacubex/mihomo/common/atomic"
+	"github.com/metacubex/mihomo/common/deque"
 	"github.com/metacubex/mihomo/common/xsync"
 	"github.com/metacubex/mihomo/component/memory"
 
@@ -39,8 +40,10 @@ type Manager struct {
 	pid           int32
 	memory        uint64
 
-	snapshotStreamsMu sync.RWMutex
+	snapshotMu        sync.Mutex
 	snapshotStreams   map[*SnapshotStream]struct{}
+	closedConnections deque.Deque[*TrackerInfo]
+	closedSequence    uint64
 }
 
 func (m *Manager) Join(c Tracker) {
@@ -53,12 +56,11 @@ func (m *Manager) Leave(c Tracker) {
 		return
 	}
 
-	info := tracker.Info()
-	m.snapshotStreamsMu.RLock()
-	defer m.snapshotStreamsMu.RUnlock()
-	for stream := range m.snapshotStreams {
-		stream.pushClosed(info)
+	m.snapshotMu.Lock()
+	if len(m.snapshotStreams) != 0 {
+		m.closedConnections.PushBack(tracker.Info())
 	}
+	m.snapshotMu.Unlock()
 }
 
 func (m *Manager) Get(id string) (c Tracker) {
@@ -114,32 +116,44 @@ func (m *Manager) Snapshot() *Snapshot {
 // SnapshotStream includes connections closed between snapshots in the next snapshot.
 type SnapshotStream struct {
 	manager *Manager
-	mu      sync.Mutex
-	pending []*TrackerInfo
+	cursor  uint64
 }
 
 func (m *Manager) NewSnapshotStream() *SnapshotStream {
-	stream := &SnapshotStream{manager: m}
-	m.snapshotStreamsMu.Lock()
+	m.snapshotMu.Lock()
+	defer m.snapshotMu.Unlock()
+
+	stream := &SnapshotStream{
+		manager: m,
+		cursor:  m.closedSequence + uint64(m.closedConnections.Len()),
+	}
 	if m.snapshotStreams == nil {
 		m.snapshotStreams = map[*SnapshotStream]struct{}{}
 	}
 	m.snapshotStreams[stream] = struct{}{}
-	m.snapshotStreamsMu.Unlock()
 	return stream
 }
 
 func (s *SnapshotStream) Snapshot() *Snapshot {
 	snapshot := s.manager.Snapshot()
+	m := s.manager
+	m.snapshotMu.Lock()
 
-	s.mu.Lock()
-	if len(s.pending) == 0 {
-		s.mu.Unlock()
+	closedCount := m.closedConnections.Len()
+	nextSequence := m.closedSequence + uint64(closedCount)
+	if s.cursor == nextSequence {
+		m.snapshotMu.Unlock()
 		return snapshot
 	}
-	closedConnections := s.pending
-	s.pending = nil
-	s.mu.Unlock()
+
+	closedStart := int(s.cursor - m.closedSequence)
+	closedConnections := make([]*TrackerInfo, 0, closedCount-closedStart)
+	for i := closedStart; i < closedCount; i++ {
+		closedConnections = append(closedConnections, m.closedConnections.At(i))
+	}
+	s.cursor = nextSequence
+	m.pruneClosedConnectionsLocked()
+	m.snapshotMu.Unlock()
 
 	activeConnections := make(map[uuid.UUID]struct{}, len(snapshot.Connections))
 	for _, connection := range snapshot.Connections {
@@ -154,15 +168,32 @@ func (s *SnapshotStream) Snapshot() *Snapshot {
 }
 
 func (s *SnapshotStream) Close() {
-	s.manager.snapshotStreamsMu.Lock()
-	delete(s.manager.snapshotStreams, s)
-	s.manager.snapshotStreamsMu.Unlock()
+	m := s.manager
+	m.snapshotMu.Lock()
+	if _, exists := m.snapshotStreams[s]; exists {
+		delete(m.snapshotStreams, s)
+		m.pruneClosedConnectionsLocked()
+	}
+	m.snapshotMu.Unlock()
 }
 
-func (s *SnapshotStream) pushClosed(connection *TrackerInfo) {
-	s.mu.Lock()
-	s.pending = append(s.pending, connection)
-	s.mu.Unlock()
+func (m *Manager) pruneClosedConnectionsLocked() {
+	nextSequence := m.closedSequence + uint64(m.closedConnections.Len())
+	sequence := nextSequence
+	for stream := range m.snapshotStreams {
+		if stream.cursor < sequence {
+			sequence = stream.cursor
+		}
+	}
+	if sequence == nextSequence {
+		m.closedConnections = deque.Deque[*TrackerInfo]{}
+		m.closedSequence = nextSequence
+		return
+	}
+	for m.closedSequence < sequence {
+		m.closedConnections.PopFront()
+		m.closedSequence++
+	}
 }
 
 func (m *Manager) updateMemory() {

--- a/tunnel/statistic/manager.go
+++ b/tunnel/statistic/manager.go
@@ -43,7 +43,6 @@ type Manager struct {
 	snapshotMu        sync.Mutex
 	snapshotStreams   map[*SnapshotStream]struct{}
 	closedConnections deque.Deque[*TrackerInfo]
-	closedSequence    uint64
 }
 
 func (m *Manager) Join(c Tracker) {
@@ -116,7 +115,7 @@ func (m *Manager) Snapshot() *Snapshot {
 // SnapshotStream includes connections closed between snapshots in the next snapshot.
 type SnapshotStream struct {
 	manager *Manager
-	cursor  uint64
+	cursor  int
 }
 
 func (m *Manager) NewSnapshotStream() *SnapshotStream {
@@ -125,7 +124,7 @@ func (m *Manager) NewSnapshotStream() *SnapshotStream {
 
 	stream := &SnapshotStream{
 		manager: m,
-		cursor:  m.closedSequence + uint64(m.closedConnections.Len()),
+		cursor:  m.closedConnections.Len(),
 	}
 	if m.snapshotStreams == nil {
 		m.snapshotStreams = map[*SnapshotStream]struct{}{}
@@ -140,18 +139,16 @@ func (s *SnapshotStream) Snapshot() *Snapshot {
 	m.snapshotMu.Lock()
 
 	closedCount := m.closedConnections.Len()
-	nextSequence := m.closedSequence + uint64(closedCount)
-	if s.cursor == nextSequence {
+	if s.cursor == closedCount {
 		m.snapshotMu.Unlock()
 		return snapshot
 	}
 
-	closedStart := int(s.cursor - m.closedSequence)
-	closedConnections := make([]*TrackerInfo, 0, closedCount-closedStart)
-	for i := closedStart; i < closedCount; i++ {
+	closedConnections := make([]*TrackerInfo, 0, closedCount-s.cursor)
+	for i := s.cursor; i < closedCount; i++ {
 		closedConnections = append(closedConnections, m.closedConnections.At(i))
 	}
-	s.cursor = nextSequence
+	s.cursor = closedCount
 	m.pruneClosedConnectionsLocked()
 	m.snapshotMu.Unlock()
 
@@ -178,21 +175,25 @@ func (s *SnapshotStream) Close() {
 }
 
 func (m *Manager) pruneClosedConnectionsLocked() {
-	nextSequence := m.closedSequence + uint64(m.closedConnections.Len())
-	sequence := nextSequence
+	closedCount := m.closedConnections.Len()
+	pruneCount := closedCount
 	for stream := range m.snapshotStreams {
-		if stream.cursor < sequence {
-			sequence = stream.cursor
+		if stream.cursor < pruneCount {
+			pruneCount = stream.cursor
 		}
 	}
-	if sequence == nextSequence {
-		m.closedConnections = deque.Deque[*TrackerInfo]{}
-		m.closedSequence = nextSequence
+	if pruneCount == 0 {
 		return
 	}
-	for m.closedSequence < sequence {
-		m.closedConnections.PopFront()
-		m.closedSequence++
+	if pruneCount == closedCount {
+		m.closedConnections = deque.Deque[*TrackerInfo]{}
+	} else {
+		for i := 0; i < pruneCount; i++ {
+			m.closedConnections.PopFront()
+		}
+	}
+	for stream := range m.snapshotStreams {
+		stream.cursor -= pruneCount
 	}
 }
 


### PR DESCRIPTION
Short-lived connections can open and close between two WebSocket updates, causing them to be missing from the connections list. This change includes them once in the next update with their final traffic statistics.