### PR TITLE
feat: add latency-weighted sticky sessions

### DIFF
--- a/adapter/outboundgroup/loadbalance.go
+++ b/adapter/outboundgroup/loadbalance.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math"
 	"net"
 	"sync"
 	"time"
@@ -20,7 +21,9 @@ import (
 )
 
 type LoadBalanceOption struct {
-	Strategy string `group:"strategy,omitempty"`
+	Strategy  string `group:"strategy,omitempty"`
+	Weighting string `group:"weighting,omitempty"`
+	TopN      int    `group:"top-n,omitempty"`
 }
 
 type LoadBalance struct {
@@ -29,6 +32,8 @@ type LoadBalance struct {
 	strategyFn     strategyFn
 	testUrl        string
 	expectedStatus string
+	weighting      string
+	topN           int
 }
 
 type strategyFn = func(proxies []C.Proxy, metadata *C.Metadata, touch bool) C.Proxy
@@ -212,6 +217,126 @@ func strategyStickySessions(url string) strategyFn {
 	}
 }
 
+type latencyCandidate struct {
+	proxy C.Proxy
+	name  string
+	delay uint16
+}
+
+func insertTopLatencyCandidate(candidates []latencyCandidate, candidate latencyCandidate, topN int) []latencyCandidate {
+	if topN <= 0 {
+		return append(candidates, candidate)
+	}
+
+	insertAt := len(candidates)
+	for i, current := range candidates {
+		if candidate.delay < current.delay || candidate.delay == current.delay && candidate.name < current.name {
+			insertAt = i
+			break
+		}
+	}
+
+	if insertAt >= topN {
+		return candidates
+	}
+
+	candidates = append(candidates, latencyCandidate{})
+	copy(candidates[insertAt+1:], candidates[insertAt:])
+	candidates[insertAt] = candidate
+	if len(candidates) > topN {
+		candidates = candidates[:topN]
+	}
+	return candidates
+}
+
+func weightedCandidateScore(key uint64, candidate latencyCandidate) float64 {
+	hash := key ^ utils.MapHash(candidate.name)
+	// SplitMix64 finalizer avoids correlations between the session and proxy hashes.
+	hash ^= hash >> 30
+	hash *= 0xbf58476d1ce4e5b9
+	hash ^= hash >> 27
+	hash *= 0x94d049bb133111eb
+	hash ^= hash >> 31
+
+	// Weighted rendezvous hashing: inverse latency is the weight, so the
+	// equivalent exponential-race score is -log(U) * latency. Lowest wins.
+	uniform := (float64(hash>>11) + 1) / (1 << 53)
+	return -math.Log(uniform) * float64(candidate.delay)
+}
+
+func selectLatencyWeightedCandidate(candidates []latencyCandidate, key uint64) latencyCandidate {
+	selected := candidates[0]
+	minScore := weightedCandidateScore(key, selected)
+	for _, candidate := range candidates[1:] {
+		score := weightedCandidateScore(key, candidate)
+		if score < minScore {
+			selected = candidate
+			minScore = score
+		}
+	}
+	return selected
+}
+
+func strategyStickySessionsLatencyWeighted(url string, topN int) strategyFn {
+	ttl := time.Minute * 10
+	stickyCache := lru.New[uint64, string](
+		lru.WithAge[uint64, string](int64(ttl.Seconds())),
+		lru.WithSize[uint64, string](1000))
+
+	return func(proxies []C.Proxy, metadata *C.Metadata, touch bool) C.Proxy {
+		key := utils.MapHash(getKeyWithSrcAndDst(metadata))
+		if cachedName, has := stickyCache.Get(key); has {
+			for _, proxy := range proxies {
+				if proxy.Name() == cachedName && proxy.AliveForTestUrl(url) {
+					return proxy
+				}
+			}
+		}
+
+		var candidates []latencyCandidate
+		alive := make([]C.Proxy, 0, len(proxies))
+		if topN > 0 {
+			capacity := topN
+			if capacity > len(proxies) {
+				capacity = len(proxies)
+			}
+			candidates = make([]latencyCandidate, 0, capacity)
+		} else {
+			candidates = make([]latencyCandidate, 0, len(proxies))
+		}
+
+		for _, proxy := range proxies {
+			if !proxy.AliveForTestUrl(url) {
+				continue
+			}
+			alive = append(alive, proxy)
+			delay := proxy.LastDelayForTestUrl(url)
+			if delay == math.MaxUint16 {
+				continue
+			}
+			candidates = insertTopLatencyCandidate(candidates, latencyCandidate{
+				proxy: proxy,
+				name:  proxy.Name(),
+				delay: delay,
+			}, topN)
+		}
+
+		var selected C.Proxy
+		if len(candidates) > 0 {
+			selected = selectLatencyWeightedCandidate(candidates, key).proxy
+		} else if len(alive) > 0 {
+			// Until the first health-check result is available, retain usable
+			// sticky behavior without treating unknown latency as the fastest.
+			selected = alive[int(jumpHash(key, int32(len(alive))))]
+		} else {
+			selected = proxies[0]
+		}
+
+		stickyCache.Set(key, selected.Name())
+		return selected
+	}
+}
+
 // Unwrap implements C.ProxyAdapter
 func (lb *LoadBalance) Unwrap(metadata *C.Metadata, touch bool) C.Proxy {
 	proxies := lb.GetProxies(touch)
@@ -229,6 +354,8 @@ func (lb *LoadBalance) MarshalJSON() ([]byte, error) {
 		"all":            all,
 		"testUrl":        lb.testUrl,
 		"expectedStatus": lb.expectedStatus,
+		"weighting":      lb.weighting,
+		"topN":           lb.topN,
 		"hidden":         lb.Hidden(),
 		"icon":           lb.Icon(),
 		"emptyFallback":  lb.EmptyFallback().Name(),
@@ -248,6 +375,16 @@ func (lb *LoadBalance) Now() string {
 }
 
 func NewLoadBalance(option GroupCommonOption, loadBalanceOption LoadBalanceOption, emptyFallback C.Proxy, providers []P.ProxyProvider) (lb *LoadBalance, err error) {
+	if loadBalanceOption.TopN < 0 {
+		return nil, errors.New("top-n must not be negative")
+	}
+	if loadBalanceOption.TopN > 0 && loadBalanceOption.Weighting == "" {
+		return nil, errors.New("top-n requires weighting")
+	}
+	if loadBalanceOption.Weighting != "" && loadBalanceOption.Strategy != "sticky-sessions" {
+		return nil, errors.New("weighting is only supported by sticky-sessions")
+	}
+
 	var strategyFn strategyFn
 	switch loadBalanceOption.Strategy {
 	case "", "consistent-hashing":
@@ -255,7 +392,14 @@ func NewLoadBalance(option GroupCommonOption, loadBalanceOption LoadBalanceOptio
 	case "round-robin":
 		strategyFn = strategyRoundRobin(option.URL)
 	case "sticky-sessions":
-		strategyFn = strategyStickySessions(option.URL)
+		switch loadBalanceOption.Weighting {
+		case "":
+			strategyFn = strategyStickySessions(option.URL)
+		case "inverse-latency":
+			strategyFn = strategyStickySessionsLatencyWeighted(option.URL, loadBalanceOption.TopN)
+		default:
+			return nil, fmt.Errorf("unsupported weighting: %s", loadBalanceOption.Weighting)
+		}
 	default:
 		return nil, fmt.Errorf("%w: %s", errStrategy, loadBalanceOption.Strategy)
 	}
@@ -277,5 +421,7 @@ func NewLoadBalance(option GroupCommonOption, loadBalanceOption LoadBalanceOptio
 		disableUDP:     option.DisableUDP,
 		testUrl:        option.URL,
 		expectedStatus: option.ExpectedStatus,
+		weighting:      loadBalanceOption.Weighting,
+		topN:           loadBalanceOption.TopN,
 	}, nil
 }

--- a/adapter/outboundgroup/loadbalance_test.go
+++ b/adapter/outboundgroup/loadbalance_test.go
@@ -1,0 +1,178 @@
+package outboundgroup
+
+import (
+	"fmt"
+	"math"
+	"sync"
+	"testing"
+
+	"github.com/metacubex/mihomo/common/structure"
+	C "github.com/metacubex/mihomo/constant"
+	"github.com/stretchr/testify/require"
+)
+
+type latencyTestProxy struct {
+	C.Proxy
+	name  string
+	alive bool
+	delay uint16
+}
+
+func (p *latencyTestProxy) Name() string {
+	return p.name
+}
+
+func (p *latencyTestProxy) AliveForTestUrl(string) bool {
+	return p.alive
+}
+
+func (p *latencyTestProxy) LastDelayForTestUrl(string) uint16 {
+	if !p.alive || p.delay == 0 {
+		return math.MaxUint16
+	}
+	return p.delay
+}
+
+func testMetadata(id int) *C.Metadata {
+	return &C.Metadata{Host: fmt.Sprintf("192.0.2.%d", id%254+1)}
+}
+
+func TestInsertTopLatencyCandidate(t *testing.T) {
+	candidates := []latencyCandidate{}
+	for _, candidate := range []latencyCandidate{
+		{name: "slow", delay: 90},
+		{name: "fast", delay: 20},
+		{name: "middle", delay: 50},
+		{name: "slower", delay: 70},
+	} {
+		candidates = insertTopLatencyCandidate(candidates, candidate, 3)
+	}
+
+	require.Equal(t, []string{"fast", "middle", "slower"}, []string{
+		candidates[0].name,
+		candidates[1].name,
+		candidates[2].name,
+	})
+}
+
+func TestInverseLatencyWeighting(t *testing.T) {
+	candidates := []latencyCandidate{
+		{name: "fast", delay: 30},
+		{name: "middle", delay: 60},
+		{name: "slow", delay: 120},
+	}
+	counts := map[string]int{}
+	const samples = 20000
+	for key := uint64(1); key <= samples; key++ {
+		counts[selectLatencyWeightedCandidate(candidates, key).name]++
+	}
+
+	// Inverse latency gives an expected ratio of 4:2:1. The bounds are wide
+	// enough to avoid flakiness while still detecting an unweighted selector.
+	require.InDelta(t, 4.0/7.0, float64(counts["fast"])/samples, 0.03)
+	require.InDelta(t, 2.0/7.0, float64(counts["middle"])/samples, 0.03)
+	require.InDelta(t, 1.0/7.0, float64(counts["slow"])/samples, 0.03)
+}
+
+func TestLatencyWeightedStickySessionConcurrentAccess(t *testing.T) {
+	proxies := []C.Proxy{
+		&latencyTestProxy{name: "fast", alive: true, delay: 20},
+		&latencyTestProxy{name: "middle", alive: true, delay: 40},
+		&latencyTestProxy{name: "slow", alive: true, delay: 80},
+	}
+	strategy := strategyStickySessionsLatencyWeighted("test", 3)
+
+	var waitGroup sync.WaitGroup
+	for i := 1; i <= 100; i++ {
+		waitGroup.Add(1)
+		go func(id int) {
+			defer waitGroup.Done()
+			metadata := testMetadata(id)
+			first := strategy(proxies, metadata, true)
+			for j := 0; j < 10; j++ {
+				if selected := strategy(proxies, metadata, true); selected.Name() != first.Name() {
+					t.Errorf("session changed from %s to %s", first.Name(), selected.Name())
+					return
+				}
+			}
+		}(i)
+	}
+	waitGroup.Wait()
+}
+
+func TestLatencyWeightedStickySessionUsesStableProxyIdentity(t *testing.T) {
+	fast := &latencyTestProxy{name: "fast", alive: true, delay: 20}
+	slow := &latencyTestProxy{name: "slow", alive: true, delay: 100}
+	strategy := strategyStickySessionsLatencyWeighted("test", 2)
+	metadata := testMetadata(1)
+
+	first := strategy([]C.Proxy{fast, slow}, metadata, true)
+	fast.delay, slow.delay = 200, 10
+	second := strategy([]C.Proxy{slow, fast}, metadata, true)
+	require.Equal(t, first.Name(), second.Name())
+
+	if first.Name() == fast.Name() {
+		fast.alive = false
+	} else {
+		slow.alive = false
+	}
+	third := strategy([]C.Proxy{fast, slow}, metadata, true)
+	require.NotEqual(t, first.Name(), third.Name())
+}
+
+func TestLatencyWeightedStickySessionTopNAndUnknownDelay(t *testing.T) {
+	fast := &latencyTestProxy{name: "fast", alive: true, delay: 20}
+	middle := &latencyTestProxy{name: "middle", alive: true, delay: 40}
+	slow := &latencyTestProxy{name: "slow", alive: true, delay: 200}
+	strategy := strategyStickySessionsLatencyWeighted("test", 2)
+
+	for i := 1; i <= 100; i++ {
+		require.NotEqual(t, slow.Name(), strategy([]C.Proxy{slow, middle, fast}, testMetadata(i), true).Name())
+	}
+
+	unknownA := &latencyTestProxy{name: "unknown-a", alive: true}
+	unknownB := &latencyTestProxy{name: "unknown-b", alive: true}
+	dead := &latencyTestProxy{name: "dead", alive: false, delay: 1}
+	selected := strategyStickySessionsLatencyWeighted("test", 2)(
+		[]C.Proxy{dead, unknownA, unknownB}, testMetadata(200), true,
+	)
+	require.Contains(t, []string{unknownA.Name(), unknownB.Name()}, selected.Name())
+}
+
+func TestLoadBalanceLatencyWeightingValidation(t *testing.T) {
+	decoder := structure.NewDecoder(structure.Option{TagName: "group", WeaklyTypedInput: true})
+	decoded := LoadBalanceOption{}
+	require.NoError(t, decoder.Decode(map[string]any{
+		"strategy":  "sticky-sessions",
+		"weighting": "inverse-latency",
+		"top-n":     3,
+	}, &decoded))
+	require.Equal(t, LoadBalanceOption{
+		Strategy:  "sticky-sessions",
+		Weighting: "inverse-latency",
+		TopN:      3,
+	}, decoded)
+
+	lb, err := NewLoadBalance(GroupCommonOption{}, decoded, nil, nil)
+	require.NoError(t, err)
+	require.Equal(t, "inverse-latency", lb.weighting)
+	require.Equal(t, 3, lb.topN)
+
+	_, err = NewLoadBalance(GroupCommonOption{}, LoadBalanceOption{
+		Strategy: "sticky-sessions",
+		TopN:     3,
+	}, nil, nil)
+	require.EqualError(t, err, "top-n requires weighting")
+
+	_, err = NewLoadBalance(GroupCommonOption{}, LoadBalanceOption{
+		Strategy:  "round-robin",
+		Weighting: "inverse-latency",
+	}, nil, nil)
+	require.EqualError(t, err, "weighting is only supported by sticky-sessions")
+
+	_, err = NewLoadBalance(GroupCommonOption{}, LoadBalanceOption{
+		Strategy:  "sticky-sessions",
+		Weighting: "unknown",
+	}, nil, nil)
+	require.EqualError(t, err, "unsupported weighting: unknown")
+}

--- a/docs/config.yaml
+++ b/docs/config.yaml
@@ -1746,6 +1746,8 @@ proxy-groups:
     url: "https://cp.cloudflare.com/generate_204"
     interval: 300
   # strategy: consistent-hashing # 可选 round-robin 和 sticky-sessions
+  # weighting: inverse-latency # sticky-sessions 可选，按健康检查延迟的倒数分配新会话
+  # top-n: 3 # weighting 启用时可选，只在延迟最低的 N 个存活节点中分配
 
   # select 用户自行选择节点
   - name: Proxy


### PR DESCRIPTION
## Summary

Add optional latency-aware allocation to the existing `sticky-sessions` load-balance strategy.

```yaml
strategy: sticky-sessions
weighting: inverse-latency
top-n: 3
```

- selects the N lowest-latency available proxies
- distributes new sticky sessions using inverse-latency weights
- keeps existing sessions on the same available proxy
- stores proxy names so provider reordering does not change cached selections
- falls back to available proxies when no delay measurement exists
- preserves the existing behavior when `weighting` is omitted

## Tests

```text
go test ./...
go test -race ./adapter/outboundgroup
go vet ./adapter/outboundgroup
```
