### PR TITLE
fix: mieru listener doesn't obey "listen" config

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/coreos/go-iptables v0.8.0
 	github.com/dlclark/regexp2 v1.12.0
 	github.com/easytier/easytier/easytier-go v0.0.0-20260910071355-3d0c9c3ca5e2
-	github.com/enfein/mieru/v3 v3.36.0
+	github.com/enfein/mieru/v3 v3.37.0
 	github.com/gobwas/ws v1.4.0
 	github.com/gofrs/uuid/v5 v5.4.0
 	github.com/golang/snappy v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -29,8 +29,8 @@ github.com/dunglas/httpsfv v1.0.2 h1:iERDp/YAfnojSDJ7PW3dj1AReJz4MrwbECSSE59JWL0
 github.com/dunglas/httpsfv v1.0.2/go.mod h1:zID2mqw9mFsnt7YC3vYQ9/cjq30q41W+1AnDwH8TiMg=
 github.com/easytier/easytier/easytier-go v0.0.0-20260910071355-3d0c9c3ca5e2 h1:2/9iRUcMR3QPrT2XFf/i7QV5YoSHPFjkgBM5tP8xbcc=
 github.com/easytier/easytier/easytier-go v0.0.0-20260910071355-3d0c9c3ca5e2/go.mod h1:fCEi5+K2yt+sPDONSWO1uNpOifrwPgFGvm3J0YrFRvk=
-github.com/enfein/mieru/v3 v3.36.0 h1:kTXfBSV6Dajk09yBYMeI1r4WAuAtMCKqZ42X5BrQZV8=
-github.com/enfein/mieru/v3 v3.36.0/go.mod h1:zJBUCsi5rxyvHM8fjFf+GLaEl4OEjjBXr1s5F6Qd3hM=
+github.com/enfein/mieru/v3 v3.37.0 h1:DKBDeBmlbpNKiOXtKXqxJo/BF+KvJKnbChn6fryeyHg=
+github.com/enfein/mieru/v3 v3.37.0/go.mod h1:zJBUCsi5rxyvHM8fjFf+GLaEl4OEjjBXr1s5F6Qd3hM=
 github.com/ericlagergren/aegis v0.0.0-20250325060835-cd0defd64358 h1:kXYqH/sL8dS/FdoFjr12ePjnLPorPo2FsnrHNuXSDyo=
 github.com/ericlagergren/aegis v0.0.0-20250325060835-cd0defd64358/go.mod h1:hkIFzoiIPZYxdFOOLyDho59b7SrDfo+w3h+yWdlg45I=
 github.com/ericlagergren/polyval v0.0.0-20220411101811-e25bc10ba391 h1:8j2RH289RJplhA6WfdaPqzg1MjH2K8wX5e0uhAxrw2g=

--- a/listener/inbound/mieru.go
+++ b/listener/inbound/mieru.go
@@ -156,6 +156,7 @@ func buildMieruServerConfig(option *MieruOption, ports utils.IntRanges[uint16]) 
 	lc := option.ListenConfig()
 	return &mieruserver.ServerConfig{
 		Config: &mierupb.ServerConfig{
+			ListenIPAddress:  proto.String(option.Listen),
 			PortBindings:     portBindings,
 			Users:            users,
 			TrafficPattern:   trafficPattern,

--- a/listener/inbound/mieru_test.go
+++ b/listener/inbound/mieru_test.go
@@ -203,6 +203,7 @@ func testInboundMieruTCP(t *testing.T, handshakeMode string) {
 	defer l.Close()
 	lc := mieruTestInboundListenConfig{
 		ListenFn: func(ctx context.Context, network, address string) (net.Listener, error) {
+			assert.Equal(t, l.Addr().String(), address)
 			return l, nil
 		},
 		ListenPacketFn: func(ctx context.Context, network, address string) (net.PacketConn, error) {
@@ -273,6 +274,7 @@ func testInboundMieruUDP(t *testing.T, handshakeMode string) {
 			panic("should not be called")
 		},
 		ListenPacketFn: func(ctx context.Context, network, address string) (net.PacketConn, error) {
+			assert.Equal(t, l.LocalAddr().String(), address)
 			return l, nil
 		},
 	}


### PR DESCRIPTION
Previously, mieru server always listen to 0.0.0.0. Version 3.37.0 allow the server listen to a user provided IP address.