### PR TITLE
fix(outbound): prevent nil pointer dereference in WireGuard initializ…

### DIFF
--- a/adapter/outbound/wireguard.go
+++ b/adapter/outbound/wireguard.go
@@ -386,6 +386,10 @@ func NewWireGuard(option WireGuardOption) (*WireGuard, error) {
 	}
 	outbound.bind = wireguard.NewClientBind(context.Background(), wgSingErrorHandler{outbound.Name()}, singDialer, isConnect, outbound.connectAddr.AddrPort(), reserved)
 
+	if outbound.bind == nil {
+		return nil, E.New("failed to create wireguard client bind")
+	}
+
 	var err error
 	outbound.localPrefixes, err = option.Prefixes()
 	if err != nil {


### PR DESCRIPTION
## Description

When initializing a WireGuard node from a malformed configuration (e.g., missing critical server/port information), `wireguard.NewClientBind` may return `nil`. 

If this malformed node also contains an `amnezia-wg-option`, the subsequent call to `outbound.bind.SetParseReserved(false)` will trigger a `nil pointer dereference` panic, causing the entire program to crash. This is especially problematic for subscription ping/check tools that handle uncontrollable node qualities.

## Solution

Added a nil check immediately after `outbound.bind` creation. If it is `nil`, gracefully return an error instead of panicking.

## Panic Trace

```text
panic: runtime error: invalid memory address or nil pointer dereference
[signal 0xc0000005 code=0x0 addr=0x0 ...]
github.com/metacubex/mihomo/adapter/outbound.NewWireGuard({...})
        github.com/metacubex/mihomo/adapter/outbound/wireguard.go:497 +0x17f2
github.com/metacubex/mihomo/adapter.ParseProxy(...)
        github.com/metacubex/mihomo/adapter/parser.go:106 +0x2a1b