### PR TITLE
fix: resolve rematch routes before URL tests

### DIFF
--- a/adapter/adapter.go
+++ b/adapter/adapter.go
@@ -16,6 +16,7 @@ import (
 	"github.com/metacubex/mihomo/component/ca"
 	C "github.com/metacubex/mihomo/constant"
 	"github.com/metacubex/mihomo/log"
+	"github.com/metacubex/mihomo/tunnel"
 
 	"github.com/metacubex/http"
 )
@@ -207,7 +208,11 @@ func (p *Proxy) URLTest(ctx context.Context, url string, expectedStatus utils.In
 	}
 
 	start := time.Now()
-	instance, err := p.DialContext(ctx, &addr)
+	proxy, err := tunnel.ResolveRematch(ctx, p, &addr)
+	if err != nil {
+		return
+	}
+	instance, err := proxy.DialContext(ctx, &addr)
 	if err != nil {
 		return
 	}

--- a/adapter/rematch_test.go
+++ b/adapter/rematch_test.go
@@ -1,0 +1,217 @@
+package adapter_test
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"net/netip"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/metacubex/mihomo/adapter"
+	"github.com/metacubex/mihomo/adapter/outbound"
+	"github.com/metacubex/mihomo/adapter/outboundgroup"
+	"github.com/metacubex/mihomo/adapter/provider"
+	"github.com/metacubex/mihomo/component/resolver"
+	C "github.com/metacubex/mihomo/constant"
+	P "github.com/metacubex/mihomo/constant/provider"
+	RC "github.com/metacubex/mihomo/rules/common"
+	"github.com/metacubex/mihomo/tunnel"
+)
+
+func TestURLTestRematch(t *testing.T) {
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodHead {
+			t.Errorf("method = %s, want HEAD", r.Method)
+		}
+		requests.Add(1)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	t.Cleanup(server.Close)
+	t.Cleanup(func() {
+		tunnel.UpdateProxies(nil, nil)
+		tunnel.UpdateRules(nil, nil, nil)
+	})
+
+	for _, target := range []string{"sub-rule", "rematch-name", "both"} {
+		t.Run(target, func(t *testing.T) {
+			mapping := map[string]any{"name": "rematch", "type": "rematch"}
+			if target != "rematch-name" {
+				mapping["target-sub-rule"] = "route"
+			}
+			if target != "sub-rule" {
+				mapping["target-rematch-name"] = "selected"
+			}
+			rematch, err := adapter.ParseProxy(mapping)
+			if err != nil {
+				t.Fatal(err)
+			}
+			direct := adapter.NewProxy(outbound.NewDirect())
+			reject := adapter.NewProxy(outbound.NewReject())
+			selected := rematchSelector(t, "selected", rematch)
+			nested := rematchSelector(t, "nested", selected)
+			tunnel.UpdateProxies(map[string]C.Proxy{
+				"DIRECT": direct, "REJECT": reject, "rematch": rematch,
+				"selected": selected, "nested": nested,
+			}, nil)
+			tcpRule, err := RC.NewNetworkType("TCP", "DIRECT")
+			if err != nil {
+				t.Fatal(err)
+			}
+			nameRule, err := RC.NewRematchName("selected", "DIRECT")
+			if err != nil {
+				t.Fatal(err)
+			}
+			route := []C.Rule{tcpRule, RC.NewMatch("REJECT")}
+			if target == "both" {
+				route = []C.Rule{nameRule, RC.NewMatch("REJECT")}
+			}
+			tunnel.UpdateRules([]C.Rule{nameRule, RC.NewMatch("REJECT")}, map[string][]C.Rule{"route": route}, nil)
+
+			for _, proxy := range []C.Proxy{rematch, selected, nested, direct} {
+				t.Run(proxy.Name(), func(t *testing.T) {
+					before := requests.Load()
+					ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+					defer cancel()
+					if _, err := proxy.URLTest(ctx, server.URL, nil); err != nil {
+						t.Fatalf("URLTest: %v", err)
+					}
+					if got := requests.Load() - before; got != 1 {
+						t.Fatalf("HTTP requests = %d, want 1", got)
+					}
+					if !proxy.AliveForTestUrl(server.URL) {
+						t.Fatal("successful rematch URL test marked the proxy unhealthy")
+					}
+				})
+			}
+		})
+	}
+}
+
+func TestURLTestRematchRouting(t *testing.T) {
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	t.Cleanup(server.Close)
+	oldMode := tunnel.Mode()
+	t.Cleanup(func() {
+		tunnel.SetMode(oldMode)
+		tunnel.UpdateProxies(nil, nil)
+		tunnel.UpdateRules(nil, nil, nil)
+	})
+	for _, mode := range []tunnel.TunnelMode{tunnel.Rule, tunnel.Global, tunnel.Direct} {
+		t.Run(mode.String(), func(t *testing.T) {
+			tunnel.SetMode(mode)
+			for _, tc := range []struct {
+				name   string
+				target string
+				second string
+				want   string
+			}{
+				{name: "nested-exit", target: "exit"},
+				{name: "multiple-rematches", target: "second", second: "exit"},
+				{name: "self-cycle", target: "first", want: "rematch cycle"},
+				{name: "two-node-cycle", target: "second", second: "first", want: "rematch cycle"},
+				{name: "reject", target: "REJECT", want: "any error"},
+				{name: "no-match", target: "missing", want: "any error"},
+			} {
+				t.Run(tc.name, func(t *testing.T) {
+					first, err := adapter.ParseProxy(map[string]any{"name": "first", "type": "rematch", "target-sub-rule": "first-rules"})
+					if err != nil {
+						t.Fatal(err)
+					}
+					second, err := adapter.ParseProxy(map[string]any{"name": "second", "type": "rematch", "target-sub-rule": "second-rules"})
+					if err != nil {
+						t.Fatal(err)
+					}
+					reject := adapter.NewProxy(outbound.NewReject())
+					exit := rematchSelector(t, "exit", adapter.NewProxy(outbound.NewDirect()))
+					tunnel.UpdateProxies(map[string]C.Proxy{
+						"first": first, "second": second, "exit": exit,
+						"GLOBAL": reject, "DIRECT": reject, "REJECT": reject,
+					}, nil)
+					tunnel.UpdateRules([]C.Rule{RC.NewMatch("REJECT")}, map[string][]C.Rule{
+						"first-rules": {RC.NewMatch(tc.target)}, "second-rules": {RC.NewMatch(tc.second)},
+					}, nil)
+					before := requests.Load()
+					ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+					defer cancel()
+					_, err = first.URLTest(ctx, server.URL, nil)
+					if tc.want != "" {
+						if err == nil || (tc.want != "any error" && !strings.Contains(err.Error(), tc.want)) {
+							t.Fatalf("URLTest error = %v, want %q", err, tc.want)
+						}
+						if requests.Load() != before || first.AliveForTestUrl(server.URL) {
+							t.Fatal("invalid route reached HTTP server or was marked healthy")
+						}
+					} else if err != nil || requests.Load()-before != 1 || !first.AliveForTestUrl(server.URL) {
+						t.Fatalf("valid route failed: error=%v requests=%d", err, requests.Load()-before)
+					}
+				})
+			}
+		})
+	}
+}
+
+func TestURLTestRematchDNSCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	oldResolver := resolver.DefaultResolver
+	// Cancel once rule matching starts DNS. A lost parent context would wait
+	// for the core's DNS timeout and then fall through to the rejecting rule.
+	resolver.DefaultResolver = &cancelingResolver{cancel: cancel}
+	t.Cleanup(func() {
+		resolver.DefaultResolver = oldResolver
+		tunnel.UpdateProxies(nil, nil)
+		tunnel.UpdateRules(nil, nil, nil)
+	})
+	rematch, err := adapter.ParseProxy(map[string]any{"name": "rematch", "type": "rematch", "target-sub-rule": "route"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ipRule, err := RC.NewIPCIDR("127.0.0.0/8", "REJECT")
+	if err != nil {
+		t.Fatal(err)
+	}
+	tunnel.UpdateProxies(map[string]C.Proxy{"REJECT": adapter.NewProxy(outbound.NewReject())}, nil)
+	tunnel.UpdateRules(nil, map[string][]C.Rule{"route": {ipRule, RC.NewMatch("REJECT")}}, nil)
+	_, err = rematch.URLTest(ctx, "http://rematch-url-test.invalid", nil)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("URLTest error = %v, want context.Canceled", err)
+	}
+}
+
+type cancelingResolver struct {
+	resolver.Resolver
+	cancel context.CancelFunc
+}
+
+func (r *cancelingResolver) Invalid() bool { return true }
+
+func (r *cancelingResolver) LookupIPv4(ctx context.Context, host string) ([]netip.Addr, error) {
+	r.cancel()
+	<-ctx.Done()
+	return nil, ctx.Err()
+}
+
+func rematchSelector(t *testing.T, name string, proxy C.Proxy) C.Proxy {
+	t.Helper()
+	proxies := []C.Proxy{proxy}
+	hc := provider.NewHealthCheck(proxies, "", 1000, 0, true, nil)
+	pd, err := provider.NewCompatibleProvider(name, proxies, hc)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = pd.Close() })
+	selector, err := outboundgroup.NewSelector(outboundgroup.GroupCommonOption{Name: name}, outboundgroup.SelectorOption{}, proxy, []P.ProxyProvider{pd})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return adapter.NewProxy(selector)
+}

--- a/tunnel/rematch.go
+++ b/tunnel/rematch.go
@@ -1,0 +1,57 @@
+package tunnel
+
+import (
+	"context"
+	"fmt"
+
+	C "github.com/metacubex/mihomo/constant"
+)
+
+// ResolveRematch resolves a rematch selected by proxy before an internal URL
+// test dials it. Ordinary proxies retain their normal dialing path. Rematching
+// applies rules regardless of the tunnel mode, since the test explicitly chose
+// the initial proxy rather than asking the tunnel to choose one.
+func ResolveRematch(ctx context.Context, proxy C.Proxy, metadata *C.Metadata) (C.Proxy, error) {
+	rematch := unwrapRematch(proxy, metadata)
+	if rematch == nil {
+		return proxy, nil
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
+	metadata.Type = C.INNER
+	conn, err := rematch.DialContext(ctx, metadata) // only updates routing metadata
+	if conn != nil {
+		_ = conn.Close()
+	}
+	if err != nil {
+		return nil, err
+	}
+	proxy, _, err = match(metadata, ruleMatchHelper(ctx, metadata))
+	if err != nil {
+		return nil, err
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	if proxy == nil {
+		return nil, fmt.Errorf("rematch %s did not resolve to a proxy", rematch.Name())
+	}
+	// The matcher returns a rematch adapter when it detects a routing cycle.
+	// That adapter's noop connection must not be used for an HTTP test.
+	if rematch := unwrapRematch(proxy, metadata); rematch != nil {
+		return nil, fmt.Errorf("rematch cycle detected on %s", rematch.Name())
+	}
+	return proxy, nil
+}
+
+func unwrapRematch(proxy C.Proxy, metadata *C.Metadata) C.Proxy {
+	for proxy != nil {
+		if proxy.Type() == C.Rematch {
+			return proxy
+		}
+		proxy = proxy.Unwrap(metadata, false)
+	}
+	return nil
+}

--- a/tunnel/tunnel.go
+++ b/tunnel/tunnel.go
@@ -323,6 +323,20 @@ func resolveMetadata(metadata *C.Metadata) (proxy C.Proxy, rule C.Rule, err erro
 		}
 		return
 	}
+	helper := ruleMatchHelper(context.Background(), metadata)
+	switch mode {
+	case Direct:
+		proxy = proxies["DIRECT"]
+	case Global:
+		proxy = proxies["GLOBAL"]
+	// Rule
+	default:
+		proxy, rule, err = match(metadata, helper)
+	}
+	return
+}
+
+func ruleMatchHelper(ctx context.Context, metadata *C.Metadata) C.RuleMatchHelper {
 	var (
 		resolved             bool
 		attemptProcessLookup = metadata.Type != C.INNER
@@ -336,7 +350,7 @@ func resolveMetadata(metadata *C.Metadata) (proxy C.Proxy, rule C.Rule, err erro
 	helper := C.RuleMatchHelper{
 		ResolveIP: func() {
 			if !resolved && metadata.Host != "" && !metadata.Resolved() {
-				ctx, cancel := context.WithTimeout(context.Background(), resolver.DefaultDNSTimeout)
+				ctx, cancel := context.WithTimeout(ctx, resolver.DefaultDNSTimeout)
 				defer cancel()
 				ip, err := resolver.ResolveIP(ctx, metadata.Host)
 				if err != nil {
@@ -398,16 +412,7 @@ func resolveMetadata(metadata *C.Metadata) (proxy C.Proxy, rule C.Rule, err erro
 		helper.FindProcess = nil
 	}
 
-	switch mode {
-	case Direct:
-		proxy = proxies["DIRECT"]
-	case Global:
-		proxy = proxies["GLOBAL"]
-	// Rule
-	default:
-		proxy, rule, err = match(metadata, helper)
-	}
-	return
+	return helper
 }
 
 // processUDP starts a loop to handle udp packet


### PR DESCRIPTION
## Summary

Fix URL tests for `rematch` outbounds, including Rematch selected through nested proxy groups.

`Proxy.URLTest` currently dials its adapter directly. A Rematch adapter only changes routing metadata and returns a noop connection, so the HTTP probe fails without reaching its destination. Normal rule-routed traffic through the same selection can work. Clients such as FlClashX display the resulting error as `Timeout`.

## Changes

- Resolve a selected Rematch through the existing rule matcher before dialing the HTTP probe. Keep ordinary proxies on their existing dialing path.
- Support both `target-rematch-name` and `target-sub-rule`, nested selectors, and chained Rematch outbounds.
- Keep explicit proxy tests independent of the tunnel's global/direct mode.
- Return an explicit error for rematch cycles or a missing final proxy.
- Reuse the existing rule-match helpers, propagating the probe's context into routing DNS lookups. Existing tunnel callers retain their current background-context behavior.

This changes URL testing only: it does not change normal traffic dialing, named-proxy DNS dialing, or configuration syntax. The delay continues to be an HTTP/TCP probe; it is not a measurement of the UDP branch.

## Local reproduction

Start a local HTTP endpoint (the short response delay avoids the existing API behavior that rejects timings rounded to 0 ms):

```python
from http.server import BaseHTTPRequestHandler, HTTPServer
from time import sleep

class Handler(BaseHTTPRequestHandler):
    def do_HEAD(self):
        sleep(0.02)
        self.send_response(200)
        self.end_headers()

HTTPServer(("127.0.0.1", 18080), Handler).serve_forever()
```

Run Mihomo with:

```yaml
mixed-port: 17890
external-controller: 127.0.0.1:19090
mode: rule
proxies:
  - name: RM
    type: rematch
    target-sub-rule: transport
proxy-groups:
  - name: COUNTRY
    type: select
    proxies: [RM]
sub-rules:
  transport:
    - NETWORK,TCP,DIRECT
    - MATCH,REJECT
rules:
  - MATCH,REJECT
```

```sh
curl --get http://127.0.0.1:19090/proxies/COUNTRY/delay \
  --data-urlencode 'url=http://127.0.0.1:18080/' \
  --data 'timeout=3000'
```

Before: HTTP probe errors (typically EOF), and the local server receives no request. After: the request reaches the endpoint through the TCP sub-rule and the API returns a delay. Testing `RM` directly has the same before/after behavior.

## Validation

- Reproduced the original bug with real localhost HTTP requests: nine Rematch/nested-selector cases failed with EOF while the DIRECT controls passed.
- `go test ./adapter ./tunnel -count=1`
- `go test ./adapter -run TestURLTestRematch -race -count=3`
- `go test ./adapter ./adapter/outboundgroup ./adapter/provider ./tunnel ./config ./hub/... -count=1`
- Built the core and verified the local controller API: both `RM` and `COUNTRY` go from HTTP 503/no endpoint request to HTTP 200/one endpoint request.
- Regression coverage includes both target fields, nested selectors, multiple rematches, cycles, rejection, no-match fallback, Rule/Global/Direct modes, and cancellation during routing DNS resolution.
- The full `go test ./...` run was stopped while the unrelated inbound interoperability suite was fetching V2Ray (`go get github.com/v2fly/v2ray-core/v5@v5.51.2`). The full suite is not claimed as passing; the focused checks above completed successfully on macOS arm64 / Go 1.25.1.

Prepared with AI assistance and independently reviewed; tests exercise the real adapters and routing engine with a local HTTP endpoint.
