### PR TITLE
[Alpha]fix(ssh): support net.Conn deadline on ssh outbound

### DIFF
--- a/adapter/outbound/ssh.go
+++ b/adapter/outbound/ssh.go
@@ -51,7 +51,7 @@ func (s *Ssh) DialContext(ctx context.Context, metadata *C.Metadata) (_ C.Conn, 
 		return nil, err
 	}
 
-	return NewConn(c, s), nil
+	return NewConn(N.NewEmulatedDeadlineConn(c), s), nil
 }
 
 func (s *Ssh) connect(ctx context.Context, addr string) (client *ssh.Client, err error) {

--- a/common/net/deadline/conn.go
+++ b/common/net/deadline/conn.go
@@ -19,11 +19,13 @@ type connReadResult struct {
 
 type Conn struct {
 	network.ExtendedConn
-	deadline     atomic.TypedValue[time.Time]
-	pipeDeadline PipeDeadline
-	disablePipe  atomic.Bool
-	inRead       atomic.Bool
-	resultCh     chan *connReadResult
+	deadline      atomic.TypedValue[time.Time]
+	pipeDeadline  PipeDeadline
+	disablePipe   atomic.Bool
+	inRead        atomic.Bool
+	resultCh      chan *connReadResult
+	emulated      bool
+	writeDeadline atomic.TypedValue[time.Time]
 }
 
 func IsConn(conn any) bool {
@@ -38,6 +40,12 @@ func NewConn(conn net.Conn) *Conn {
 		resultCh:     make(chan *connReadResult, 1),
 	}
 	c.resultCh <- nil
+	return c
+}
+
+func NewEmulatedConn(conn net.Conn) *Conn {
+	c := NewConn(conn)
+	c.emulated = true
 	return c
 }
 
@@ -123,15 +131,57 @@ func (c *Conn) ReadBuffer(buffer *buf.Buffer) (err error) {
 }
 
 func (c *Conn) SetReadDeadline(t time.Time) error {
-	if c.disablePipe.Load() {
-		return c.ExtendedConn.SetReadDeadline(t)
-	} else if c.inRead.Load() {
-		c.disablePipe.Store(true)
-		return c.ExtendedConn.SetReadDeadline(t)
+	if !c.emulated {
+		if c.disablePipe.Load() {
+			return c.ExtendedConn.SetReadDeadline(t)
+		} else if c.inRead.Load() {
+			c.disablePipe.Store(true)
+			return c.ExtendedConn.SetReadDeadline(t)
+		}
 	}
 	c.deadline.Store(t)
 	c.pipeDeadline.Set(t)
 	return nil
+}
+
+func (c *Conn) SetDeadline(t time.Time) error {
+	if !c.emulated {
+		return c.ExtendedConn.SetDeadline(t)
+	}
+	if err := c.SetReadDeadline(t); err != nil {
+		return err
+	}
+	return c.SetWriteDeadline(t)
+}
+
+func (c *Conn) SetWriteDeadline(t time.Time) error {
+	if !c.emulated {
+		return c.ExtendedConn.SetWriteDeadline(t)
+	}
+	c.writeDeadline.Store(t)
+	return nil
+}
+
+func (c *Conn) writeDeadlineExceeded() bool {
+	if !c.emulated {
+		return false
+	}
+	deadline := c.writeDeadline.Load()
+	return !deadline.IsZero() && !time.Now().Before(deadline)
+}
+
+func (c *Conn) Write(p []byte) (n int, err error) {
+	if c.writeDeadlineExceeded() {
+		return 0, os.ErrDeadlineExceeded
+	}
+	return c.ExtendedConn.Write(p)
+}
+
+func (c *Conn) WriteBuffer(buffer *buf.Buffer) error {
+	if c.writeDeadlineExceeded() {
+		return os.ErrDeadlineExceeded
+	}
+	return c.ExtendedConn.WriteBuffer(buffer)
 }
 
 func (c *Conn) ReaderReplaceable() bool {
@@ -150,7 +200,7 @@ func (c *Conn) ReaderReplaceable() bool {
 }
 
 func (c *Conn) WriterReplaceable() bool {
-	return true
+	return !c.emulated
 }
 
 func (c *Conn) Upstream() any {

--- a/common/net/sing.go
+++ b/common/net/sing.go
@@ -46,6 +46,10 @@ func NewDeadlineConn(conn net.Conn) ExtendedConn {
 	return deadline.NewConn(conn)
 }
 
+func NewEmulatedDeadlineConn(conn net.Conn) ExtendedConn {
+	return deadline.NewEmulatedConn(conn)
+}
+
 func NeedHandshake(conn any) bool {
 	if earlyConn, isEarlyConn := common.Cast[network.EarlyConn](conn); isEarlyConn && earlyConn.NeedHandshake() {
 		return true


### PR DESCRIPTION
由于工作场景需求，部分网段需要使用 `openvpn` 和 `ssh` 组合进行出网。
当 `openvpn` proxy 配置带 `dialer-proxy` 字段，指向一个 `ssh` proxy 出站进行转发时，`openvpn` 会不断握手失败：

```
[TCP] dial ovpn-over-ssh (match DstPort/8082) 127.0.0.1:42366 --> 10.8.0.1:8082 error: make OpenVPN handshake: send hard reset: ssh: tcpChan: deadline not supported
```

已在 Alpha @ `f295ba6da4928af24f6f4c15f732e728b045db0a` 上测试，用 `go1.24.7` 和 `CGO_ENABLED=0 go build -tags with_gvisor` 进行构建。

我的操作系统是 `macOS 15.7.2 (Apple Silicon)`，目前在我的系统上运行良好。
但是我怕这个改动影响面太大，加了个 `emulated` 字段来控制是否启用这个特性，请求帮忙看看。
