### PR TITLE
feat: add JSON rule format support for rule-providers

### DIFF
--- a/constant/provider/interface.go
+++ b/constant/provider/interface.go
@@ -149,6 +149,7 @@ const (
 	YamlRule RuleFormat = iota
 	TextRule
 	MrsRule
+	JsonRule
 )
 
 type RuleFormat int
@@ -161,6 +162,8 @@ func (rf RuleFormat) String() string {
 		return "TextRule"
 	case MrsRule:
 		return "MrsRule"
+	case JsonRule:
+		return "JsonRule"
 	default:
 		return "Unknown"
 	}
@@ -174,6 +177,8 @@ func ParseRuleFormat(s string) (format RuleFormat, err error) {
 		format = TextRule
 	case "mrs":
 		format = MrsRule
+	case "json":
+		format = JsonRule
 	default:
 		err = fmt.Errorf("unsupported format type: %s", s)
 	}

--- a/docs/config.yaml
+++ b/docs/config.yaml
@@ -1934,6 +1934,34 @@ rule-providers:
       - '.blogger.com'
       - '*.*.microsoft.com'
       - 'books.itunes.apple.com'
+  rule5:
+    # json类型ruleset，通过 json.paths 的简单路径表达式从JSON文档中提取规则字符串,
+    # 路径表达式语法: 以点号分隔的键访问，任何一段都可以以 [] 结尾表示遍历数组并自动展开(拍平)，
+    # 例如 prefixes[].ipv4Prefix 、 actions[] 、 [](根数组)、a.b.c；同 JSONPath 中 "$" 为可选前缀,
+    # 提取时自动忽略 null、缺失字段，数组自动拍平，仅收集字符串(及数字)值,
+    # 如果一条规则都没有提取到则会报错
+    type: http
+    url: "https://www.gstatic.com/ipranges/cloud.json" # 例如 Google Cloud 的IP段, AWS: https://ip-ranges.amazonaws.com/ip-ranges.json
+    format: json
+    behavior: ipcidr
+    # path: /path/to/save/file.json # 同 http 的默认行为，可省略
+    interval: 86400
+    json:
+      paths:
+        - prefixes[].ipv4Prefix # 遍历 prefixes 数组取每个元素的 ipv4Prefix
+        - prefixes[].ipv6Prefix # 遍历 prefixes 数组取每个元素的 ipv6Prefix
+  rule6:
+    # json类型ruleset的另一个例子，GitHub Meta 中的多个数组,
+    # 如果不配置 json.paths 或者 format 不是 json 时配置了 json，加载配置时会报错
+    type: http
+    url: "https://api.github.com/meta"
+    format: json
+    behavior: ipcidr
+    json:
+      paths:
+        - actions[]
+        - git[]
+        - hooks[]
 
 rules:
   - RULE-SET,rule1,REJECT

--- a/rules/provider/json.go
+++ b/rules/provider/json.go
@@ -1,0 +1,144 @@
+package provider
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// jsonPathSegment is one segment of a simplified JSON path expression.
+//
+// A path is composed of key accesses separated by dots, where any
+// segment may end with "[]" to iterate over an array and flatten its
+// elements, e.g.:
+//
+//	prefixes[].ipv4Prefix  -> iterate the "prefixes" array and take "ipv4Prefix" of each element
+//	actions[]              -> iterate the "actions" array and take its elements
+//	[]                     -> iterate the root array
+//	a.b                    -> nested object key access
+type jsonPathSegment struct {
+	key     string
+	iterate bool
+}
+
+// parseJSONPath compiles a simplified JSON path expression into segments.
+func parseJSONPath(path string) ([]jsonPathSegment, error) {
+	p := strings.TrimSpace(path)
+	p = strings.TrimPrefix(p, "$")
+	p = strings.TrimPrefix(p, ".")
+	if p == "" {
+		return nil, fmt.Errorf("empty json path")
+	}
+	var segments []jsonPathSegment
+	for _, raw := range strings.Split(p, ".") {
+		raw = strings.TrimSpace(raw)
+		if raw == "" {
+			return nil, fmt.Errorf("invalid json path %q: empty segment", path)
+		}
+		segment := jsonPathSegment{}
+		if strings.HasSuffix(raw, "[]") {
+			segment.iterate = true
+			raw = strings.TrimSuffix(raw, "[]")
+		}
+		if strings.ContainsAny(raw, "[]") {
+			return nil, fmt.Errorf("invalid json path %q: only the [] iteration is supported", path)
+		}
+		segment.key = raw
+		segments = append(segments, segment)
+	}
+	return segments, nil
+}
+
+// appendJSONLeaves collects string leaves from a JSON value, flattening
+// arrays automatically and ignoring null, boolean and object values.
+func appendJSONLeaves(value any, rules *[]string) {
+	switch v := value.(type) {
+	case string:
+		if s := strings.TrimSpace(v); s != "" {
+			*rules = append(*rules, s)
+		}
+	case json.Number:
+		*rules = append(*rules, v.String())
+	case []any:
+		for _, item := range v {
+			appendJSONLeaves(item, rules)
+		}
+	default:
+		// ignore nil, bool and map values
+	}
+}
+
+// extractJSONRules walks the decoded JSON document with the compiled
+// paths and returns every string leaf found, in order of appearance.
+func extractJSONRules(root any, compiled [][]jsonPathSegment) []string {
+	var rules []string
+	for _, segments := range compiled {
+		frontier := []any{root}
+		for _, segment := range segments {
+			next := make([]any, 0, len(frontier))
+			for _, value := range frontier {
+				if segment.key != "" {
+					obj, ok := value.(map[string]any)
+					if !ok {
+						continue // missing field or non-object intermediate value
+					}
+					value = obj[segment.key]
+				}
+				if segment.iterate {
+					arr, ok := value.([]any)
+					if !ok {
+						continue // not an array, ignore silently
+					}
+					next = append(next, arr...)
+				} else {
+					if segment.key == "" {
+						continue
+					}
+					next = append(next, value)
+				}
+			}
+			frontier = next
+		}
+		for _, value := range frontier {
+			appendJSONLeaves(value, &rules)
+		}
+	}
+	return rules
+}
+
+// rulesJSONParse decodes a JSON rule payload and inserts every string
+// extracted by the configured paths into the strategy.
+func rulesJSONParse(buf []byte, strategy ruleStrategy, paths []string) (ruleStrategy, error) {
+	if len(paths) == 0 {
+		return nil, errors.New("json format requires `json.paths` in rule-provider config")
+	}
+	compiled := make([][]jsonPathSegment, 0, len(paths))
+	for _, path := range paths {
+		segments, err := parseJSONPath(path)
+		if err != nil {
+			return nil, err
+		}
+		compiled = append(compiled, segments)
+	}
+
+	var root any
+	decoder := json.NewDecoder(bytes.NewReader(buf))
+	decoder.UseNumber()
+	if err := decoder.Decode(&root); err != nil {
+		return nil, fmt.Errorf("invalid json rule provider: %w", err)
+	}
+
+	rules := extractJSONRules(root, compiled)
+	if len(rules) == 0 {
+		return nil, errors.New("no rules extracted from json rule provider")
+	}
+
+	for _, rule := range rules {
+		strategy.Insert(rule)
+	}
+	strategy.FinishInsert()
+
+	return strategy, nil
+}

--- a/rules/provider/json_test.go
+++ b/rules/provider/json_test.go
@@ -1,0 +1,221 @@
+package provider
+
+import (
+	"net/netip"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/metacubex/mihomo/common/utils"
+	"github.com/metacubex/mihomo/component/resource"
+	C "github.com/metacubex/mihomo/constant"
+	P "github.com/metacubex/mihomo/constant/provider"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// google cloud like document
+var testGCloudJson = []byte(`{
+  "syncToken": "123",
+  "prefixes": [
+    {
+      "ipv4Prefix": "8.8.8.0/24",
+      "scope": "us-east1"
+    },
+    {
+      "ipv6Prefix": "2001:4860:4860::/64"
+    },
+    {
+      "ipv4Prefix": null
+    }
+  ]
+}`)
+
+// github meta like document
+var testGithubJson = []byte(`{
+  "verifiable_password_authentication": true,
+  "actions": ["192.30.252.0/22", "185.199.108.0/22"],
+  "git": [
+    "140.82.112.25/32",
+    "140.82.114.25/32"
+  ],
+  "hooks": [],
+  "pages": ["1.2.3.4"]
+}`)
+
+func TestParseJSONPath(t *testing.T) {
+	segments, err := parseJSONPath("prefixes[].ipv4Prefix")
+	require.NoError(t, err)
+	assert.Equal(t, []jsonPathSegment{
+		{key: "prefixes", iterate: true},
+		{key: "ipv4Prefix"},
+	}, segments)
+
+	segments, err = parseJSONPath("$.actions[]")
+	require.NoError(t, err)
+	assert.Equal(t, []jsonPathSegment{
+		{key: "actions", iterate: true},
+	}, segments)
+
+	segments, err = parseJSONPath("[]")
+	require.NoError(t, err)
+	assert.Equal(t, []jsonPathSegment{
+		{key: "", iterate: true},
+	}, segments)
+
+	segments, err = parseJSONPath("a.b.c")
+	require.NoError(t, err)
+	assert.Equal(t, []jsonPathSegment{
+		{key: "a"},
+		{key: "b"},
+		{key: "c"},
+	}, segments)
+
+	_, err = parseJSONPath("")
+	assert.Error(t, err)
+
+	_, err = parseJSONPath("a[0].b")
+	assert.Error(t, err)
+}
+
+func TestRulesJSONParseIPCIDR(t *testing.T) {
+	strategy := NewIPCidrStrategy()
+	strategy.Reset()
+
+	_, err := rulesJSONParse(testGCloudJson, strategy, []string{
+		"prefixes[].ipv4Prefix",
+		"prefixes[].ipv6Prefix",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 2, strategy.Count())
+}
+
+func TestRulesJSONParseFlattenArrays(t *testing.T) {
+	strategy := NewIPCidrStrategy()
+	strategy.Reset()
+
+	_, err := rulesJSONParse(testGithubJson, strategy, []string{
+		"actions[]",
+		"git[]",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 4, strategy.Count())
+}
+
+func TestRulesJSONParseRootArray(t *testing.T) {
+	buf := []byte(`["1.1.1.1/32", "8.8.8.8/32", null]`)
+	strategy := NewIPCidrStrategy()
+	strategy.Reset()
+
+	_, err := rulesJSONParse(buf, strategy, []string{"[]"})
+	require.NoError(t, err)
+	assert.Equal(t, 2, strategy.Count())
+}
+
+func TestRulesJSONParseClassical(t *testing.T) {
+	buf := []byte(`{"rules": ["DOMAIN-SUFFIX,google.com", "IP-CIDR,8.8.8.8/32"]}`)
+	strategy := NewClassicalStrategy(func(tp, payload, target string, params []string, subRules map[string][]C.Rule) (C.Rule, error) {
+		// a minimal fake rule is enough to verify insertion
+		return &stubRule{tp: tp, payload: payload}, nil
+	})
+
+	_, err := rulesJSONParse(buf, strategy, []string{"rules[]"})
+	require.NoError(t, err)
+	assert.Equal(t, 2, strategy.Count())
+}
+
+type stubRule struct {
+	tp      string
+	payload string
+}
+
+func (r *stubRule) RuleType() C.RuleType { return C.DomainSuffix }
+
+func (r *stubRule) Match(metadata *C.Metadata, helper C.RuleMatchHelper) (bool, string) {
+	return false, ""
+}
+
+func (r *stubRule) Adapter() string                { return "" }
+func (r *stubRule) Payload() string                { return r.payload }
+func (r *stubRule) ShouldFindProcess() bool        { return false }
+func (r *stubRule) RuleNames() []string            { return nil }
+func (r *stubRule) ProviderNames() []string        { return nil }
+func (r *stubRule) ShouldResolveIP() bool          { return false }
+func (r *stubRule) MatchDomain(domain string) bool { return false }
+func (r *stubRule) MatchIp(ip netip.Addr) bool     { return false }
+
+// stubTunnel implements P.Tunnel for tests (only callback parts are used).
+type stubTunnel struct{}
+
+func (stubTunnel) Providers() map[string]P.ProxyProvider    { return nil }
+func (stubTunnel) RuleProviders() map[string]P.RuleProvider { return nil }
+func (stubTunnel) RuleUpdateCallback() *utils.Callback[P.RuleProvider] {
+	return utils.NewCallback[P.RuleProvider]()
+}
+
+func TestParseRuleProviderJSONFile(t *testing.T) {
+	SetTunnel(stubTunnel{})
+
+	dir := t.TempDir()
+	defaultTestHomeDir := C.Path.HomeDir()
+	C.SetHomeDir(dir)
+	defer C.SetHomeDir(defaultTestHomeDir)
+
+	path := filepath.Join(dir, "cloud.json")
+	content := []byte(`{"prefixes":[{"ipv4Prefix":"8.8.8.0/24"},{"ipv6Prefix":"2001:4860:4860::/64"}]}`)
+	require.NoError(t, os.WriteFile(path, content, 0o644))
+
+	rp, err := ParseRuleProvider("gcloud", map[string]any{
+		"type":     "file",
+		"behavior": "ipcidr",
+		"format":   "json",
+		"path":     path,
+		"json": map[string]any{
+			"paths": []any{"prefixes[].ipv4Prefix", "prefixes[].ipv6Prefix"},
+		},
+	}, nil, func(string) resource.BundleFile { return nil })
+	require.NoError(t, err)
+	require.NotNil(t, rp)
+
+	require.NoError(t, rp.Initial())
+	assert.Equal(t, 2, rp.Count())
+
+	metadata := &C.Metadata{DstIP: netip.MustParseAddr("8.8.8.8")}
+	matched := rp.Match(metadata, C.RuleMatchHelper{})
+	assert.True(t, matched)
+
+	metadata = &C.Metadata{DstIP: netip.MustParseAddr("1.1.1.1")}
+	matched = rp.Match(metadata, C.RuleMatchHelper{})
+	assert.False(t, matched)
+}
+
+func TestParseRuleProviderJSONValidation(t *testing.T) {
+	mk := func(extra map[string]any) map[string]any {
+		mapping := map[string]any{
+			"type":     "file",
+			"behavior": "ipcidr",
+			"path":     "rules.json",
+		}
+		for k, v := range extra {
+			mapping[k] = v
+		}
+		return mapping
+	}
+
+	// format json without json.paths must fail
+	_, err := ParseRuleProvider("bad1", mk(map[string]any{"format": "json"}), nil, func(string) resource.BundleFile { return nil })
+	assert.ErrorContains(t, err, "json.paths")
+
+	// json block with yaml format must fail
+	_, err = ParseRuleProvider("bad2", mk(map[string]any{
+		"json": map[string]any{"paths": []any{"prefixes[].ipv4Prefix"}},
+	}), nil, func(string) resource.BundleFile { return nil })
+	assert.ErrorContains(t, err, "json")
+
+	// empty paths block is tolerated for non-json formats
+	rp, err := ParseRuleProvider("ok", mk(map[string]any{
+		"json": map[string]any{},
+	}), nil, func(string) resource.BundleFile { return nil })
+	require.NoError(t, err)
+	assert.NotNil(t, rp)
+}

--- a/rules/provider/mrs_converter.go
+++ b/rules/provider/mrs_converter.go
@@ -14,7 +14,7 @@ import (
 
 func ConvertToMrs(buf []byte, behavior P.RuleBehavior, format P.RuleFormat, w io.Writer) (err error) {
 	strategy := newStrategy(behavior, nil)
-	strategy, err = rulesParse(buf, strategy, format)
+	strategy, err = rulesParse(buf, strategy, format, nil)
 	if err != nil {
 		return err
 	}

--- a/rules/provider/parse.go
+++ b/rules/provider/parse.go
@@ -11,6 +11,10 @@ import (
 	"github.com/metacubex/mihomo/rules/common"
 )
 
+type ruleJsonSchema struct {
+	Paths []string `provider:"paths,omitempty"`
+}
+
 type ruleProviderSchema struct {
 	Type         string              `provider:"type"`
 	Behavior     string              `provider:"behavior"`
@@ -23,6 +27,7 @@ type ruleProviderSchema struct {
 	Payload      []string            `provider:"payload,omitempty"`
 	Header       map[string][]string `provider:"header,omitempty"`
 	PathInBundle string              `provider:"path-in-bundle,omitempty"`
+	Json         *ruleJsonSchema     `provider:"json,omitempty"`
 }
 
 func ParseRuleProvider(name string, mapping map[string]any, parse common.ParseRuleFunc, makeBundleFile func(pathInBundle string) resource.BundleFile) (P.RuleProvider, error) {
@@ -38,6 +43,17 @@ func ParseRuleProvider(name string, mapping map[string]any, parse common.ParseRu
 	format, err := P.ParseRuleFormat(schema.Format)
 	if err != nil {
 		return nil, err
+	}
+
+	var jsonPaths []string
+	if schema.Json != nil && len(schema.Json.Paths) > 0 {
+		if format != P.JsonRule {
+			return nil, fmt.Errorf("`json` is only supported with `format: json`")
+		}
+		jsonPaths = schema.Json.Paths
+	}
+	if format == P.JsonRule && len(jsonPaths) == 0 {
+		return nil, fmt.Errorf("`format: json` requires `json.paths`")
 	}
 
 	var vehicle P.Vehicle
@@ -65,5 +81,5 @@ func ParseRuleProvider(name string, mapping map[string]any, parse common.ParseRu
 
 	interval := time.Duration(uint(schema.Interval)) * time.Second
 
-	return NewRuleSetProvider(name, behavior, format, interval, vehicle, schema.Payload, makeBundleFile(schema.PathInBundle), parse), nil
+	return NewRuleSetProvider(name, behavior, format, interval, vehicle, schema.Payload, makeBundleFile(schema.PathInBundle), parse, jsonPaths), nil
 }

--- a/rules/provider/provider.go
+++ b/rules/provider/provider.go
@@ -122,7 +122,7 @@ func (rp *RuleSetProvider) Close() error {
 	return rp.ruleSetProvider.Close()
 }
 
-func NewRuleSetProvider(name string, behavior P.RuleBehavior, format P.RuleFormat, interval time.Duration, vehicle P.Vehicle, payload []string, bundleFile resource.BundleFile, parse common.ParseRuleFunc) P.RuleProvider {
+func NewRuleSetProvider(name string, behavior P.RuleBehavior, format P.RuleFormat, interval time.Duration, vehicle P.Vehicle, payload []string, bundleFile resource.BundleFile, parse common.ParseRuleFunc, jsonPaths []string) P.RuleProvider {
 	rp := &ruleSetProvider{
 		baseProvider: baseProvider{
 			behavior: behavior,
@@ -140,7 +140,7 @@ func NewRuleSetProvider(name string, behavior P.RuleBehavior, format P.RuleForma
 		rp.strategy = rulesParseInline(payload, rp.strategy)
 	}
 	rp.Fetcher = resource.NewFetcher(name, interval, vehicle, bundleFile, func(bytes []byte) (ruleStrategy, error) {
-		return rulesParse(bytes, newStrategy(behavior, parse), format)
+		return rulesParse(bytes, newStrategy(behavior, parse), format, jsonPaths)
 	}, onUpdate)
 
 	wrapper := &RuleSetProvider{
@@ -172,10 +172,13 @@ var (
 	ErrInvalidFormat = errors.New("invalid format")
 )
 
-func rulesParse(buf []byte, strategy ruleStrategy, format P.RuleFormat) (ruleStrategy, error) {
+func rulesParse(buf []byte, strategy ruleStrategy, format P.RuleFormat, jsonPaths []string) (ruleStrategy, error) {
 	strategy.Reset()
 	if format == P.MrsRule {
 		return rulesMrsParse(buf, strategy)
+	}
+	if format == P.JsonRule {
+		return rulesJSONParse(buf, strategy, jsonPaths)
 	}
 
 	schema := &RulePayload{}


### PR DESCRIPTION
## What does this PR do?

Adds a new `json` format for `rule-providers` that extracts rule strings from raw JSON documents using simplified path expressions, so upstream public IP-range JSON sources (Google Cloud, AWS, GitHub Meta, …) can be used directly without maintaining YAML/text mirrors or a one-off mrs conversion pipeline.

Closes #2706

## Motivation

Many useful rule sources are only published as JSON (e.g. `https://www.gstatic.com/ipranges/cloud.json`, `https://ip-ranges.amazonaws.com/ip-ranges.json`, `https://api.github.com/meta`). Until now they had to be converted offline first. This PR lets mihomo consume them natively.

## Config example

```yaml
rule-providers:
  gcloud:
    type: http
    url: "https://www.gstatic.com/ipranges/cloud.json"
    format: json
    behavior: ipcidr
    interval: 86400
    json:
      paths:
        - prefixes[].ipv4Prefix # iterate the "prefixes" array, take "ipv4Prefix" of each element
        - prefixes[].ipv6Prefix
  github-meta:
    type: http
    url: "https://api.github.com/meta"
    format: json
    behavior: ipcidr
    json:
      paths:
        - actions[]
        - git[]
        - hooks[]
```

## Path expression syntax

A simplified subset of JSONPath: dot-separated key access, where **any** segment may end with `[]` to iterate an array and flatten its elements:

- `prefixes[].ipv4Prefix` — iterate `prefixes`, take `ipv4Prefix` of each element
- `actions[]` — iterate the `actions` array and take its elements
- `[]` — iterate the root array
- `a.b.c` — nested object access
- optional `$` prefix (`$.actions[]`)

Extraction semantics: `null` / missing fields are ignored, arrays are flattened automatically, only string (and number) leaves are collected. An error is raised if no rules are extracted.

## Validation rules

- `format: json` requires `json.paths` (config load error otherwise)
- `json.paths` is only allowed together with `format: json`
- JSON payload must decode to a valid document; empty extraction result is an error

## How has this been tested?

- `go test ./rules/provider/` — new unit tests covering path parsing, extraction (nested arrays, root array, flattening, `json.Number`), classical/ipcidr strategies, provider parsing end-to-end (file vehicle + `Initial()` + match), and config validation error cases
- `go build ./...` passes
