### PR TITLE
chore: reduce memory usage in converter

### DIFF
--- a/common/convert/converter.go
+++ b/common/convert/converter.go
@@ -16,13 +16,13 @@ import (
 func ConvertsV2Ray(buf []byte) ([]map[string]any, error) {
 	data := DecodeBase64(buf)
 
-	arr := strings.Split(string(data), "\n")
+	rawLines := bytes.Split(data, []byte("\n"))
 
-	proxies := make([]map[string]any, 0, len(arr))
+	proxies := make([]map[string]any, 0, len(rawLines))
 	names := make(map[string]int, 200)
 
-	for _, line := range arr {
-		line = strings.TrimRight(line, " \r")
+	for _, raw := range rawLines {
+		line := strings.TrimRight(string(raw), " \r")
 		if line == "" {
 			continue
 		}


### PR DESCRIPTION
之前用strings，后续很多地方都引用，这部分的大块内存不一定正常释放

```
github.com/metacubex/mihomo/common/convert.ConvertsV2Ray
github.com/metacubex/mihomo@v1.19.29/common/convert/converter.go

  Total:    323.96MB   323.96MB (flat, cum) 98.33%
     17            .          .           ??? 
     19     323.96MB   323.96MB           ??? 
     21            .          .           ??? 
     22            .          .           ??? 
```