### PR TITLE
fix: restore hysteria v1 udp handling

### DIFF
--- a/transport/hysteria/core/client.go
+++ b/transport/hysteria/core/client.go
@@ -230,7 +230,7 @@ func (c *Client) DialUDP(dialer utils.PacketDialer) (UDPConn, error) {
 	}
 	// Send request
 	err = WriteClientRequest(stream, ClientRequest{
-		UDP: false,
+		UDP: true,
 	})
 	if err != nil {
 		_ = stream.Close()

--- a/transport/hysteria/core/protocol.go
+++ b/transport/hysteria/core/protocol.go
@@ -248,7 +248,7 @@ func (m udpMessage) Size() int {
 }
 
 func (m udpMessage) Pack() []byte {
-	data := make([]byte, m.Size())
+	data := make([]byte, 0, m.Size())
 	buffer := bytes.NewBuffer(data)
 	_ = binary.Write(buffer, binary.BigEndian, m.SessionID)
 	_ = binary.Write(buffer, binary.BigEndian, uint16(len(m.Host)))


### PR DESCRIPTION
Fixed two Hysteria v1 UDP regressions introduced in 48c1b1cdb2a3e003723b6fc9504e950355efd42c :
- Mark UDP session requests correctly with UDP: true.
- Initialize the packet buffer with zero length and preallocated capacity to prevent leading zero bytes.