### PR TITLE
feat: add load-balance hash-key to pin a session on the inbound user

### DIFF
--- a/adapter/outboundgroup/loadbalance.go
+++ b/adapter/outboundgroup/loadbalance.go
@@ -21,6 +21,7 @@ import (
 
 type LoadBalanceOption struct {
 	Strategy string `group:"strategy,omitempty"`
+	HashKey  string `group:"hash-key,omitempty"`
 }
 
 type LoadBalance struct {
@@ -34,6 +35,10 @@ type LoadBalance struct {
 type strategyFn = func(proxies []C.Proxy, metadata *C.Metadata, touch bool) C.Proxy
 
 var errStrategy = errors.New("unsupported strategy")
+var errHashKey = errors.New("unsupported hash-key")
+
+// keyFn derives the value a hashing strategy pins a request on.
+type keyFn = func(metadata *C.Metadata) string
 
 func getKey(metadata *C.Metadata) string {
 	if metadata == nil {
@@ -66,6 +71,37 @@ func getKeyWithSrcAndDst(metadata *C.Metadata) string {
 	}
 
 	return fmt.Sprintf("%s%s", src, dst)
+}
+
+// getKeyWithUser pins on the authenticated inbound user instead of on an
+// address. Both address-derived keys assume one client's traffic to one
+// destination is one unit of work, which is false for a client whose single
+// unit of work walks several destinations: the hash moves with the host, and
+// the egress IP changes underneath a session the destination is tracking.
+// The inbound user is the only identity the client itself controls, and
+// `IN-USER` rules already match on it. An unauthenticated request keeps the
+// strategy's own key rather than collapsing every such request onto one node.
+func getKeyWithUser(fallback keyFn) keyFn {
+	return func(metadata *C.Metadata) string {
+		if metadata != nil && metadata.InUser != "" {
+			return metadata.InUser
+		}
+
+		return fallback(metadata)
+	}
+}
+
+// hashKey resolves the `hash-key` option into a decorator over whichever key
+// the chosen strategy derives by default.
+func hashKey(name string) (func(keyFn) keyFn, error) {
+	switch name {
+	case "":
+		return func(fn keyFn) keyFn { return fn }, nil
+	case "user":
+		return getKeyWithUser, nil
+	}
+
+	return nil, fmt.Errorf("%w: %s", errHashKey, name)
 }
 
 func jumpHash(key uint64, buckets int32) int32 {
@@ -155,10 +191,10 @@ func strategyRoundRobin(url string) strategyFn {
 	}
 }
 
-func strategyConsistentHashing(url string) strategyFn {
+func strategyConsistentHashing(url string, keyOf keyFn) strategyFn {
 	maxRetry := 5
 	return func(proxies []C.Proxy, metadata *C.Metadata, touch bool) C.Proxy {
-		key := utils.MapHash(getKey(metadata))
+		key := utils.MapHash(keyOf(metadata))
 		buckets := int32(len(proxies))
 		for i := 0; i < maxRetry; i, key = i+1, key+1 {
 			idx := jumpHash(key, buckets)
@@ -179,14 +215,14 @@ func strategyConsistentHashing(url string) strategyFn {
 	}
 }
 
-func strategyStickySessions(url string) strategyFn {
+func strategyStickySessions(url string, keyOf keyFn) strategyFn {
 	ttl := time.Minute * 10
 	maxRetry := 5
 	lruCache := lru.New[uint64, int](
 		lru.WithAge[uint64, int](int64(ttl.Seconds())),
 		lru.WithSize[uint64, int](1000))
 	return func(proxies []C.Proxy, metadata *C.Metadata, touch bool) C.Proxy {
-		key := utils.MapHash(getKeyWithSrcAndDst(metadata))
+		key := utils.MapHash(keyOf(metadata))
 		length := len(proxies)
 		idx, has := lruCache.Get(key)
 		if !has || idx >= length {
@@ -249,13 +285,22 @@ func (lb *LoadBalance) Now() string {
 
 func NewLoadBalance(option GroupCommonOption, loadBalanceOption LoadBalanceOption, emptyFallback C.Proxy, providers []P.ProxyProvider) (lb *LoadBalance, err error) {
 	var strategyFn strategyFn
+	withKey, err := hashKey(loadBalanceOption.HashKey)
+	if err != nil {
+		return nil, err
+	}
 	switch loadBalanceOption.Strategy {
 	case "", "consistent-hashing":
-		strategyFn = strategyConsistentHashing(option.URL)
+		strategyFn = strategyConsistentHashing(option.URL, withKey(getKey))
 	case "round-robin":
+		// Rejected rather than ignored: round-robin hashes nothing, so a
+		// hash-key here means the config expects stickiness it will not get.
+		if loadBalanceOption.HashKey != "" {
+			return nil, fmt.Errorf("%w: round-robin does not hash", errHashKey)
+		}
 		strategyFn = strategyRoundRobin(option.URL)
 	case "sticky-sessions":
-		strategyFn = strategyStickySessions(option.URL)
+		strategyFn = strategyStickySessions(option.URL, withKey(getKeyWithSrcAndDst))
 	default:
 		return nil, fmt.Errorf("%w: %s", errStrategy, loadBalanceOption.Strategy)
 	}

--- a/adapter/outboundgroup/loadbalance_test.go
+++ b/adapter/outboundgroup/loadbalance_test.go
@@ -1,0 +1,120 @@
+package outboundgroup
+
+import (
+	"net/netip"
+	"testing"
+
+	"github.com/metacubex/mihomo/adapter"
+	"github.com/metacubex/mihomo/adapter/outbound"
+	C "github.com/metacubex/mihomo/constant"
+
+	"github.com/stretchr/testify/require"
+)
+
+const testUrl = "https://www.gstatic.com/generate_204"
+
+func balancedProxies(count int) []C.Proxy {
+	proxies := make([]C.Proxy, 0, count)
+	for i := 0; i < count; i++ {
+		proxies = append(proxies, adapter.NewProxy(outbound.NewDirect()))
+	}
+	return proxies
+}
+
+// The proxies are indistinguishable by name, so identity is the pointer.
+func indexOf(t *testing.T, proxies []C.Proxy, selected C.Proxy) int {
+	t.Helper()
+	for i, proxy := range proxies {
+		if proxy == selected {
+			return i
+		}
+	}
+	require.Fail(t, "selected proxy is not a member of the group")
+	return -1
+}
+
+func request(user, host string) *C.Metadata {
+	return &C.Metadata{
+		NetWork: C.TCP,
+		Host:    host,
+		DstPort: 443,
+		SrcIP:   netip.MustParseAddr("127.0.0.1"),
+		InUser:  user,
+	}
+}
+
+// One unit of work walking several destinations is the case both address-derived
+// keys get wrong: the group is meant to hold that work on one egress, and the
+// default key moves it as soon as the host changes.
+func TestLoadBalanceHashKeyUserSurvivesADestinationChange(t *testing.T) {
+	proxies := balancedProxies(8)
+	hosts := []string{"a.example.com", "b.example.org", "c.example.net", "d.example.io"}
+
+	byUser := strategyConsistentHashing(testUrl, getKeyWithUser(getKey))
+	pinned := indexOf(t, proxies, byUser(proxies, request("job-1", hosts[0]), false))
+	for _, host := range hosts {
+		selected := byUser(proxies, request("job-1", host), false)
+		require.Equal(t, pinned, indexOf(t, proxies, selected),
+			"hash-key: user must ignore the destination")
+	}
+
+	byDestination := strategyConsistentHashing(testUrl, getKey)
+	seen := map[int]bool{}
+	for _, host := range hosts {
+		seen[indexOf(t, proxies, byDestination(proxies, request("job-1", host), false))] = true
+	}
+	require.Greater(t, len(seen), 1,
+		"the default key is expected to move with the destination")
+}
+
+// Pinning must not become a single node: distinct users still spread.
+func TestLoadBalanceHashKeyUserSpreadsUsers(t *testing.T) {
+	proxies := balancedProxies(8)
+	strategy := strategyConsistentHashing(testUrl, getKeyWithUser(getKey))
+
+	seen := map[int]bool{}
+	for _, user := range []string{"job-1", "job-2", "job-3", "job-4", "job-5", "job-6"} {
+		selected := strategy(proxies, request(user, "a.example.com"), false)
+		seen[indexOf(t, proxies, selected)] = true
+	}
+	require.Greater(t, len(seen), 1)
+}
+
+// Sticky sessions keys on source and destination; a client behind one source
+// address cannot separate its own concurrent jobs without a supplied identity.
+func TestLoadBalanceHashKeyUserSeparatesJobsSharingASourceAddress(t *testing.T) {
+	proxies := balancedProxies(8)
+	strategy := strategyStickySessions(testUrl, getKeyWithUser(getKeyWithSrcAndDst))
+
+	first := indexOf(t, proxies, strategy(proxies, request("job-1", "a.example.com"), false))
+	require.Equal(t, first,
+		indexOf(t, proxies, strategy(proxies, request("job-1", "b.example.org"), false)))
+
+	shared := strategyStickySessions(testUrl, getKeyWithSrcAndDst)
+	require.Equal(t,
+		indexOf(t, proxies, shared(proxies, request("job-1", "a.example.com"), false)),
+		indexOf(t, proxies, shared(proxies, request("job-2", "a.example.com"), false)),
+		"without a supplied key the two jobs are one session")
+}
+
+// An unauthenticated request keeps the strategy's own key. Returning a constant
+// instead would herd every anonymous request onto one member.
+func TestLoadBalanceHashKeyUserFallsBackWhenUnauthenticated(t *testing.T) {
+	keyed := getKeyWithUser(getKey)
+	require.Equal(t, "example.com", keyed(request("", "a.example.com")))
+	require.Equal(t, "job-1", keyed(request("job-1", "a.example.com")))
+	require.Equal(t, getKey(nil), keyed(nil))
+}
+
+func TestLoadBalanceHashKeyRejectsUnusableConfigs(t *testing.T) {
+	_, err := hashKey("session")
+	require.ErrorIs(t, err, errHashKey)
+
+	_, err = NewLoadBalance(GroupCommonOption{Name: "lb"},
+		LoadBalanceOption{Strategy: "round-robin", HashKey: "user"}, nil, nil)
+	require.ErrorIs(t, err, errHashKey)
+
+	_, err = NewLoadBalance(GroupCommonOption{Name: "lb"},
+		LoadBalanceOption{Strategy: "consistent-hashing", HashKey: "nonsense"}, nil, nil)
+	require.ErrorIs(t, err, errHashKey)
+}


### PR DESCRIPTION
### Problem

Both hashing strategies of a `load-balance` group derive their key from addresses:

| strategy | key |
|---|---|
| `consistent-hashing` | destination (eTLD+1, or destination IP) |
| `sticky-sessions` | source IP + destination |

That assumes one client's traffic to one destination is one unit of work.

It is not, for a client whose single unit of work walks several destinations — an entry URL, a redirect to another domain, then that domain's CDN. The hash moves with the host, so the egress IP changes underneath a session the destination is tracking, and any state bound to the first address (a cookie issued to that IP, an authenticated session) is dead on the next request. The group is supposed to be the thing that holds such work on one member, and today it cannot.

`sticky-sessions` does not solve it either: a client like this is usually one local source address, so its concurrent jobs share a key and cannot be told apart, while the destination half still moves the pin.

### What this adds

An opt-in `hash-key` option on `load-balance` groups. `hash-key: user` keys on the authenticated inbound user instead of on an address:

```yaml
proxy-groups:
  - name: pool
    type: load-balance
    strategy: consistent-hashing   # or sticky-sessions
    hash-key: user
    use: [my-provider]
```

The client varies the proxy-auth username per unit of work, and every request carrying that username lands on the same member for as long as it stays healthy.

The inbound user is the one identity the client itself controls and can vary per job, and `IN-USER` rules already match on it, so this asks nothing new of the config format.

Routing each job through an `IN-USER` rule instead is not equivalent: that enumerates users statically in the config, and these identities are minted per job.

### Behaviour

- Unset by default. When `hash-key` is absent the code path is unchanged, so no existing config behaves differently.
- An unauthenticated request falls back to the strategy's own key rather than to a constant, which would herd every anonymous request onto one member.
- `round-robin` rejects `hash-key` at parse time instead of ignoring it — it hashes nothing, so accepting the option would promise stickiness it cannot provide.
- An unrecognised value is rejected at parse time.

### Tests

`adapter/outboundgroup/loadbalance_test.go`, 6 cases, including two that assert the current behaviour is what it is: the default key demonstrably moves across destinations for one user, and `sticky-sessions` demonstrably cannot separate two jobs sharing a source address.

Also checked end to end with `mihomo -t`: `hash-key: user` loads on both hashing strategies, `hash-key: nonsense` fails with `unsupported hash-key: nonsense`, `round-robin` + `hash-key` fails with `round-robin does not hash`, and a group without the option still loads.

### Notes

No new dependency. Documentation lives in `MetaCubeX/Meta-Docs`; happy to open the matching docs PR if this direction is acceptable.
