### PR TITLE
feat: configure serving expired DNS cache entries

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -145,23 +145,28 @@ type NTP struct {
 
 // DNS config
 type DNS struct {
-	Enable                bool
-	PreferH3              bool
-	IPv6                  bool
-	IPv6Timeout           uint
-	UseHosts              bool
-	UseSystemHosts        bool
-	NameServer            []dns.NameServer
-	Fallback              []dns.NameServer
-	FallbackIPFilter      []C.IpMatcher
-	FallbackDomainFilter  []C.DomainMatcher
-	FallbackLazyQuery     bool
-	Listen                string
-	ListenRoutingMark     int
-	EnhancedMode          C.DNSMode
-	DefaultNameserver     []dns.NameServer
-	CacheAlgorithm        string
-	CacheMaxSize          int
+	Enable               bool
+	PreferH3             bool
+	IPv6                 bool
+	IPv6Timeout          uint
+	UseHosts             bool
+	UseSystemHosts       bool
+	NameServer           []dns.NameServer
+	Fallback             []dns.NameServer
+	FallbackIPFilter     []C.IpMatcher
+	FallbackDomainFilter []C.DomainMatcher
+	FallbackLazyQuery    bool
+	Listen               string
+	ListenRoutingMark    int
+	EnhancedMode         C.DNSMode
+	DefaultNameserver    []dns.NameServer
+	CacheAlgorithm       string
+	CacheMaxSize         int
+
+	ServeExpired              bool
+	ServeExpiredTTL           time.Duration
+	ServeExpiredClientTimeout time.Duration
+
 	FakeIPRange           netip.Prefix
 	FakeIPPool            *fakeip.Pool
 	FakeIPRange6          netip.Prefix
@@ -241,6 +246,9 @@ type RawDNS struct {
 	DefaultNameserver            []string                            `yaml:"default-nameserver" json:"default-nameserver"`
 	CacheAlgorithm               string                              `yaml:"cache-algorithm" json:"cache-algorithm"`
 	CacheMaxSize                 int                                 `yaml:"cache-max-size" json:"cache-max-size"`
+	ServeExpired                 bool                                `yaml:"serve-expired" json:"serve-expired"`
+	ServeExpiredTTL              uint                                `yaml:"serve-expired-ttl" json:"serve-expired-ttl"`
+	ServeExpiredClientTimeout    uint                                `yaml:"serve-expired-client-timeout" json:"serve-expired-client-timeout"`
 	NameServerPolicy             *orderedmap.OrderedMap[string, any] `yaml:"nameserver-policy" json:"nameserver-policy"`
 	ProxyServerNameserver        []string                            `yaml:"proxy-server-nameserver" json:"proxy-server-nameserver"`
 	ProxyServerNameserverPolicy  *orderedmap.OrderedMap[string, any] `yaml:"proxy-server-nameserver-policy" json:"proxy-server-nameserver-policy"`
@@ -507,6 +515,11 @@ func DefaultRawConfig() *RawConfig {
 			EnhancedMode:   C.DNSMapping,
 			FakeIPRange:    "198.18.0.1/16",
 			FakeIPTTL:      1,
+
+			ServeExpired:              true,
+			ServeExpiredTTL:           86400,
+			ServeExpiredClientTimeout: 1800,
+
 			FallbackFilter: RawFallbackFilter{
 				GeoIP:     true,
 				GeoIPCode: "CN",
@@ -1422,6 +1435,10 @@ func parseDNS(rawCfg *RawConfig, ruleProviders map[string]P.RuleProvider) (*DNS,
 		EnhancedMode:      cfg.EnhancedMode,
 		CacheAlgorithm:    cfg.CacheAlgorithm,
 		CacheMaxSize:      cfg.CacheMaxSize,
+
+		ServeExpired:              cfg.ServeExpired,
+		ServeExpiredTTL:           time.Duration(cfg.ServeExpiredTTL) * time.Second,
+		ServeExpiredClientTimeout: time.Duration(cfg.ServeExpiredClientTimeout) * time.Millisecond,
 	}
 	var err error
 	if dnsCfg.NameServer, err = parseNameServer(cfg.NameServer, cfg.RespectRules, cfg.PreferH3); err != nil {

--- a/dns/resolver.go
+++ b/dns/resolver.go
@@ -48,6 +48,10 @@ type Resolver struct {
 	cache                 dnsCache
 	policy                []dnsPolicy
 	defaultResolver       *Resolver
+
+	serveExpired              bool
+	serveExpiredTTL           time.Duration
+	serveExpiredClientTimeout time.Duration
 }
 
 func (r *Resolver) LookupIPPrimaryIPv4(ctx context.Context, host string) (ips []netip.Addr, err error) {
@@ -153,9 +157,8 @@ func (r *Resolver) ExchangeContext(ctx context.Context, m *D.Msg) (msg *D.Msg, e
 	if len(m.Question) == 0 {
 		return nil, errors.New("should have one question at least")
 	}
-	continueFetch := false
 	defer func() {
-		if continueFetch || errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
+		if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
 			go func() {
 				ctx, cancel := context.WithTimeout(context.Background(), resolver.DefaultDNSTimeout)
 				defer cancel()
@@ -171,8 +174,10 @@ func (r *Resolver) ExchangeContext(ctx context.Context, m *D.Msg) (msg *D.Msg, e
 		log.Debugln("[DNS] cache hit %s --> %s, expire at %s", domain, msgToLogString(msg), expireTime.Format("2006-01-02 15:04:05"))
 		now := time.Now()
 		if expireTime.Before(now) {
-			setMsgTTL(msg, uint32(1)) // Continue fetch
-			continueFetch = true
+			if !r.serveExpired || (r.serveExpiredTTL > 0 && now.Sub(expireTime) > r.serveExpiredTTL) {
+				return r.exchangeWithoutCache(ctx, m)
+			}
+			return r.exchangeWithExpired(ctx, m, msg)
 		} else {
 			// updating TTL by subtracting common delta time from each DNS record
 			updateMsgTTL(msg, uint32(time.Until(expireTime).Seconds()))
@@ -180,6 +185,32 @@ func (r *Resolver) ExchangeContext(ctx context.Context, m *D.Msg) (msg *D.Msg, e
 		return
 	}
 	return r.exchangeWithoutCache(ctx, m)
+}
+
+func (r *Resolver) exchangeWithExpired(ctx context.Context, query, expired *D.Msg) (*D.Msg, error) {
+	refreshCh := make(chan result, 1)
+	go func() {
+		refreshCtx, cancel := context.WithTimeout(context.Background(), resolver.DefaultDNSTimeout)
+		defer cancel()
+		msg, err := r.exchangeWithoutCache(refreshCtx, query)
+		refreshCh <- result{Msg: msg, Error: err}
+	}()
+
+	if r.serveExpiredClientTimeout > 0 {
+		timer := time.NewTimer(r.serveExpiredClientTimeout)
+		defer timer.Stop()
+		select {
+		case refresh := <-refreshCh:
+			if refresh.Error == nil {
+				return refresh.Msg, nil
+			}
+		case <-timer.C:
+		case <-ctx.Done():
+		}
+	}
+
+	setMsgTTL(expired, uint32(1))
+	return expired, nil
 }
 
 // ExchangeWithoutCache a batch of dns request, and it do NOT GET from cache
@@ -483,6 +514,10 @@ type Config struct {
 	ProxyServerPolicy    []Policy
 	CacheAlgorithm       string
 	CacheMaxSize         int
+
+	ServeExpired              bool
+	ServeExpiredTTL           time.Duration
+	ServeExpiredClientTimeout time.Duration
 }
 
 func (config Config) newCache() dnsCache {
@@ -528,6 +563,10 @@ func NewResolver(config Config) (rs Resolvers) {
 		main:        transform(config.Default, nil),
 		cache:       config.newCache(),
 		ipv6Timeout: time.Duration(config.IPv6Timeout) * time.Millisecond,
+
+		serveExpired:              config.ServeExpired,
+		serveExpiredTTL:           config.ServeExpiredTTL,
+		serveExpiredClientTimeout: config.ServeExpiredClientTimeout,
 	}
 
 	var nameServerCache []struct {
@@ -600,6 +639,10 @@ func NewResolver(config Config) (rs Resolvers) {
 		cache:       config.newCache(),
 		ipv6Timeout: time.Duration(config.IPv6Timeout) * time.Millisecond,
 		policy:      makePolicy(config.Policy),
+
+		serveExpired:              config.ServeExpired,
+		serveExpiredTTL:           config.ServeExpiredTTL,
+		serveExpiredClientTimeout: config.ServeExpiredClientTimeout,
 	}
 	r.defaultResolver = defaultResolver
 	rs.Resolver = r
@@ -611,6 +654,10 @@ func NewResolver(config Config) (rs Resolvers) {
 			cache:       config.newCache(),
 			ipv6Timeout: time.Duration(config.IPv6Timeout) * time.Millisecond,
 			policy:      makePolicy(config.ProxyServerPolicy),
+
+			serveExpired:              config.ServeExpired,
+			serveExpiredTTL:           config.ServeExpiredTTL,
+			serveExpiredClientTimeout: config.ServeExpiredClientTimeout,
 		}
 	}
 
@@ -620,6 +667,10 @@ func NewResolver(config Config) (rs Resolvers) {
 			main:        cacheTransform(config.DirectServer),
 			cache:       config.newCache(),
 			ipv6Timeout: time.Duration(config.IPv6Timeout) * time.Millisecond,
+
+			serveExpired:              config.ServeExpired,
+			serveExpiredTTL:           config.ServeExpiredTTL,
+			serveExpiredClientTimeout: config.ServeExpiredClientTimeout,
 		}
 		if config.DirectFollowPolicy {
 			rs.DirectResolver.policy = r.policy

--- a/docs/config.yaml
+++ b/docs/config.yaml
@@ -247,6 +247,12 @@ tunnels: # one line config
 # DNS 配置
 dns:
   cache-algorithm: arc
+  # 是否允许在上游解析失败或超时时返回过期缓存，默认 true
+  serve-expired: true
+  # 过期缓存的最大可复用时间，单位：秒；默认 86400，设置为 0 时不限制
+  serve-expired-ttl: 86400
+  # 返回过期缓存前等待上游解析的时间，单位：毫秒；默认 1800，设置为 0 时立即返回
+  serve-expired-client-timeout: 1800
   enable: false # 关闭将使用系统 DNS
   prefer-h3: false # 是否开启 DoH 支持 HTTP/3，将并发尝试
   listen: 0.0.0.0:53 # 开启 DNS 服务器监听

--- a/hub/executor/executor.go
+++ b/hub/executor/executor.go
@@ -263,6 +263,10 @@ func updateDNS(c *config.DNS, generalIPv6 bool) {
 		DirectFollowPolicy:   c.DirectFollowPolicy,
 		CacheAlgorithm:       c.CacheAlgorithm,
 		CacheMaxSize:         c.CacheMaxSize,
+
+		ServeExpired:              c.ServeExpired,
+		ServeExpiredTTL:           c.ServeExpiredTTL,
+		ServeExpiredClientTimeout: c.ServeExpiredClientTimeout,
 	})
 	m := dns.NewEnhancer(dns.EnhancerConfig{
 		IPv6:          ipv6,


### PR DESCRIPTION
结合 https://github.com/MetaCubeX/mihomo/issues/2937#issuecomment-5449991112 这里的描述，这里提供3个新的选项，对齐到unbound的行为，并且默认打开 `serve-expired` 尽量降低对已有用户的影响