### PR TITLE
feat: support `^` prefix in group `use` to prepend providers

### DIFF
--- a/adapter/outboundgroup/parser.go
+++ b/adapter/outboundgroup/parser.go
@@ -82,8 +82,6 @@ func ParseProxyGroup(config map[string]any, proxyMap map[string]C.Proxy, provide
 		return nil, fmt.Errorf("%s: empty fallback proxy '%s' not found", groupName, groupOption.EmptyFallback)
 	}
 
-	providers := []P.ProxyProvider{}
-
 	if groupOption.IncludeAll {
 		groupOption.IncludeAllProviders = true
 		groupOption.IncludeAllProxies = true
@@ -129,8 +127,9 @@ func ParseProxyGroup(config map[string]any, proxyMap map[string]C.Proxy, provide
 	}
 	groupOption.ExpectedStatus = status
 
+	var useFront, useBack []P.ProxyProvider
 	if len(groupOption.Use) != 0 {
-		PDs, err := getProviders(providersMap, groupOption.Use)
+		PDs, prependFlags, err := getProviders(providersMap, groupOption.Use)
 		if err != nil {
 			return nil, fmt.Errorf("%s: %w", groupName, err)
 		}
@@ -149,8 +148,18 @@ func ParseProxyGroup(config map[string]any, proxyMap map[string]C.Proxy, provide
 		} else {
 			addTestUrlToProviders(PDs, groupOption.URL, expectedStatus, groupOption.Filter, uint(groupOption.Interval))
 		}
-		providers = append(providers, PDs...)
+
+		for i, pd := range PDs {
+			if prependFlags[i] {
+				useFront = append(useFront, pd)
+			} else {
+				useBack = append(useBack, pd)
+			}
+		}
 	}
+
+	providers := make([]P.ProxyProvider, 0, len(useFront)+len(useBack)+1)
+	providers = append(providers, useFront...)
 
 	if len(groupOption.Proxies) != 0 {
 		ps, err := getProxies(proxyMap, groupOption.Proxies)
@@ -180,9 +189,11 @@ func ParseProxyGroup(config map[string]any, proxyMap map[string]C.Proxy, provide
 			return nil, fmt.Errorf("%s: %w", groupName, err)
 		}
 
-		providers = append([]P.ProxyProvider{pd}, providers...)
+		providers = append(providers, pd)
 		providersMap[groupName] = pd
 	}
+
+	providers = append(providers, useBack...)
 
 	switch groupOption.Type {
 	case "url-test":
@@ -232,20 +243,49 @@ func getProxies(mapping map[string]C.Proxy, list []string) ([]C.Proxy, error) {
 	return ps, nil
 }
 
-func getProviders(mapping map[string]P.ProxyProvider, list []string) ([]P.ProxyProvider, error) {
-	var ps []P.ProxyProvider
-	for _, name := range list {
-		p, ok := mapping[name]
-		if !ok {
-			return nil, fmt.Errorf("'%s' not found", name)
-		}
+const usePrependPrefix = "^"
 
-		if p.VehicleType() == P.Compatible {
-			return nil, fmt.Errorf("proxy group %s can't contains in `use`", name)
+func getProviders(mapping map[string]P.ProxyProvider, list []string) ([]P.ProxyProvider, []bool, error) {
+	ps := make([]P.ProxyProvider, 0, len(list))
+	prepend := make([]bool, 0, len(list))
+	for _, name := range list {
+		p, front, err := parseUseItem(mapping, name)
+		if err != nil {
+			return nil, nil, err
 		}
 		ps = append(ps, p)
+		prepend = append(prepend, front)
 	}
-	return ps, nil
+	return ps, prepend, nil
+}
+
+// parseUseItem resolves a `use` entry.
+// A leading '^' places that provider before `proxies`; unprefixed names still
+// append after `proxies`. Exact name match always wins, so a provider literally
+// named "^foo" can still be referenced as "^foo".
+func parseUseItem(mapping map[string]P.ProxyProvider, name string) (P.ProxyProvider, bool, error) {
+	p, ok := mapping[name]
+	if !ok && strings.HasPrefix(name, usePrependPrefix) {
+		realName := name[len(usePrependPrefix):]
+		if realName == "" {
+			return nil, false, fmt.Errorf("invalid `use` item '%s'", name)
+		}
+		p, ok = mapping[realName]
+		if !ok {
+			return nil, false, fmt.Errorf("'%s' not found", name)
+		}
+		if p.VehicleType() == P.Compatible {
+			return nil, false, fmt.Errorf("proxy group %s can't contains in `use`", realName)
+		}
+		return p, true, nil
+	}
+	if !ok {
+		return nil, false, fmt.Errorf("'%s' not found", name)
+	}
+	if p.VehicleType() == P.Compatible {
+		return nil, false, fmt.Errorf("proxy group %s can't contains in `use`", name)
+	}
+	return p, false, nil
 }
 
 func addTestUrlToProviders(providers []P.ProxyProvider, url string, expectedStatus utils.IntRanges[uint16], filter string, interval uint) {

--- a/adapter/outboundgroup/parser_test.go
+++ b/adapter/outboundgroup/parser_test.go
@@ -1,0 +1,202 @@
+package outboundgroup
+
+import (
+	"testing"
+
+	"github.com/metacubex/mihomo/adapter"
+	"github.com/metacubex/mihomo/adapter/outbound"
+	"github.com/metacubex/mihomo/adapter/provider"
+	"github.com/metacubex/mihomo/common/utils"
+	C "github.com/metacubex/mihomo/constant"
+	P "github.com/metacubex/mihomo/constant/provider"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseProxyGroupUsePrepend(t *testing.T) {
+	t.Parallel()
+
+	newEnv := func() (map[string]C.Proxy, map[string]P.ProxyProvider) {
+		proxies := map[string]C.Proxy{
+			"DIRECT":     adapter.NewProxy(outbound.NewDirect()),
+			"REJECT":     adapter.NewProxy(outbound.NewReject()),
+			"COMPATIBLE": adapter.NewProxy(outbound.NewCompatible()),
+			"AUTO":       namedProxy("AUTO"),
+		}
+		providers := map[string]P.ProxyProvider{
+			"pd1":      newStubProvider("pd1", "p1a", "p1b"),
+			"pd2":      newStubProvider("pd2", "p2a"),
+			"pd3":      newStubProvider("pd3", "p3a"),
+			"^special": newStubProvider("^special", "s1"),
+			"special":  newStubProvider("special", "s2"),
+		}
+		return proxies, providers
+	}
+
+	tests := []struct {
+		name             string
+		use              []string
+		proxies          []string
+		filter           string
+		includeAllPd     bool
+		allProviders     []string
+		want             []string
+		errContains      string
+		withCompatiblePd bool
+	}{
+		{
+			name:    "use appends after proxies by default",
+			use:     []string{"pd1", "pd2"},
+			proxies: []string{"DIRECT", "REJECT"},
+			want:    []string{"DIRECT", "REJECT", "p1a", "p1b", "p2a"},
+		},
+		{
+			name:    "caret prepends a provider before proxies",
+			use:     []string{"^pd1"},
+			proxies: []string{"DIRECT", "REJECT"},
+			want:    []string{"p1a", "p1b", "DIRECT", "REJECT"},
+		},
+		{
+			name:    "multiple carets keep listed order in front",
+			use:     []string{"^pd1", "^pd2"},
+			proxies: []string{"DIRECT"},
+			want:    []string{"p1a", "p1b", "p2a", "DIRECT"},
+		},
+		{
+			name:    "mixed caret and plain use",
+			use:     []string{"^pd1", "pd2", "^pd3"},
+			proxies: []string{"AUTO", "DIRECT"},
+			want:    []string{"p1a", "p1b", "p3a", "AUTO", "DIRECT", "p2a"},
+		},
+		{
+			name: "caret still orders in front when proxies is empty",
+			use:  []string{"pd2", "^pd1"},
+			want: []string{"p1a", "p1b", "p2a"},
+		},
+		{
+			name:    "exact provider name starting with caret is not treated as prepend",
+			use:     []string{"^special"},
+			proxies: []string{"DIRECT"},
+			want:    []string{"DIRECT", "s1"},
+		},
+		{
+			name:    "double caret prepends a provider whose name starts with caret",
+			use:     []string{"^^special"},
+			proxies: []string{"DIRECT"},
+			want:    []string{"s1", "DIRECT"},
+		},
+		{
+			name:    "filter still applies to prepended providers",
+			use:     []string{"^pd1", "pd2"},
+			proxies: []string{"DIRECT"},
+			filter:  "p1a|p2a",
+			want:    []string{"p1a", "DIRECT", "p2a"},
+		},
+		{
+			name:         "include-all-providers still appends after proxies",
+			proxies:      []string{"DIRECT"},
+			includeAllPd: true,
+			allProviders: []string{"pd1", "pd2"},
+			want:         []string{"DIRECT", "p1a", "p1b", "p2a"},
+		},
+		{
+			name:        "unknown caret provider",
+			use:         []string{"^missing"},
+			proxies:     []string{"DIRECT"},
+			errContains: "'^missing' not found",
+		},
+		{
+			name:        "invalid caret-only use item",
+			use:         []string{"^"},
+			proxies:     []string{"DIRECT"},
+			errContains: "invalid `use` item '^'",
+		},
+		{
+			name:             "caret cannot reference a compatible provider",
+			use:              []string{"^other-group"},
+			proxies:          []string{"DIRECT"},
+			withCompatiblePd: true,
+			errContains:      "can't contains in `use`",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			proxies, providers := newEnv()
+			if tt.withCompatiblePd {
+				hc := provider.NewHealthCheck([]C.Proxy{namedProxy("x")}, "", 0, 0, true, nil)
+				pd, err := provider.NewCompatibleProvider("other-group", []C.Proxy{namedProxy("x")}, hc)
+				require.NoError(t, err)
+				providers["other-group"] = pd
+			}
+
+			config := map[string]any{
+				"name": "GROUP",
+				"type": "select",
+			}
+			if len(tt.use) > 0 {
+				config["use"] = tt.use
+			}
+			if len(tt.proxies) > 0 {
+				config["proxies"] = tt.proxies
+			}
+			if tt.filter != "" {
+				config["filter"] = tt.filter
+			}
+			if tt.includeAllPd {
+				config["include-all-providers"] = true
+			}
+
+			group, err := ParseProxyGroup(config, proxies, providers, nil, tt.allProviders)
+			if tt.errContains != "" {
+				require.Error(t, err)
+				require.ErrorContains(t, err, tt.errContains)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.want, proxyNames(group))
+		})
+	}
+}
+
+func namedProxy(name string) C.Proxy {
+	return adapter.NewProxy(outbound.NewDirectWithOption(outbound.DirectOption{Name: name}))
+}
+
+func proxyNames(g ProxyGroup) []string {
+	ps := g.Proxies()
+	names := make([]string, 0, len(ps))
+	for _, p := range ps {
+		names = append(names, p.Name())
+	}
+	return names
+}
+
+type stubProvider struct {
+	name    string
+	proxies []C.Proxy
+}
+
+func newStubProvider(name string, proxyNames ...string) *stubProvider {
+	proxies := make([]C.Proxy, 0, len(proxyNames))
+	for _, proxyName := range proxyNames {
+		proxies = append(proxies, namedProxy(proxyName))
+	}
+	return &stubProvider{name: name, proxies: proxies}
+}
+
+func (s *stubProvider) Name() string               { return s.name }
+func (s *stubProvider) VehicleType() P.VehicleType { return P.Inline }
+func (s *stubProvider) Type() P.ProviderType       { return P.Proxy }
+func (s *stubProvider) Initial() error             { return nil }
+func (s *stubProvider) Update() error              { return nil }
+func (s *stubProvider) Proxies() []C.Proxy         { return s.proxies }
+func (s *stubProvider) Count() int                 { return len(s.proxies) }
+func (s *stubProvider) Touch()                     {}
+func (s *stubProvider) HealthCheck()               {}
+func (s *stubProvider) Version() uint32            { return 1 }
+func (s *stubProvider) HealthCheckURL() string     { return "" }
+func (s *stubProvider) RegisterHealthCheckTask(string, utils.IntRanges[uint16], string, uint) {
+}

--- a/docs/config.yaml
+++ b/docs/config.yaml
@@ -1762,10 +1762,12 @@ proxy-groups:
     type: select
     filter: "HK|TW" # 正则表达式，过滤 provider1 中节点名包含 HK 或 TW
     use:
-      - provider1
+      - ^provider1 # 以 ^ 开头的代理集合会排在 proxies 前面；多个 ^ 按书写顺序依次前置
+      # - provider2 # 不加 ^ 则追加在 proxies 后面（默认行为）
     proxies:
       - Proxy
       - DIRECT
+    # 最终顺序: [provider1 过滤后的节点] -> Proxy -> DIRECT -> [未加 ^ 的 use]
     # empty-fallback: COMPATIBLE # 设置当组为空时的回退proxy（这里不支持填写代理组，只支持填写proxy名称）
 
 # Mihomo 格式的节点或支持 *ray 的分享格式


### PR DESCRIPTION
## Summary

Allow proxy-group `use` entries to be placed **before** `proxies` by prefixing the provider name with `^`. Unprefixed entries keep the current behavior (appended after `proxies`).

```yaml
proxy-groups:
  - name: PROXY
    type: select
    use:
      - ^vip      # before proxies
      - free      # after proxies (existing behavior)
    proxies:
      - AUTO
      - DIRECT
# order: [vip...] -> AUTO -> DIRECT -> [free...]
```

## Motivation

A group currently always concatenates members as `[proxies] + [use]`. There is no way to put a provider's nodes in front of the inline `proxies` list (for example subscription nodes first, then `DIRECT` / `REJECT`).

## Semantics

Member order is:

```
[ ^use in listed order ] + [ proxies ] + [ unprefixed use in listed order ]
```

- Multiple `^` entries keep their relative order.
- Exact provider name match always wins, so a provider literally named `^foo` can still be referenced as `^foo`. Use `^^foo` to prepend that provider.
- `include-all-providers` still replaces `use` and appends (unchanged).

## Changes

- `adapter/outboundgroup/parser.go`: parse `^` and assemble providers as front + compatible(`proxies`) + back.
- `adapter/outboundgroup/parser_test.go`: coverage for default append, prepend, mixed order, filter, `include-all-providers`, and error paths.
- `docs/config.yaml`: document the prefix.

## Tests

```text
gofmt -w adapter/outboundgroup/parser.go adapter/outboundgroup/parser_test.go
git diff --check
go vet ./adapter/outboundgroup
go test ./adapter/outboundgroup -count=1
go test -race ./adapter/outboundgroup -count=1
```

All passed. Backward compatible: configs without `^` keep the existing order.