### PR TITLE
fix: typo in config.yaml

### DIFF
--- a/docs/config.yaml
+++ b/docs/config.yaml
@@ -1603,7 +1603,7 @@ proxies: # socks5
     port: 22
     username: root
     password: password
-    privateKey: path
+    private-key: path
 
   # mieru
   - name: mieru


### PR DESCRIPTION
https://github.com/MetaCubeX/mihomo/blob/163ce6abd42be2638c6de67cf64fae4826788477/adapter/outbound/ssh.go#L38