### PR TITLE
fix: ipv6 url parse in xhttp

### DIFF
--- a/adapter/outbound/vless.go
+++ b/adapter/outbound/vless.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"net/netip"
 	"strconv"
 	"strings"
 	"time"
@@ -618,6 +619,9 @@ func NewVless(option VlessOption) (*Vless, error) {
 			} else {
 				requestHost = v.option.Server
 			}
+			if ip, err := netip.ParseAddr(requestHost); err == nil && ip.Is6() {
+				requestHost = "[" + requestHost + "]"
+			}
 		}
 
 		var hKeepAlivePeriod time.Duration
@@ -796,6 +800,9 @@ func NewVless(option VlessOption) (*Vless, error) {
 					downloadHost = downloadServerName
 				} else {
 					downloadHost = downloadServer
+				}
+				if ip, err := netip.ParseAddr(downloadHost); err == nil && ip.Is6() {
+					downloadHost = "[" + downloadHost + "]"
 				}
 			}
 


### PR DESCRIPTION
### problem 1:
in adapter/outbound/vless.go:614:
```go
requestHost := v.option.XHTTPOpts.Host
if requestHost == "" {
	if v.option.ServerName != "" {
		requestHost = v.option.ServerName
	} else {
		requestHost = v.option.Server
	}
}
```
1. if tls isn't enabled, v.option.ServerName shouldn't be used.
2. if requestHost == "" and v.option.ServerName == "", it will use v.option.Server, but v.option.Port is unused.

### fix:
only use ServerName when TLS enabled, and use v.addr rather than v.option.Server.

### problem 2:
in transport/xhttp/client.go, all URL.Scheme is hardcoded "https". But when TLS is disabled, URL.Scheme should be "http". Hardcoded "https" is unexpected behavior.

### fix:
Add Scheme in Config in transport/xhttp/config.go.

### problem 3:
in transport/xhttp/client.go:210:
```go
protocols := new(http.Protocols)
protocols.SetUnencryptedHTTP2(true)
return &http.Transport{
	DialTLSContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
		raw, err := dialRaw(ctx)
		if err != nil {
			return nil, err
		}
		wrapped, err := wrapTLS(ctx, raw, true)
		if err != nil {
			_ = raw.Close()
			return nil, err
		}
		return wrapped, nil
	},
	IdleConnTimeout: ConnIdleTimeout,
	Protocols:       protocols,
	HTTP2: &http.HTTP2Config{
		SendPingTimeout: keepAlivePeriod,
	},
}
```
Transport.DialContext isn't set. which means h2c can bypass the injected XHTTP dialer.

### fix:
set Transport.DialContext too.

btw I wonder whether code refactor is acceptable.  I think there are some unnecessary function calls like NormalizedPath, GetNormalizedUplinkHTTPMethod, etc. in every Dial. Why should these functions be called every Dial? Shouldn't these functions only be called once during initialization?