### PR TITLE
feat: reroute connections after late sniff

### DIFF
--- a/component/sniffer/dispatcher.go
+++ b/component/sniffer/dispatcher.go
@@ -146,7 +146,10 @@ func (sd *Dispatcher) TCPSniff(conn *N.BufferedConn, metadata *C.Metadata) bool 
 
 		host, config, err := sd.sniffDomain(conn, metadata)
 		if err != nil {
-			if !forceSniffer {
+			// No buffered data means the client did not send an application
+			// payload during the initial sniff window. It says nothing about
+			// whether later data is sniffable, so do not suppress future attempts.
+			if !forceSniffer && conn.Buffered() > 0 {
 				sd.cacheSniffFailed(metadata)
 			}
 			log.Debugln("[Sniffer] All sniffing sniff failed with from [%s:%d] to [%s:%d]", metadata.SrcIP, metadata.SrcPort, metadata.String(), metadata.DstPort)

--- a/component/sniffer/dispatcher_test.go
+++ b/component/sniffer/dispatcher_test.go
@@ -366,7 +366,7 @@ func TestDispatcherMultipleSniffers(t *testing.T) {
 		assert.False(t, cached)
 	})
 
-	t.Run("keeps the connection open and caches an initial read failure once", func(t *testing.T) {
+	t.Run("keeps the connection open without caching an empty initial read", func(t *testing.T) {
 		waiting := &stubSniffer{reply: func(data []byte) (string, error) {
 			return "", needAtLeast(len(data) + 1)
 		}}
@@ -389,10 +389,36 @@ func TestDispatcherMultipleSniffers(t *testing.T) {
 		assert.False(t, sniffed)
 		assert.False(t, raw.closed)
 		assert.Empty(t, waiting.seen)
+		_, cached := sd.skipList.Get(metadata.AddrPort())
+		assert.False(t, cached)
+		assert.True(t, raw.deadline.IsZero(), "read deadline was not cleared")
+	})
+
+	t.Run("caches a sniff failure after receiving client data", func(t *testing.T) {
+		waiting := &stubSniffer{reply: func(data []byte) (string, error) {
+			return "", needAtLeast(len(data) + 1)
+		}}
+		sd, err := NewDispatcher(&Config{Enable: true, ParsePureIp: true})
+		assert.NoError(t, err)
+		sd.sniffers = []configuredSniffer{{Sniffer: waiting}}
+		raw := &chunkedConn{
+			t:       t,
+			chunks:  [][]byte{segment},
+			readErr: &net.OpError{Op: "read", Net: "tcp", Err: io.ErrNoProgress},
+		}
+		t.Cleanup(raw.stopTimer)
+		metadata := &C.Metadata{
+			NetWork: C.TCP,
+			DstIP:   netip.MustParseAddr("192.0.2.1"),
+			DstPort: 80,
+		}
+
+		sniffed := sd.TCPSniff(N.NewBufferedConn(raw), metadata)
+
+		assert.False(t, sniffed)
 		failures, cached := sd.skipList.Get(metadata.AddrPort())
 		assert.True(t, cached)
 		assert.Equal(t, uint8(1), failures)
-		assert.True(t, raw.deadline.IsZero(), "read deadline was not cleared")
 	})
 
 	t.Run("does not cache a forced initial read failure", func(t *testing.T) {

--- a/tunnel/late_sniff_test.go
+++ b/tunnel/late_sniff_test.go
@@ -1,0 +1,102 @@
+package tunnel
+
+import (
+	"net"
+	"testing"
+	"time"
+
+	N "github.com/metacubex/mihomo/common/net"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWaitForLateSniffClientData(t *testing.T) {
+	t.Run("client data arrives first", func(t *testing.T) {
+		clientApp, clientTunnel := net.Pipe()
+		remoteTunnel, remoteServer := net.Pipe()
+		t.Cleanup(func() {
+			_ = clientApp.Close()
+			_ = clientTunnel.Close()
+			_ = remoteTunnel.Close()
+			_ = remoteServer.Close()
+		})
+
+		go func() {
+			_, _ = clientApp.Write([]byte("client hello"))
+		}()
+
+		clientConn := N.NewBufferedConn(clientTunnel)
+		remoteConn := N.NewBufferedConn(remoteTunnel)
+		assert.True(t, waitForLateSniffClientData(clientConn, remoteConn))
+		data, err := clientConn.Peek(len("client hello"))
+		require.NoError(t, err)
+		assert.Equal(t, "client hello", string(data))
+		assert.Zero(t, remoteConn.Buffered())
+	})
+
+	t.Run("server greeting arrives first", func(t *testing.T) {
+		clientApp, clientTunnel := net.Pipe()
+		remoteTunnel, remoteServer := net.Pipe()
+		t.Cleanup(func() {
+			_ = clientApp.Close()
+			_ = clientTunnel.Close()
+			_ = remoteTunnel.Close()
+			_ = remoteServer.Close()
+		})
+
+		go func() {
+			_, _ = remoteServer.Write([]byte("server greeting"))
+		}()
+
+		clientConn := N.NewBufferedConn(clientTunnel)
+		remoteConn := N.NewBufferedConn(remoteTunnel)
+		assert.False(t, waitForLateSniffClientData(clientConn, remoteConn))
+		data, err := remoteConn.Peek(len("server greeting"))
+		require.NoError(t, err)
+		assert.Equal(t, "server greeting", string(data))
+		assert.Zero(t, clientConn.Buffered())
+	})
+
+	t.Run("server data after client win is detected before reroute", func(t *testing.T) {
+		clientApp, clientTunnel := net.Pipe()
+		remoteTunnel, remoteServer := net.Pipe()
+		t.Cleanup(func() {
+			_ = clientApp.Close()
+			_ = clientTunnel.Close()
+			_ = remoteTunnel.Close()
+			_ = remoteServer.Close()
+		})
+
+		go func() {
+			_, _ = clientApp.Write([]byte("client"))
+		}()
+
+		clientConn := N.NewBufferedConn(clientTunnel)
+		remoteConn := N.NewBufferedConn(remoteTunnel)
+		assert.True(t, waitForLateSniffClientData(clientConn, remoteConn))
+
+		require.True(t, remoteConn.AppendData([]byte("server")))
+		assert.True(t, hasPendingData(remoteConn))
+	})
+}
+
+func TestHasPendingData(t *testing.T) {
+	app, tunnel := net.Pipe()
+	t.Cleanup(func() {
+		_ = app.Close()
+		_ = tunnel.Close()
+	})
+
+	conn := N.NewBufferedConn(tunnel)
+	assert.False(t, hasPendingData(conn))
+
+	go func() {
+		_, _ = app.Write([]byte("x"))
+	}()
+	deadline := time.Now().Add(time.Second)
+	_ = conn.SetReadDeadline(deadline)
+	_, err := conn.Peek(1)
+	require.NoError(t, err)
+	_ = conn.SetReadDeadline(time.Time{})
+	assert.True(t, hasPendingData(conn))
+}

--- a/tunnel/tunnel.go
+++ b/tunnel/tunnel.go
@@ -72,6 +72,65 @@ var (
 
 type tunnel struct{}
 
+type bufferedProxyConn struct {
+	*N.BufferedConn
+	C.Connection
+}
+
+func newBufferedProxyConn(conn C.Conn) *bufferedProxyConn {
+	return &bufferedProxyConn{
+		BufferedConn: N.NewBufferedConn(conn),
+		Connection:   conn,
+	}
+}
+
+type firstDataResult struct {
+	client bool
+	err    error
+}
+
+// waitForLateSniffClientData reports whether the client produced application
+// data before the selected outbound did. Both reads are peeks, so the winner's
+// data remains buffered for sniffing or relaying.
+func waitForLateSniffClientData(clientConn, remoteConn *N.BufferedConn) bool {
+	result := make(chan firstDataResult, 2)
+	peek := func(client bool, conn *N.BufferedConn) {
+		_, err := conn.Peek(1)
+		result <- firstDataResult{client: client, err: err}
+	}
+
+	go peek(true, clientConn)
+	go peek(false, remoteConn)
+
+	first := <-result
+	if first.client {
+		_ = remoteConn.SetReadDeadline(time.Now())
+	} else {
+		_ = clientConn.SetReadDeadline(time.Now())
+	}
+	second := <-result
+
+	_ = clientConn.SetReadDeadline(time.Time{})
+	_ = remoteConn.SetReadDeadline(time.Time{})
+
+	if first.err != nil || !first.client {
+		return false
+	}
+	// If the server also produced data while its peek was being interrupted,
+	// preserve the fallback route so a server-first greeting is never discarded.
+	return second.err != nil
+}
+
+func hasPendingData(conn *N.BufferedConn) bool {
+	if conn.Buffered() > 0 {
+		return true
+	}
+	_ = conn.SetReadDeadline(time.Now())
+	_, err := conn.Peek(1)
+	_ = conn.SetReadDeadline(time.Time{})
+	return err == nil
+}
+
 var Tunnel = tunnel{}
 var _ C.Tunnel = Tunnel
 var _ P.Tunnel = Tunnel
@@ -524,13 +583,21 @@ func handleTCPConn(connCtx C.ConnContext) {
 
 	conn := connCtx.Conn()
 	conn.ResetPeeked() // reset before sniffer
+	lateSniffPending := false
 	if sniffingEnable && snifferDispatcher.Enable() {
 		// Try to sniff a domain when `preHandleMetadata` failed, this is usually
 		// caused by a "Fake DNS record missing" error when enhanced-mode is fake-ip.
-		if snifferDispatcher.TCPSniff(conn, metadata) {
+		sniffed := snifferDispatcher.TCPSniff(conn, metadata)
+		if sniffed {
 			// we now have a domain name
 			preHandleFailed = false
 		}
+		// A peeked connection with an empty buffer means the initial sniff waited
+		// for client data and returned without receiving any. Keep the ordinary
+		// metadata-based route as a speculative outbound, then give a later client
+		// first packet one final chance to supply a domain before any application
+		// data crosses that outbound.
+		lateSniffPending = !sniffed && conn.Peeked() && conn.Buffered() == 0
 	}
 
 	// If both trials have failed, we can do nothing but give up
@@ -557,65 +624,94 @@ func handleTCPConn(connCtx C.ConnContext) {
 		return
 	}
 
-	dialMetadata := metadata
-	if len(metadata.Host) > 0 {
-		if node, ok := resolver.DefaultHosts.Search(metadata.Host, false); ok {
-			if dstIp, _ := node.RandIP(); !resolver.IsFakeIP(dstIp) {
-				dialMetadata.DstIP = dstIp
-				dialMetadata.DNSMode = C.DNSHosts
-				dialMetadata = dialMetadata.Pure()
+	dialRemote := func(metadata *C.Metadata, proxy C.Proxy, rule C.Rule) (remoteConn C.Conn, peekLen int, err error) {
+		dialMetadata := metadata
+		if len(metadata.Host) > 0 {
+			if node, ok := resolver.DefaultHosts.Search(metadata.Host, false); ok {
+				if dstIp, _ := node.RandIP(); !resolver.IsFakeIP(dstIp) {
+					dialMetadata.DstIP = dstIp
+					dialMetadata.DNSMode = C.DNSHosts
+					dialMetadata = dialMetadata.Pure()
+				}
 			}
 		}
-	}
 
-	var peekBytes []byte
-	var peekLen int
-
-	ctx, cancel := context.WithTimeout(context.Background(), C.DefaultTCPTimeout)
-	defer cancel()
-	remoteConn, err := retry(ctx, func(ctx context.Context) (remoteConn C.Conn, err error) {
-		remoteConn, err = proxy.DialContext(ctx, dialMetadata)
-		if err != nil {
-			return
-		}
-
-		if N.NeedHandshake(remoteConn) {
-			defer func() {
-				if err != nil {
-					_ = remoteConn.Close()
-					for _, chain := range remoteConn.Chains() {
-						if chain == "REJECT" {
-							err = nil
-							return
-						}
-					}
-					remoteConn = nil
-				}
-			}()
-			peekMutex.Lock()
-			defer peekMutex.Unlock()
-			peekBytes, _ = conn.Peek(conn.Buffered())
-			_, err = remoteConn.Write(peekBytes)
+		ctx, cancel := context.WithTimeout(context.Background(), C.DefaultTCPTimeout)
+		defer cancel()
+		remoteConn, err = retry(ctx, func(ctx context.Context) (remoteConn C.Conn, err error) {
+			remoteConn, err = proxy.DialContext(ctx, dialMetadata)
 			if err != nil {
 				return
 			}
-			if peekLen = len(peekBytes); peekLen > 0 {
-				_, _ = conn.Discard(peekLen)
+
+			if N.NeedHandshake(remoteConn) {
+				defer func() {
+					if err != nil {
+						_ = remoteConn.Close()
+						for _, chain := range remoteConn.Chains() {
+							if chain == "REJECT" {
+								err = nil
+								return
+							}
+						}
+						remoteConn = nil
+					}
+				}()
+				peekMutex.Lock()
+				defer peekMutex.Unlock()
+				peekBytes, _ := conn.Peek(conn.Buffered())
+				_, err = remoteConn.Write(peekBytes)
+				if err != nil {
+					return
+				}
+				if peekLen = len(peekBytes); peekLen > 0 {
+					_, _ = conn.Discard(peekLen)
+				}
 			}
-		}
+			return
+		}, func(err error) {
+			logMetadataErr(metadata, rule, proxy, err)
+		})
 		return
-	}, func(err error) {
-		logMetadataErr(metadata, rule, proxy, err)
-	})
+	}
+
+	remoteConn, peekLen, err := dialRemote(metadata, proxy, rule)
 	if err != nil {
 		return
 	}
+	defer func() {
+		if remoteConn != nil {
+			_ = remoteConn.Close()
+		}
+	}()
+
+	if lateSniffPending && remoteConn != nil {
+		bufferedRemote := newBufferedProxyConn(remoteConn)
+		remoteConn = bufferedRemote
+		if waitForLateSniffClientData(conn, bufferedRemote.BufferedConn) {
+			lateMetadata := metadata.Clone()
+			if snifferDispatcher.TCPSniff(conn, lateMetadata) && !hasPendingData(bufferedRemote.BufferedConn) {
+				lateProxy, lateRule, resolveErr := resolveMetadata(lateMetadata)
+				if resolveErr != nil {
+					log.Warnln("[Metadata] late sniff parse failed: %s", resolveErr.Error())
+					return
+				}
+
+				_ = remoteConn.Close()
+				*metadata = *lateMetadata
+				proxy = lateProxy
+				rule = lateRule
+				remoteConn, peekLen, err = dialRemote(metadata, proxy, rule)
+				if err != nil {
+					return
+				}
+			}
+		}
+	}
+
 	logMetadata(metadata, rule, remoteConn)
 
 	remoteConn = statistic.NewTCPTracker(remoteConn, statistic.DefaultManager, metadata, rule, int64(peekLen), 0, true)
-	defer func(remoteConn C.Conn) {
-		_ = remoteConn.Close()
-	}(remoteConn)
 
 	_ = conn.SetReadDeadline(time.Now()) // stop unfinished peek
 	peekMutex.Lock()


### PR DESCRIPTION
## Summary

- establish a speculative outbound using the currently available metadata when the initial TCP sniff receives no client payload
- preserve the selected route when server application data arrives first
- when client data arrives first, sniff it and rematch rules using the discovered domain
- close and redial the speculative outbound only when no server application data is pending
- avoid caching an empty initial read as a sniff failure, while retaining failure caching after client data has been received

## Motivation

After the initial sniff timeout, the current Alpha behavior keeps the connection open and routes it using the available metadata. However, if the client sends a sniffable payload later, the route cannot currently be revised using the newly discovered domain.

This matters when the IP-based fallback route differs from the matching domain rule.

## Safety

- server-first greetings are buffered and forwarded without rerouting
- rerouting is allowed only before server application data becomes available
- client data remains buffered during sniffing and is sent through the final outbound
- no additional configuration option is introduced

## Tests

- `go test ./tunnel ./component/sniffer`
- `go test ./...`
- `go vet ./tunnel ./component/sniffer`
- late-sniff concurrency tests repeated 100 times