### PR TITLE
fix: keep health check when proxy group is named default

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -967,7 +967,15 @@ func parseProxies(cfg *RawConfig) (proxies map[string]C.Proxy, providersMap map[
 	}
 	hc := provider.NewHealthCheck(ps, "", 5000, 0, true, nil)
 	pd, _ := provider.NewCompatibleProvider(provider.ReservedName, ps, hc)
-	providersMap[provider.ReservedName] = pd
+	// Reserved "default" backs the implicit GLOBAL selector. A user proxy-group
+	// of the same name already registered its compatible provider (url/interval)
+	// in the map. Overwriting it drops that health check because loadProvider
+	// only Initial()s map entries, so fallback/url-test interval never starts.
+	if _, exist := providersMap[provider.ReservedName]; exist {
+		log.Warnln("keep proxy group `%s` provider; reserved provider is used by GLOBAL only", provider.ReservedName)
+	} else {
+		providersMap[provider.ReservedName] = pd
+	}
 
 	if !hasGlobal {
 		global, err := outboundgroup.NewSelector(

--- a/config/utils_test.go
+++ b/config/utils_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"testing"
 
+	"github.com/metacubex/mihomo/adapter/provider"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -76,4 +77,52 @@ func TestValidateDialerProxies(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestParseProxiesReservedDefaultProvider(t *testing.T) {
+	t.Run("WithoutDefaultGroup", func(t *testing.T) {
+		cfg := RawConfig{
+			Proxy: []map[string]any{
+				{"name": "node-a", "type": "socks5", "server": "127.0.0.1", "port": 1080},
+			},
+			ProxyGroup: []map[string]any{
+				{"name": "proxy", "type": "select", "proxies": []string{"node-a"}},
+			},
+		}
+		_, providers, err := parseProxies(&cfg)
+		assert.NoError(t, err)
+		pd, ok := providers[provider.ReservedName]
+		assert.True(t, ok)
+		assert.Empty(t, pd.HealthCheckURL())
+		assert.Greater(t, pd.Count(), 2)
+	})
+
+	t.Run("WithDefaultFallbackGroup", func(t *testing.T) {
+		const testURL = "http://www.gstatic.com/generate_204"
+		cfg := RawConfig{
+			Proxy: []map[string]any{
+				{"name": "node-a", "type": "socks5", "server": "127.0.0.1", "port": 1080},
+				{"name": "node-b", "type": "socks5", "server": "127.0.0.1", "port": 1081},
+			},
+			ProxyGroup: []map[string]any{
+				{
+					"name":     provider.ReservedName,
+					"type":     "fallback",
+					"url":      testURL,
+					"interval": 30,
+					"proxies":  []string{"node-a", "node-b"},
+				},
+			},
+		}
+		proxies, providers, err := parseProxies(&cfg)
+		assert.NoError(t, err)
+		pd, ok := providers[provider.ReservedName]
+		assert.True(t, ok)
+		assert.Equal(t, testURL, pd.HealthCheckURL())
+		assert.Equal(t, 2, pd.Count())
+		_, ok = proxies["GLOBAL"]
+		assert.True(t, ok)
+		_, ok = proxies[provider.ReservedName]
+		assert.True(t, ok)
+	})
 }


### PR DESCRIPTION
## Description

A `fallback` / `url-test` / `load-balance` proxy group named `default` never runs its periodic health check. Traffic stays on the first node until someone triggers a manual delay test.

This was found on a gateway running Mihomo Meta v1.19.30: a `fallback` group named `default` with `interval: 30` did not URL-test for hours. After a restart it still selected the first node with empty delay history. `GET /group/default/delay` immediately marked dead nodes and switched. Renaming the group to `proxy` made the 30s ticker start on boot.

`proxy-providers` cannot be named `default` (`ReservedName`), but a **proxy-group** of the same name is allowed. `ParseProxyGroup` registers that group's compatible provider (with `url` / `interval`) as `providersMap["default"]`. `parseProxies` then overwrites the map entry with the reserved compatible provider used by `GLOBAL` (`url == ""`, `interval == 0`). `loadProvider` only `Initial()`s map entries, so the group's health-check goroutine never starts. Untested nodes are treated as alive, so fallback sticks to the first member.

## Change

Create the reserved provider for `GLOBAL` as before. If a user group already claimed `providersMap["default"]`, keep that entry and only attach the reserved provider to `GLOBAL`. Configs without a group named `default` are unchanged.

## Reproduction

```yaml
proxies:
  - { name: node-a, type: socks5, server: 127.0.0.1, port: 1080 }
  - { name: node-b, type: socks5, server: 127.0.0.1, port: 1081 }
proxy-groups:
  - name: default
    type: fallback
    url: http://www.gstatic.com/generate_204
    interval: 30
    proxies: [node-a, node-b]
```

After startup, `GET /providers/proxies/default` shows an empty `testUrl` and the reserved all-outbound list, not the group's members. Delay history stays empty until a manual group delay test.

## Validation

```text
gofmt -l config/config.go config/utils_test.go
git diff --check
go test ./config/
```