### PR TITLE
fix(dns): skip invalid names in fake-IP middleware

### DIFF
--- a/dns/middleware.go
+++ b/dns/middleware.go
@@ -12,6 +12,7 @@ import (
 	icontext "github.com/metacubex/mihomo/context"
 	"github.com/metacubex/mihomo/log"
 
+	M "github.com/metacubex/sing/common/metadata"
 	D "github.com/miekg/dns"
 )
 
@@ -152,6 +153,9 @@ func withFakeIP(skipper *fakeip.Skipper, fakePool *fakeip.Pool, fakePool6 *fakei
 			q := r.Question[0]
 
 			host := strings.TrimRight(q.Name, ".")
+			if !M.IsDomainName(host) {
+				return next(ctx, r)
+			}
 			if skipper.ShouldSkipped(host) {
 				return next(ctx, r)
 			}

--- a/dns/middleware_test.go
+++ b/dns/middleware_test.go
@@ -1,0 +1,68 @@
+package dns
+
+import (
+	"context"
+	"net/netip"
+	"testing"
+
+	"github.com/metacubex/mihomo/component/fakeip"
+	icontext "github.com/metacubex/mihomo/context"
+
+	D "github.com/miekg/dns"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWithFakeIPSkipsInvalidDomain(t *testing.T) {
+	pool, err := fakeip.New(fakeip.Options{
+		IPNet: netip.MustParsePrefix("198.18.0.1/16"),
+		Size:  10,
+	})
+	require.NoError(t, err)
+
+	downstreamCalled := false
+	next := func(_ *icontext.DNSContext, request *D.Msg) (*D.Msg, error) {
+		downstreamCalled = true
+		response := new(D.Msg)
+		response.SetReply(request)
+		return response, nil
+	}
+
+	request := new(D.Msg)
+	request.SetQuestion("n-relay-ipc-txc-nj-00.tplinkcloud.com.cn\\152.", D.TypeA)
+	response, err := withFakeIP(&fakeip.Skipper{}, pool, nil, 1)(next)(icontext.NewDNSContext(context.Background()), request)
+
+	require.NoError(t, err)
+	require.True(t, downstreamCalled)
+	require.Empty(t, response.Answer)
+	_, mapped := pool.LookBack(netip.MustParseAddr("198.18.0.4"))
+	require.False(t, mapped)
+}
+
+func TestWithFakeIPKeepsValidDomain(t *testing.T) {
+	pool, err := fakeip.New(fakeip.Options{
+		IPNet: netip.MustParsePrefix("198.18.0.1/16"),
+		Size:  10,
+	})
+	require.NoError(t, err)
+
+	downstreamCalled := false
+	next := func(_ *icontext.DNSContext, request *D.Msg) (*D.Msg, error) {
+		downstreamCalled = true
+		response := new(D.Msg)
+		response.SetReply(request)
+		return response, nil
+	}
+
+	request := new(D.Msg)
+	request.SetQuestion("n-relay-ipc-txc-nj-00.tplinkcloud.com.cn.", D.TypeA)
+	dnsCtx := icontext.NewDNSContext(context.Background())
+	response, err := withFakeIP(&fakeip.Skipper{}, pool, nil, 1)(next)(dnsCtx, request)
+
+	require.NoError(t, err)
+	require.False(t, downstreamCalled)
+	require.Len(t, response.Answer, 1)
+	require.Equal(t, icontext.DNSTypeFakeIP, dnsCtx.Type())
+	host, mapped := pool.LookBack(netip.MustParseAddr("198.18.0.4"))
+	require.True(t, mapped)
+	require.Equal(t, "n-relay-ipc-txc-nj-00.tplinkcloud.com.cn", host)
+}


### PR DESCRIPTION
## Summary

- skip fake-IP allocation when a decoded DNS query name is not a valid outbound domain
- fall through to the real resolver for these queries
- add regression coverage for an escaped invalid DNS label and a valid control case

## Problem

DNS labels may contain bytes that `miekg/dns` renders in presentation form as `\DDD`. The fake-IP middleware currently accepts and stores such names. When the mapping is later restored for a connection, the outbound metadata serializer rejects the host and repeatedly reports `unsupported address`.

This was reproduced on OpenWrt with TP-Link IoT devices. The same patch has been deployed downstream, and the reporter confirmed that the repeated error no longer occurs after observing the affected devices for an afternoon: https://github.com/kenzok8/openwrt-clashoo/issues/45#issuecomment-5407145785

## Validation

- confirmed the new invalid-domain test fails before the fix and passes after it
- `CGO_ENABLED=0 GOTOOLCHAIN=local SKIP_INTEROP_TEST=1` test run passed for all packages except `listener/inbound`, whose tests are removed by the upstream macOS CI job
- the focused DNS regression tests also pass with the `with_gvisor` tag
